### PR TITLE
fix(web): removed description column from protocols table

### DIFF
--- a/apps/web/components/list-protocols.tsx
+++ b/apps/web/components/list-protocols.tsx
@@ -40,7 +40,6 @@ export function ListProtocols({ userId }: ListProtocolsProps) {
         <TableHeader>
           <TableRow>
             <TableHead>Protocol name</TableHead>
-            <TableHead>Description</TableHead>
             <TableHead>Created</TableHead>
             <TableHead>Updated</TableHead>
             <TableHead className="text-center">Actions</TableHead>
@@ -70,9 +69,6 @@ function ProtocolRow({ protocol, userId }: { protocol: Protocol; userId: string 
       <TableCell className="flex items-center gap-2">
         <CodeIcon size={16} className="text-muted-foreground" />
         {protocol.name}
-      </TableCell>
-      <TableCell className="max-w-[300px] truncate">
-        {protocol.description ?? "No description"}
       </TableCell>
       <TableCell>{formatDate(protocol.createdAt)}</TableCell>
       <TableCell>{formatDate(protocol.updatedAt)}</TableCell>


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Other (please describe)

## Description

Removed description column from protocols table in overview due to the complexity of displaying rich text in a small column field.

## Related Issues

- Closes #
- Related to #

## Testing Instructions

- [ ] Test case 1
- [ ] Test case 2

## Changes Made

-
-

## Checklist

- [ ] I have added/updated tests for my changes
- [ ] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have tested these changes locally
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code

## Screenshots/Recordings

## Additional Notes
