### PR TITLE
fix(backend): Updating experiment name was limited to 100 characters

### DIFF
--- a/packages/api/src/schemas/experiment.schema.ts
+++ b/packages/api/src/schemas/experiment.schema.ts
@@ -97,7 +97,7 @@ export const zUpdateExperimentBody = z.object({
   name: z
     .string()
     .min(1)
-    .max(100)
+    .max(255)
     .optional()
     .describe("Updated experiment name"),
   description: z.string().optional().describe("Updated experiment description"),


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Bug Fix

## Description

Fixed maximum number of characters for name field in updates to be 255.
