### PR TITLE
feat(backend): support-adding-protocols-to-experiments

### DIFF
--- a/apps/backend/src/experiments/application/use-cases/experiment-protocols/add-experiment-protocols.spec.ts
+++ b/apps/backend/src/experiments/application/use-cases/experiment-protocols/add-experiment-protocols.spec.ts
@@ -1,0 +1,136 @@
+import { protocols } from "@repo/database";
+
+import { assertFailure, assertSuccess } from "../../../../common/utils/fp-utils";
+import { TestHarness } from "../../../../test/test-harness";
+import type { ExperimentProtocolDto } from "../../../core/models/experiment-protocols.model";
+import { AddExperimentProtocolsUseCase } from "./add-experiment-protocols";
+
+describe("AddExperimentProtocolsUseCase", () => {
+  const testApp = TestHarness.App;
+  let testUserId: string;
+  let useCase: AddExperimentProtocolsUseCase;
+  let protocol1Id: string;
+  let protocol2Id: string;
+
+  beforeAll(async () => {
+    await testApp.setup();
+  });
+
+  beforeEach(async () => {
+    await testApp.beforeEach();
+    testUserId = await testApp.createTestUser({});
+    useCase = testApp.module.get(AddExperimentProtocolsUseCase);
+    // Create two protocols
+    [protocol1Id, protocol2Id] = await Promise.all([
+      testApp.database
+        .insert(protocols)
+        .values({
+          name: "Protocol 1",
+          code: {},
+          family: "multispeq",
+          createdBy: testUserId,
+        })
+        .returning()
+        .then((rows) => rows[0].id),
+      testApp.database
+        .insert(protocols)
+        .values({
+          name: "Protocol 2",
+          code: {},
+          family: "ambit",
+          createdBy: testUserId,
+        })
+        .returning()
+        .then((rows) => rows[0].id),
+    ]);
+  });
+
+  afterEach(() => {
+    testApp.afterEach();
+  });
+
+  afterAll(async () => {
+    await testApp.teardown();
+  });
+
+  it("should add multiple protocols to an experiment", async () => {
+    // Create an experiment
+    const { experiment } = await testApp.createExperiment({
+      name: "Add Protocols Test Experiment",
+      userId: testUserId,
+    });
+
+    // Add the protocols through the use case
+    const result = await useCase.execute(
+      experiment.id,
+      [
+        { protocolId: protocol1Id, order: 0 },
+        { protocolId: protocol2Id, order: 1 },
+      ],
+      testUserId,
+    );
+
+    // Verify result is success
+    expect(result.isSuccess()).toBe(true);
+    assertSuccess(result);
+
+    const protocols = result.value;
+    expect(Array.isArray(protocols)).toBe(true);
+    expect(protocols.length).toBe(2);
+
+    expect(protocols).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          order: 0,
+          protocol: expect.objectContaining({
+            id: protocol1Id,
+            name: "Protocol 1",
+          }) as Partial<ExperimentProtocolDto>,
+        }),
+        expect.objectContaining({
+          order: 1,
+          protocol: expect.objectContaining({
+            id: protocol2Id,
+            name: "Protocol 2",
+          }) as Partial<ExperimentProtocolDto>,
+        }),
+      ]),
+    );
+  });
+
+  it("should return NOT_FOUND error if experiment does not exist", async () => {
+    const nonExistentId = "00000000-0000-0000-0000-000000000000";
+    const result = await useCase.execute(
+      nonExistentId,
+      [{ protocolId: protocol1Id, order: 0 }],
+      testUserId,
+    );
+    expect(result.isSuccess()).toBe(false);
+    assertFailure(result);
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should return FORBIDDEN error if user is not an admin", async () => {
+    // Create an experiment
+    const { experiment } = await testApp.createExperiment({
+      name: "Forbidden Protocol Test Experiment",
+      userId: testUserId,
+    });
+
+    // Create a non-admin user
+    const nonAdminId = await testApp.createTestUser({
+      email: "nonadmin-protocol@example.com",
+    });
+
+    // Try to add protocols as a non-admin user
+    const result = await useCase.execute(
+      experiment.id,
+      [{ protocolId: protocol1Id, order: 0 }],
+      nonAdminId,
+    );
+
+    expect(result.isSuccess()).toBe(false);
+    assertFailure(result);
+    expect(result.error.code).toBe("FORBIDDEN");
+  });
+});

--- a/apps/backend/src/experiments/application/use-cases/experiment-protocols/add-experiment-protocols.ts
+++ b/apps/backend/src/experiments/application/use-cases/experiment-protocols/add-experiment-protocols.ts
@@ -1,0 +1,67 @@
+import { Injectable, Logger } from "@nestjs/common";
+
+import { Result, success, failure, AppError } from "../../../../common/utils/fp-utils";
+import { ExperimentProtocolDto } from "../../../core/models/experiment-protocols.model";
+import { ExperimentDto } from "../../../core/models/experiment.model";
+import { ExperimentProtocolRepository } from "../../../core/repositories/experiment-protocol.repository";
+import { ExperimentRepository } from "../../../core/repositories/experiment.repository";
+
+@Injectable()
+export class AddExperimentProtocolsUseCase {
+  private readonly logger = new Logger(AddExperimentProtocolsUseCase.name);
+
+  constructor(
+    private readonly experimentRepository: ExperimentRepository,
+    private readonly experimentProtocolRepository: ExperimentProtocolRepository,
+  ) {}
+
+  async execute(
+    experimentId: string,
+    protocols: { protocolId: string; order?: number }[],
+    currentUserId: string,
+  ): Promise<Result<ExperimentProtocolDto[]>> {
+    this.logger.log(
+      `Adding protocols [${protocols.map((p) => p.protocolId).join(", ")}] to experiment ${experimentId} by user ${currentUserId}`,
+    );
+
+    // Check if the experiment exists and if the user is an admin
+    const accessCheckResult = await this.experimentRepository.checkAccess(
+      experimentId,
+      currentUserId,
+    );
+
+    return accessCheckResult.chain(
+      async ({ experiment, isAdmin }: { experiment: ExperimentDto | null; isAdmin: boolean }) => {
+        if (!experiment) {
+          this.logger.warn(
+            `Attempt to add protocols to non-existent experiment with ID ${experimentId}`,
+          );
+          return failure(AppError.notFound(`Experiment with ID ${experimentId} not found`));
+        }
+
+        if (!isAdmin) {
+          this.logger.warn(`User ${currentUserId} is not admin for experiment ${experimentId}`);
+          return failure(AppError.forbidden("Only admins can add experiment protocols"));
+        }
+
+        // Add the protocols
+        const addProtocolsResult = await this.experimentProtocolRepository.addProtocols(
+          experimentId,
+          protocols,
+        );
+
+        if (addProtocolsResult.isFailure()) {
+          this.logger.error(`Failed to add protocols to experiment ${experimentId}`);
+          return failure(AppError.internal("Failed to add experiment protocols"));
+        }
+
+        this.logger.log(
+          `Successfully added protocols [${protocols
+            .map((p) => p.protocolId)
+            .join(", ")}] to experiment "${experiment.name}" (ID: ${experimentId})`,
+        );
+        return success(addProtocolsResult.value);
+      },
+    );
+  }
+}

--- a/apps/backend/src/experiments/application/use-cases/experiment-protocols/list-experiment-protocols.spec.ts
+++ b/apps/backend/src/experiments/application/use-cases/experiment-protocols/list-experiment-protocols.spec.ts
@@ -1,0 +1,137 @@
+import { assertFailure } from "../../../../common/utils/fp-utils";
+import { TestHarness } from "../../../../test/test-harness";
+import type { ExperimentProtocolDto } from "../../../core/models/experiment-protocols.model";
+import { ListExperimentProtocolsUseCase } from "./list-experiment-protocols";
+
+describe("ListExperimentProtocolsUseCase", () => {
+  const testApp = TestHarness.App;
+  let testUserId: string;
+  let useCase: ListExperimentProtocolsUseCase;
+
+  beforeAll(async () => {
+    await testApp.setup();
+  });
+
+  beforeEach(async () => {
+    await testApp.beforeEach();
+    testUserId = await testApp.createTestUser({});
+    useCase = testApp.module.get(ListExperimentProtocolsUseCase);
+  });
+
+  afterEach(() => {
+    testApp.afterEach();
+  });
+
+  afterAll(async () => {
+    await testApp.teardown();
+  });
+
+  it("should list protocols of an experiment", async () => {
+    // Create an experiment
+    const { experiment } = await testApp.createExperiment({
+      name: "List Protocols Test Experiment",
+      userId: testUserId,
+    });
+
+    // Create and add protocols
+    const protocol1 = await testApp.createProtocol({
+      name: "Protocol 1",
+      createdBy: testUserId,
+    });
+    const protocol2 = await testApp.createProtocol({
+      name: "Protocol 2",
+      createdBy: testUserId,
+    });
+    await testApp.addExperimentProtocol(experiment.id, protocol1.id, 0);
+    await testApp.addExperimentProtocol(experiment.id, protocol2.id, 1);
+
+    // List protocols
+    const result = await useCase.execute(experiment.id, testUserId);
+
+    expect(result.isSuccess()).toBe(true);
+    const protocols = result._tag === "success" ? result.value : [];
+    expect(protocols).toHaveLength(2);
+    // Check that both protocols are present by id and name, using objectContaining for flexibility
+    expect(protocols).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          protocol: expect.objectContaining({
+            id: protocol1.id,
+            name: protocol1.name,
+          }) as Partial<ExperimentProtocolDto>,
+        }),
+        expect.objectContaining({
+          protocol: expect.objectContaining({
+            id: protocol2.id,
+            name: protocol2.name,
+          }) as Partial<ExperimentProtocolDto>,
+        }),
+      ]),
+    );
+  });
+
+  it("should return NOT_FOUND error if experiment does not exist", async () => {
+    const nonExistentId = "00000000-0000-0000-0000-000000000000";
+    const result = await useCase.execute(nonExistentId, testUserId);
+    expect(result.isSuccess()).toBe(false);
+    assertFailure(result);
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should return FORBIDDEN error if user has no access to private experiment", async () => {
+    // Create a private experiment
+    const { experiment } = await testApp.createExperiment({
+      name: "Private Experiment",
+      visibility: "private",
+      userId: testUserId,
+    });
+
+    // Create a user who is not a member
+    const nonMemberId = await testApp.createTestUser({
+      email: "nonmember@example.com",
+    });
+
+    // Try to list protocols as non-member
+    const result = await useCase.execute(experiment.id, nonMemberId);
+    expect(result.isSuccess()).toBe(false);
+    assertFailure(result);
+    expect(result.error.code).toBe("FORBIDDEN");
+  });
+
+  it("should allow any user to list protocols of a public experiment", async () => {
+    // Create a public experiment
+    const { experiment } = await testApp.createExperiment({
+      name: "Public Experiment",
+      visibility: "public",
+      userId: testUserId,
+    });
+
+    // Create and add a protocol
+    const protocol = await testApp.createProtocol({
+      name: "Public Protocol",
+      createdBy: testUserId,
+    });
+    await testApp.addExperimentProtocol(experiment.id, protocol.id, 0);
+
+    // Create a user who is not a member
+    const nonMemberId = await testApp.createTestUser({
+      email: "nonmember@example.com",
+    });
+
+    // List protocols as non-member
+    const result = await useCase.execute(experiment.id, nonMemberId);
+    expect(result.isSuccess()).toBe(true);
+    const protocols = result._tag === "success" ? result.value : [];
+    expect(protocols).toHaveLength(1);
+    expect(protocols).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          protocol: expect.objectContaining({
+            id: protocol.id,
+            name: protocol.name,
+          }) as Partial<ExperimentProtocolDto>,
+        }),
+      ]),
+    );
+  });
+});

--- a/apps/backend/src/experiments/application/use-cases/experiment-protocols/list-experiment-protocols.ts
+++ b/apps/backend/src/experiments/application/use-cases/experiment-protocols/list-experiment-protocols.ts
@@ -1,0 +1,60 @@
+import { Injectable, Logger } from "@nestjs/common";
+
+import { Result, failure, AppError } from "../../../../common/utils/fp-utils";
+import { ExperimentProtocolDto } from "../../../core/models/experiment-protocols.model";
+import { ExperimentDto } from "../../../core/models/experiment.model";
+import { ExperimentProtocolRepository } from "../../../core/repositories/experiment-protocol.repository";
+import { ExperimentRepository } from "../../../core/repositories/experiment.repository";
+
+@Injectable()
+export class ListExperimentProtocolsUseCase {
+  private readonly logger = new Logger(ListExperimentProtocolsUseCase.name);
+
+  constructor(
+    private readonly experimentRepository: ExperimentRepository,
+    private readonly experimentProtocolRepository: ExperimentProtocolRepository,
+  ) {}
+
+  async execute(experimentId: string, userId: string): Promise<Result<ExperimentProtocolDto[]>> {
+    this.logger.log(`Listing protocols of experiment ${experimentId} for user ${userId}`);
+
+    // Check if experiment exists and if user has access
+    const accessResult = await this.experimentRepository.checkAccess(experimentId, userId);
+
+    return accessResult.chain(
+      async ({
+        experiment,
+        hasAccess,
+      }: {
+        experiment: ExperimentDto | null;
+        hasAccess: boolean;
+        isAdmin: boolean;
+      }) => {
+        if (!experiment) {
+          this.logger.warn(
+            `Attempt to list protocols of non-existent experiment with ID ${experimentId}`,
+          );
+          return failure(AppError.notFound(`Experiment with ID ${experimentId} not found`));
+        }
+
+        if (!hasAccess && experiment.visibility !== "public") {
+          this.logger.warn(
+            `User ${userId} attempted to access protocols of experiment ${experimentId} without proper permissions`,
+          );
+          return failure(AppError.forbidden("You do not have access to this experiment"));
+        }
+
+        this.logger.debug(
+          `Fetching protocols for experiment "${experiment.name}" (ID: ${experimentId})`,
+        );
+        // Return the protocols
+        const result = this.experimentProtocolRepository.listProtocols(experimentId);
+
+        this.logger.debug(
+          `Successfully retrieved protocols for experiment "${experiment.name}" (ID: ${experimentId})`,
+        );
+        return result;
+      },
+    );
+  }
+}

--- a/apps/backend/src/experiments/application/use-cases/experiment-protocols/remove-experiment-protocol.spec.ts
+++ b/apps/backend/src/experiments/application/use-cases/experiment-protocols/remove-experiment-protocol.spec.ts
@@ -1,0 +1,97 @@
+import { assertFailure } from "../../../../common/utils/fp-utils";
+import { TestHarness } from "../../../../test/test-harness";
+import { RemoveExperimentProtocolUseCase } from "./remove-experiment-protocol";
+
+describe("RemoveExperimentProtocolUseCase", () => {
+  const testApp = TestHarness.App;
+  let testUserId: string;
+  let useCase: RemoveExperimentProtocolUseCase;
+
+  beforeAll(async () => {
+    await testApp.setup();
+  });
+
+  beforeEach(async () => {
+    await testApp.beforeEach();
+    testUserId = await testApp.createTestUser({});
+    useCase = testApp.module.get(RemoveExperimentProtocolUseCase);
+  });
+
+  afterEach(() => {
+    testApp.afterEach();
+  });
+
+  afterAll(async () => {
+    await testApp.teardown();
+  });
+
+  it("should allow admin to remove a protocol", async () => {
+    // Create an experiment (creator is admin)
+    const { experiment } = await testApp.createExperiment({
+      name: "Remove Protocol Test Experiment",
+      userId: testUserId,
+    });
+
+    // Create a protocol and associate it
+    const protocol = await testApp.createProtocol({
+      name: "Test Protocol",
+      createdBy: testUserId,
+    });
+    await testApp.addExperimentProtocol(experiment.id, protocol.id);
+
+    // Remove the protocol as admin
+    const result = await useCase.execute(experiment.id, protocol.id, testUserId);
+    expect(result.isSuccess()).toBe(true);
+  });
+
+  it("should return NOT_FOUND error if experiment does not exist", async () => {
+    const nonExistentId = "00000000-0000-0000-0000-000000000000";
+    const protocol = await testApp.createProtocol({
+      name: "Nonexistent Protocol",
+      createdBy: testUserId,
+    });
+    const result = await useCase.execute(nonExistentId, protocol.id, testUserId);
+    expect(result.isSuccess()).toBe(false);
+    assertFailure(result);
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should return FORBIDDEN error if user is not an admin", async () => {
+    // Create experiment and admin
+    const { experiment } = await testApp.createExperiment({
+      name: "Forbidden Protocol Remove Test",
+      userId: testUserId,
+    });
+    // Create a regular user
+    const regularUserId = await testApp.createTestUser({ email: "regular@example.com" });
+    // Create and associate protocol
+    const protocol = await testApp.createProtocol({
+      name: "Test Protocol",
+      createdBy: testUserId,
+    });
+    await testApp.addExperimentProtocol(experiment.id, protocol.id);
+    // Try to remove as non-admin
+    const result = await useCase.execute(experiment.id, protocol.id, regularUserId);
+    expect(result.isSuccess()).toBe(false);
+    assertFailure(result);
+    expect(result.error.code).toBe("FORBIDDEN");
+  });
+
+  it("should return NOT_FOUND error if protocol is not associated", async () => {
+    // Create experiment and admin
+    const { experiment } = await testApp.createExperiment({
+      name: "Protocol Not Found Test",
+      userId: testUserId,
+    });
+    // Create a protocol but do not associate
+    const protocol = await testApp.createProtocol({
+      name: "Unlinked Protocol",
+      createdBy: testUserId,
+    });
+    // Try to remove unassociated protocol
+    const result = await useCase.execute(experiment.id, protocol.id, testUserId);
+    expect(result.isSuccess()).toBe(false);
+    assertFailure(result);
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/apps/backend/src/experiments/application/use-cases/experiment-protocols/remove-experiment-protocol.ts
+++ b/apps/backend/src/experiments/application/use-cases/experiment-protocols/remove-experiment-protocol.ts
@@ -1,0 +1,79 @@
+import { Injectable, Logger } from "@nestjs/common";
+
+import { Result, failure, AppError } from "../../../../common/utils/fp-utils";
+import { ExperimentProtocolRepository } from "../../../core/repositories/experiment-protocol.repository";
+import { ExperimentRepository } from "../../../core/repositories/experiment.repository";
+
+@Injectable()
+export class RemoveExperimentProtocolUseCase {
+  private readonly logger = new Logger(RemoveExperimentProtocolUseCase.name);
+
+  constructor(
+    private readonly experimentRepository: ExperimentRepository,
+    private readonly experimentProtocolRepository: ExperimentProtocolRepository,
+  ) {}
+
+  async execute(
+    experimentId: string,
+    protocolId: string,
+    currentUserId: string,
+  ): Promise<Result<void>> {
+    this.logger.log(
+      `Removing protocol ${protocolId} from experiment ${experimentId} by user ${currentUserId}`,
+    );
+
+    // Check if experiment exists and if user is admin
+    const accessResult = await this.experimentRepository.checkAccess(experimentId, currentUserId);
+
+    return accessResult.chain(
+      async ({ experiment, isAdmin }: { experiment: any; isAdmin: boolean }) => {
+        if (!experiment) {
+          this.logger.warn(
+            `Attempt to remove protocol from non-existent experiment with ID ${experimentId}`,
+          );
+          return failure(AppError.notFound(`Experiment with ID ${experimentId} not found`));
+        }
+
+        if (!isAdmin) {
+          this.logger.warn(
+            `User ${currentUserId} attempted to remove protocol from experiment ${experimentId} without admin privileges`,
+          );
+          return failure(AppError.forbidden("Only experiment admins can remove protocols"));
+        }
+
+        // Check if protocol association exists before removing
+        const protocolsResult = await this.experimentProtocolRepository.listProtocols(experimentId);
+        if (protocolsResult.isFailure()) {
+          this.logger.error(`Failed to fetch protocols for experiment ${experimentId}`);
+          return failure(AppError.internal("Failed to fetch experiment protocols"));
+        }
+        const protocols = protocolsResult.value;
+        const protocolExists = protocols.some((p) => p.protocol.id === protocolId);
+        if (!protocolExists) {
+          this.logger.warn(
+            `Attempt to remove non-existent protocol ${protocolId} from experiment ${experimentId}`,
+          );
+          return failure(
+            AppError.notFound(`Protocol with ID ${protocolId} not found in this experiment`),
+          );
+        }
+
+        // Remove the protocol association
+        const removeResult = await this.experimentProtocolRepository.removeProtocols(experimentId, [
+          protocolId,
+        ]);
+        if (removeResult.isFailure()) {
+          this.logger.error(
+            `Failed to remove protocol ${protocolId} from experiment ${experimentId}`,
+          );
+          return failure(AppError.internal("Failed to remove experiment protocol"));
+        }
+
+        this.logger.log(
+          `Successfully removed protocol ${protocolId} from experiment (ID: ${experimentId})`,
+        );
+        return removeResult;
+      },
+    );
+  }
+}

--- a/apps/backend/src/experiments/core/models/experiment-protocols.model.ts
+++ b/apps/backend/src/experiments/core/models/experiment-protocols.model.ts
@@ -11,7 +11,7 @@ export const experimentProtocolSchema = createSelectSchema(experimentProtocols)
       id: z.string().uuid(),
       name: z.string(),
       family: z.enum(["multispeq", "ambit"]),
-      createdby: z.string().uuid(),
+      createdBy: z.string().uuid(),
     }),
   });
 

--- a/apps/backend/src/experiments/core/models/experiment-protocols.model.ts
+++ b/apps/backend/src/experiments/core/models/experiment-protocols.model.ts
@@ -1,0 +1,19 @@
+import { createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+
+import { experimentProtocols } from "@repo/database";
+
+// Schema for returning experiment protocols
+export const experimentProtocolSchema = createSelectSchema(experimentProtocols)
+  .omit({ protocolId: true })
+  .extend({
+    protocol: z.object({
+      id: z.string().uuid(),
+      name: z.string(),
+      family: z.enum(["multispeq", "ambit"]),
+      createdby: z.string().uuid(),
+    }),
+  });
+
+// DTOs
+export type ExperimentProtocolDto = typeof experimentProtocolSchema._type;

--- a/apps/backend/src/experiments/core/models/experiment.model.ts
+++ b/apps/backend/src/experiments/core/models/experiment.model.ts
@@ -24,6 +24,9 @@ export const createExperimentSchema = createInsertSchema(experiments)
       )
       .min(1)
       .optional(),
+    protocols: z
+      .array(z.object({ protocolId: z.string(), order: z.number().optional() }))
+      .optional(),
   });
 export const updateExperimentSchema = createInsertSchema(experiments).partial().omit({
   id: true,

--- a/apps/backend/src/experiments/core/repositories/experiment-protocol.repository.spec.ts
+++ b/apps/backend/src/experiments/core/repositories/experiment-protocol.repository.spec.ts
@@ -1,0 +1,145 @@
+import { assertSuccess } from "../../../common/utils/fp-utils";
+import { TestHarness } from "../../../test/test-harness";
+import { ExperimentProtocolRepository } from "./experiment-protocol.repository";
+
+describe("ExperimentProtocolRepository", () => {
+  const testApp = TestHarness.App;
+  let repository: ExperimentProtocolRepository;
+  let testUserId: string;
+  let experimentId: string;
+  let protocolId1: string;
+  let protocolId2: string;
+
+  beforeAll(async () => {
+    await testApp.setup();
+  });
+
+  beforeEach(async () => {
+    await testApp.beforeEach();
+    testUserId = await testApp.createTestUser({});
+    repository = testApp.module.get(ExperimentProtocolRepository);
+    // Create experiment and two protocols
+    const { experiment } = await testApp.createExperiment({
+      name: "Experiment for Protocols",
+      userId: testUserId,
+    });
+    experimentId = experiment.id;
+    protocolId1 = (await testApp.createProtocol({ name: "Protocol 1", createdBy: testUserId })).id;
+    protocolId2 = (await testApp.createProtocol({ name: "Protocol 2", createdBy: testUserId })).id;
+  });
+
+  afterEach(() => {
+    testApp.afterEach();
+  });
+
+  afterAll(async () => {
+    await testApp.teardown();
+  });
+
+  describe("addProtocols", () => {
+    it("should add multiple protocols to an experiment with order", async () => {
+      const result = await repository.addProtocols(experimentId, [
+        { protocolId: protocolId1, order: 0 },
+        { protocolId: protocolId2, order: 1 },
+      ]);
+      expect(result.isSuccess()).toBe(true);
+      assertSuccess(result);
+      const protocols = result.value;
+      expect(protocols.length).toBe(2);
+      expect(protocols[0]).toMatchObject({ order: 0 });
+      expect(protocols[0].protocol.id).toBe(protocolId1);
+      expect(protocols[1]).toMatchObject({ order: 1 });
+      expect(protocols[1].protocol.id).toBe(protocolId2);
+    });
+
+    it("should return empty array and not fail if protocols array is empty", async () => {
+      const result = await repository.addProtocols(experimentId, []);
+      expect(result.isSuccess()).toBe(true);
+      assertSuccess(result);
+      expect(result.value).toEqual([]);
+    });
+  });
+
+  describe("listProtocols", () => {
+    it("should return all protocols for an experiment", async () => {
+      await repository.addProtocols(experimentId, [
+        { protocolId: protocolId1, order: 0 },
+        { protocolId: protocolId2, order: 1 },
+      ]);
+      const result = await repository.listProtocols(experimentId);
+      expect(result.isSuccess()).toBe(true);
+      assertSuccess(result);
+      const protocols = result.value;
+      expect(protocols.length).toBe(2);
+      expect(protocols.map((p) => p.protocol.id)).toEqual(
+        expect.arrayContaining([protocolId1, protocolId2]),
+      );
+    });
+
+    it("should return empty array when experiment has no protocols", async () => {
+      const result = await repository.listProtocols(experimentId);
+      expect(result.isSuccess()).toBe(true);
+      assertSuccess(result);
+      expect(result.value).toEqual([]);
+    });
+  });
+
+  describe("removeProtocols", () => {
+    it("should remove a protocol from an experiment", async () => {
+      await repository.addProtocols(experimentId, [
+        { protocolId: protocolId1, order: 0 },
+        { protocolId: protocolId2, order: 1 },
+      ]);
+      const removeResult = await repository.removeProtocols(experimentId, [protocolId1]);
+      expect(removeResult.isSuccess()).toBe(true);
+      assertSuccess(removeResult);
+      // Only protocolId2 should remain
+      const listResult = await repository.listProtocols(experimentId);
+      assertSuccess(listResult);
+      const protocols = listResult.value;
+      expect(protocols.length).toBe(1);
+      expect(protocols[0].protocol.id).toBe(protocolId2);
+    });
+
+    it("should remove multiple protocols at once", async () => {
+      // Add three protocols
+      const protocolId3 = (
+        await testApp.createProtocol({ name: "Protocol 3", createdBy: testUserId })
+      ).id;
+      await repository.addProtocols(experimentId, [
+        { protocolId: protocolId1, order: 0 },
+        { protocolId: protocolId2, order: 1 },
+        { protocolId: protocolId3, order: 2 },
+      ]);
+      // Remove two protocols at once
+      const removeResult = await repository.removeProtocols(experimentId, [
+        protocolId1,
+        protocolId3,
+      ]);
+      expect(removeResult.isSuccess()).toBe(true);
+      assertSuccess(removeResult);
+      // Only protocolId2 should remain
+      const listResult = await repository.listProtocols(experimentId);
+      assertSuccess(listResult);
+      const protocols = listResult.value;
+      expect(protocols.length).toBe(1);
+      expect(protocols[0].protocol.id).toBe(protocolId2);
+    });
+  });
+
+  describe("updateProtocolOrder", () => {
+    it("should update the order of a protocol", async () => {
+      await repository.addProtocols(experimentId, [
+        { protocolId: protocolId1, order: 0 },
+        { protocolId: protocolId2, order: 1 },
+      ]);
+      const updateResult = await repository.updateProtocolOrder(experimentId, protocolId1, 5);
+      expect(updateResult.isSuccess()).toBe(true);
+      assertSuccess(updateResult);
+      const listResult = await repository.listProtocols(experimentId);
+      assertSuccess(listResult);
+      const updated = listResult.value.find((p) => p.protocol.id === protocolId1);
+      expect(updated?.order).toBe(5);
+    });
+  });
+});

--- a/apps/backend/src/experiments/core/repositories/experiment-protocol.repository.ts
+++ b/apps/backend/src/experiments/core/repositories/experiment-protocol.repository.ts
@@ -1,0 +1,107 @@
+import { Injectable, Inject } from "@nestjs/common";
+
+import { and, eq, experimentProtocols, inArray, protocols } from "@repo/database";
+import type { DatabaseInstance } from "@repo/database";
+
+import { Result, tryCatch } from "../../../common/utils/fp-utils";
+import { ExperimentProtocolDto } from "../models/experiment-protocols.model";
+
+@Injectable()
+export class ExperimentProtocolRepository {
+  constructor(
+    @Inject("DATABASE")
+    private readonly database: DatabaseInstance,
+  ) {}
+
+  async listProtocols(experimentId: string): Promise<Result<ExperimentProtocolDto[]>> {
+    return tryCatch(async () => {
+      return this.database
+        .select({
+          experimentId: experimentProtocols.experimentId,
+          order: experimentProtocols.order,
+          addedAt: experimentProtocols.addedAt,
+          protocol: {
+            id: protocols.id,
+            name: protocols.name,
+            family: protocols.family,
+            createdby: protocols.createdBy,
+          },
+        })
+        .from(experimentProtocols)
+        .innerJoin(protocols, eq(experimentProtocols.protocolId, protocols.id))
+        .where(eq(experimentProtocols.experimentId, experimentId))
+        .orderBy(experimentProtocols.order);
+    });
+  }
+
+  async addProtocols(
+    experimentId: string,
+    protocolsToAdd: { protocolId: string; order?: number }[],
+  ): Promise<Result<ExperimentProtocolDto[]>> {
+    return tryCatch(async () => {
+      if (!protocolsToAdd.length) return [];
+      await this.database.insert(experimentProtocols).values(
+        protocolsToAdd.map((p, idx) => ({
+          experimentId,
+          protocolId: p.protocolId,
+          order: p.order ?? idx,
+        })),
+      );
+      const protocolIds = protocolsToAdd.map((p) => p.protocolId);
+      return this.database
+        .select({
+          experimentId: experimentProtocols.experimentId,
+          order: experimentProtocols.order,
+          addedAt: experimentProtocols.addedAt,
+          protocol: {
+            id: protocols.id,
+            name: protocols.name,
+            family: protocols.family,
+            createdby: protocols.createdBy,
+          },
+        })
+        .from(experimentProtocols)
+        .innerJoin(protocols, eq(experimentProtocols.protocolId, protocols.id))
+        .where(
+          and(
+            eq(experimentProtocols.experimentId, experimentId),
+            inArray(experimentProtocols.protocolId, protocolIds),
+          ),
+        )
+        .orderBy(experimentProtocols.order);
+    });
+  }
+
+  async removeProtocols(experimentId: string, protocolIds: string[]): Promise<Result<void>> {
+    return tryCatch(async () => {
+      await this.database
+        .delete(experimentProtocols)
+        .where(
+          and(
+            eq(experimentProtocols.experimentId, experimentId),
+            inArray(experimentProtocols.protocolId, protocolIds),
+          ),
+        );
+      return undefined;
+    });
+  }
+
+  async updateProtocolOrder(
+    experimentId: string,
+    protocolId: string,
+    order: number,
+  ): Promise<Result<void>> {
+    return tryCatch(async () => {
+      await this.database
+        .update(experimentProtocols)
+        .set({ order })
+        .where(
+          and(
+            eq(experimentProtocols.experimentId, experimentId),
+            eq(experimentProtocols.protocolId, protocolId),
+          ),
+        );
+      return undefined;
+    });
+  }
+}

--- a/apps/backend/src/experiments/core/repositories/experiment-protocol.repository.ts
+++ b/apps/backend/src/experiments/core/repositories/experiment-protocol.repository.ts
@@ -24,7 +24,7 @@ export class ExperimentProtocolRepository {
             id: protocols.id,
             name: protocols.name,
             family: protocols.family,
-            createdby: protocols.createdBy,
+            createdBy: protocols.createdBy,
           },
         })
         .from(experimentProtocols)
@@ -57,7 +57,7 @@ export class ExperimentProtocolRepository {
             id: protocols.id,
             name: protocols.name,
             family: protocols.family,
-            createdby: protocols.createdBy,
+            createdBy: protocols.createdBy,
           },
         })
         .from(experimentProtocols)

--- a/apps/backend/src/experiments/experiment.module.ts
+++ b/apps/backend/src/experiments/experiment.module.ts
@@ -24,6 +24,7 @@ import { ExperimentRepository } from "./core/repositories/experiment.repository"
 import { ExperimentDataController } from "./presentation/experiment-data.controller";
 import { ExperimentMembersController } from "./presentation/experiment-members.controller";
 import { ExperimentProtocolsController } from "./presentation/experiment-protocols.controller";
+import { ExperimentWebhookController } from "./presentation/experiment-webhook.controller";
 import { ExperimentController } from "./presentation/experiment.controller";
 
 @Module({
@@ -32,6 +33,7 @@ import { ExperimentController } from "./presentation/experiment.controller";
     ExperimentController,
     ExperimentDataController,
     ExperimentMembersController,
+    ExperimentWebhookController,
     ExperimentProtocolsController,
   ],
   providers: [

--- a/apps/backend/src/experiments/experiment.module.ts
+++ b/apps/backend/src/experiments/experiment.module.ts
@@ -9,17 +9,21 @@ import { GetExperimentDataUseCase } from "./application/use-cases/experiment-dat
 import { AddExperimentMembersUseCase } from "./application/use-cases/experiment-members/add-experiment-members";
 import { ListExperimentMembersUseCase } from "./application/use-cases/experiment-members/list-experiment-members";
 import { RemoveExperimentMemberUseCase } from "./application/use-cases/experiment-members/remove-experiment-member";
+import { AddExperimentProtocolsUseCase } from "./application/use-cases/experiment-protocols/add-experiment-protocols";
+import { ListExperimentProtocolsUseCase } from "./application/use-cases/experiment-protocols/list-experiment-protocols";
+import { RemoveExperimentProtocolUseCase } from "./application/use-cases/experiment-protocols/remove-experiment-protocol";
 import { GetExperimentUseCase } from "./application/use-cases/get-experiment/get-experiment";
 import { ListExperimentsUseCase } from "./application/use-cases/list-experiments/list-experiments";
 import { UpdateExperimentUseCase } from "./application/use-cases/update-experiment/update-experiment";
 import { UpdateProvisioningStatusUseCase } from "./application/use-cases/update-provisioning-status/update-provisioning-status";
 // Repositories
 import { ExperimentMemberRepository } from "./core/repositories/experiment-member.repository";
+import { ExperimentProtocolRepository } from "./core/repositories/experiment-protocol.repository";
 import { ExperimentRepository } from "./core/repositories/experiment.repository";
 // Controllers
 import { ExperimentDataController } from "./presentation/experiment-data.controller";
 import { ExperimentMembersController } from "./presentation/experiment-members.controller";
-import { ExperimentWebhookController } from "./presentation/experiment-webhook.controller";
+import { ExperimentProtocolsController } from "./presentation/experiment-protocols.controller";
 import { ExperimentController } from "./presentation/experiment.controller";
 
 @Module({
@@ -28,12 +32,13 @@ import { ExperimentController } from "./presentation/experiment.controller";
     ExperimentController,
     ExperimentDataController,
     ExperimentMembersController,
-    ExperimentWebhookController,
+    ExperimentProtocolsController,
   ],
   providers: [
     // Repositories
     ExperimentRepository,
     ExperimentMemberRepository,
+    ExperimentProtocolRepository,
 
     // General experiment use cases
     CreateExperimentUseCase,
@@ -51,6 +56,11 @@ import { ExperimentController } from "./presentation/experiment.controller";
     ListExperimentMembersUseCase,
     AddExperimentMembersUseCase,
     RemoveExperimentMemberUseCase,
+
+    // Experiment protocol use cases
+    AddExperimentProtocolsUseCase,
+    ListExperimentProtocolsUseCase,
+    RemoveExperimentProtocolUseCase,
   ],
   exports: [ExperimentRepository, ExperimentMemberRepository],
 })

--- a/apps/backend/src/experiments/presentation/experiment-protocols.controller.spec.ts
+++ b/apps/backend/src/experiments/presentation/experiment-protocols.controller.spec.ts
@@ -47,7 +47,7 @@ describe("ExperimentProtocolsController", () => {
       await testApp.addExperimentProtocol(experiment.id, protocol1.id, 0);
       await testApp.addExperimentProtocol(experiment.id, protocol2.id, 1);
 
-      const path = testApp.resolvePath(contract.protocols.listExperimentProtocols.path, {
+      const path = testApp.resolvePath(contract.experiments.listExperimentProtocols.path, {
         id: experiment.id,
       });
 
@@ -75,7 +75,7 @@ describe("ExperimentProtocolsController", () => {
 
     it("should return 404 if experiment doesn't exist", async () => {
       const nonExistentId = "00000000-0000-0000-0000-000000000000";
-      const path = testApp.resolvePath(contract.protocols.listExperimentProtocols.path, {
+      const path = testApp.resolvePath(contract.experiments.listExperimentProtocols.path, {
         id: nonExistentId,
       });
       await testApp.get(path).withAuth(testUserId).expect(StatusCodes.NOT_FOUND);
@@ -83,7 +83,7 @@ describe("ExperimentProtocolsController", () => {
 
     it("should return 400 for invalid experiment UUID", async () => {
       const invalidId = "not-a-uuid";
-      const path = testApp.resolvePath(contract.protocols.listExperimentProtocols.path, {
+      const path = testApp.resolvePath(contract.experiments.listExperimentProtocols.path, {
         id: invalidId,
       });
       await testApp.get(path).withAuth(testUserId).expect(StatusCodes.BAD_REQUEST);
@@ -94,7 +94,7 @@ describe("ExperimentProtocolsController", () => {
         name: "Test Experiment for Protocols List",
         userId: testUserId,
       });
-      const path = testApp.resolvePath(contract.protocols.listExperimentProtocols.path, {
+      const path = testApp.resolvePath(contract.experiments.listExperimentProtocols.path, {
         id: experiment.id,
       });
       await testApp.get(path).withoutAuth().expect(StatusCodes.UNAUTHORIZED);
@@ -118,7 +118,7 @@ describe("ExperimentProtocolsController", () => {
         family: "ambit",
       });
 
-      const path = testApp.resolvePath(contract.protocols.addExperimentProtocols.path, {
+      const path = testApp.resolvePath(contract.experiments.addExperimentProtocols.path, {
         id: experiment.id,
       });
       const body = {
@@ -146,7 +146,7 @@ describe("ExperimentProtocolsController", () => {
         createdBy: testUserId,
         family: "multispeq",
       });
-      const path = testApp.resolvePath(contract.protocols.addExperimentProtocols.path, {
+      const path = testApp.resolvePath(contract.experiments.addExperimentProtocols.path, {
         id: nonExistentId,
       });
       await testApp
@@ -161,7 +161,7 @@ describe("ExperimentProtocolsController", () => {
         name: "Test Experiment for Invalid Protocol Data",
         userId: testUserId,
       });
-      const path = testApp.resolvePath(contract.protocols.addExperimentProtocols.path, {
+      const path = testApp.resolvePath(contract.experiments.addExperimentProtocols.path, {
         id: experiment.id,
       });
       // Missing protocolId
@@ -188,7 +188,7 @@ describe("ExperimentProtocolsController", () => {
         createdBy: testUserId,
         family: "multispeq",
       });
-      const path = testApp.resolvePath(contract.protocols.addExperimentProtocols.path, {
+      const path = testApp.resolvePath(contract.experiments.addExperimentProtocols.path, {
         id: experiment.id,
       });
       await testApp
@@ -212,7 +212,7 @@ describe("ExperimentProtocolsController", () => {
       });
       await testApp.addExperimentProtocol(experiment.id, protocol1.id, 0);
 
-      const path = testApp.resolvePath(contract.protocols.removeExperimentProtocol.path, {
+      const path = testApp.resolvePath(contract.experiments.removeExperimentProtocol.path, {
         id: experiment.id,
         protocolId: protocol1.id,
       });
@@ -220,7 +220,7 @@ describe("ExperimentProtocolsController", () => {
       await testApp.delete(path).withAuth(testUserId).expect(StatusCodes.NO_CONTENT);
 
       // Should be empty after removal
-      const listPath = testApp.resolvePath(contract.protocols.listExperimentProtocols.path, {
+      const listPath = testApp.resolvePath(contract.experiments.listExperimentProtocols.path, {
         id: experiment.id,
       });
       const listResponse = await testApp.get(listPath).withAuth(testUserId).expect(StatusCodes.OK);
@@ -234,7 +234,7 @@ describe("ExperimentProtocolsController", () => {
         createdBy: testUserId,
         family: "multispeq",
       });
-      const path = testApp.resolvePath(contract.protocols.removeExperimentProtocol.path, {
+      const path = testApp.resolvePath(contract.experiments.removeExperimentProtocol.path, {
         id: nonExistentId,
         protocolId: protocol1.id,
       });
@@ -247,7 +247,7 @@ describe("ExperimentProtocolsController", () => {
         userId: testUserId,
       });
       const nonExistentProtocolId = "00000000-0000-0000-0000-000000000000";
-      const path = testApp.resolvePath(contract.protocols.removeExperimentProtocol.path, {
+      const path = testApp.resolvePath(contract.experiments.removeExperimentProtocol.path, {
         id: experiment.id,
         protocolId: nonExistentProtocolId,
       });
@@ -259,7 +259,7 @@ describe("ExperimentProtocolsController", () => {
         name: "Test Experiment for Protocol Remove Invalid",
         userId: testUserId,
       });
-      const path = testApp.resolvePath(contract.protocols.removeExperimentProtocol.path, {
+      const path = testApp.resolvePath(contract.experiments.removeExperimentProtocol.path, {
         id: experiment.id,
         protocolId: "not-a-uuid",
       });
@@ -277,7 +277,7 @@ describe("ExperimentProtocolsController", () => {
         family: "multispeq",
       });
       await testApp.addExperimentProtocol(experiment.id, protocol1.id, 0);
-      const path = testApp.resolvePath(contract.protocols.removeExperimentProtocol.path, {
+      const path = testApp.resolvePath(contract.experiments.removeExperimentProtocol.path, {
         id: experiment.id,
         protocolId: protocol1.id,
       });

--- a/apps/backend/src/experiments/presentation/experiment-protocols.controller.spec.ts
+++ b/apps/backend/src/experiments/presentation/experiment-protocols.controller.spec.ts
@@ -1,0 +1,287 @@
+import { StatusCodes } from "http-status-codes";
+
+import { contract } from "@repo/api";
+
+import { TestHarness } from "../../test/test-harness";
+import type { ExperimentProtocolDto } from "../core/models/experiment-protocols.model";
+
+describe("ExperimentProtocolsController", () => {
+  const testApp = TestHarness.App;
+  let testUserId: string;
+
+  beforeAll(async () => {
+    await testApp.setup();
+  });
+
+  beforeEach(async () => {
+    await testApp.beforeEach();
+    testUserId = await testApp.createTestUser({});
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    testApp.afterEach();
+  });
+
+  afterAll(async () => {
+    await testApp.teardown();
+  });
+
+  describe("listExperimentProtocols", () => {
+    it("should return all protocols of an experiment", async () => {
+      // Create experiment and protocols
+      const { experiment } = await testApp.createExperiment({
+        name: "Test Experiment for Protocols List",
+        userId: testUserId,
+      });
+      const protocol1 = await testApp.createProtocol({
+        name: "Protocol 1",
+        createdBy: testUserId,
+        family: "multispeq",
+      });
+      const protocol2 = await testApp.createProtocol({
+        name: "Protocol 2",
+        createdBy: testUserId,
+        family: "ambit",
+      });
+      await testApp.addExperimentProtocol(experiment.id, protocol1.id, 0);
+      await testApp.addExperimentProtocol(experiment.id, protocol2.id, 1);
+
+      const path = testApp.resolvePath(contract.protocols.listExperimentProtocols.path, {
+        id: experiment.id,
+      });
+
+      const response = await testApp.get(path).withAuth(testUserId).expect(StatusCodes.OK);
+      expect(response.body).toHaveLength(2);
+      expect(response.body).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            order: 0,
+            protocol: expect.objectContaining({
+              id: protocol1.id,
+              family: "multispeq",
+            }) as Partial<ExperimentProtocolDto>,
+          }),
+          expect.objectContaining({
+            order: 1,
+            protocol: expect.objectContaining({
+              id: protocol2.id,
+              family: "ambit",
+            }) as Partial<ExperimentProtocolDto>,
+          }),
+        ]),
+      );
+    });
+
+    it("should return 404 if experiment doesn't exist", async () => {
+      const nonExistentId = "00000000-0000-0000-0000-000000000000";
+      const path = testApp.resolvePath(contract.protocols.listExperimentProtocols.path, {
+        id: nonExistentId,
+      });
+      await testApp.get(path).withAuth(testUserId).expect(StatusCodes.NOT_FOUND);
+    });
+
+    it("should return 400 for invalid experiment UUID", async () => {
+      const invalidId = "not-a-uuid";
+      const path = testApp.resolvePath(contract.protocols.listExperimentProtocols.path, {
+        id: invalidId,
+      });
+      await testApp.get(path).withAuth(testUserId).expect(StatusCodes.BAD_REQUEST);
+    });
+
+    it("should return 401 if not authenticated", async () => {
+      const { experiment } = await testApp.createExperiment({
+        name: "Test Experiment for Protocols List",
+        userId: testUserId,
+      });
+      const path = testApp.resolvePath(contract.protocols.listExperimentProtocols.path, {
+        id: experiment.id,
+      });
+      await testApp.get(path).withoutAuth().expect(StatusCodes.UNAUTHORIZED);
+    });
+  });
+
+  describe("addExperimentProtocols", () => {
+    it("should add new protocols to an experiment", async () => {
+      const { experiment } = await testApp.createExperiment({
+        name: "Test Experiment for Adding Protocols",
+        userId: testUserId,
+      });
+      const protocol1 = await testApp.createProtocol({
+        name: "Protocol 1",
+        createdBy: testUserId,
+        family: "multispeq",
+      });
+      const protocol2 = await testApp.createProtocol({
+        name: "Protocol 2",
+        createdBy: testUserId,
+        family: "ambit",
+      });
+
+      const path = testApp.resolvePath(contract.protocols.addExperimentProtocols.path, {
+        id: experiment.id,
+      });
+      const body = {
+        protocols: [
+          { protocolId: protocol1.id, order: 0 },
+          { protocolId: protocol2.id, order: 1 },
+        ],
+      };
+
+      const response = await testApp
+        .post(path)
+        .withAuth(testUserId)
+        .send(body)
+        .expect(StatusCodes.CREATED);
+      const protocols = response.body as ExperimentProtocolDto[];
+      expect(protocols).toHaveLength(2);
+      expect(protocols.some((p) => p.protocol.id === protocol1.id && p.order === 0)).toBe(true);
+      expect(protocols.some((p) => p.protocol.id === protocol2.id && p.order === 1)).toBe(true);
+    });
+
+    it("should return 404 when adding protocols to non-existent experiment", async () => {
+      const nonExistentId = "00000000-0000-0000-0000-000000000000";
+      const protocol1 = await testApp.createProtocol({
+        name: "Protocol 1",
+        createdBy: testUserId,
+        family: "multispeq",
+      });
+      const path = testApp.resolvePath(contract.protocols.addExperimentProtocols.path, {
+        id: nonExistentId,
+      });
+      await testApp
+        .post(path)
+        .withAuth(testUserId)
+        .send({ protocols: [{ protocolId: protocol1.id, order: 0 }] })
+        .expect(StatusCodes.NOT_FOUND);
+    });
+
+    it("should return 400 for invalid protocol data", async () => {
+      const { experiment } = await testApp.createExperiment({
+        name: "Test Experiment for Invalid Protocol Data",
+        userId: testUserId,
+      });
+      const path = testApp.resolvePath(contract.protocols.addExperimentProtocols.path, {
+        id: experiment.id,
+      });
+      // Missing protocolId
+      await testApp
+        .post(path)
+        .withAuth(testUserId)
+        .send({ protocols: [{ order: 0 }] })
+        .expect(StatusCodes.BAD_REQUEST);
+      // Invalid order type
+      await testApp
+        .post(path)
+        .withAuth(testUserId)
+        .send({ protocols: [{ protocolId: "not-a-uuid", order: "first" }] })
+        .expect(StatusCodes.BAD_REQUEST);
+    });
+
+    it("should return 401 if not authenticated", async () => {
+      const { experiment } = await testApp.createExperiment({
+        name: "Test Experiment for Protocols Add",
+        userId: testUserId,
+      });
+      const protocol1 = await testApp.createProtocol({
+        name: "Protocol 1",
+        createdBy: testUserId,
+        family: "multispeq",
+      });
+      const path = testApp.resolvePath(contract.protocols.addExperimentProtocols.path, {
+        id: experiment.id,
+      });
+      await testApp
+        .post(path)
+        .withoutAuth()
+        .send({ protocols: [{ protocolId: protocol1.id, order: 0 }] })
+        .expect(StatusCodes.UNAUTHORIZED);
+    });
+  });
+
+  describe("removeExperimentProtocol", () => {
+    it("should remove a protocol from an experiment", async () => {
+      const { experiment } = await testApp.createExperiment({
+        name: "Test Experiment for Removing Protocol",
+        userId: testUserId,
+      });
+      const protocol1 = await testApp.createProtocol({
+        name: "Protocol 1",
+        createdBy: testUserId,
+        family: "multispeq",
+      });
+      await testApp.addExperimentProtocol(experiment.id, protocol1.id, 0);
+
+      const path = testApp.resolvePath(contract.protocols.removeExperimentProtocol.path, {
+        id: experiment.id,
+        protocolId: protocol1.id,
+      });
+
+      await testApp.delete(path).withAuth(testUserId).expect(StatusCodes.NO_CONTENT);
+
+      // Should be empty after removal
+      const listPath = testApp.resolvePath(contract.protocols.listExperimentProtocols.path, {
+        id: experiment.id,
+      });
+      const listResponse = await testApp.get(listPath).withAuth(testUserId).expect(StatusCodes.OK);
+      expect(listResponse.body).toHaveLength(0);
+    });
+
+    it("should return 404 when removing protocol from non-existent experiment", async () => {
+      const nonExistentId = "00000000-0000-0000-0000-000000000000";
+      const protocol1 = await testApp.createProtocol({
+        name: "Protocol 1",
+        createdBy: testUserId,
+        family: "multispeq",
+      });
+      const path = testApp.resolvePath(contract.protocols.removeExperimentProtocol.path, {
+        id: nonExistentId,
+        protocolId: protocol1.id,
+      });
+      await testApp.delete(path).withAuth(testUserId).expect(StatusCodes.NOT_FOUND);
+    });
+
+    it("should return 404 when protocol doesn't exist in experiment", async () => {
+      const { experiment } = await testApp.createExperiment({
+        name: "Test Experiment for Protocol Remove",
+        userId: testUserId,
+      });
+      const nonExistentProtocolId = "00000000-0000-0000-0000-000000000000";
+      const path = testApp.resolvePath(contract.protocols.removeExperimentProtocol.path, {
+        id: experiment.id,
+        protocolId: nonExistentProtocolId,
+      });
+      await testApp.delete(path).withAuth(testUserId).expect(StatusCodes.NOT_FOUND);
+    });
+
+    it("should return 400 for invalid UUIDs", async () => {
+      const { experiment } = await testApp.createExperiment({
+        name: "Test Experiment for Protocol Remove Invalid",
+        userId: testUserId,
+      });
+      const path = testApp.resolvePath(contract.protocols.removeExperimentProtocol.path, {
+        id: experiment.id,
+        protocolId: "not-a-uuid",
+      });
+      await testApp.delete(path).withAuth(testUserId).expect(StatusCodes.BAD_REQUEST);
+    });
+
+    it("should return 401 if not authenticated", async () => {
+      const { experiment } = await testApp.createExperiment({
+        name: "Test Experiment for Protocol Remove Auth",
+        userId: testUserId,
+      });
+      const protocol1 = await testApp.createProtocol({
+        name: "Protocol 1",
+        createdBy: testUserId,
+        family: "multispeq",
+      });
+      await testApp.addExperimentProtocol(experiment.id, protocol1.id, 0);
+      const path = testApp.resolvePath(contract.protocols.removeExperimentProtocol.path, {
+        id: experiment.id,
+        protocolId: protocol1.id,
+      });
+      await testApp.delete(path).withoutAuth().expect(StatusCodes.UNAUTHORIZED);
+    });
+  });
+});

--- a/apps/backend/src/experiments/presentation/experiment-protocols.controller.ts
+++ b/apps/backend/src/experiments/presentation/experiment-protocols.controller.ts
@@ -27,9 +27,9 @@ export class ExperimentProtocolsController {
     private readonly removeExperimentProtocolUseCase: RemoveExperimentProtocolUseCase,
   ) {}
 
-  @TsRestHandler(contract.protocols.listExperimentProtocols)
+  @TsRestHandler(contract.experiments.listExperimentProtocols)
   listProtocols(@CurrentUser() user: SessionUser) {
-    return tsRestHandler(contract.protocols.listExperimentProtocols, async ({ params }) => {
+    return tsRestHandler(contract.experiments.listExperimentProtocols, async ({ params }) => {
       const result = await this.listExperimentProtocolsUseCase.execute(params.id, user.id);
 
       if (result.isSuccess()) {
@@ -57,9 +57,9 @@ export class ExperimentProtocolsController {
     });
   }
 
-  @TsRestHandler(contract.protocols.addExperimentProtocols)
+  @TsRestHandler(contract.experiments.addExperimentProtocols)
   addProtocols(@CurrentUser() user: SessionUser) {
-    return tsRestHandler(contract.protocols.addExperimentProtocols, async ({ params, body }) => {
+    return tsRestHandler(contract.experiments.addExperimentProtocols, async ({ params, body }) => {
       const result = await this.addExperimentProtocolsUseCase.execute(
         params.id,
         body.protocols,
@@ -94,9 +94,9 @@ export class ExperimentProtocolsController {
     });
   }
 
-  @TsRestHandler(contract.protocols.removeExperimentProtocol)
+  @TsRestHandler(contract.experiments.removeExperimentProtocol)
   removeProtocol(@CurrentUser() user: SessionUser) {
-    return tsRestHandler(contract.protocols.removeExperimentProtocol, async ({ params }) => {
+    return tsRestHandler(contract.experiments.removeExperimentProtocol, async ({ params }) => {
       const result = await this.removeExperimentProtocolUseCase.execute(
         params.id,
         params.protocolId,

--- a/apps/backend/src/experiments/presentation/experiment-protocols.controller.ts
+++ b/apps/backend/src/experiments/presentation/experiment-protocols.controller.ts
@@ -1,0 +1,119 @@
+import { Controller, Logger, UseGuards } from "@nestjs/common";
+import { TsRestHandler, tsRestHandler } from "@ts-rest/nest";
+import { StatusCodes } from "http-status-codes";
+
+import { contract } from "@repo/api";
+import type { SessionUser } from "@repo/auth/config";
+
+import { CurrentUser } from "../../common/decorators/current-user.decorator";
+import { AuthGuard } from "../../common/guards/auth.guard";
+import { handleFailure } from "../../common/utils/fp-utils";
+import { AddExperimentProtocolsUseCase } from "../application/use-cases/experiment-protocols/add-experiment-protocols";
+import { ListExperimentProtocolsUseCase } from "../application/use-cases/experiment-protocols/list-experiment-protocols";
+import { RemoveExperimentProtocolUseCase } from "../application/use-cases/experiment-protocols/remove-experiment-protocol";
+
+function isProtocolFamily(family: unknown): family is "multispeq" | "ambit" {
+  return family === "multispeq" || family === "ambit";
+}
+
+@Controller()
+@UseGuards(AuthGuard)
+export class ExperimentProtocolsController {
+  private readonly logger = new Logger(ExperimentProtocolsController.name);
+
+  constructor(
+    private readonly listExperimentProtocolsUseCase: ListExperimentProtocolsUseCase,
+    private readonly addExperimentProtocolsUseCase: AddExperimentProtocolsUseCase,
+    private readonly removeExperimentProtocolUseCase: RemoveExperimentProtocolUseCase,
+  ) {}
+
+  @TsRestHandler(contract.protocols.listExperimentProtocols)
+  listProtocols(@CurrentUser() user: SessionUser) {
+    return tsRestHandler(contract.protocols.listExperimentProtocols, async ({ params }) => {
+      const result = await this.listExperimentProtocolsUseCase.execute(params.id, user.id);
+
+      if (result.isSuccess()) {
+        const serialized = result.value.map((assoc) => {
+          const family = assoc.protocol.family;
+          if (!isProtocolFamily(family)) {
+            throw new Error('Protocol family must be "multispeq" or "ambit"');
+          }
+          return {
+            ...assoc,
+            addedAt: assoc.addedAt instanceof Date ? assoc.addedAt.toISOString() : assoc.addedAt,
+            protocol: {
+              ...assoc.protocol,
+              family,
+            },
+          };
+        });
+        return {
+          status: StatusCodes.OK as const,
+          body: serialized,
+        };
+      }
+
+      return handleFailure(result, this.logger);
+    });
+  }
+
+  @TsRestHandler(contract.protocols.addExperimentProtocols)
+  addProtocols(@CurrentUser() user: SessionUser) {
+    return tsRestHandler(contract.protocols.addExperimentProtocols, async ({ params, body }) => {
+      const result = await this.addExperimentProtocolsUseCase.execute(
+        params.id,
+        body.protocols,
+        user.id,
+      );
+
+      if (result.isSuccess()) {
+        this.logger.log(
+          `Protocols [${body.protocols.map((p) => p.protocolId).join(", ")}] added to experiment ${params.id} by user ${user.id}`,
+        );
+        const serialized = result.value.map((assoc) => {
+          const family = assoc.protocol.family;
+          if (!isProtocolFamily(family)) {
+            throw new Error('Protocol family must be "multispeq" or "ambit"');
+          }
+          return {
+            ...assoc,
+            addedAt: assoc.addedAt instanceof Date ? assoc.addedAt.toISOString() : assoc.addedAt,
+            protocol: {
+              ...assoc.protocol,
+              family,
+            },
+          };
+        });
+        return {
+          status: StatusCodes.CREATED as const,
+          body: serialized,
+        };
+      }
+
+      return handleFailure(result, this.logger);
+    });
+  }
+
+  @TsRestHandler(contract.protocols.removeExperimentProtocol)
+  removeProtocol(@CurrentUser() user: SessionUser) {
+    return tsRestHandler(contract.protocols.removeExperimentProtocol, async ({ params }) => {
+      const result = await this.removeExperimentProtocolUseCase.execute(
+        params.id,
+        params.protocolId,
+        user.id,
+      );
+
+      if (result.isSuccess()) {
+        this.logger.log(
+          `Protocol ${params.protocolId} removed from experiment ${params.id} by user ${user.id}`,
+        );
+        return {
+          status: StatusCodes.NO_CONTENT,
+          body: null,
+        };
+      }
+
+      return handleFailure(result, this.logger);
+    });
+  }
+}

--- a/apps/backend/src/test/test-harness.ts
+++ b/apps/backend/src/test/test-harness.ts
@@ -19,6 +19,7 @@ import {
   auditLogs,
   profiles,
   protocols,
+  experimentProtocols,
 } from "@repo/database";
 
 import { AppModule } from "../app.module";
@@ -253,6 +254,44 @@ export class TestHarness {
       .returning();
 
     return membership;
+  }
+
+  /**
+   * Helper to create a protocol for testing
+   */
+  public async createProtocol(data: {
+    name: string;
+    description?: string;
+    code?: Record<string, unknown>[];
+    family?: "multispeq" | "ambit";
+    createdBy: string;
+  }) {
+    const [protocol] = await this.database
+      .insert(protocols)
+      .values({
+        name: data.name,
+        description: data.description ?? "Test protocol description",
+        code: data.code ?? [{}],
+        family: data.family ?? "multispeq",
+        createdBy: data.createdBy,
+      })
+      .returning();
+    return protocol;
+  }
+
+  /**
+   * Helper to associate a protocol with an experiment
+   */
+  public async addExperimentProtocol(experimentId: string, protocolId: string, order = 0) {
+    const [association] = await this.database
+      .insert(experimentProtocols)
+      .values({
+        experimentId,
+        protocolId,
+        order,
+      })
+      .returning();
+    return association;
   }
 
   /**

--- a/packages/api/src/contracts/experiment.contract.ts
+++ b/packages/api/src/contracts/experiment.contract.ts
@@ -19,6 +19,11 @@ import {
   zExperimentWebhookSuccessResponse,
   zExperimentWebhookErrorResponse,
 } from "../schemas/experiment.schema";
+import {
+  zExperimentProtocolList,
+  zAddExperimentProtocolsBody,
+  zExperimentProtocolPathParam,
+} from "../schemas/experiment.schema";
 
 const c = initContract();
 
@@ -153,5 +158,51 @@ export const experimentContract = c.router({
     summary: "Handle experiment provisioning status updates",
     description:
       "Receives status updates from Databricks workflows and updates the corresponding experiment status",
+  },
+
+  listExperimentProtocols: {
+    method: "GET",
+    path: "/api/v1/experiments/:id/protocols",
+    pathParams: zIdPathParam,
+    responses: {
+      200: zExperimentProtocolList,
+      400: zErrorResponse,
+      401: zErrorResponse,
+      403: zErrorResponse,
+      404: zErrorResponse,
+    },
+    summary: "List protocols associated with an experiment",
+    description: "Returns a list of protocol associations for the specified experiment.",
+  },
+
+  addExperimentProtocols: {
+    method: "POST",
+    path: "/api/v1/experiments/:id/protocols",
+    pathParams: zIdPathParam,
+    body: zAddExperimentProtocolsBody,
+    responses: {
+      201: zExperimentProtocolList,
+      400: zErrorResponse,
+      401: zErrorResponse,
+      403: zErrorResponse,
+      404: zErrorResponse,
+    },
+    summary: "Add protocols to an experiment",
+    description: "Associates one or more protocols with an experiment.",
+  },
+
+  removeExperimentProtocol: {
+    method: "DELETE",
+    path: "/api/v1/experiments/:id/protocols/:protocolId",
+    pathParams: zExperimentProtocolPathParam,
+    responses: {
+      204: null,
+      400: zErrorResponse,
+      401: zErrorResponse,
+      403: zErrorResponse,
+      404: zErrorResponse,
+    },
+    summary: "Remove a protocol from an experiment",
+    description: "Removes the association between a protocol and an experiment.",
   },
 });

--- a/packages/api/src/contracts/protocol.contract.ts
+++ b/packages/api/src/contracts/protocol.contract.ts
@@ -1,6 +1,12 @@
 import { initContract } from "@ts-rest/core";
 
 import {
+  zExperimentProtocolList,
+  zAddExperimentProtocolsBody,
+  zExperimentProtocolPathParam,
+} from "../schemas/experiment.schema";
+import { zIdPathParam, zErrorResponse } from "../schemas/experiment.schema";
+import {
   zProtocol,
   zProtocolList,
   zProtocolErrorResponse,
@@ -23,6 +29,53 @@ export const protocolContract = c.router({
     },
     summary: "List protocols",
     description: "Returns a list of protocols based on the specified filter criteria",
+  },
+
+  // Experiment Protocol Association Endpoints
+  listExperimentProtocols: {
+    method: "GET",
+    path: "/api/v1/experiments/:id/protocols",
+    pathParams: zIdPathParam,
+    responses: {
+      200: zExperimentProtocolList,
+      400: zErrorResponse,
+      401: zErrorResponse,
+      403: zErrorResponse,
+      404: zErrorResponse,
+    },
+    summary: "List protocols associated with an experiment",
+    description: "Returns a list of protocol associations for the specified experiment.",
+  },
+
+  addExperimentProtocols: {
+    method: "POST",
+    path: "/api/v1/experiments/:id/protocols",
+    pathParams: zIdPathParam,
+    body: zAddExperimentProtocolsBody,
+    responses: {
+      201: zExperimentProtocolList,
+      400: zErrorResponse,
+      401: zErrorResponse,
+      403: zErrorResponse,
+      404: zErrorResponse,
+    },
+    summary: "Add protocols to an experiment",
+    description: "Associates one or more protocols with an experiment.",
+  },
+
+  removeExperimentProtocol: {
+    method: "DELETE",
+    path: "/api/v1/experiments/:id/protocols/:protocolId",
+    pathParams: zExperimentProtocolPathParam,
+    responses: {
+      204: null,
+      400: zErrorResponse,
+      401: zErrorResponse,
+      403: zErrorResponse,
+      404: zErrorResponse,
+    },
+    summary: "Remove a protocol from an experiment",
+    description: "Removes the association between a protocol and an experiment.",
   },
 
   getProtocol: {

--- a/packages/api/src/contracts/protocol.contract.ts
+++ b/packages/api/src/contracts/protocol.contract.ts
@@ -1,12 +1,6 @@
 import { initContract } from "@ts-rest/core";
 
 import {
-  zExperimentProtocolList,
-  zAddExperimentProtocolsBody,
-  zExperimentProtocolPathParam,
-} from "../schemas/experiment.schema";
-import { zIdPathParam, zErrorResponse } from "../schemas/experiment.schema";
-import {
   zProtocol,
   zProtocolList,
   zProtocolErrorResponse,
@@ -29,53 +23,6 @@ export const protocolContract = c.router({
     },
     summary: "List protocols",
     description: "Returns a list of protocols based on the specified filter criteria",
-  },
-
-  // Experiment Protocol Association Endpoints
-  listExperimentProtocols: {
-    method: "GET",
-    path: "/api/v1/experiments/:id/protocols",
-    pathParams: zIdPathParam,
-    responses: {
-      200: zExperimentProtocolList,
-      400: zErrorResponse,
-      401: zErrorResponse,
-      403: zErrorResponse,
-      404: zErrorResponse,
-    },
-    summary: "List protocols associated with an experiment",
-    description: "Returns a list of protocol associations for the specified experiment.",
-  },
-
-  addExperimentProtocols: {
-    method: "POST",
-    path: "/api/v1/experiments/:id/protocols",
-    pathParams: zIdPathParam,
-    body: zAddExperimentProtocolsBody,
-    responses: {
-      201: zExperimentProtocolList,
-      400: zErrorResponse,
-      401: zErrorResponse,
-      403: zErrorResponse,
-      404: zErrorResponse,
-    },
-    summary: "Add protocols to an experiment",
-    description: "Associates one or more protocols with an experiment.",
-  },
-
-  removeExperimentProtocol: {
-    method: "DELETE",
-    path: "/api/v1/experiments/:id/protocols/:protocolId",
-    pathParams: zExperimentProtocolPathParam,
-    responses: {
-      204: null,
-      400: zErrorResponse,
-      401: zErrorResponse,
-      403: zErrorResponse,
-      404: zErrorResponse,
-    },
-    summary: "Remove a protocol from an experiment",
-    description: "Removes the association between a protocol and an experiment.",
   },
 
   getProtocol: {

--- a/packages/api/src/schemas/experiment.schema.ts
+++ b/packages/api/src/schemas/experiment.schema.ts
@@ -88,6 +88,10 @@ export const zCreateExperimentBody = z.object({
     )
     .optional()
     .describe("Optional array of member objects with userId and role"),
+  protocols: z
+    .array(z.string().uuid())
+    .optional()
+    .describe("Optional array of protocol IDs to associate with the experiment"),
 });
 
 export const zUpdateExperimentBody = z.object({

--- a/packages/api/src/schemas/experiment.schema.ts
+++ b/packages/api/src/schemas/experiment.schema.ts
@@ -5,7 +5,7 @@ export const zExperimentProtocolDetails = z.object({
   id: z.string().uuid(),
   name: z.string(),
   family: z.enum(["multispeq", "ambit"]),
-  createdby: z.string().uuid(),
+  createdBy: z.string().uuid(),
 });
 
 export const zExperimentProtocol = z.object({

--- a/packages/api/src/schemas/experiment.schema.ts
+++ b/packages/api/src/schemas/experiment.schema.ts
@@ -1,5 +1,36 @@
 import { z } from "zod";
 
+// --- Protocol Association Schemas ---
+export const zExperimentProtocolDetails = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  family: z.enum(["multispeq", "ambit"]),
+  createdby: z.string().uuid(),
+});
+
+export const zExperimentProtocol = z.object({
+  experimentId: z.string().uuid(),
+  order: z.number().int(),
+  addedAt: z.string().datetime(),
+  protocol: zExperimentProtocolDetails,
+});
+
+export const zExperimentProtocolList = z.array(zExperimentProtocol);
+
+export const zExperimentProtocolPathParam = z.object({
+  id: z.string().uuid().describe("ID of the experiment"),
+  protocolId: z.string().uuid().describe("ID of the protocol association"),
+});
+
+export const zAddExperimentProtocolsBody = z.object({
+  protocols: z.array(
+    z.object({
+      protocolId: z.string().uuid(),
+      order: z.number().int().optional(),
+    }),
+  ),
+});
+
 // Define Zod schemas for experiment models
 export const zExperimentStatus = z.enum([
   "provisioning",
@@ -89,9 +120,16 @@ export const zCreateExperimentBody = z.object({
     .optional()
     .describe("Optional array of member objects with userId and role"),
   protocols: z
-    .array(z.string().uuid())
+    .array(
+      z.object({
+        protocolId: z.string().uuid(),
+        order: z.number().int().optional(),
+      }),
+    )
     .optional()
-    .describe("Optional array of protocol IDs to associate with the experiment"),
+    .describe(
+      "Optional array of protocol objects with protocolId and order to associate with the experiment",
+    ),
 });
 
 export const zUpdateExperimentBody = z.object({

--- a/packages/database/drizzle/0004_overjoyed_shocker.sql
+++ b/packages/database/drizzle/0004_overjoyed_shocker.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "experiment_protocols" (
+	"experiment_id" uuid NOT NULL,
+	"protocol_id" uuid NOT NULL,
+	"order" integer DEFAULT 0 NOT NULL,
+	"added_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "experiment_protocols_experiment_id_protocol_id_pk" PRIMARY KEY("experiment_id","protocol_id")
+);
+--> statement-breakpoint
+ALTER TABLE "experiment_protocols" ADD CONSTRAINT "experiment_protocols_experiment_id_experiments_id_fk" FOREIGN KEY ("experiment_id") REFERENCES "public"."experiments"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "experiment_protocols" ADD CONSTRAINT "experiment_protocols_protocol_id_protocols_id_fk" FOREIGN KEY ("protocol_id") REFERENCES "public"."protocols"("id") ON DELETE no action ON UPDATE no action;

--- a/packages/database/drizzle/meta/0004_snapshot.json
+++ b/packages/database/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,985 @@
+{
+  "id": "da88b972-1158-4ec3-8c1f-390e556d933d",
+  "prevId": "92508d1c-11f1-4e48-85fc-e7833f836579",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_userId_users_id_fk": {
+          "name": "accounts_userId_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authenticators": {
+      "name": "authenticators",
+      "schema": "",
+      "columns": {
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialPublicKey": {
+          "name": "credentialPublicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialDeviceType": {
+          "name": "credentialDeviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialBackedUp": {
+          "name": "credentialBackedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticators_userId_users_id_fk": {
+          "name": "authenticators_userId_users_id_fk",
+          "tableFrom": "authenticators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authenticators_credentialID_unique": {
+          "name": "authenticators_credentialID_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credentialID"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_members": {
+      "name": "experiment_members",
+      "schema": "",
+      "columns": {
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "experiment_members_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_members_experiment_id_experiments_id_fk": {
+          "name": "experiment_members_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_members",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "experiment_members_user_id_users_id_fk": {
+          "name": "experiment_members_user_id_users_id_fk",
+          "tableFrom": "experiment_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "experiment_members_experiment_id_user_id_pk": {
+          "name": "experiment_members_experiment_id_user_id_pk",
+          "columns": [
+            "experiment_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_protocols": {
+      "name": "experiment_protocols",
+      "schema": "",
+      "columns": {
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol_id": {
+          "name": "protocol_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_protocols_experiment_id_experiments_id_fk": {
+          "name": "experiment_protocols_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_protocols",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_protocols_protocol_id_protocols_id_fk": {
+          "name": "experiment_protocols_protocol_id_protocols_id_fk",
+          "tableFrom": "experiment_protocols",
+          "tableTo": "protocols",
+          "columnsFrom": [
+            "protocol_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "experiment_protocols_experiment_id_protocol_id_pk": {
+          "name": "experiment_protocols_experiment_id_protocol_id_pk",
+          "columns": [
+            "experiment_id",
+            "protocol_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiments": {
+      "name": "experiments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "experiment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'provisioning'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "experiment_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "embargo_interval_days": {
+          "name": "embargo_interval_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 90
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiments_created_by_users_id_fk": {
+          "name": "experiments_created_by_users_id_fk",
+          "tableFrom": "experiments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "experiments_name_unique": {
+          "name": "experiments_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "organization_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_user_id_users_id_fk": {
+          "name": "profiles_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profiles_organization_id_organizations_id_fk": {
+          "name": "profiles_organization_id_organizations_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.protocols": {
+      "name": "protocols",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "sensor_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "protocols_created_by_users_id_fk": {
+          "name": "protocols_created_by_users_id_fk",
+          "tableFrom": "protocols",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "protocols_name_unique": {
+          "name": "protocols_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sensors": {
+      "name": "sensors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "sensor_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sensors_serial_number_unique": {
+          "name": "sensors_serial_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "serial_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_userId_users_id_fk": {
+          "name": "sessions_userId_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.experiment_members_role": {
+      "name": "experiment_members_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member"
+      ]
+    },
+    "public.experiment_status": {
+      "name": "experiment_status",
+      "schema": "public",
+      "values": [
+        "provisioning",
+        "provisioning_failed",
+        "active",
+        "stale",
+        "archived",
+        "published"
+      ]
+    },
+    "public.experiment_visibility": {
+      "name": "experiment_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "public"
+      ]
+    },
+    "public.organization_type": {
+      "name": "organization_type",
+      "schema": "public",
+      "values": [
+        "research_institute",
+        "non_profit",
+        "private_company",
+        "government_agency",
+        "university"
+      ]
+    },
+    "public.sensor_family": {
+      "name": "sensor_family",
+      "schema": "public",
+      "values": [
+        "multispeq",
+        "ambit"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1751450722378,
       "tag": "0003_chunky_cyclops",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1751882968577,
+      "tag": "0004_overjoyed_shocker",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -189,6 +189,26 @@ export const experimentMembers = pgTable(
   (table) => [primaryKey({ columns: [table.experimentId, table.userId] })],
 );
 
+// Associative table: Experiment Protocols
+export const experimentProtocols = pgTable(
+  "experiment_protocols",
+  {
+    experimentId: uuid("experiment_id")
+      .references(() => experiments.id, { onDelete: "cascade" })
+      .notNull(),
+    protocolId: uuid("protocol_id")
+      .references(() => protocols.id)
+      .notNull(),
+    order: integer("order").default(0).notNull(),
+    addedAt: timestamp("added_at").defaultNow().notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.experimentId, table.protocolId] }),
+    // Add index on experimentId for faster lookups
+    { index: { columns: [table.experimentId] } },
+  ],
+);
+
 // Audit Log Table
 export const auditLogs = pgTable("audit_logs", {
   id: uuid("id").primaryKey().defaultRandom(),


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Other (please describe)

## Description

Adds end-to-end support for associating protocols with experiments, including database migrations, API schemas, contract definitions, repository logic, use cases, controllers, and tests.

- Introduce experiment_protocols associative table (schema, drizzle meta, migrations)
- Define Zod schemas and ts-rest contract for listing, adding, and removing experiment protocols
- Implement repository, use-cases, controller wiring, test-harness helpers, and comprehensive unit & integration tests
