### PR TITLE
fix(web): Numeric field must stay number after input changes

### DIFF
--- a/apps/web/components/new-experiment.tsx
+++ b/apps/web/components/new-experiment.tsx
@@ -120,7 +120,11 @@ export function NewExperimentForm() {
             <FormItem>
               <FormLabel>Embargo interval days</FormLabel>
               <FormControl>
-                <Input type="number" {...field} />
+                <Input
+                  type="number"
+                  {...field}
+                  onChange={(event) => field.onChange(+event.target.value)}
+                />
               </FormControl>
               <FormMessage />
             </FormItem>


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Bug Fix

## Description

Numeric fields need an extra step to keep their value numeric after changing it.