### PR TITLE
chore: temporarily renames py tool install script to setup

### DIFF
--- a/apps/tools/multispeq_mqtt_interface/package.json
+++ b/apps/tools/multispeq_mqtt_interface/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "pyenv local 3.12 && pip install .",
+    "setup": "pyenv local 3.12 && pip install .",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "dev": "PYTHONPATH=src pyenv local 3.12 && python3 -m multispeq_mqtt_interface.main"
   }


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Other (please describe)

## Description

This pull request makes a small change to the `package.json` file for the `multispeq_mqtt_interface` application. The change renames the `build` script to `setup` so that the CICD process is unblocked until we handle `pyenv` in the workflows.
