### PR TITLE
feat: Implement Clean Logout System with Custom API Route

### DIFF
--- a/apps/web/app/api/logout/route.ts
+++ b/apps/web/app/api/logout/route.ts
@@ -1,0 +1,30 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+export function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const backUrl = searchParams.get("backUrl") ?? "/";
+
+  // Redirect to NextAuth's signout endpoint with callbackUrl
+  // This will show the confirmation page and then redirect back
+  const signOutUrl = new URL("/api/auth/signout", request.url);
+  signOutUrl.searchParams.set("callbackUrl", backUrl);
+
+  return NextResponse.redirect(signOutUrl);
+}
+
+export async function POST(request: NextRequest) {
+  const body = (await request.json().catch(() => ({}))) as { backUrl?: string };
+  const backUrl = body.backUrl ?? "/";
+
+  // For POST requests, construct the signout URL but don't redirect
+  // Return it as JSON so the client can handle it
+  const signOutUrl = new URL("/api/auth/signout", request.url);
+  signOutUrl.searchParams.set("callbackUrl", backUrl);
+
+  return NextResponse.json({
+    success: true,
+    signOutUrl: signOutUrl.toString(),
+    message: "Use the signOutUrl to complete logout",
+  });
+}

--- a/apps/web/app/api/logout/route.ts
+++ b/apps/web/app/api/logout/route.ts
@@ -3,7 +3,16 @@ import { NextResponse } from "next/server";
 
 export function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
-  const backUrl = searchParams.get("backUrl") ?? "/";
+  let backUrl = searchParams.get("backUrl") ?? "/";
+  // Validate backUrl to prevent open redirect vulnerabilities
+  if (
+    typeof backUrl !== "string" ||
+    !backUrl.startsWith("/") ||
+    backUrl.startsWith("//") ||
+    backUrl.includes("://")
+  ) {
+    backUrl = "/";
+  }
 
   // Redirect to NextAuth's signout endpoint with callbackUrl
   // This will show the confirmation page and then redirect back

--- a/apps/web/components/nav-user.tsx
+++ b/apps/web/components/nav-user.tsx
@@ -80,7 +80,7 @@ export function NavUser({
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild>
               <Link
-                href={`/${locale}/platform/signout`}
+                href={`/api/logout?backUrl=${encodeURIComponent(`/${locale}`)}`}
                 className="flex w-full cursor-default items-center"
               >
                 <LogOut className="mr-2 h-4 w-4" />

--- a/apps/web/components/nav-user.tsx
+++ b/apps/web/components/nav-user.tsx
@@ -2,6 +2,7 @@
 
 import { ChevronsUpDown, LogOut } from "lucide-react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 import type { Locale } from "@repo/i18n";
 import { useTranslation } from "@repo/i18n";
@@ -34,6 +35,10 @@ export function NavUser({
 }) {
   const { isMobile } = useSidebar();
   const { t } = useTranslation(undefined, "common");
+  const pathname = usePathname();
+
+  // Determine the appropriate backUrl based on current location
+  const backUrl = (pathname.includes("/platform") ? `/${locale}` : pathname) || "/";
 
   return (
     <SidebarMenu>
@@ -80,7 +85,7 @@ export function NavUser({
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild>
               <Link
-                href={`/api/logout?backUrl=${encodeURIComponent(`/${locale}`)}`}
+                href={`/api/logout?backUrl=${encodeURIComponent(backUrl)}`}
                 className="flex w-full cursor-pointer items-center"
               >
                 <LogOut className="mr-2 h-4 w-4" />

--- a/apps/web/components/nav-user.tsx
+++ b/apps/web/components/nav-user.tsx
@@ -81,7 +81,7 @@ export function NavUser({
             <DropdownMenuItem asChild>
               <Link
                 href={`/api/logout?backUrl=${encodeURIComponent(`/${locale}`)}`}
-                className="flex w-full cursor-default items-center"
+                className="flex w-full cursor-pointer items-center"
               >
                 <LogOut className="mr-2 h-4 w-4" />
                 {t("navigation.logout")}

--- a/apps/web/components/unified-navbar.tsx
+++ b/apps/web/components/unified-navbar.tsx
@@ -250,9 +250,7 @@ export function UnifiedNavbar({ locale, session }: UnifiedNavbarProps) {
                     </DropdownMenuItem>
                     <DropdownMenuItem asChild>
                       <Link
-                        href={`/api/logout?backUrl=${encodeURIComponent(
-                          pathname.includes("/platform") ? `/${locale}` : pathname,
-                        )}`}
+                        href={`/api/logout?backUrl=${encodeURIComponent(backUrl)}`}
                         className="flex w-full items-center space-x-3"
                       >
                         <LogOut className="h-4 w-4" />

--- a/apps/web/components/unified-navbar.tsx
+++ b/apps/web/components/unified-navbar.tsx
@@ -21,8 +21,6 @@ import {
   DropdownMenuTrigger,
 } from "@repo/ui/components";
 
-import { handleLogout } from "../app/actions/auth";
-
 interface UnifiedNavbarProps {
   locale: Locale;
   session: Session | null;
@@ -32,11 +30,11 @@ interface UnifiedNavbarProps {
 function UserMenu({
   locale,
   session,
-  onSignOut,
+  pathname,
 }: {
   locale: Locale;
   session: Session | null;
-  onSignOut: () => void;
+  pathname: string;
 }) {
   const { t } = useTranslation("common");
 
@@ -50,6 +48,8 @@ function UserMenu({
       </Button>
     );
   }
+
+  const backUrl = pathname.includes("/platform") ? `/${locale}` : pathname;
 
   return (
     <DropdownMenu>
@@ -94,12 +94,13 @@ function UserMenu({
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
-          <form action={onSignOut} className="w-full">
-            <button type="submit" className="flex w-full cursor-pointer items-center">
-              <LogOut className="mr-2 h-4 w-4" />
-              {t("auth.signOut", "Sign Out")}
-            </button>
-          </form>
+          <Link
+            href={`/api/logout?backUrl=${encodeURIComponent(backUrl)}`}
+            className="flex w-full cursor-pointer items-center"
+          >
+            <LogOut className="mr-2 h-4 w-4" />
+            {t("auth.signOut", "Sign Out")}
+          </Link>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
@@ -111,12 +112,6 @@ export function UnifiedNavbar({ locale, session }: UnifiedNavbarProps) {
   const pathname = usePathname();
 
   const isAuthenticated = !!session?.user;
-
-  const handleSignOut = () => {
-    return handleLogout({
-      redirectTo: pathname.includes("/platform") ? `/${locale}` : pathname,
-    });
-  };
 
   // Navigation items (memoised)
   const navItems = useMemo(
@@ -186,7 +181,7 @@ export function UnifiedNavbar({ locale, session }: UnifiedNavbarProps) {
           <LanguageSwitcher locale={locale} />
 
           {/* Desktop User Menu */}
-          <UserMenu locale={locale} session={session} onSignOut={handleSignOut} />
+          <UserMenu locale={locale} session={session} pathname={pathname} />
 
           {/* Mobile Navigation Menu */}
           <div className="md:hidden">
@@ -254,12 +249,15 @@ export function UnifiedNavbar({ locale, session }: UnifiedNavbarProps) {
                       </div>
                     </DropdownMenuItem>
                     <DropdownMenuItem asChild>
-                      <form action={handleSignOut} className="w-full">
-                        <button type="submit" className="flex w-full items-center space-x-3">
-                          <LogOut className="h-4 w-4" />
-                          <span>{t("auth.signOut", "Sign Out")}</span>
-                        </button>
-                      </form>
+                      <Link
+                        href={`/api/logout?backUrl=${encodeURIComponent(
+                          pathname.includes("/platform") ? `/${locale}` : pathname,
+                        )}`}
+                        className="flex w-full items-center space-x-3"
+                      >
+                        <LogOut className="h-4 w-4" />
+                        <span>{t("auth.signOut", "Sign Out")}</span>
+                      </Link>
                     </DropdownMenuItem>
                   </>
                 )}

--- a/apps/web/components/unified-navbar.tsx
+++ b/apps/web/components/unified-navbar.tsx
@@ -24,6 +24,7 @@ import {
 interface UnifiedNavbarProps {
   locale: Locale;
   session: Session | null;
+  backUrl?: string; // Optional backUrl for logout
 }
 
 // Extract UserMenu as a separate component to prevent re-renders
@@ -49,7 +50,7 @@ function UserMenu({
     );
   }
 
-  const backUrl = pathname.includes("/platform") ? `/${locale}` : pathname;
+  const backUrl = (pathname.includes("/platform") ? `/${locale}` : pathname) || "/";
 
   return (
     <DropdownMenu>
@@ -107,7 +108,7 @@ function UserMenu({
   );
 }
 
-export function UnifiedNavbar({ locale, session }: UnifiedNavbarProps) {
+export function UnifiedNavbar({ locale, session, backUrl = "/" }: UnifiedNavbarProps) {
   const { t } = useTranslation();
   const pathname = usePathname();
 


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Other (please describe)


## Summary
Replaces the existing form-based logout mechanism with a clean, Link-based approach using a custom `/api/logout` route that provides better UX and maintainability.

## Changes Made

### 🔧 New API Route (`/app/api/logout/route.ts`)
- **GET endpoint**: Accepts `backUrl` query parameter and redirects to NextAuth's signout with confirmation
- **POST endpoint**: Returns signout URL as JSON for programmatic use
- Properly handles NextAuth integration with callback URL support

### 🔄 Component Updates
- **`unified-navbar.tsx`**: 
  - Removed `handleLogout` server action dependency
  - Updated UserMenu to use Link components instead of form submissions
  - Simplified props by passing `pathname` instead of callback functions
  - Updated both desktop and mobile logout buttons

- **`nav-user.tsx`**: 
  - Replaced Link to platform signout page with new API route
  - Updated to use button-free Link approach
  - Maintains consistent backUrl logic

### ✨ Benefits
- **Better UX**: Semantic Link components support right-click, copy URL, etc.
- **Cleaner Code**: No JavaScript event handlers or `window.location.href`
- **Progressive Enhancement**: Works without JavaScript
- **Consistent API**: Single logout endpoint with flexible redirect handling
- **Maintainable**: Centralized logout logic in one place

### 🔄 Usage
```typescript
// Simple link-based logout
<Link href="/api/logout?backUrl=/home">Logout</Link>

// Programmatic usage
 router.push(`/api/logout?backUrl=${encodeURIComponent(currentPath)}`);