### PR TITLE
feat(ci): enforce Conventional Commits for PR titles using GitHub Actions

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,23 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+            wip: true

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ cd my-turborepo
 pnpm dev
 ```
 
+
 ### Remote Caching
 
 > [!TIP]


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to lint pull requests. The workflow is designed to validate the pull request title using the `amannn/action-semantic-pull-request` action.

The most important changes include:

* [`.github/workflows/lint-pr.yml`](diffhunk://#diff-70c3a017bfdb629fd50281fe5f7ad22e29c0ddac36e7065e9dc6d4f0924104f4R1-R23): Added a new workflow named "Lint PR" that triggers on pull request events (opened, edited, synchronized, and reopened) and uses the `amannn/action-semantic-pull-request` action to validate the PR title.