### PR TITLE
feat(backend, web): prevent updating protocols assigned to experiments

### DIFF
--- a/apps/backend/src/protocols/application/use-cases/update-protocol/update-protocol.ts
+++ b/apps/backend/src/protocols/application/use-cases/update-protocol/update-protocol.ts
@@ -27,8 +27,12 @@ export class UpdateProtocolUseCase {
     }
 
     // Prevent update if protocol is assigned to any experiment
-    const isAssigned = await this.protocolRepository.isAssignedToAnyExperiment(id);
-    if (isAssigned) {
+    const isAssignedResult = await this.protocolRepository.isAssignedToAnyExperiment(id);
+    if (isAssignedResult.isFailure()) {
+      this.logger.error(`Error checking protocol assignment for ID ${id}:`, isAssignedResult.error);
+      return failure(isAssignedResult.error);
+    }
+    if (isAssignedResult.value) {
       this.logger.warn(
         `Attempt to update protocol with ID ${id} which is assigned to an experiment`,
       );

--- a/apps/backend/src/protocols/application/use-cases/update-protocol/update-protocol.ts
+++ b/apps/backend/src/protocols/application/use-cases/update-protocol/update-protocol.ts
@@ -26,7 +26,16 @@ export class UpdateProtocolUseCase {
       return failure(AppError.notFound(`Protocol not found`));
     }
 
-    // Protocol exists, now update it
+    // Prevent update if protocol is assigned to any experiment
+    const isAssigned = await this.protocolRepository.isAssignedToAnyExperiment(id);
+    if (isAssigned) {
+      this.logger.warn(
+        `Attempt to update protocol with ID ${id} which is assigned to an experiment`,
+      );
+      return failure(AppError.forbidden("Cannot update protocol assigned to an experiment"));
+    }
+
+    // Protocol exists and is not assigned, now update it
     const updateResult = await this.protocolRepository.update(id, updateProtocolDto);
 
     if (updateResult.isFailure()) {

--- a/apps/backend/src/protocols/core/repositories/protocol.repository.spec.ts
+++ b/apps/backend/src/protocols/core/repositories/protocol.repository.spec.ts
@@ -399,7 +399,8 @@ describe("ProtocolRepository", () => {
       const isAssigned = await repository.isAssignedToAnyExperiment(protocolId);
 
       // Assert
-      expect(isAssigned).toBe(false);
+      assertSuccess(isAssigned);
+      expect(isAssigned.value).toBe(false);
     });
 
     it("should return true if protocol is assigned to an experiment", async () => {
@@ -430,7 +431,8 @@ describe("ProtocolRepository", () => {
       const isAssigned = await repository.isAssignedToAnyExperiment(protocolId);
 
       // Assert
-      expect(isAssigned).toBe(true);
+      assertSuccess(isAssigned);
+      expect(isAssigned.value).toBe(true);
     });
   });
 });

--- a/apps/backend/src/protocols/core/repositories/protocol.repository.ts
+++ b/apps/backend/src/protocols/core/repositories/protocol.repository.ts
@@ -98,12 +98,14 @@ export class ProtocolRepository {
     });
   }
 
-  async isAssignedToAnyExperiment(protocolId: string): Promise<boolean> {
-    const result = await this.database
-      .select()
-      .from(experimentProtocols)
-      .where(eq(experimentProtocols.protocolId, protocolId))
-      .limit(1);
-    return result.length > 0;
+  async isAssignedToAnyExperiment(protocolId: string): Promise<Result<boolean>> {
+    return tryCatch(async () => {
+      const result = await this.database
+        .select()
+        .from(experimentProtocols)
+        .where(eq(experimentProtocols.protocolId, protocolId))
+        .limit(1);
+      return result.length > 0;
+    });
   }
 }

--- a/apps/backend/src/protocols/core/repositories/protocol.repository.ts
+++ b/apps/backend/src/protocols/core/repositories/protocol.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable, Inject } from "@nestjs/common";
 
 import { ProtocolFilter } from "@repo/api";
-import { eq, ilike, protocols } from "@repo/database";
+import { eq, ilike, protocols, experimentProtocols } from "@repo/database";
 import type { DatabaseInstance } from "@repo/database";
 
 import { Result, tryCatch } from "../../../common/utils/fp-utils";
@@ -96,5 +96,14 @@ export class ProtocolRepository {
 
       return results as unknown as ProtocolDto[];
     });
+  }
+
+  async isAssignedToAnyExperiment(protocolId: string): Promise<boolean> {
+    const result = await this.database
+      .select()
+      .from(experimentProtocols)
+      .where(eq(experimentProtocols.protocolId, protocolId))
+      .limit(1);
+    return result.length > 0;
   }
 }

--- a/apps/web/app/[locale]/platform/protocols/[id]/page.tsx
+++ b/apps/web/app/[locale]/platform/protocols/[id]/page.tsx
@@ -66,9 +66,9 @@ export default function ProtocolOverviewPage({ params }: ProtocolOverviewPagePro
             </div>
             <div>
               <h4 className="text-muted-foreground text-sm font-medium">
-                {t("protocols.protocolId")}
+                {t("experiments.createdBy")}
               </h4>
-              <p className="truncate font-mono text-xs">{protocol.id}</p>
+              <p className="truncate font-mono text-xs">{protocol.createdBy}</p>
             </div>
           </div>
         </CardContent>

--- a/apps/web/components/new-protocol/new-protocol.tsx
+++ b/apps/web/components/new-protocol/new-protocol.tsx
@@ -10,6 +10,7 @@ import type { CreateProtocolRequestBody } from "@repo/api";
 import { zCreateProtocolRequestBody } from "@repo/api";
 import { useTranslation } from "@repo/i18n";
 import { Button, Form, FormField } from "@repo/ui/components";
+import { toast } from "@repo/ui/hooks";
 
 import ProtocolCodeEditor from "../protocol-code-editor";
 import { NewProtocolDetailsCard } from "./new-protocol-details-card";
@@ -46,6 +47,7 @@ export function NewProtocolForm() {
         family: data.family,
       },
     });
+    toast({ description: t("protocols.protocolCreated") });
   }
 
   return (

--- a/apps/web/components/protocol-settings/protocol-details-card.tsx
+++ b/apps/web/components/protocol-settings/protocol-details-card.tsx
@@ -153,7 +153,6 @@ export function ProtocolDetailsCard({
                         error={form.formState.errors.code?.message?.toString()}
                       />
                     </FormControl>
-                    <FormMessage />
                   </FormItem>
                 )}
               />


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Other (please describe)

## Description

This PR implements backend and frontend changes to prevent updating protocols that are already assigned to experiments. The feature adds validation logic that checks for experiment assignments before allowing protocol updates and improves user feedback.

- Adds database-level checking for protocol-experiment assignments
- Implements business logic to prevent updates to assigned protocols
- Improves user experience with toast notifications and UI updates

## Related Issues

- Closes #
- Related to #

## Testing Instructions

- [ ] Test case 1
- [ ] Test case 2

## Changes Made

## Checklist

- [ ] I have added/updated tests for my changes
- [ ] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have tested these changes locally
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code

## Screenshots/Recordings

## Additional Notes