### PR TITLE
feat(web): devtools optionally enabled

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ["@repo/ui"],
+  devIndicators: process.env.NEXT_PUBLIC_ENABLE_DEVTOOLS === "true",
 };
 
 export default nextConfig;

--- a/apps/web/providers/QueryProvider.tsx
+++ b/apps/web/providers/QueryProvider.tsx
@@ -13,7 +13,7 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
     <QueryClientProvider client={queryClient}>
       <tsr.ReactQueryProvider>
         {children}
-        <ReactQueryDevtools initialIsOpen={false} />
+        { process.env.NEXT_PUBLIC_ENABLE_DEVTOOLS === "true" && <ReactQueryDevtools initialIsOpen={false} /> }
       </tsr.ReactQueryProvider>
     </QueryClientProvider>
   );

--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,7 @@
       "dependsOn": ["^check-types"]
     },
     "dev": {
+      "env": ["NEXT_PUBLIC_ENABLE_DEVTOOLS"],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature

## Description

Sometimes it can be practical to have the two development tools enabled on the site, but not always. Having the tools
always enabled during development makes proper styling more difficult.
These will now be disabled by default and can be enabled by creating a local `.env` file containing:

```
NEXT_PUBLIC_ENABLE_DEVTOOLS=true
```
