### PR TITLE
feat(infra): enables route53

### DIFF
--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -25,32 +25,44 @@ module "cloudwatch" {
 }
 
 # Route53 DNS configuration
-# module "route53" {
-#   source = "../../modules/route53"
+module "route53" {
+  source = "../../modules/route53"
 
-#   domain_name         = var.domain_name
-#   create_route53_zone = var.create_route53_zone
-#   route53_zone_id     = var.route53_zone_id
-#   environment         = "Dev"
-#   environments        = [var.environment_subdomain]
+  domain_name = var.domain_name
+  environment = var.environment
 
-#   # These will be populated after ALB and CloudFront are created
-#   alb_records        = {}
-#   cloudfront_records = {}
+  # Connect your services to your domain
+  alb_records = {
+    "api" = {
+      dns_name = module.backend_alb.alb_dns_name
+      zone_id  = module.backend_alb.alb_zone_id
+    }
+  }
 
-#   tags = {
-#     Environment = "Dev"
-#     ManagedBy   = "Terraform"
-#   }
-# }
+  cloudfront_records = {
+    "docs" = {
+      domain_name    = module.cloudfront.cloudfront_distribution_domain_name
+      hosted_zone_id = module.cloudfront.cloudfront_hosted_zone_id
+    },
+    "" = {
+      domain_name    = module.opennext.cloudfront_distribution_domain_name
+      hosted_zone_id = module.opennext.cloudfront_hosted_zone_id
+    }
+  }
+
+  tags = {
+    Environment = "dev"
+    ManagedBy   = "Terraform"
+  }
+}
 
 
 module "cloudfront" {
-  source      = "../../modules/cloudfront"
-  bucket_name = var.docusaurus_s3_bucket_name
-  aws_region  = var.aws_region
-  # certificate_arn = module.route53.certificate_arn
-  # custom_domain   = "docs.${var.environment_subdomain}.${var.domain_name}"
+  source          = "../../modules/cloudfront"
+  bucket_name     = var.docusaurus_s3_bucket_name
+  aws_region      = var.aws_region
+  certificate_arn = module.route53.certificate_arn
+  custom_domain   = module.route53.docs_domain
 }
 
 
@@ -346,10 +358,9 @@ module "opennext" {
   region       = var.aws_region
 
   # Domain configuration
-  domain_name     = var.opennext_domain_name
-  subdomain       = var.opennext_subdomain
-  certificate_arn = var.opennext_certificate_arn
-  hosted_zone_id  = var.opennext_hosted_zone_id
+  domain_name     = module.route53.environment_domain
+  certificate_arn = module.route53.certificate_arn
+  hosted_zone_id  = module.route53.route53_zone_id
 
   # VPC configuration for server Lambda database access
   enable_server_vpc               = true
@@ -518,8 +529,8 @@ module "backend_alb" {
   health_check_unhealthy_threshold = 3
   health_check_matcher             = "200-299" # Accept any 2XX response as healthy
 
-  # SSL/TLS configuration - Uncomment when Route53 module is enabled
-  # certificate_arn = module.route53.certificate_arn
+  # SSL/TLS configuration for HTTPS
+  certificate_arn = module.route53.certificate_arn # Use the ACM certificate managed by the Route53 module
 
   # Enable access logs for production but not for dev
   enable_access_logs = false

--- a/infrastructure/env/dev/variables.tf
+++ b/infrastructure/env/dev/variables.tf
@@ -152,19 +152,13 @@ variable "opennext_price_class" {
   default     = "PriceClass_100"
 }
 
-# variable "domain_name" {
-#   description = "Base domain name (e.g., my-company.com)"
-#   type        = string
-# }
+variable "domain_name" {
+  description = "Base domain name (e.g., my-company.com)"
+  type        = string
+}
 
-# variable "route53_zone_id" {
-#   description = "Existing Route53 zone ID (required if create_route53_zone is false)"
-#   type        = string
-#   default     = ""
-# }
-
-variable "environment_subdomain" {
-  description = "Environment subdomain prefix (e.g., 'dev' for dev.my-company.com)"
+variable "environment" {
+  description = "Environment name (e.g., 'dev' for dev.my-company.com)"
   type        = string
   default     = "dev"
 }

--- a/infrastructure/modules/cloudfront/variables.tf
+++ b/infrastructure/modules/cloudfront/variables.tf
@@ -25,4 +25,3 @@ variable "custom_domain" {
   type        = string
   default     = ""
 }
-

--- a/infrastructure/modules/route53/outputs.tf
+++ b/infrastructure/modules/route53/outputs.tf
@@ -16,27 +16,21 @@ output "certificate_arn" {
 }
 
 output "name_servers" {
-  description = "Name servers for the Route53 zone (if created)"
-  value       = var.create_route53_zone ? aws_route53_zone.main[0].name_servers : []
+  description = "Name servers for the Route53 zone"
+  value       = aws_route53_zone.main.name_servers
 }
 
-output "environment_domains" {
-  description = "Map of environment domain names"
-  value = {
-    for env in var.environments : env => "${env}.${var.domain_name}"
-  }
+output "environment_domain" {
+  description = "Environment domain name"
+  value       = "${var.environment}.${var.domain_name}"
 }
 
-output "api_domains" {
-  description = "Map of API domain names for each environment"
-  value = {
-    for env in var.environments : env => "api.${env}.${var.domain_name}"
-  }
+output "api_domain" {
+  description = "API domain name for environment"
+  value       = "api.${var.environment}.${var.domain_name}"
 }
 
-output "docs_domains" {
-  description = "Map of docs domain names for each environment"
-  value = {
-    for env in var.environments : env => "docs.${env}.${var.domain_name}"
-  }
+output "docs_domain" {
+  description = "Docs domain name for environment"
+  value       = "docs.${var.environment}.${var.domain_name}"
 }

--- a/infrastructure/modules/route53/variables.tf
+++ b/infrastructure/modules/route53/variables.tf
@@ -5,28 +5,10 @@ variable "domain_name" {
   type        = string
 }
 
-variable "create_route53_zone" {
-  description = "Whether to create a new Route53 hosted zone (set to false if you've transferred in an existing domain)"
-  type        = bool
-  default     = false
-}
-
-variable "route53_zone_id" {
-  description = "Existing Route53 zone ID (required if create_route53_zone is false)"
-  type        = string
-  default     = ""
-}
-
 variable "environment" {
-  description = "Environment name (e.g., Dev, Staging, Prod)"
+  description = "Environment name/subdomain prefix (e.g., dev, staging, prod)"
   type        = string
-  default     = "Dev"
-}
-
-variable "environments" {
-  description = "List of environments to create subdomains for (e.g., ['dev', 'staging', 'prod'])"
-  type        = list(string)
-  default     = ["dev"]
+  default     = "dev"
 }
 
 variable "create_certificate" {


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Other (please describe)

## Description
  
This pull request introduces significant updates to the Terraform configuration for managing DNS and SSL/TLS in the development environment. The changes primarily focus on simplifying the Route53 and ACM certificate configuration by removing multi-environment support and adopting a single-environment model. Key updates include enabling the Route53 module, refining domain and subdomain handling, and improving SSL/TLS certificate management.

### Route53 Module Updates:
* Enabled the Route53 module in `infrastructure/env/dev/main.tf` to manage DNS resources, including ALB and CloudFront records, and updated tags to reflect the "dev" environment.
* Simplified the `aws_route53_zone` resource by removing conditional creation logic and hardcoding support for a single environment. [[1]](diffhunk://#diff-983472b3738974a34cda698b8f155ab850aae579c60a52c0bd037c1a1002c79bL4-L6) [[2]](diffhunk://#diff-983472b3738974a34cda698b8f155ab850aae579c60a52c0bd037c1a1002c79bL20-R18)
* Updated Route53 record configurations to include the environment as part of the subdomain, ensuring proper DNS resolution for environment-specific services. [[1]](diffhunk://#diff-983472b3738974a34cda698b8f155ab850aae579c60a52c0bd037c1a1002c79bL91-R89) [[2]](diffhunk://#diff-983472b3738974a34cda698b8f155ab850aae579c60a52c0bd037c1a1002c79bL106-R106)

### ACM Certificate Improvements:
* Refined the `aws_acm_certificate` resource to explicitly list subdomains for the current environment instead of using wildcards, enhancing security.
* Integrated the ACM certificate ARN from the Route53 module into other modules, such as CloudFront and ALB, to enable HTTPS. [[1]](diffhunk://#diff-f6672b4c785f679251f4f9dbd2e79d208b1486eb63bcb0db45be92c90197d13eL349-R363) [[2]](diffhunk://#diff-f6672b4c785f679251f4f9dbd2e79d208b1486eb63bcb0db45be92c90197d13eL521-R533)

### Variable and Output Simplifications:
* Removed multi-environment variables like `environments` and `environment_subdomain`, replacing them with a single `environment` variable to streamline configuration. [[1]](diffhunk://#diff-938b9b12810f664f0cc490249b784ae90a9bda9de5fe30b8ad2f3633a48ffcbcL155-R161) [[2]](diffhunk://#diff-56fc9170ed40633cbc43065e1b615c39c345afd0c15dd7c556c13357f7cee7d7L8-R11)
* Simplified Route53 module outputs to return single environment-specific values (e.g., `environment_domain`, `api_domain`, `docs_domain`) instead of maps for multiple environments.

These changes collectively simplify the infrastructure codebase, reduce complexity, and improve maintainability by focusing on a single-environment setup.

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #69 
- Related to #69 