### PR TITLE
fix(web): disable theme switcher

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -3,7 +3,6 @@ import { Poppins, Overpass } from "next/font/google";
 import type React from "react";
 
 import { cn } from "@repo/ui/lib/utils";
-import { ThemeProvider } from "@repo/ui/components";
 
 import { QueryProvider } from "../providers/QueryProvider";
 import "./globals.css";
@@ -39,14 +38,7 @@ export default function RootLayout({
           overpass.variable,
         )}
       >
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="light"
-          enableSystem
-          disableTransitionOnChange
-        >
-          <QueryProvider>{children}</QueryProvider>
-        </ThemeProvider>
+        <QueryProvider>{children}</QueryProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Bug Fix

## Description

The theme switcher causes the react error "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client.". As theme switching has not been implemented, it is easiest to remove the component for the moment. This resolves the error.
