### PR TITLE
feat(backend): introduces dedicated endpoint to retrieve experiment datasets

### DIFF
--- a/apps/backend/.env.test
+++ b/apps/backend/.env.test
@@ -1,3 +1,18 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/openjii_local
 NODE_ENV=test
 PORT=3020
+
+# Auth configuration for testing
+AUTH_SECRET=test-auth-secret
+
+# External Providers (Test credentials)
+AUTH_GITHUB_ID=test-github-id
+AUTH_GITHUB_SECRET=test-github-secret
+
+# Databricks configuration for testing
+DATABRICKS_HOST=https://test-databricks.example.com
+DATABRICKS_CLIENT_ID=test-client-id
+DATABRICKS_CLIENT_SECRET=test-client-secret
+DATABRICKS_JOB_ID=0123456789
+DATABRICKS_WAREHOUSE_ID=test-warehouse-id
+DATABRICKS_CATALOG_NAME=test_catalog

--- a/apps/backend/src/common/services/databricks/databricks.types.ts
+++ b/apps/backend/src/common/services/databricks/databricks.types.ts
@@ -82,6 +82,22 @@ export interface SchemaData {
   truncated: boolean;
 }
 
+export interface TableInfo {
+  name: string;
+  catalog_name: string;
+  schema_name: string;
+  table_id?: string;
+  table_type?: string;
+  comment?: string;
+  created_at?: number;
+  owner?: string;
+}
+
+export interface ListTablesResponse {
+  tables: TableInfo[];
+  next_page_token?: string;
+}
+
 // Common enums for type safety
 export enum LifeCycleState {
   PENDING = "PENDING",

--- a/apps/backend/src/experiments/application/use-cases/create-experiment/create-experiment.spec.ts
+++ b/apps/backend/src/experiments/application/use-cases/create-experiment/create-experiment.spec.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../../common/utils/fp-utils";
 import { ExperimentMemberRepository } from "../../../../experiments/core/repositories/experiment-member.repository";
 import { TestHarness } from "../../../../test/test-harness";
+import type { UserDto } from "../../../../users/core/models/user.model";
 import { CreateExperimentUseCase } from "./create-experiment";
 
 describe("CreateExperimentUseCase", () => {
@@ -105,8 +106,8 @@ describe("CreateExperimentUseCase", () => {
     // Verify the creator was added as an admin
     expect(members[0]).toMatchObject({
       experimentId: createdExperiment.id,
-      userId: testUserId,
       role: "admin",
+      user: expect.objectContaining({ id: testUserId }) as Partial<UserDto>,
     });
   });
 

--- a/apps/backend/src/experiments/application/use-cases/experiment-data/get-experiment-data.spec.ts
+++ b/apps/backend/src/experiments/application/use-cases/experiment-data/get-experiment-data.spec.ts
@@ -1,0 +1,494 @@
+import nock from "nock";
+
+import { DatabricksService } from "../../../../common/services/databricks/databricks.service";
+import {
+  assertFailure,
+  assertSuccess,
+} from "../../../../common/utils/fp-utils";
+import { TestHarness } from "../../../../test/test-harness";
+import { GetExperimentDataUseCase } from "./get-experiment-data";
+
+const DATABRICKS_HOST = "https://databricks.example.com";
+
+describe("GetExperimentDataUseCase", () => {
+  const testApp = TestHarness.App;
+  let testUserId: string;
+  let useCase: GetExperimentDataUseCase;
+
+  beforeAll(async () => {
+    await testApp.setup();
+  });
+
+  beforeEach(async () => {
+    await testApp.beforeEach();
+    testUserId = await testApp.createTestUser({});
+
+    useCase = testApp.module.get(GetExperimentDataUseCase);
+
+    // Reset any mocks before each test
+    jest.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  afterEach(() => {
+    testApp.afterEach();
+    nock.cleanAll();
+  });
+
+  afterAll(async () => {
+    await testApp.teardown();
+  });
+
+  it("should return table data when table name is specified", async () => {
+    // Create an experiment in the database
+    const { experiment } = await testApp.createExperiment({
+      name: "Test Experiment",
+      description: "Test Description",
+      status: "active",
+      visibility: "private",
+      embargoIntervalDays: 90,
+      userId: testUserId,
+    });
+
+    // Mock the DatabricksService methods
+    const mockCountData = {
+      columns: [{ name: "count", type_name: "LONG", type_text: "LONG" }],
+      rows: [["100"]],
+      totalRows: 1,
+      truncated: false,
+    };
+
+    const mockTableData = {
+      columns: [
+        { name: "column1", type_name: "string", type_text: "string" },
+        { name: "column2", type_name: "number", type_text: "number" },
+      ],
+      rows: [
+        ["value1", "1"],
+        ["value2", "2"],
+      ],
+      totalRows: 2,
+      truncated: false,
+    };
+
+    // Mock token request
+    nock(DATABRICKS_HOST).post(DatabricksService.TOKEN_ENDPOINT).reply(200, {
+      access_token: "mock-token",
+      expires_in: 3600,
+      token_type: "Bearer",
+    });
+
+    // Mock SQL query for row count
+    nock(DATABRICKS_HOST)
+      .post(DatabricksService.SQL_STATEMENTS_ENDPOINT)
+      .query(() => true)
+      .reply(200, {
+        statement_id: "mock-count-id",
+        status: { state: "SUCCEEDED" },
+        result: mockCountData,
+      });
+
+    // Mock SQL query for table data
+    nock(DATABRICKS_HOST)
+      .post(DatabricksService.SQL_STATEMENTS_ENDPOINT)
+      .query(() => true)
+      .reply(200, {
+        statement_id: "mock-data-id",
+        status: { state: "SUCCEEDED" },
+        result: mockTableData,
+      });
+
+    // Act
+    const result = await useCase.execute(experiment.id, testUserId, {
+      tableName: "test_table",
+      page: 1,
+      pageSize: 20,
+    });
+
+    // Assert result is success
+    expect(result.isSuccess()).toBe(true);
+    assertSuccess(result);
+
+    // Verify response structure
+    expect(result.value).toMatchObject({
+      data: mockTableData,
+      tableName: "test_table",
+      page: 1,
+      pageSize: 20,
+      totalRows: 100,
+      totalPages: 5, // 100 rows / 20 per page = 5 pages
+    });
+  });
+
+  it("should return table list and sample data when no table name is specified", async () => {
+    jest.setTimeout(30000); // Increase timeout for this test
+    // Create an experiment in the database
+    const { experiment } = await testApp.createExperiment({
+      name: "Test Experiment",
+      description: "Test Description",
+      status: "active",
+      visibility: "private",
+      embargoIntervalDays: 90,
+      userId: testUserId,
+    });
+
+    // Mock the DatabricksService methods
+    const mockTables = {
+      tables: [
+        {
+          name: "table1",
+          catalog_name: "catalog1",
+          schema_name: `exp_${experiment.name}_${experiment.id}`,
+        },
+        {
+          name: "table2",
+          catalog_name: "catalog1",
+          schema_name: `exp_${experiment.name}_${experiment.id}`,
+        },
+      ],
+    };
+
+    // Mock sample data for each table
+    const mockSampleData1 = {
+      columns: [
+        { name: "column1", type_name: "string", type_text: "string" },
+        { name: "column2", type_name: "number", type_text: "number" },
+      ],
+      rows: [
+        ["value1", "1"],
+        ["value2", "2"],
+      ],
+      totalRows: 2,
+      truncated: false,
+    };
+
+    const mockSampleData2 = {
+      columns: [
+        { name: "column1", type_name: "string", type_text: "string" },
+        { name: "column2", type_name: "number", type_text: "number" },
+      ],
+      rows: [
+        ["value3", "3"],
+        ["value4", "4"],
+      ],
+      totalRows: 2,
+      truncated: false,
+    };
+
+    // Mock token request
+    nock(DATABRICKS_HOST).post(DatabricksService.TOKEN_ENDPOINT).reply(200, {
+      access_token: "mock-token",
+      expires_in: 3600,
+      token_type: "Bearer",
+    });
+
+    // Mock listTables API call
+    nock(DATABRICKS_HOST)
+      .post(DatabricksService.TABLES_ENDPOINT)
+      .reply(200, mockTables);
+
+    // Mock SQL query for sample data - first table
+    nock(DATABRICKS_HOST)
+      .post(DatabricksService.SQL_STATEMENTS_ENDPOINT)
+      .query(() => true)
+      .reply(200, {
+        statement_id: "mock-sample1-id",
+        status: { state: "SUCCEEDED" },
+        result: mockSampleData1,
+      });
+
+    // Mock SQL query for sample data - second table
+    nock(DATABRICKS_HOST)
+      .post(DatabricksService.SQL_STATEMENTS_ENDPOINT)
+      .query(() => true)
+      .reply(200, {
+        statement_id: "mock-sample2-id",
+        status: { state: "SUCCEEDED" },
+        result: mockSampleData2,
+      });
+
+    // Act
+    const result = await useCase.execute(experiment.id, testUserId, {
+      page: 1,
+      pageSize: 5,
+    });
+
+    // Assert result is success
+    expect(result.isSuccess()).toBe(true);
+    assertSuccess(result);
+
+    // Verify response structure
+    // Check main structure properties
+    expect(result.value.tables).toEqual(mockTables.tables);
+    expect(result.value.page).toBe(1);
+    expect(result.value.pageSize).toBe(5);
+    expect(result.value.totalRows).toBe(2);
+    expect(result.value.totalPages).toBe(1);
+
+    // Check data structure
+    expect(result.value.data?.totalRows).toBe(2);
+
+    // Check columns
+    const columns = result.value.data?.columns;
+    expect(columns).toHaveLength(2);
+    expect(columns?.[0]).toMatchObject({
+      name: "table_name",
+      type_name: "STRING",
+      type_text: "STRING",
+    });
+    expect(columns?.[1]).toMatchObject({
+      name: "sample_data",
+      type_name: "STRING",
+      type_text: "STRING",
+    });
+
+    // Check rows
+    const rows = result.value.data?.rows;
+    expect(rows).toHaveLength(2);
+    expect(rows?.[0][0]).toBe("table1");
+    expect(rows?.[1][0]).toBe("table2");
+    expect(typeof rows?.[0][1]).toBe("string");
+    expect(typeof rows?.[1][1]).toBe("string");
+  });
+
+  it("should return not found error when experiment does not exist", async () => {
+    const nonExistentId = "00000000-0000-0000-0000-000000000000";
+
+    // Act
+    const result = await useCase.execute(nonExistentId, testUserId, {
+      page: 1,
+      pageSize: 20,
+    });
+
+    // Assert result is failure
+    expect(result.isSuccess()).toBe(false);
+    assertFailure(result);
+    expect(result.error.code).toBe("NOT_FOUND");
+    expect(result.error.message).toContain(
+      `Experiment with ID ${nonExistentId} not found`,
+    );
+  });
+
+  it("should return forbidden error when user does not have access to private experiment", async () => {
+    // Create experiment with another user
+    const otherUserId = await testApp.createTestUser({
+      email: "other@example.com",
+    });
+
+    const { experiment } = await testApp.createExperiment({
+      name: "Private Experiment",
+      description: "Private experiment",
+      status: "active",
+      visibility: "private", // Important: set to private
+      userId: otherUserId, // Created by another user
+    });
+
+    // Act
+    const result = await useCase.execute(experiment.id, testUserId, {
+      page: 1,
+      pageSize: 20,
+    });
+
+    // Assert result is failure
+    expect(result.isSuccess()).toBe(false);
+    assertFailure(result);
+    expect(result.error.code).toBe("FORBIDDEN");
+    expect(result.error.message).toContain(
+      "You do not have access to this experiment",
+    );
+  });
+
+  it("should allow access to public experiment even if user is not a member", async () => {
+    // Create a public experiment with another user
+    const otherUserId = await testApp.createTestUser({
+      email: "other@example.com",
+    });
+
+    const { experiment } = await testApp.createExperiment({
+      name: "Public Experiment",
+      description: "Public experiment",
+      status: "active",
+      visibility: "public",
+      userId: otherUserId,
+    });
+
+    // Mock the DatabricksService methods
+    const mockTables = {
+      tables: [
+        {
+          name: "public_table",
+          catalog_name: "catalog1",
+          schema_name: `exp_${experiment.name}_${experiment.id}`,
+        },
+      ],
+    };
+
+    // Mock sample data for the table
+    const mockSampleData = {
+      columns: [
+        { name: "column1", type_name: "string", type_text: "string" },
+        { name: "column2", type_name: "number", type_text: "number" },
+      ],
+      rows: [
+        ["value1", "1"],
+        ["value2", "2"],
+      ],
+      totalRows: 2,
+      truncated: false,
+    };
+
+    // Mock token request
+    nock(DATABRICKS_HOST).post(DatabricksService.TOKEN_ENDPOINT).reply(200, {
+      access_token: "mock-token",
+      expires_in: 3600,
+      token_type: "Bearer",
+    });
+
+    // Mock listTables API call
+    nock(DATABRICKS_HOST)
+      .post(DatabricksService.TABLES_ENDPOINT)
+      .reply(200, mockTables);
+
+    // Mock SQL query for sample data
+    nock(DATABRICKS_HOST)
+      .post(DatabricksService.SQL_STATEMENTS_ENDPOINT)
+      .query(() => true)
+      .reply(200, {
+        statement_id: "mock-statement-id",
+        status: { state: "SUCCEEDED" },
+        result: mockSampleData,
+      });
+
+    // Act
+    const result = await useCase.execute(experiment.id, testUserId, {
+      page: 1,
+      pageSize: 5, // Using the default 5 now
+    });
+
+    // Assert result is success
+    expect(result.isSuccess()).toBe(true);
+    assertSuccess(result);
+
+    // Verify tables are returned
+    expect(result.value).toHaveProperty("tables");
+    expect(result.value.tables).toEqual(mockTables.tables);
+  });
+
+  it("should handle Databricks service errors appropriately when getting table data", async () => {
+    // Create an experiment
+    const { experiment } = await testApp.createExperiment({
+      name: "Test Experiment",
+      userId: testUserId,
+    });
+
+    // Mock count query success but data query failure
+    const mockCountData = {
+      columns: [{ name: "count", type_name: "LONG", type_text: "LONG" }],
+      rows: [["100"]],
+      totalRows: 1,
+      truncated: false,
+    };
+
+    // Mock token request
+    nock(DATABRICKS_HOST).post(DatabricksService.TOKEN_ENDPOINT).reply(200, {
+      access_token: "mock-token",
+      expires_in: 3600,
+      token_type: "Bearer",
+    });
+
+    // Mock SQL query for row count - success
+    nock(DATABRICKS_HOST)
+      .post(DatabricksService.SQL_STATEMENTS_ENDPOINT)
+      .query(() => true)
+      .reply(200, {
+        statement_id: "mock-count-id",
+        status: { state: "SUCCEEDED" },
+        result: mockCountData,
+      });
+
+    // Mock SQL query for table data - error
+    nock(DATABRICKS_HOST)
+      .post(DatabricksService.SQL_STATEMENTS_ENDPOINT)
+      .query(() => true)
+      .reply(500, { error: "Databricks error" });
+
+    // Act
+    const result = await useCase.execute(experiment.id, testUserId, {
+      tableName: "test_table",
+      page: 1,
+      pageSize: 20,
+    });
+
+    // Assert result is failure
+    expect(result.isSuccess()).toBe(false);
+    assertFailure(result);
+    expect(result.error.code).toBe("INTERNAL_ERROR");
+    expect(result.error.message).toContain("Failed to get table data");
+  });
+
+  it("should handle Databricks service errors appropriately when getting row count", async () => {
+    // Create an experiment
+    const { experiment } = await testApp.createExperiment({
+      name: "Test Experiment",
+      userId: testUserId,
+    });
+
+    // Mock token request
+    nock(DATABRICKS_HOST).post(DatabricksService.TOKEN_ENDPOINT).reply(200, {
+      access_token: "mock-token",
+      expires_in: 3600,
+      token_type: "Bearer",
+    });
+
+    // Mock SQL query for row count - error
+    nock(DATABRICKS_HOST)
+      .post(DatabricksService.SQL_STATEMENTS_ENDPOINT)
+      .query(() => true)
+      .reply(500, { error: "Count query error" });
+
+    // Act
+    const result = await useCase.execute(experiment.id, testUserId, {
+      tableName: "test_table",
+      page: 1,
+      pageSize: 20,
+    });
+
+    // Assert result is failure
+    expect(result.isSuccess()).toBe(false);
+    assertFailure(result);
+    expect(result.error.code).toBe("INTERNAL_ERROR");
+    expect(result.error.message).toContain("Failed to get row count");
+  });
+
+  it("should handle Databricks service errors appropriately when listing tables", async () => {
+    // Create an experiment
+    const { experiment } = await testApp.createExperiment({
+      name: "Test Experiment",
+      userId: testUserId,
+    });
+
+    // Mock token request
+    nock(DATABRICKS_HOST).post(DatabricksService.TOKEN_ENDPOINT).reply(200, {
+      access_token: "mock-token",
+      expires_in: 3600,
+      token_type: "Bearer",
+    });
+
+    // Mock listTables API call - error
+    nock(DATABRICKS_HOST)
+      .post(DatabricksService.TABLES_ENDPOINT)
+      .reply(500, { error: "Tables listing error" });
+
+    // Act
+    const result = await useCase.execute(experiment.id, testUserId, {
+      page: 1,
+      pageSize: 20,
+    });
+
+    // Assert result is failure
+    expect(result.isSuccess()).toBe(false);
+    assertFailure(result);
+    expect(result.error.code).toBe("INTERNAL_ERROR");
+    expect(result.error.message).toContain("Failed to list tables");
+  });
+});

--- a/apps/backend/src/experiments/application/use-cases/experiment-data/get-experiment-data.ts
+++ b/apps/backend/src/experiments/application/use-cases/experiment-data/get-experiment-data.ts
@@ -167,7 +167,18 @@ export class GetExperimentDataUseCase {
             // Get 5 rows of data for each table
             // We'll create a combined data object that follows SchemaData structure
             const combinedData: SchemaData = {
-              columns: [],
+              columns: [
+                {
+                  name: "table_name",
+                  type_name: "STRING",
+                  type_text: "STRING",
+                },
+                {
+                  name: "sample_data",
+                  type_name: "STRING",
+                  type_text: "STRING",
+                },
+              ],
               rows: [],
               totalRows: 0,
               truncated: false,

--- a/apps/backend/src/experiments/application/use-cases/experiment-data/get-experiment-data.ts
+++ b/apps/backend/src/experiments/application/use-cases/experiment-data/get-experiment-data.ts
@@ -1,0 +1,226 @@
+import { Injectable, Logger } from "@nestjs/common";
+
+import { ExperimentDataQuery } from "@repo/api";
+
+import { DatabricksService } from "../../../../common/services/databricks/databricks.service";
+import { SchemaData } from "../../../../common/services/databricks/databricks.types";
+import {
+  Result,
+  success,
+  failure,
+  AppError,
+} from "../../../../common/utils/fp-utils";
+import { ExperimentDto } from "../../../core/models/experiment.model";
+import { ExperimentRepository } from "../../../core/repositories/experiment.repository";
+
+export interface ExperimentDataDto {
+  tables?: {
+    name: string;
+    catalog_name: string;
+    schema_name: string;
+  }[];
+  data?: SchemaData;
+  tableName?: string;
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  totalRows: number;
+}
+
+@Injectable()
+export class GetExperimentDataUseCase {
+  private readonly logger = new Logger(GetExperimentDataUseCase.name);
+
+  constructor(
+    private readonly experimentRepository: ExperimentRepository,
+    private readonly databricksService: DatabricksService,
+  ) {}
+
+  async execute(
+    experimentId: string,
+    userId: string,
+    query: ExperimentDataQuery,
+  ): Promise<Result<ExperimentDataDto>> {
+    this.logger.log(
+      `Getting experiment data for experiment ${experimentId}, user ${userId}, query: ${JSON.stringify(
+        query,
+      )}`,
+    );
+
+    // Check if experiment exists and user has access
+    const experimentResult =
+      await this.experimentRepository.findOne(experimentId);
+
+    return experimentResult.chain(async (experiment: ExperimentDto | null) => {
+      if (!experiment) {
+        this.logger.warn(`Experiment with ID ${experimentId} not found`);
+        return failure(
+          AppError.notFound(`Experiment with ID ${experimentId} not found`),
+        );
+      }
+
+      // Check if user has access to the experiment
+      const accessResult = await this.experimentRepository.hasAccess(
+        experimentId,
+        userId,
+      );
+
+      return accessResult.chain(async (hasAccess: boolean) => {
+        if (!hasAccess && experiment.visibility !== "public") {
+          this.logger.warn(
+            `User ${userId} attempted to access data of experiment ${experimentId} without proper permissions`,
+          );
+          return failure(
+            AppError.forbidden("You do not have access to this experiment"),
+          );
+        }
+
+        // Initialize response with pagination info
+        const page = query.page || 1;
+        const pageSize = query.pageSize || 5; // Default to 5 rows per table
+        const response: ExperimentDataDto = {
+          page,
+          pageSize,
+          totalPages: 0,
+          totalRows: 0,
+        };
+
+        // Form the schema name based on experiment ID and name
+        const schemaName = `exp_${experiment.name}_${experimentId}`;
+
+        try {
+          // If table name is specified, fetch data for that table
+          if (query.tableName) {
+            this.logger.debug(
+              `Fetching data for table ${query.tableName} in experiment ${experimentId}`,
+            );
+
+            // Execute SQL query to get experiment data with pagination
+            const offset = (page - 1) * pageSize;
+            const sqlQuery = `SELECT * FROM ${query.tableName} LIMIT ${pageSize} OFFSET ${offset}`;
+
+            // Get row count first for pagination metadata
+            const countResult = await this.databricksService.executeSqlQuery(
+              schemaName,
+              `SELECT COUNT(*) as count FROM ${query.tableName}`,
+            );
+
+            if (countResult.isFailure()) {
+              return failure(
+                AppError.internal(
+                  `Failed to get row count: ${countResult.error.message}`,
+                ),
+              );
+            }
+
+            // Extract count from result
+            const totalRows = parseInt(
+              countResult.value.rows[0]?.[0] ?? "0",
+              10,
+            );
+            const totalPages = Math.ceil(totalRows / pageSize);
+
+            // Execute the actual data query
+            const dataResult = await this.databricksService.executeSqlQuery(
+              schemaName,
+              sqlQuery,
+            );
+
+            if (dataResult.isFailure()) {
+              return failure(
+                AppError.internal(
+                  `Failed to get table data: ${dataResult.error.message}`,
+                ),
+              );
+            }
+
+            response.data = dataResult.value;
+            response.tableName = query.tableName;
+            response.totalRows = totalRows;
+            response.totalPages = totalPages;
+
+            return success(response);
+          }
+          // Otherwise, list all tables in the schema
+          else {
+            this.logger.debug(
+              `Listing all tables for experiment ${experimentId}`,
+            );
+
+            const tablesResult = await this.databricksService.listTables(
+              experiment.name,
+              experimentId,
+            );
+
+            if (tablesResult.isFailure()) {
+              return failure(
+                AppError.internal(
+                  `Failed to list tables: ${tablesResult.error.message}`,
+                ),
+              );
+            }
+
+            response.tables = tablesResult.value.tables;
+            response.totalRows = tablesResult.value.tables.length;
+            response.totalPages = 1; // Tables listing is not paginated in this implementation
+
+            // Get 5 rows of data for each table
+            // We'll create a combined data object that follows SchemaData structure
+            const combinedData: SchemaData = {
+              columns: [],
+              rows: [],
+              totalRows: 0,
+              truncated: false,
+            };
+
+            for (const table of tablesResult.value.tables) {
+              const sqlQuery = `SELECT * FROM ${table.name} LIMIT ${pageSize}`;
+              const dataResult = await this.databricksService.executeSqlQuery(
+                schemaName,
+                sqlQuery,
+              );
+
+              if (dataResult.isSuccess()) {
+                // Add sample data rows for this table
+                const tableData = dataResult.value;
+
+                // Create a simplified string representation of the table data
+                const sampleData = JSON.stringify(tableData);
+
+                // Add a row for this table
+                combinedData.rows.push([table.name, sampleData]);
+                combinedData.totalRows += 1;
+              } else {
+                this.logger.warn(
+                  `Failed to get sample data for table ${table.name}: ${dataResult.error.message}`,
+                );
+                // Still include the table but with error message as sample
+                combinedData.rows.push([
+                  table.name,
+                  `Error retrieving data: ${dataResult.error.message}`,
+                ]);
+                combinedData.totalRows += 1;
+              }
+            }
+
+            response.data = combinedData;
+            return success(response);
+          }
+        } catch (error) {
+          this.logger.error(
+            `Error fetching experiment data: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+          return failure(
+            AppError.internal(
+              `Failed to fetch experiment data: ${
+                error instanceof Error ? error.message : "Unknown error"
+              }`,
+            ),
+          );
+        }
+      });
+    });
+  }
+}

--- a/apps/backend/src/experiments/application/use-cases/experiment-members/list-experiment-members.spec.ts
+++ b/apps/backend/src/experiments/application/use-cases/experiment-members/list-experiment-members.spec.ts
@@ -1,5 +1,6 @@
 import { assertFailure } from "../../../../common/utils/fp-utils";
 import { TestHarness } from "../../../../test/test-harness";
+import type { UserDto } from "../../../../users/core/models/user.model";
 import { ListExperimentMembersUseCase } from "./list-experiment-members";
 
 describe("ListExperimentMembersUseCase", () => {
@@ -53,12 +54,14 @@ describe("ListExperimentMembersUseCase", () => {
     expect(members).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          userId: experimentAdmin.userId,
           role: "admin",
+          user: expect.objectContaining({
+            id: experimentAdmin.userId,
+          }) as Partial<UserDto>,
         }),
         expect.objectContaining({
-          userId: memberId,
           role: "member",
+          user: expect.objectContaining({ id: memberId }) as Partial<UserDto>,
         }),
       ]),
     );
@@ -119,8 +122,10 @@ describe("ListExperimentMembersUseCase", () => {
     // Verify members are returned
     expect(members).toHaveLength(1); // Just the creator
     expect(members[0]).toMatchObject({
-      userId: experimentAdmin.userId,
       role: "admin",
+      user: expect.objectContaining({
+        id: experimentAdmin.userId,
+      }) as Partial<UserDto>,
     });
   });
 });

--- a/apps/backend/src/experiments/application/use-cases/get-experiment/get-experiment.spec.ts
+++ b/apps/backend/src/experiments/application/use-cases/get-experiment/get-experiment.spec.ts
@@ -1,9 +1,6 @@
-import { DatabricksService } from "../../../../common/services/databricks/databricks.service";
 import {
   assertFailure,
   assertSuccess,
-  failure,
-  success,
 } from "../../../../common/utils/fp-utils";
 import { TestHarness } from "../../../../test/test-harness";
 import { GetExperimentUseCase } from "./get-experiment";
@@ -12,7 +9,6 @@ describe("GetExperimentUseCase", () => {
   const testApp = TestHarness.App;
   let testUserId: string;
   let useCase: GetExperimentUseCase;
-  let databricksService: DatabricksService;
 
   beforeAll(async () => {
     await testApp.setup();
@@ -23,35 +19,17 @@ describe("GetExperimentUseCase", () => {
     testUserId = await testApp.createTestUser({});
 
     useCase = testApp.module.get(GetExperimentUseCase);
-    databricksService = testApp.module.get(DatabricksService);
-
-    // Mock the Databricks service to return successful data
-    jest.spyOn(databricksService, "getExperimentSchemaData").mockResolvedValue(
-      success({
-        columns: [
-          { name: "id", type_name: "STRING", type_text: "STRING" },
-          { name: "value", type_name: "DOUBLE", type_text: "DOUBLE" },
-        ],
-        rows: [
-          ["exp-123", "123.45"],
-          ["exp-123", "67.89"],
-        ],
-        totalRows: 2,
-        truncated: false,
-      }),
-    );
   });
 
   afterEach(() => {
     testApp.afterEach();
-    jest.restoreAllMocks();
   });
 
   afterAll(async () => {
     await testApp.teardown();
   });
 
-  it("should return an experiment with data when found", async () => {
+  it("should return an experiment when found", async () => {
     // Create an experiment in the database
     const { experiment } = await testApp.createExperiment({
       name: "Test Experiment",
@@ -81,73 +59,6 @@ describe("GetExperimentUseCase", () => {
       embargoIntervalDays: experiment.embargoIntervalDays,
       createdBy: testUserId,
     });
-
-    // Verify data was included
-    expect(retrievedExperiment.data).toBeDefined();
-    expect(retrievedExperiment.data).toEqual({
-      columns: [
-        { name: "id", type_name: "STRING", type_text: "STRING" },
-        { name: "value", type_name: "DOUBLE", type_text: "DOUBLE" },
-      ],
-      rows: [
-        ["exp-123", "123.45"],
-        ["exp-123", "67.89"],
-      ],
-      totalRows: 2,
-      truncated: false,
-    });
-
-    // Verify Databricks service was called
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(databricksService.getExperimentSchemaData).toHaveBeenCalledWith(
-      experiment.id,
-      experiment.name,
-    );
-  });
-
-  it("should return experiment without data when Databricks fails", async () => {
-    // Mock Databricks service to fail
-    jest.spyOn(databricksService, "getExperimentSchemaData").mockResolvedValue(
-      failure({
-        name: "DatabricksError",
-        code: "INTERNAL_ERROR",
-        message: "Failed to fetch data",
-        statusCode: 500,
-      }),
-    );
-
-    // Create an experiment in the database
-    const { experiment } = await testApp.createExperiment({
-      name: "Test Experiment",
-      description: "Test Description",
-      userId: testUserId,
-    });
-
-    // Act
-    const result = await useCase.execute(experiment.id);
-
-    // Assert result is success (experiment should still be returned)
-    expect(result.isSuccess()).toBe(true);
-    assertSuccess(result);
-    const retrievedExperiment = result.value;
-
-    // Verify experiment properties
-    expect(retrievedExperiment).toMatchObject({
-      id: experiment.id,
-      name: experiment.name,
-      description: experiment.description,
-      createdBy: testUserId,
-    });
-
-    // Verify data is undefined when Databricks fails
-    expect(retrievedExperiment.data).toBeUndefined();
-
-    // Verify Databricks service was called
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(databricksService.getExperimentSchemaData).toHaveBeenCalledWith(
-      experiment.id,
-      experiment.name,
-    );
   });
 
   it("should return not found error when experiment does not exist", async () => {
@@ -162,58 +73,6 @@ describe("GetExperimentUseCase", () => {
     expect(result.error.code).toBe("NOT_FOUND");
     expect(result.error.message).toContain(
       `Experiment with ID ${nonExistentId} not found`,
-    );
-
-    // Verify Databricks service was not called since experiment wasn't found
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(databricksService.getExperimentSchemaData).not.toHaveBeenCalled();
-  });
-
-  it("should include data with empty results when Databricks returns no results", async () => {
-    // Mock Databricks service to return empty results
-    jest.spyOn(databricksService, "getExperimentSchemaData").mockResolvedValue(
-      success({
-        columns: [
-          { name: "id", type_name: "STRING", type_text: "STRING" },
-          { name: "value", type_name: "DOUBLE", type_text: "DOUBLE" },
-        ],
-        rows: [],
-        totalRows: 0,
-        truncated: false,
-      }),
-    );
-
-    // Create an experiment in the database
-    const { experiment } = await testApp.createExperiment({
-      name: "Empty Data Experiment",
-      userId: testUserId,
-    });
-
-    // Act
-    const result = await useCase.execute(experiment.id);
-
-    // Assert result is success
-    expect(result.isSuccess()).toBe(true);
-    assertSuccess(result);
-    const retrievedExperiment = result.value;
-
-    // Verify experiment properties
-    expect(retrievedExperiment).toMatchObject({
-      id: experiment.id,
-      name: experiment.name,
-      createdBy: testUserId,
-    });
-
-    // Verify data is included but empty
-    expect(retrievedExperiment.data).toBeDefined();
-    expect(retrievedExperiment.data?.rows).toEqual([]);
-    expect(retrievedExperiment.data?.totalRows).toBe(0);
-
-    // Verify Databricks service was called
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(databricksService.getExperimentSchemaData).toHaveBeenCalledWith(
-      experiment.id,
-      experiment.name,
     );
   });
 });

--- a/apps/backend/src/experiments/application/use-cases/get-experiment/get-experiment.ts
+++ b/apps/backend/src/experiments/application/use-cases/get-experiment/get-experiment.ts
@@ -1,33 +1,26 @@
 import { Injectable, Logger } from "@nestjs/common";
 
-import { DatabricksService } from "../../../../common/services/databricks/databricks.service";
 import {
   Result,
   success,
   failure,
   AppError,
 } from "../../../../common/utils/fp-utils";
-import {
-  ExperimentDto,
-  ExperimentDtoWithData,
-} from "../../../core/models/experiment.model";
+import { ExperimentDto } from "../../../core/models/experiment.model";
 import { ExperimentRepository } from "../../../core/repositories/experiment.repository";
 
 @Injectable()
 export class GetExperimentUseCase {
   private readonly logger = new Logger(GetExperimentUseCase.name);
 
-  constructor(
-    private readonly experimentRepository: ExperimentRepository,
-    private readonly databricksService: DatabricksService,
-  ) {}
+  constructor(private readonly experimentRepository: ExperimentRepository) {}
 
-  async execute(id: string): Promise<Result<ExperimentDtoWithData>> {
+  async execute(id: string): Promise<Result<ExperimentDto>> {
     this.logger.log(`Getting experiment with ID ${id}`);
 
     const experimentResult = await this.experimentRepository.findOne(id);
 
-    return experimentResult.chain(async (experiment: ExperimentDto | null) => {
+    return experimentResult.chain((experiment: ExperimentDto | null) => {
       if (!experiment) {
         this.logger.warn(`Experiment with ID ${id} not found`);
         return failure(AppError.notFound(`Experiment with ID ${id} not found`));
@@ -35,26 +28,7 @@ export class GetExperimentUseCase {
 
       this.logger.debug(`Found experiment "${experiment.name}" (ID: ${id})`);
 
-      // Fetch additional data from Databricks
-      const databricksResult =
-        await this.databricksService.getExperimentSchemaData(
-          id,
-          experiment.name,
-        );
-
-      // Combine experiment data with Databricks data
-      const response: ExperimentDtoWithData = {
-        ...experiment,
-        data: databricksResult.isSuccess() ? databricksResult.value : undefined,
-      };
-
-      if (databricksResult.isFailure()) {
-        this.logger.warn(
-          `Failed to fetch Databricks data for experiment ${id}: ${databricksResult.error.message}`,
-        );
-      }
-
-      return success(response);
+      return success(experiment);
     });
   }
 }

--- a/apps/backend/src/experiments/core/repositories/experiment-member.repository.spec.ts
+++ b/apps/backend/src/experiments/core/repositories/experiment-member.repository.spec.ts
@@ -4,6 +4,7 @@ import { experiments } from "@repo/database";
 
 import { assertFailure, assertSuccess } from "../../../common/utils/fp-utils";
 import { TestHarness } from "../../../test/test-harness";
+import type { UserDto } from "../../../users/core/models/user.model";
 import { ExperimentMemberRepository } from "./experiment-member.repository";
 
 describe("ExperimentMemberRepository", () => {
@@ -64,9 +65,24 @@ describe("ExperimentMemberRepository", () => {
       expect(members.length).toBe(3); // Creator + 2 added members
       expect(members).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ userId: testUserId, role: "admin" }),
-          expect.objectContaining({ userId: memberId1, role: "member" }),
-          expect.objectContaining({ userId: memberId2, role: "admin" }),
+          expect.objectContaining({
+            role: "admin",
+            user: expect.objectContaining({
+              id: testUserId,
+            }) as Partial<UserDto>,
+          }),
+          expect.objectContaining({
+            role: "member",
+            user: expect.objectContaining({
+              id: memberId1,
+            }) as Partial<UserDto>,
+          }),
+          expect.objectContaining({
+            role: "admin",
+            user: expect.objectContaining({
+              id: memberId2,
+            }) as Partial<UserDto>,
+          }),
         ]),
       );
 
@@ -141,8 +157,10 @@ describe("ExperimentMemberRepository", () => {
       // Assert
       expect(member).toMatchObject({
         experimentId: experiment.id,
-        userId: memberId,
         role: "member",
+        user: expect.objectContaining({
+          id: memberId,
+        }) as Partial<UserDto>,
       });
       // Assert name and email are present and correct
       expect(member.user.name).toBe("New Member");

--- a/apps/backend/src/experiments/experiment.module.ts
+++ b/apps/backend/src/experiments/experiment.module.ts
@@ -5,6 +5,7 @@ import { DatabricksModule } from "../common/services/databricks/databricks.modul
 import { ChangeExperimentStatusUseCase } from "./application/use-cases/change-experiment-status/change-experiment-status";
 import { CreateExperimentUseCase } from "./application/use-cases/create-experiment/create-experiment";
 import { DeleteExperimentUseCase } from "./application/use-cases/delete-experiment/delete-experiment";
+import { GetExperimentDataUseCase } from "./application/use-cases/experiment-data/get-experiment-data";
 import { AddExperimentMemberUseCase } from "./application/use-cases/experiment-members/add-experiment-member";
 import { ListExperimentMembersUseCase } from "./application/use-cases/experiment-members/list-experiment-members";
 import { RemoveExperimentMemberUseCase } from "./application/use-cases/experiment-members/remove-experiment-member";
@@ -15,24 +16,32 @@ import { UpdateExperimentUseCase } from "./application/use-cases/update-experime
 import { ExperimentMemberRepository } from "./core/repositories/experiment-member.repository";
 import { ExperimentRepository } from "./core/repositories/experiment.repository";
 // Controllers
+import { ExperimentDataController } from "./presentation/experiment-data.controller";
 import { ExperimentMembersController } from "./presentation/experiment-members.controller";
 import { ExperimentController } from "./presentation/experiment.controller";
 
 @Module({
   imports: [DatabricksModule],
-  controllers: [ExperimentController, ExperimentMembersController],
+  controllers: [
+    ExperimentController,
+    ExperimentMembersController,
+    ExperimentDataController,
+  ],
   providers: [
     // Repositories
     ExperimentRepository,
     ExperimentMemberRepository,
 
-    // Use case providers
+    // General experiment use cases
     CreateExperimentUseCase,
     GetExperimentUseCase,
     ListExperimentsUseCase,
     UpdateExperimentUseCase,
     DeleteExperimentUseCase,
     ChangeExperimentStatusUseCase,
+
+    // Experiment data use cases
+    GetExperimentDataUseCase,
 
     // Experiment member use cases
     ListExperimentMembersUseCase,

--- a/apps/backend/src/experiments/presentation/experiment-data.controller.spec.ts
+++ b/apps/backend/src/experiments/presentation/experiment-data.controller.spec.ts
@@ -1,0 +1,442 @@
+import { faker } from "@faker-js/faker";
+import { StatusCodes } from "http-status-codes";
+
+import type { ErrorResponse, ExperimentDataResponse } from "@repo/api";
+import { contract } from "@repo/api";
+
+import { DatabricksService } from "../../common/services/databricks/databricks.service";
+import { success, failure, AppError } from "../../common/utils/fp-utils";
+import type { SuperTestResponse } from "../../test/test-harness";
+import { TestHarness } from "../../test/test-harness";
+
+describe("ExperimentDataController", () => {
+  const testApp = TestHarness.App;
+  let testUserId: string;
+  let databricksService: DatabricksService;
+
+  beforeAll(async () => {
+    await testApp.setup();
+  });
+
+  beforeEach(async () => {
+    await testApp.beforeEach();
+    testUserId = await testApp.createTestUser({});
+
+    // Get the DatabricksService instance
+    databricksService = testApp.module.get(DatabricksService);
+
+    // Reset any mocks before each test
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    testApp.afterEach();
+  });
+
+  afterAll(async () => {
+    await testApp.teardown();
+  });
+
+  describe("getExperimentData", () => {
+    it("should return experiment data successfully when table name is specified", async () => {
+      // Create an experiment
+      const { experiment } = await testApp.createExperiment({
+        name: "Test Experiment for Data",
+        userId: testUserId,
+      });
+
+      // Mock the DatabricksService methods
+      const mockCountData = {
+        columns: [{ name: "count", type_name: "LONG", type_text: "LONG" }],
+        rows: [["100"]],
+        totalRows: 1,
+        truncated: false,
+      };
+
+      const mockTableData = {
+        columns: [
+          { name: "column1", type_name: "string", type_text: "string" },
+          { name: "column2", type_name: "number", type_text: "number" },
+        ],
+        rows: [
+          ["value1", "1"],
+          ["value2", "2"],
+        ],
+        totalRows: 2,
+        truncated: false,
+      };
+
+      jest
+        .spyOn(databricksService, "executeSqlQuery")
+        .mockResolvedValueOnce(success(mockCountData)) // First call for count
+        .mockResolvedValueOnce(success(mockTableData)); // Second call for actual data
+
+      // Get the path
+      const path = testApp.resolvePath(
+        contract.experiments.getExperimentData.path,
+        {
+          id: experiment.id,
+        },
+      );
+
+      // Add query parameters
+      const queryParams = {
+        tableName: "test_table",
+        page: 1,
+        pageSize: 5,
+      };
+
+      // Make the request
+      const response: SuperTestResponse<ExperimentDataResponse> = await testApp
+        .get(path)
+        .withAuth(testUserId)
+        .query(queryParams)
+        .expect(StatusCodes.OK);
+
+      // Verify the response structure
+      expect(response.body).toMatchObject({
+        data: mockTableData,
+        tableName: "test_table",
+        page: 1,
+        pageSize: 5,
+        totalPages: 20, // 100 / 5
+        totalRows: 100,
+      });
+
+      // Verify the DatabricksService was called correctly
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(databricksService.executeSqlQuery).toHaveBeenCalledTimes(2);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(databricksService.executeSqlQuery).toHaveBeenNthCalledWith(
+        1,
+        `exp_${experiment.name}_${experiment.id}`,
+        "SELECT COUNT(*) as count FROM test_table",
+      );
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(databricksService.executeSqlQuery).toHaveBeenNthCalledWith(
+        2,
+        `exp_${experiment.name}_${experiment.id}`,
+        "SELECT * FROM test_table LIMIT 5 OFFSET 0",
+      );
+    });
+
+    it("should return tables list with sample data when no table name is specified", async () => {
+      // Create an experiment
+      const { experiment } = await testApp.createExperiment({
+        name: "Test Experiment for Tables",
+        userId: testUserId,
+      });
+
+      // Mock the DatabricksService listTables method
+      const mockTablesResponse = {
+        tables: [
+          {
+            name: "bronze_data",
+            catalog_name: "test_catalog",
+            schema_name: `exp_${experiment.name}_${experiment.id}`,
+          },
+          {
+            name: "silver_data",
+            catalog_name: "test_catalog",
+            schema_name: `exp_${experiment.name}_${experiment.id}`,
+          },
+        ],
+      };
+
+      // Sample data for each table
+      const mockBronzeTableData = {
+        columns: [
+          { name: "id", type_name: "string", type_text: "string" },
+          { name: "value", type_name: "number", type_text: "number" },
+        ],
+        rows: [
+          ["1", "100"],
+          ["2", "200"],
+        ],
+        totalRows: 2,
+        truncated: false,
+      };
+
+      const mockSilverTableData = {
+        columns: [
+          { name: "id", type_name: "string", type_text: "string" },
+          { name: "processed", type_name: "boolean", type_text: "boolean" },
+        ],
+        rows: [
+          ["1", "true"],
+          ["2", "false"],
+        ],
+        totalRows: 2,
+        truncated: false,
+      };
+
+      // Setup mocks
+      jest
+        .spyOn(databricksService, "listTables")
+        .mockResolvedValue(success(mockTablesResponse));
+
+      jest
+        .spyOn(databricksService, "executeSqlQuery")
+        .mockResolvedValueOnce(success(mockBronzeTableData))
+        .mockResolvedValueOnce(success(mockSilverTableData));
+
+      // Get the path
+      const path = testApp.resolvePath(
+        contract.experiments.getExperimentData.path,
+        {
+          id: experiment.id,
+        },
+      );
+
+      // Make the request without tableName parameter
+      const response: SuperTestResponse<ExperimentDataResponse> = await testApp
+        .get(path)
+        .withAuth(testUserId)
+        .expect(StatusCodes.OK);
+
+      // Verify the response structure
+      expect(response.body).toMatchObject({
+        tables: mockTablesResponse.tables,
+        page: 1,
+        pageSize: 5,
+        totalPages: 1,
+        totalRows: 2, // Number of tables
+      });
+
+      // Check data exists
+      expect(response.body.data).toBeDefined();
+
+      // Verify the DatabricksService was called correctly
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(databricksService.listTables).toHaveBeenCalledWith(
+        experiment.name,
+        experiment.id,
+      );
+
+      // Verify SQL queries were executed for each table
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(databricksService.executeSqlQuery).toHaveBeenCalledTimes(2);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(databricksService.executeSqlQuery).toHaveBeenNthCalledWith(
+        1,
+        `exp_${experiment.name}_${experiment.id}`,
+        "SELECT * FROM bronze_data LIMIT 5",
+      );
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(databricksService.executeSqlQuery).toHaveBeenNthCalledWith(
+        2,
+        `exp_${experiment.name}_${experiment.id}`,
+        "SELECT * FROM silver_data LIMIT 5",
+      );
+    });
+
+    it("should return 404 if experiment doesn't exist", async () => {
+      const nonExistentId = faker.string.uuid();
+
+      const path = testApp.resolvePath(
+        contract.experiments.getExperimentData.path,
+        {
+          id: nonExistentId,
+        },
+      );
+
+      await testApp
+        .get(path)
+        .withAuth(testUserId)
+        .expect(StatusCodes.NOT_FOUND)
+        .expect(({ body }: { body: ErrorResponse }) => {
+          expect(body.message).toContain("not found");
+        });
+    });
+
+    it("should return 403 if user doesn't have access to the experiment", async () => {
+      // Create a different user
+      const otherUserId = await testApp.createTestUser({});
+
+      // Create an experiment owned by the other user
+      const { experiment } = await testApp.createExperiment({
+        name: "Restricted Experiment",
+        userId: otherUserId,
+        visibility: "private",
+      });
+
+      const path = testApp.resolvePath(
+        contract.experiments.getExperimentData.path,
+        {
+          id: experiment.id,
+        },
+      );
+
+      await testApp
+        .get(path)
+        .withAuth(testUserId) // Use the first user who doesn't have access
+        .expect(StatusCodes.FORBIDDEN)
+        .expect(({ body }: { body: ErrorResponse }) => {
+          expect(body.message).toContain("access");
+        });
+    });
+
+    it("should return 400 for invalid experiment UUID", async () => {
+      const invalidId = "not-a-uuid";
+      const path = testApp.resolvePath(
+        contract.experiments.getExperimentData.path,
+        {
+          id: invalidId,
+        },
+      );
+
+      await testApp
+        .get(path)
+        .withAuth(testUserId)
+        .expect(StatusCodes.BAD_REQUEST);
+    });
+
+    it("should return 401 if not authenticated", async () => {
+      const { experiment } = await testApp.createExperiment({
+        name: "Test Experiment for Data",
+        userId: testUserId,
+      });
+
+      const path = testApp.resolvePath(
+        contract.experiments.getExperimentData.path,
+        {
+          id: experiment.id,
+        },
+      );
+
+      await testApp.get(path).withoutAuth().expect(StatusCodes.UNAUTHORIZED);
+    });
+
+    it("should handle Databricks service errors appropriately", async () => {
+      // Create an experiment
+      const { experiment } = await testApp.createExperiment({
+        name: "Test Experiment with Databricks Error",
+        userId: testUserId,
+      });
+
+      // Mock the DatabricksService to return an error
+      jest
+        .spyOn(databricksService, "listTables")
+        .mockResolvedValue(
+          failure(AppError.internal("Error retrieving data from Databricks")),
+        );
+
+      const path = testApp.resolvePath(
+        contract.experiments.getExperimentData.path,
+        {
+          id: experiment.id,
+        },
+      );
+
+      await testApp
+        .get(path)
+        .withAuth(testUserId)
+        .expect(StatusCodes.INTERNAL_SERVER_ERROR)
+        .expect(({ body }: { body: ErrorResponse }) => {
+          expect(body.message).toContain("Failed to list tables");
+        });
+    });
+
+    it("should handle SQL execution errors when fetching table data", async () => {
+      // Create an experiment
+      const { experiment } = await testApp.createExperiment({
+        name: "Test Experiment SQL Error",
+        userId: testUserId,
+      });
+
+      // Mock the DatabricksService to fail on SQL execution
+      jest
+        .spyOn(databricksService, "executeSqlQuery")
+        .mockResolvedValue(
+          failure(AppError.internal("SQL execution failed: table not found")),
+        );
+
+      const path = testApp.resolvePath(
+        contract.experiments.getExperimentData.path,
+        {
+          id: experiment.id,
+        },
+      );
+
+      await testApp
+        .get(path)
+        .withAuth(testUserId)
+        .query({ tableName: "nonexistent_table" })
+        .expect(StatusCodes.INTERNAL_SERVER_ERROR)
+        .expect(({ body }: { body: ErrorResponse }) => {
+          expect(body.message).toContain("Failed to get row count");
+        });
+    });
+
+    it("should correctly handle pagination parameters", async () => {
+      // Create an experiment
+      const { experiment } = await testApp.createExperiment({
+        name: "Test Experiment for Pagination",
+        userId: testUserId,
+      });
+
+      // Define pagination parameters
+      const page = 2;
+      const pageSize = 10;
+
+      // Mock the DatabricksService methods
+      const mockCountData = {
+        columns: [{ name: "count", type_name: "LONG", type_text: "LONG" }],
+        rows: [["42"]],
+        totalRows: 1,
+        truncated: false,
+      };
+
+      const mockTableData = {
+        columns: [
+          { name: "column1", type_name: "string", type_text: "string" },
+          { name: "column2", type_name: "number", type_text: "number" },
+        ],
+        rows: [
+          ["value1", "1"],
+          ["value2", "2"],
+        ],
+        totalRows: 2,
+        truncated: false,
+      };
+
+      jest
+        .spyOn(databricksService, "executeSqlQuery")
+        .mockResolvedValueOnce(success(mockCountData)) // First call for count
+        .mockResolvedValueOnce(success(mockTableData)); // Second call for actual data
+
+      // Get the path
+      const path = testApp.resolvePath(
+        contract.experiments.getExperimentData.path,
+        {
+          id: experiment.id,
+        },
+      );
+
+      // Make the request with pagination parameters
+      const response: SuperTestResponse<ExperimentDataResponse> = await testApp
+        .get(path)
+        .withAuth(testUserId)
+        .query({
+          tableName: "test_table",
+          page: page,
+          pageSize: pageSize,
+        })
+        .expect(StatusCodes.OK);
+
+      // Verify the response includes correct pagination information
+      expect(response.body.page).toBe(page);
+      expect(response.body.pageSize).toBe(pageSize);
+      expect(response.body.totalPages).toBe(5); // Math.ceil(42 / 10)
+      expect(response.body.totalRows).toBe(42);
+
+      // Verify the DatabricksService was called with correct pagination
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(databricksService.executeSqlQuery).toHaveBeenNthCalledWith(
+        2,
+        `exp_${experiment.name}_${experiment.id}`,
+        "SELECT * FROM test_table LIMIT 10 OFFSET 10", // page 2 with pageSize 10
+      );
+    });
+  });
+});

--- a/apps/backend/src/experiments/presentation/experiment-data.controller.spec.ts
+++ b/apps/backend/src/experiments/presentation/experiment-data.controller.spec.ts
@@ -93,10 +93,14 @@ describe("ExperimentDataController", () => {
         .query(queryParams)
         .expect(StatusCodes.OK);
 
-      // Verify the response structure
-      expect(response.body).toMatchObject({
+      // Verify the response structure - now an array with one element
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(response.body).toHaveLength(1);
+      expect(response.body[0]).toMatchObject({
+        name: "test_table",
+        catalog_name: experiment.name,
+        schema_name: `exp_${experiment.name}_${experiment.id}`,
         data: mockTableData,
-        tableName: "test_table",
         page: 1,
         pageSize: 5,
         totalPages: 20, // 100 / 5
@@ -194,17 +198,33 @@ describe("ExperimentDataController", () => {
         .withAuth(testUserId)
         .expect(StatusCodes.OK);
 
-      // Verify the response structure
-      expect(response.body).toMatchObject({
-        tables: mockTablesResponse.tables,
+      // Verify the response structure - array with two elements
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(response.body).toHaveLength(2);
+
+      // Check first table
+      expect(response.body[0]).toMatchObject({
+        name: mockTablesResponse.tables[0].name,
+        catalog_name: mockTablesResponse.tables[0].catalog_name,
+        schema_name: mockTablesResponse.tables[0].schema_name,
         page: 1,
         pageSize: 5,
         totalPages: 1,
-        totalRows: 2, // Number of tables
       });
 
-      // Check data exists
-      expect(response.body.data).toBeDefined();
+      // Check second table
+      expect(response.body[1]).toMatchObject({
+        name: mockTablesResponse.tables[1].name,
+        catalog_name: mockTablesResponse.tables[1].catalog_name,
+        schema_name: mockTablesResponse.tables[1].schema_name,
+        page: 1,
+        pageSize: 5,
+        totalPages: 1,
+      });
+
+      // Check data exists for each table
+      expect(response.body[0].data).toBeDefined();
+      expect(response.body[1].data).toBeDefined();
 
       // Verify the DatabricksService was called correctly
       // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -424,11 +444,15 @@ describe("ExperimentDataController", () => {
         })
         .expect(StatusCodes.OK);
 
+      // Verify the response is an array with one element
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(response.body).toHaveLength(1);
+
       // Verify the response includes correct pagination information
-      expect(response.body.page).toBe(page);
-      expect(response.body.pageSize).toBe(pageSize);
-      expect(response.body.totalPages).toBe(5); // Math.ceil(42 / 10)
-      expect(response.body.totalRows).toBe(42);
+      expect(response.body[0].page).toBe(page);
+      expect(response.body[0].pageSize).toBe(pageSize);
+      expect(response.body[0].totalPages).toBe(5); // Math.ceil(42 / 10)
+      expect(response.body[0].totalRows).toBe(42);
 
       // Verify the DatabricksService was called with correct pagination
       // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/apps/backend/src/experiments/presentation/experiment-data.controller.ts
+++ b/apps/backend/src/experiments/presentation/experiment-data.controller.ts
@@ -1,0 +1,61 @@
+import { Controller, Logger, UseGuards } from "@nestjs/common";
+import { TsRestHandler, tsRestHandler } from "@ts-rest/nest";
+import { StatusCodes } from "http-status-codes";
+
+import { contract } from "@repo/api";
+import type { SessionUser } from "@repo/auth/config";
+
+import { CurrentUser } from "../../common/decorators/current-user.decorator";
+import { AuthGuard } from "../../common/guards/auth.guard";
+import { handleFailure } from "../../common/utils/fp-utils";
+import { GetExperimentDataUseCase } from "../application/use-cases/experiment-data/get-experiment-data";
+
+@Controller()
+@UseGuards(AuthGuard)
+export class ExperimentDataController {
+  private readonly logger = new Logger(ExperimentDataController.name);
+
+  constructor(
+    private readonly getExperimentDataUseCase: GetExperimentDataUseCase,
+  ) {}
+
+  @TsRestHandler(contract.experiments.getExperimentData)
+  getExperimentData(@CurrentUser() user: SessionUser) {
+    return tsRestHandler(
+      contract.experiments.getExperimentData,
+      async ({ params, query }) => {
+        const { id: experimentId } = params;
+        const { page, pageSize, tableName } = query;
+
+        this.logger.log(
+          `Processing data request for experiment ${experimentId} by user ${user.id}`,
+        );
+
+        const result = await this.getExperimentDataUseCase.execute(
+          experimentId,
+          user.id,
+          {
+            page,
+            pageSize,
+            tableName,
+          },
+        );
+
+        if (result.isSuccess()) {
+          const data = result.value;
+
+          this.logger.log(
+            `Successfully retrieved data for experiment ${experimentId}`,
+          );
+
+          return {
+            status: StatusCodes.OK,
+            body: data,
+          };
+        }
+
+        return handleFailure(result, this.logger);
+      },
+    );
+  }
+}

--- a/apps/backend/src/experiments/presentation/experiment-members.controller.spec.ts
+++ b/apps/backend/src/experiments/presentation/experiment-members.controller.spec.ts
@@ -6,6 +6,7 @@ import { contract } from "@repo/api";
 
 import type { SuperTestResponse } from "../../test/test-harness";
 import { TestHarness } from "../../test/test-harness";
+import type { UserDto } from "../../users/core/models/user.model";
 
 describe("ExperimentMembersController", () => {
   const testApp = TestHarness.App;
@@ -64,8 +65,18 @@ describe("ExperimentMembersController", () => {
       expect(response.body).toHaveLength(2);
       expect(response.body).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ userId: testUserId, role: "admin" }),
-          expect.objectContaining({ userId: memberId, role: "member" }),
+          expect.objectContaining({
+            role: "admin",
+            user: expect.objectContaining({
+              id: testUserId,
+            }) as Partial<UserDto>,
+          }),
+          expect.objectContaining({
+            role: "member",
+            user: expect.objectContaining({
+              id: memberId,
+            }) as Partial<UserDto>,
+          }),
         ]),
       );
     });
@@ -153,9 +164,11 @@ describe("ExperimentMembersController", () => {
 
       // Assert the response
       expect(response.body).toMatchObject({
-        userId: newMemberId,
         role: "member",
         experimentId: experiment.id,
+        user: expect.objectContaining({
+          id: newMemberId,
+        }) as Partial<UserDto>,
       });
 
       // Verify with a list request
@@ -174,8 +187,18 @@ describe("ExperimentMembersController", () => {
       expect(listResponse.body).toHaveLength(2);
       expect(listResponse.body).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ userId: testUserId, role: "admin" }),
-          expect.objectContaining({ userId: newMemberId, role: "member" }),
+          expect.objectContaining({
+            role: "admin",
+            user: expect.objectContaining({
+              id: testUserId,
+            }) as Partial<UserDto>,
+          }),
+          expect.objectContaining({
+            role: "member",
+            user: expect.objectContaining({
+              id: newMemberId,
+            }) as Partial<UserDto>,
+          }),
         ]),
       );
     });

--- a/apps/backend/src/experiments/presentation/experiment.controller.spec.ts
+++ b/apps/backend/src/experiments/presentation/experiment.controller.spec.ts
@@ -1,7 +1,11 @@
 import { faker } from "@faker-js/faker";
 import { StatusCodes } from "http-status-codes";
 
-import type { ErrorResponse, ExperimentMemberList } from "@repo/api";
+import type {
+  ErrorResponse,
+  Experiment,
+  ExperimentMemberList,
+} from "@repo/api";
 import type { ExperimentList } from "@repo/api";
 import { contract } from "@repo/api";
 
@@ -23,32 +27,17 @@ describe("ExperimentController", () => {
     await testApp.beforeEach();
     testUserId = await testApp.createTestUser({});
 
-    // Get the databricks service instance
+    // Get the databricks service instance for create experiment tests
     databricksService = testApp.module.get(DatabricksService);
 
     // Reset any mocks before each test
     jest.restoreAllMocks();
 
-    // Set up default mocks for databricks service
+    // Set up default mocks for databricks service (only needed for create experiment)
     jest.spyOn(databricksService, "triggerJob").mockResolvedValue(
       success({
         run_id: 12345,
         number_in_job: 1,
-      }),
-    );
-
-    jest.spyOn(databricksService, "getExperimentSchemaData").mockResolvedValue(
-      success({
-        columns: [
-          { name: "experiment_id", type_name: "STRING", type_text: "STRING" },
-          { name: "value", type_name: "DOUBLE", type_text: "DOUBLE" },
-        ],
-        rows: [
-          ["exp-123", "123.45"],
-          ["exp-123", "67.89"],
-        ],
-        totalRows: 2,
-        truncated: false,
       }),
     );
   });
@@ -164,7 +153,7 @@ describe("ExperimentController", () => {
     });
 
     it("should return 400 if name is too long", async () => {
-      const tooLongName = "a".repeat(65);
+      const tooLongName = "a".repeat(300);
 
       await testApp
         .post(contract.experiments.createExperiment.path)
@@ -338,7 +327,7 @@ describe("ExperimentController", () => {
   });
 
   describe("getExperiment", () => {
-    it("should return an experiment by ID with data", async () => {
+    it("should return an experiment by ID", async () => {
       const { experiment } = await testApp.createExperiment({
         name: "Experiment to Get",
         description: "Detailed description",
@@ -352,7 +341,7 @@ describe("ExperimentController", () => {
         },
       );
 
-      const response = await testApp
+      const response: SuperTestResponse<Experiment> = await testApp
         .get(path)
         .withAuth(testUserId)
         .expect(StatusCodes.OK);
@@ -365,75 +354,8 @@ describe("ExperimentController", () => {
         createdBy: testUserId,
       });
 
-      // Type the response properly
-      const responseBody = response.body as {
-        data?: { columns: unknown[]; rows: unknown[] };
-      };
-
-      // Verify data is included
-      expect(responseBody.data).toBeDefined();
-      expect(responseBody.data?.columns).toHaveLength(2);
-      expect(responseBody.data?.rows).toHaveLength(2);
-
-      // Verify that Databricks was called
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(databricksService.getExperimentSchemaData).toHaveBeenCalledWith(
-        experiment.id,
-        experiment.name,
-      );
-    });
-
-    it("should return experiment without data when Databricks fails", async () => {
-      // Mock Databricks to fail
-      jest
-        .spyOn(databricksService, "getExperimentSchemaData")
-        .mockResolvedValue(
-          failure({
-            name: "DatabricksError",
-            code: "INTERNAL_ERROR",
-            message: "Failed to fetch data",
-            statusCode: 500,
-          }),
-        );
-
-      const { experiment } = await testApp.createExperiment({
-        name: "Experiment without Data",
-        description: "Detailed description",
-        userId: testUserId,
-      });
-
-      const path = testApp.resolvePath(
-        contract.experiments.getExperiment.path,
-        {
-          id: experiment.id,
-        },
-      );
-
-      const response = await testApp
-        .get(path)
-        .withAuth(testUserId)
-        .expect(StatusCodes.OK);
-
-      expect(response.body).toMatchObject({
-        id: experiment.id,
-        name: experiment.name,
-        description: experiment.description,
-        visibility: experiment.visibility,
-        createdBy: testUserId,
-      });
-
-      // Type the response properly
-      const responseBody = response.body as { data?: unknown };
-
-      // Verify data is undefined when Databricks fails
-      expect(responseBody.data).toBeUndefined();
-
-      // Verify that Databricks was still called
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(databricksService.getExperimentSchemaData).toHaveBeenCalledWith(
-        experiment.id,
-        experiment.name,
-      );
+      // Verify no data is included (since we removed experiment data functionality)
+      expect(response.body.data).toBeUndefined();
     });
 
     it("should return 404 if experiment does not exist", async () => {
@@ -452,10 +374,6 @@ describe("ExperimentController", () => {
         .expect(({ body }: { body: ErrorResponse }) => {
           expect(body.message).toContain("not found");
         });
-
-      // Verify that Databricks was not called since experiment wasn't found
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(databricksService.getExperimentSchemaData).not.toHaveBeenCalled();
     });
 
     it("should return 400 for invalid UUID", async () => {
@@ -790,38 +708,6 @@ describe("ExperimentController", () => {
         .delete(removePath)
         .withoutAuth()
         .expect(StatusCodes.UNAUTHORIZED);
-    });
-  });
-
-  describe("createExperiment", () => {
-    it("should return 400 if name is too long", async () => {
-      const tooLongName = "a".repeat(65);
-
-      await testApp
-        .post(contract.experiments.createExperiment.path)
-        .withAuth(testUserId)
-        .send({
-          name: tooLongName,
-          description: "Test Description",
-          status: "provisioning",
-          visibility: "private",
-          embargoIntervalDays: 90,
-        })
-        .expect(StatusCodes.BAD_REQUEST);
-    });
-
-    it("should return 400 if embargoIntervalDays is negative", async () => {
-      await testApp
-        .post(contract.experiments.createExperiment.path)
-        .withAuth(testUserId)
-        .send({
-          name: "Test Experiment",
-          description: "Test Description",
-          status: "provisioning",
-          visibility: "private",
-          embargoIntervalDays: -1,
-        })
-        .expect(StatusCodes.BAD_REQUEST);
     });
   });
 });

--- a/apps/backend/src/experiments/presentation/experiment.controller.spec.ts
+++ b/apps/backend/src/experiments/presentation/experiment.controller.spec.ts
@@ -13,6 +13,7 @@ import { DatabricksService } from "../../common/services/databricks/databricks.s
 import { success, failure } from "../../common/utils/fp-utils";
 import type { SuperTestResponse } from "../../test/test-harness";
 import { TestHarness } from "../../test/test-harness";
+import type { UserDto } from "../../users/core/models/user.model";
 
 describe("ExperimentController", () => {
   const testApp = TestHarness.App;
@@ -552,8 +553,10 @@ describe("ExperimentController", () => {
 
       expect(response.body).toHaveLength(1);
       expect(response.body[0]).toMatchObject({
-        userId: testUserId,
         role: "admin",
+        user: expect.objectContaining({
+          id: testUserId,
+        }) as Partial<UserDto>,
       });
     });
 
@@ -596,8 +599,10 @@ describe("ExperimentController", () => {
         .expect(StatusCodes.CREATED)
         .expect(({ body }) => {
           expect(body).toMatchObject({
-            userId: newMemberId,
             role: "member",
+            user: expect.objectContaining({
+              id: newMemberId,
+            }) as Partial<UserDto>,
           });
         });
 

--- a/apps/docs/static/api/rest/openapi.json
+++ b/apps/docs/static/api/rest/openapi.json
@@ -430,7 +430,7 @@
                   "name": {
                     "type": "string",
                     "minLength": 1,
-                    "maxLength": 100,
+                    "maxLength": 255,
                     "description": "Updated experiment name"
                   },
                   "description": {
@@ -840,6 +840,206 @@
         "responses": {
           "204": {
             "description": "204"
+          },
+          "403": {
+            "description": "403",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "404",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/experiments/{id}/data": {
+      "get": {
+        "description": "Retrieves data tables from the experiment with pagination support",
+        "summary": "Get experiment data",
+        "tags": ["experiments"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "ID of the experiment"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number for pagination",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "default": 1,
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of rows per page",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "default": 5,
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 100
+                }
+              }
+            }
+          },
+          {
+            "name": "tableName",
+            "in": "query",
+            "description": "Optional table name to filter results to a specific table",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "operationId": "experiments.getExperimentData",
+        "responses": {
+          "200": {
+            "description": "200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "tables": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string",
+                            "description": "Name of the table"
+                          },
+                          "catalog_name": {
+                            "type": "string",
+                            "description": "Catalog name"
+                          },
+                          "schema_name": {
+                            "type": "string",
+                            "description": "Schema name"
+                          }
+                        },
+                        "required": ["name", "catalog_name", "schema_name"]
+                      }
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "columns": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "type_name": {
+                                "type": "string"
+                              },
+                              "type_text": {
+                                "type": "string"
+                              }
+                            },
+                            "required": ["name", "type_name", "type_text"]
+                          }
+                        },
+                        "rows": {
+                          "type": "array",
+                          "items": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          }
+                        },
+                        "totalRows": {
+                          "type": "integer"
+                        },
+                        "truncated": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["columns", "rows", "totalRows", "truncated"]
+                    },
+                    "tableName": {
+                      "type": "string"
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "pageSize": {
+                      "type": "integer"
+                    },
+                    "totalPages": {
+                      "type": "integer"
+                    },
+                    "totalRows": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["page", "pageSize", "totalPages", "totalRows"]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "400",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": ["message"]
+                }
+              }
+            }
           },
           "403": {
             "description": "403",

--- a/apps/docs/static/api/rest/openapi.json
+++ b/apps/docs/static/api/rest/openapi.json
@@ -5,7 +5,9 @@
       "post": {
         "description": "Creates a new experiment with the provided configuration",
         "summary": "Create a new experiment",
-        "tags": ["experiments"],
+        "tags": [
+          "experiments"
+        ],
         "parameters": [],
         "operationId": "experiments.createExperiment",
         "requestBody": {
@@ -39,7 +41,10 @@
                   },
                   "visibility": {
                     "type": "string",
-                    "enum": ["private", "public"],
+                    "enum": [
+                      "private",
+                      "public"
+                    ],
                     "description": "Experiment visibility setting"
                   },
                   "embargoIntervalDays": {
@@ -49,7 +54,9 @@
                     "description": "Embargo period in days"
                   }
                 },
-                "required": ["name"]
+                "required": [
+                  "name"
+                ]
               }
             }
           }
@@ -67,7 +74,9 @@
                       "format": "uuid"
                     }
                   },
-                  "required": ["id"]
+                  "required": [
+                    "id"
+                  ]
                 }
               }
             }
@@ -83,7 +92,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -93,7 +104,9 @@
       "get": {
         "description": "Returns a list of experiments based on the specified filter criteria",
         "summary": "List experiments",
-        "tags": ["experiments"],
+        "tags": [
+          "experiments"
+        ],
         "parameters": [
           {
             "name": "filter",
@@ -103,7 +116,11 @@
               "application/json": {
                 "schema": {
                   "type": "string",
-                  "enum": ["my", "member", "related"]
+                  "enum": [
+                    "my",
+                    "member",
+                    "related"
+                  ]
                 }
               }
             }
@@ -164,7 +181,10 @@
                       },
                       "visibility": {
                         "type": "string",
-                        "enum": ["private", "public"]
+                        "enum": [
+                          "private",
+                          "public"
+                        ]
                       },
                       "embargoIntervalDays": {
                         "type": "integer"
@@ -199,7 +219,11 @@
                                   "type": "string"
                                 }
                               },
-                              "required": ["name", "type_name", "type_text"]
+                              "required": [
+                                "name",
+                                "type_name",
+                                "type_text"
+                              ]
                             }
                           },
                           "rows": {
@@ -254,7 +278,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -266,7 +292,9 @@
       "get": {
         "description": "Returns detailed information about a specific experiment",
         "summary": "Get experiment details",
-        "tags": ["experiments"],
+        "tags": [
+          "experiments"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -312,7 +340,10 @@
                     },
                     "visibility": {
                       "type": "string",
-                      "enum": ["private", "public"]
+                      "enum": [
+                        "private",
+                        "public"
+                      ]
                     },
                     "embargoIntervalDays": {
                       "type": "integer"
@@ -347,7 +378,11 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "type_name", "type_text"]
+                            "required": [
+                              "name",
+                              "type_name",
+                              "type_text"
+                            ]
                           }
                         },
                         "rows": {
@@ -367,7 +402,12 @@
                           "type": "boolean"
                         }
                       },
-                      "required": ["columns", "rows", "totalRows", "truncated"]
+                      "required": [
+                        "columns",
+                        "rows",
+                        "totalRows",
+                        "truncated"
+                      ]
                     }
                   },
                   "required": [
@@ -396,7 +436,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -406,7 +448,9 @@
       "patch": {
         "description": "Updates an existing experiment with the provided changes",
         "summary": "Update experiment",
-        "tags": ["experiments"],
+        "tags": [
+          "experiments"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -451,7 +495,10 @@
                   },
                   "visibility": {
                     "type": "string",
-                    "enum": ["private", "public"],
+                    "enum": [
+                      "private",
+                      "public"
+                    ],
                     "description": "Updated visibility setting"
                   },
                   "embargoIntervalDays": {
@@ -495,7 +542,10 @@
                     },
                     "visibility": {
                       "type": "string",
-                      "enum": ["private", "public"]
+                      "enum": [
+                        "private",
+                        "public"
+                      ]
                     },
                     "embargoIntervalDays": {
                       "type": "integer"
@@ -530,7 +580,11 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["name", "type_name", "type_text"]
+                            "required": [
+                              "name",
+                              "type_name",
+                              "type_text"
+                            ]
                           }
                         },
                         "rows": {
@@ -550,7 +604,12 @@
                           "type": "boolean"
                         }
                       },
-                      "required": ["columns", "rows", "totalRows", "truncated"]
+                      "required": [
+                        "columns",
+                        "rows",
+                        "totalRows",
+                        "truncated"
+                      ]
                     }
                   },
                   "required": [
@@ -579,7 +638,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -589,7 +650,9 @@
       "delete": {
         "description": "Deletes an experiment and all associated data",
         "summary": "Delete experiment",
-        "tags": ["experiments"],
+        "tags": [
+          "experiments"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -618,7 +681,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -630,7 +695,9 @@
       "get": {
         "description": "Returns a list of all users who are members of the specified experiment",
         "summary": "List experiment members",
-        "tags": ["experiments"],
+        "tags": [
+          "experiments"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -654,20 +721,46 @@
                   "items": {
                     "type": "object",
                     "properties": {
-                      "userId": {
-                        "type": "string",
-                        "format": "uuid"
+                      "user": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "name": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "email": {
+                            "type": "string",
+                            "format": "email",
+                            "nullable": true
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "email"
+                        ]
                       },
                       "role": {
                         "type": "string",
-                        "enum": ["admin", "member"]
+                        "enum": [
+                          "admin",
+                          "member"
+                        ]
                       },
                       "joinedAt": {
                         "type": "string",
                         "format": "date-time"
                       }
                     },
-                    "required": ["userId", "role", "joinedAt"]
+                    "required": [
+                      "user",
+                      "role",
+                      "joinedAt"
+                    ]
                   }
                 }
               }
@@ -684,7 +777,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -700,7 +795,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -710,7 +807,9 @@
       "post": {
         "description": "Adds a new member to the experiment with the specified role",
         "summary": "Add experiment member",
-        "tags": ["experiments"],
+        "tags": [
+          "experiments"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -739,11 +838,16 @@
                   "role": {
                     "default": "member",
                     "type": "string",
-                    "enum": ["admin", "member"],
+                    "enum": [
+                      "admin",
+                      "member"
+                    ],
                     "description": "Role to assign to the new member"
                   }
                 },
-                "required": ["userId"]
+                "required": [
+                  "userId"
+                ]
               }
             }
           }
@@ -756,20 +860,46 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "userId": {
-                      "type": "string",
-                      "format": "uuid"
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        "name": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "email": {
+                          "type": "string",
+                          "format": "email",
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "email"
+                      ]
                     },
                     "role": {
                       "type": "string",
-                      "enum": ["admin", "member"]
+                      "enum": [
+                        "admin",
+                        "member"
+                      ]
                     },
                     "joinedAt": {
                       "type": "string",
                       "format": "date-time"
                     }
                   },
-                  "required": ["userId", "role", "joinedAt"]
+                  "required": [
+                    "user",
+                    "role",
+                    "joinedAt"
+                  ]
                 }
               }
             }
@@ -785,7 +915,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -801,7 +933,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -813,7 +947,9 @@
       "delete": {
         "description": "Removes a member from the experiment",
         "summary": "Remove experiment member",
-        "tags": ["experiments"],
+        "tags": [
+          "experiments"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -852,7 +988,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -868,7 +1006,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -880,7 +1020,9 @@
       "get": {
         "description": "Retrieves data tables from the experiment with pagination support",
         "summary": "Get experiment data",
-        "tags": ["experiments"],
+        "tags": [
+          "experiments"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -941,86 +1083,94 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "tables": {
-                      "type": "array",
-                      "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "Name of the table"
+                      },
+                      "catalog_name": {
+                        "type": "string",
+                        "description": "Catalog name"
+                      },
+                      "schema_name": {
+                        "type": "string",
+                        "description": "Schema name"
+                      },
+                      "data": {
                         "type": "object",
                         "properties": {
-                          "name": {
-                            "type": "string",
-                            "description": "Name of the table"
-                          },
-                          "catalog_name": {
-                            "type": "string",
-                            "description": "Catalog name"
-                          },
-                          "schema_name": {
-                            "type": "string",
-                            "description": "Schema name"
-                          }
-                        },
-                        "required": ["name", "catalog_name", "schema_name"]
-                      }
-                    },
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "columns": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "name": {
-                                "type": "string"
-                              },
-                              "type_name": {
-                                "type": "string"
-                              },
-                              "type_text": {
-                                "type": "string"
-                              }
-                            },
-                            "required": ["name", "type_name", "type_text"]
-                          }
-                        },
-                        "rows": {
-                          "type": "array",
-                          "items": {
+                          "columns": {
                             "type": "array",
                             "items": {
-                              "type": "string",
-                              "nullable": true
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "type_name": {
+                                  "type": "string"
+                                },
+                                "type_text": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "type_name",
+                                "type_text"
+                              ]
                             }
+                          },
+                          "rows": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            }
+                          },
+                          "totalRows": {
+                            "type": "integer"
+                          },
+                          "truncated": {
+                            "type": "boolean"
                           }
                         },
-                        "totalRows": {
-                          "type": "integer"
-                        },
-                        "truncated": {
-                          "type": "boolean"
-                        }
+                        "required": [
+                          "columns",
+                          "rows",
+                          "totalRows",
+                          "truncated"
+                        ]
                       },
-                      "required": ["columns", "rows", "totalRows", "truncated"]
+                      "page": {
+                        "type": "integer"
+                      },
+                      "pageSize": {
+                        "type": "integer"
+                      },
+                      "totalPages": {
+                        "type": "integer"
+                      },
+                      "totalRows": {
+                        "type": "integer"
+                      }
                     },
-                    "tableName": {
-                      "type": "string"
-                    },
-                    "page": {
-                      "type": "integer"
-                    },
-                    "pageSize": {
-                      "type": "integer"
-                    },
-                    "totalPages": {
-                      "type": "integer"
-                    },
-                    "totalRows": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": ["page", "pageSize", "totalPages", "totalRows"]
+                    "required": [
+                      "name",
+                      "catalog_name",
+                      "schema_name",
+                      "page",
+                      "pageSize",
+                      "totalPages",
+                      "totalRows"
+                    ]
+                  }
                 }
               }
             }
@@ -1036,7 +1186,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -1052,7 +1204,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -1068,7 +1222,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -1080,7 +1236,9 @@
       "get": {
         "description": "Search for users by name or email with pagination support",
         "summary": "Search users",
-        "tags": ["users"],
+        "tags": [
+          "users"
+        ],
         "parameters": [
           {
             "name": "query",
@@ -1187,7 +1345,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }
@@ -1199,7 +1359,9 @@
       "get": {
         "description": "Returns a single user by their unique identifier",
         "summary": "Get a user by ID",
-        "tags": ["users"],
+        "tags": [
+          "users"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -1271,7 +1433,9 @@
                       "type": "string"
                     }
                   },
-                  "required": ["message"]
+                  "required": [
+                    "message"
+                  ]
                 }
               }
             }

--- a/packages/api/src/contracts/experiment.contract.ts
+++ b/packages/api/src/contracts/experiment.contract.ts
@@ -13,6 +13,8 @@ import {
   zCreateExperimentResponse,
   zIdPathParam,
   zExperimentMemberPathParam,
+  zExperimentDataQuery,
+  zExperimentDataResponse,
 } from "../schemas/experiment.schema";
 
 const c = initContract();
@@ -119,5 +121,21 @@ export const experimentContract = c.router({
     },
     summary: "Remove experiment member",
     description: "Removes a member from the experiment",
+  },
+
+  getExperimentData: {
+    method: "GET",
+    path: "/api/v1/experiments/:id/data",
+    pathParams: zIdPathParam,
+    query: zExperimentDataQuery,
+    responses: {
+      200: zExperimentDataResponse,
+      404: zErrorResponse,
+      403: zErrorResponse,
+      400: zErrorResponse,
+    },
+    summary: "Get experiment data",
+    description:
+      "Retrieves data tables from the experiment with pagination support",
   },
 });

--- a/packages/api/src/schemas/experiment.schema.ts
+++ b/packages/api/src/schemas/experiment.schema.ts
@@ -156,19 +156,17 @@ export const zExperimentDataTableInfo = z.object({
   name: z.string().describe("Name of the table"),
   catalog_name: z.string().describe("Catalog name"),
   schema_name: z.string().describe("Schema name"),
-});
-
-export const zExperimentDataTableList = z.array(zExperimentDataTableInfo);
-
-export const zExperimentDataResponse = z.object({
-  tables: zExperimentDataTableList.optional(),
   data: zExperimentData.optional(),
-  tableName: z.string().optional(),
   page: z.number().int(),
   pageSize: z.number().int(),
   totalPages: z.number().int(),
   totalRows: z.number().int(),
 });
+
+export const zExperimentDataTableList = z.array(zExperimentDataTableInfo);
+
+// Now the response is an array of table data objects
+export const zExperimentDataResponse = zExperimentDataTableList;
 
 export const zCreateExperimentResponse = z.object({ id: z.string().uuid() });
 

--- a/packages/api/src/schemas/experiment.schema.ts
+++ b/packages/api/src/schemas/experiment.schema.ts
@@ -130,6 +130,46 @@ export const zExperimentFilterQuery = z.object({
     .describe("Filter experiments by their status"),
 });
 
+export const zExperimentDataQuery = z.object({
+  page: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .default(1)
+    .describe("Page number for pagination"),
+  pageSize: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .default(5)
+    .describe("Number of rows per page"),
+  tableName: z
+    .string()
+    .optional()
+    .describe("Optional table name to filter results to a specific table"),
+});
+
+export const zExperimentDataTableInfo = z.object({
+  name: z.string().describe("Name of the table"),
+  catalog_name: z.string().describe("Catalog name"),
+  schema_name: z.string().describe("Schema name"),
+});
+
+export const zExperimentDataTableList = z.array(zExperimentDataTableInfo);
+
+export const zExperimentDataResponse = z.object({
+  tables: zExperimentDataTableList.optional(),
+  data: zExperimentData.optional(),
+  tableName: z.string().optional(),
+  page: z.number().int(),
+  pageSize: z.number().int(),
+  totalPages: z.number().int(),
+  totalRows: z.number().int(),
+});
+
 export const zCreateExperimentResponse = z.object({ id: z.string().uuid() });
 
 // Infer request and response types
@@ -141,6 +181,8 @@ export type ExperimentFilter = ExperimentFilterQuery["filter"];
 export type CreateExperimentResponse = z.infer<
   typeof zCreateExperimentResponse
 >;
+export type ExperimentDataQuery = z.infer<typeof zExperimentDataQuery>;
+export type ExperimentDataResponse = z.infer<typeof zExperimentDataResponse>;
 
 export const zIdPathParam = z.object({
   id: z.string().uuid().describe("ID of the experiment"),

--- a/packages/database/eslint.config.js
+++ b/packages/database/eslint.config.js
@@ -3,7 +3,7 @@ import baseConfig from "@repo/eslint-config/base";
 /** @type {import('typescript-eslint').Config} */
 export default [
   {
-    ignores: ["dist/**"],
+    ignores: ["dist/**", "scripts/**"],
   },
   ...baseConfig,
 ];


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Other (please describe)

## Description

This PR refactors and enhances the experiment data handling capabilities by adding a dedicated endpoint for retrieving experiment data tables with pagination support.

### 🔧 Core Features
- **New Experiment Data API** (`GET /api/v1/experiments/:id/data`)
  - Retrieves experiment data tables with advanced pagination
  - Supports filtering by specific table name
  - Returns sample data when no table is specified
  - Securely handles access control for private experiments

### 🏗 Architecture Implementation
- Refactored Databricks service with improved API endpoints handling
  - Added dedicated constants for API endpoints
  - Enhanced error handling with specific error messages
  - Added support for listing tables in schemas
- Implemented a clean separation of concerns by:
  - Moving experiment data retrieval to a dedicated use case
  - Creating a separate controller for data-specific operations
  - Removing data functionality from the main experiment retrieval flow

### 📁 Key Changes
- Added new `GetExperimentDataUseCase` with comprehensive test coverage
- Enhanced Databricks service with new `executeSqlQuery` and `listTables` methods
- Updated API schema to support data pagination parameters
- Added new test environment variables for Databricks integration testing
- Improved test harness with nock configuration to prevent real HTTP requests during tests

### 🔌 Integration
- Updated OpenAPI schema documentation
- Extended API contracts with new data endpoints
- Modified experiment schema validation (increased name max length from 100 to 255)
- Removed `getExperimentSchemaData` in favor of more modular `executeSqlQuery` and `listTables`

## Related Issues

- Closes #330 
- Related to #330 