### PR TITLE
refactor: remove redundant validation, let database handle constraints

### DIFF
--- a/apps/backend/src/experiments/application/use-cases/create-experiment/create-experiment.ts
+++ b/apps/backend/src/experiments/application/use-cases/create-experiment/create-experiment.ts
@@ -1,12 +1,7 @@
 import { Injectable, Logger } from "@nestjs/common";
 
 import { DatabricksService } from "../../../../common/services/databricks/databricks.service";
-import {
-  Result,
-  success,
-  failure,
-  AppError,
-} from "../../../../common/utils/fp-utils";
+import { Result, success } from "../../../../common/utils/fp-utils";
 import {
   CreateExperimentDto,
   ExperimentDto,
@@ -30,103 +25,44 @@ export class CreateExperimentUseCase {
   ): Promise<Result<ExperimentDto>> {
     this.logger.log(`Creating experiment "${data.name}" for user ${userId}`);
 
-    // Validate that the user ID is provided
-    if (!userId) {
-      this.logger.warn("Attempt to create experiment without user ID");
-      return failure(
-        AppError.badRequest("User ID is required to create an experiment"),
-      );
-    }
-
-    // Validate that name is provided
-    if (!data.name || data.name.trim() === "") {
-      this.logger.warn(`Invalid experiment name provided by user ${userId}`);
-      return failure(AppError.badRequest("Experiment name is required"));
-    }
-
-    // Check if an experiment with the same name already exists
-    const existingExperimentResult = await this.experimentRepository.findByName(
-      data.name,
+    // Create the experiment with members in a single transaction
+    const experimentResult = await this.experimentRepository.createWithMembers(
+      data,
+      userId,
+      data.members,
     );
 
-    return existingExperimentResult.chain(async (existingExperiment) => {
-      if (existingExperiment) {
+    return experimentResult.chain(async (experiment: ExperimentDto) => {
+      this.logger.debug(
+        `Successfully created experiment ${experiment.id} with members`,
+      );
+
+      this.logger.debug(
+        `Triggering Databricks job for experiment ${experiment.id}`,
+      );
+      // Trigger Databricks job for the new experiment
+      const databricksResult = await this.databricksService.triggerJob({
+        experimentId: experiment.id,
+        experimentName: experiment.name,
+        userId: userId,
+      });
+
+      // Log Databricks job trigger result but don't fail experiment creation
+      if (databricksResult.isFailure()) {
         this.logger.warn(
-          `Attempt to create duplicate experiment "${data.name}" by user ${userId}`,
+          `Failed to trigger Databricks job for experiment ${experiment.id}:`,
+          databricksResult.error.message,
         );
-        return failure(
-          AppError.badRequest(
-            `An experiment with the name "${data.name}" already exists`,
-          ),
+      } else {
+        this.logger.log(
+          `Successfully triggered Databricks job for experiment ${experiment.id}`,
         );
       }
 
-      this.logger.debug(`Creating experiment in repository: "${data.name}"`);
-      // Create the experiment
-      const experimentResult = await this.experimentRepository.create(
-        data,
-        userId,
+      this.logger.log(
+        `Successfully created experiment "${experiment.name}" (ID: ${experiment.id})`,
       );
-
-      return experimentResult.chain(async (experiments: ExperimentDto[]) => {
-        if (experiments.length === 0) {
-          this.logger.error(
-            `Failed to create experiment "${data.name}" for user ${userId}`,
-          );
-          return failure(AppError.internal("Failed to create experiment"));
-        }
-
-        const experiment = experiments[0];
-        this.logger.debug(
-          `Adding user ${userId} as admin to experiment ${experiment.id}`,
-        );
-
-        // Filter out any member with the same userId as the admin
-        const filteredMembers = (
-          Array.isArray(data.members) ? data.members : []
-        ).filter((member) => member.userId !== userId);
-
-        // Add the user as an admin member + the rest of the members if provided
-        const allMembers = [
-          { userId, role: "admin" as const },
-          ...filteredMembers,
-        ];
-
-        const addMembersResult =
-          await this.experimentMemberRepository.addMembers(
-            experiment.id,
-            allMembers,
-          );
-
-        return addMembersResult.chain(async () => {
-          this.logger.debug(
-            `Triggering Databricks job for experiment ${experiment.id}`,
-          );
-          // Trigger Databricks job for the new experiment
-          const databricksResult = await this.databricksService.triggerJob({
-            experimentId: experiment.id,
-            experimentName: experiment.name,
-            userId: userId,
-          });
-
-          // Log Databricks job trigger result but don't fail experiment creation
-          if (databricksResult.isFailure()) {
-            this.logger.warn(
-              `Failed to trigger Databricks job for experiment ${experiment.id}:`,
-              databricksResult.error.message,
-            );
-          } else {
-            this.logger.log(
-              `Successfully triggered Databricks job for experiment ${experiment.id}`,
-            );
-          }
-
-          this.logger.log(
-            `Successfully created experiment "${experiment.name}" (ID: ${experiment.id})`,
-          );
-          return success(experiment);
-        });
-      });
+      return success(experiment);
     });
   }
 }

--- a/apps/backend/src/experiments/presentation/experiment-members.controller.spec.ts
+++ b/apps/backend/src/experiments/presentation/experiment-members.controller.spec.ts
@@ -162,13 +162,17 @@ describe("ExperimentMembersController", () => {
         .expect(StatusCodes.CREATED);
 
       // Assert the response
-      expect(response.body).toMatchObject({
-        role: "member",
-        experimentId: experiment.id,
-        user: expect.objectContaining({
-          id: newMemberId,
-        }) as Partial<UserDto>,
-      });
+      expect(response.body).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            role: "member",
+            experimentId: experiment.id,
+            user: expect.objectContaining({
+              id: newMemberId,
+            }) as Partial<UserDto>,
+          }),
+        ]),
+      );
 
       // Verify with a list request
       const listPath = testApp.resolvePath(

--- a/apps/backend/src/experiments/presentation/experiment.controller.spec.ts
+++ b/apps/backend/src/experiments/presentation/experiment.controller.spec.ts
@@ -598,12 +598,16 @@ describe("ExperimentController", () => {
         .send({ members: [{ userId: newMemberId, role: "member" }] })
         .expect(StatusCodes.CREATED)
         .expect(({ body }) => {
-          expect(body).toMatchObject({
-            role: "member",
-            user: expect.objectContaining({
-              id: newMemberId,
-            }) as Partial<UserDto>,
-          });
+          expect(body).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                role: "member",
+                user: expect.objectContaining({
+                  id: newMemberId,
+                }) as Partial<UserDto>,
+              }),
+            ]),
+          );
         });
 
       // Verify member was added

--- a/packages/database/drizzle/0003_mushy_johnny_storm.sql
+++ b/packages/database/drizzle/0003_mushy_johnny_storm.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "experiments" ADD CONSTRAINT "name_not_empty" CHECK (length(trim("experiments"."name")) > 0);

--- a/packages/database/drizzle/meta/0003_snapshot.json
+++ b/packages/database/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,814 @@
+{
+  "id": "7bb7a142-419f-4ba6-9a13-0bc6ad74ef9b",
+  "prevId": "b75286e8-e6f0-4ba7-bb67-b0f678b86890",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authenticators": {
+      "name": "authenticators",
+      "schema": "",
+      "columns": {
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialPublicKey": {
+          "name": "credentialPublicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialDeviceType": {
+          "name": "credentialDeviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialBackedUp": {
+          "name": "credentialBackedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticators_userId_users_id_fk": {
+          "name": "authenticators_userId_users_id_fk",
+          "tableFrom": "authenticators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authenticators_credentialID_unique": {
+          "name": "authenticators_credentialID_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credentialID"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_members": {
+      "name": "experiment_members",
+      "schema": "",
+      "columns": {
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "experiment_members_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_members_experiment_id_experiments_id_fk": {
+          "name": "experiment_members_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_members",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "experiment_members_user_id_users_id_fk": {
+          "name": "experiment_members_user_id_users_id_fk",
+          "tableFrom": "experiment_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "experiment_members_experiment_id_user_id_pk": {
+          "name": "experiment_members_experiment_id_user_id_pk",
+          "columns": [
+            "experiment_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiments": {
+      "name": "experiments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "experiment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "experiment_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "embargo_interval_days": {
+          "name": "embargo_interval_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 90
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiments_created_by_users_id_fk": {
+          "name": "experiments_created_by_users_id_fk",
+          "tableFrom": "experiments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "experiments_name_unique": {
+          "name": "experiments_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "name_not_empty": {
+          "name": "name_not_empty",
+          "value": "length(trim(\"experiments\".\"name\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "organization_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_user_id_users_id_fk": {
+          "name": "profiles_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profiles_organization_id_organizations_id_fk": {
+          "name": "profiles_organization_id_organizations_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sensors": {
+      "name": "sensors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sensors_serial_number_unique": {
+          "name": "sensors_serial_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "serial_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.experiment_members_role": {
+      "name": "experiment_members_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member"
+      ]
+    },
+    "public.experiment_status": {
+      "name": "experiment_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "provisioning_failed",
+        "active",
+        "stale",
+        "archived",
+        "published"
+      ]
+    },
+    "public.experiment_visibility": {
+      "name": "experiment_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "public"
+      ]
+    },
+    "public.organization_type": {
+      "name": "organization_type",
+      "schema": "public",
+      "values": [
+        "research_institute",
+        "non_profit",
+        "private_company",
+        "government_agency",
+        "university"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1749728396630,
       "tag": "0002_simple_warbound",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1750616745171,
+      "tag": "0003_mushy_johnny_storm",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { primaryKey } from "drizzle-orm/pg-core";
 import {
   pgTable,
@@ -9,6 +10,7 @@ import {
   pgEnum,
   uuid,
   integer,
+  check,
 } from "drizzle-orm/pg-core";
 
 export const users = pgTable("users", {
@@ -156,24 +158,28 @@ export const experimentVisibilityEnum = pgEnum("experiment_visibility", [
   "public",
 ]);
 
-export const experiments = pgTable("experiments", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  name: varchar("name", { length: 255 }).notNull().unique(),
-  description: text("description"),
-  status: experimentStatusEnum("status").default("provisioning").notNull(),
-  visibility: experimentVisibilityEnum("visibility")
-    .default("public")
-    .notNull(),
-  embargoIntervalDays: integer("embargo_interval_days").default(90).notNull(),
-  createdBy: uuid("created_by")
-    .references(() => users.id)
-    .notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
-    .defaultNow()
-    .$onUpdate(() => new Date())
-    .notNull(),
-});
+export const experiments = pgTable(
+  "experiments",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    name: varchar("name", { length: 255 }).notNull().unique(),
+    description: text("description"),
+    status: experimentStatusEnum("status").default("provisioning").notNull(),
+    visibility: experimentVisibilityEnum("visibility")
+      .default("public")
+      .notNull(),
+    embargoIntervalDays: integer("embargo_interval_days").default(90).notNull(),
+    createdBy: uuid("created_by")
+      .references(() => users.id)
+      .notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [check("name_not_empty", sql`length(trim(${table.name})) > 0`)],
+);
 
 export const experimentMembersEnum = pgEnum("experiment_members_role", [
   "admin",


### PR DESCRIPTION
## Summary
This PR removes redundant application-level validation for experiment creation and lets the database handle constraints through its built-in mechanisms (unique constraints, foreign keys, etc.).

## Primary Changes

### Removed Redundant Validation
- **CreateExperimentUseCase**: Removed manual checks for:
  - Empty/null experiment names 
  - Duplicate experiment names (uniqueness check)
  - Invalid user IDs
- Let database constraints handle these validations instead of duplicating logic

### Database Constraint Enhancements
- **Experiments table**: Added check constraint `name_not_empty` to prevent empty strings
- Rely on existing `unique()` constraint for duplicate name prevention
- Rely on foreign key constraints for user ID validation

### Improved Error Handling
- **ExperimentRepository**: Enhanced error messages in `createWithMembers` to provide clearer feedback when database constraints are violated
- Better error mapping for constraint violations (duplicate names, invalid foreign keys)

### Test Updates
- Updated tests to expect database constraint error codes (`REPOSITORY_DUPLICATE`, `REPOSITORY_ERROR`) instead of application validation codes (`BAD_REQUEST`)
- Fixed controller tests expecting array responses instead of single objects
- Added comprehensive tests for `createWithMembers` method

## Benefits
- **Reduced code duplication**: No need to validate what the database already validates
- **Single source of truth**: Database schema defines the constraints
- **Better performance**: Eliminates unnecessary queries (like checking if name exists before insert)
- **Simpler logic**: Less application code to maintain and test

## Database Changes
- Added check constraint to prevent empty experiment names
- Migration required: `pnpm db:generate` and `pnpm db:migrate`