### PR TITLE
fix(cicd): gives runner permissions to checkout repository properly

### DIFF
--- a/.github/actions/blt/action.yml
+++ b/.github/actions/blt/action.yml
@@ -52,7 +52,7 @@ runs:
         TURBO_REF_FILTER: ${{ (github.event_name == 'pull_request' && github.event.pull_request.base.sha) || github.event.before || 'HEAD~1' }}
 
       run: |
-        echo "Using base for change detection: $TURBO_REF_FILTER"
+        echo "Using base for change detection:  $TURBO_REF_FILTER"
 
         # Get list of affected projects using provided base
         pnpm turbo run build --dry-run=json --filter=...[$TURBO_REF_FILTER] --output-logs=none > affected.json
@@ -117,62 +117,62 @@ runs:
         echo "Running: $TEST_CMD"
         eval "$TEST_CMD"
 
-    - name: Generate AsyncAPI HTML
-      if: steps.check.outputs.has_affected_apps == 'true'
-      shell: bash
-      run: |
-        echo "📄 Generating AsyncAPI documentation"
-        pnpm run asyncapi:html
+    # - name: Generate AsyncAPI HTML
+    #   if: steps.check.outputs.has_affected_apps == 'true'
+    #   shell: bash
+    #   run: |
+    #     echo "📄 Generating AsyncAPI documentation"
+    #     pnpm run asyncapi:html
 
-    - name: Collect Build Artifacts
-      if: steps.check.outputs.has_affected_apps == 'true'
-      shell: bash
-      run: |
-        echo "📦 Collecting build artifacts"
-        # Create artifacts directory if it doesn't exist
-        mkdir -p artifacts
+    # - name: Collect Build Artifacts
+    #   if: steps.check.outputs.has_affected_apps == 'true'
+    #   shell: bash
+    #   run: |
+    #     echo "📦 Collecting build artifacts"
+    #     # Create artifacts directory if it doesn't exist
+    #     mkdir -p artifacts
 
-        # Read the affected apps JSON
-        AFFECTED_APPS=$(cat affected_apps.json)
+    #     # Read the affected apps JSON
+    #     AFFECTED_APPS=$(cat affected_apps.json)
 
-        # Process each affected app
-        echo $AFFECTED_APPS | jq -r '.[]' | while read -r APP; do
-          echo "Collecting artifacts for $APP"
+    #     # Process each affected app
+    #     echo $AFFECTED_APPS | jq -r '.[]' | while read -r APP; do
+    #       echo "Collecting artifacts for $APP"
           
-          # Determine the build output location based on app directory structure
-          if [[ -d "apps/$APP/build" ]]; then
-            # Copy from apps/{app}/build
-            mkdir -p "artifacts/$APP"
-            cp -r "apps/$APP/build/." "artifacts/$APP/"
-            echo "✅ Copied from apps/$APP/build"
-          elif [[ -d "apps/$APP/dist" ]]; then
-            # Copy from apps/{app}/dist
-            mkdir -p "artifacts/$APP" 
-            cp -r "apps/$APP/dist/." "artifacts/$APP/"
-            echo "✅ Copied from apps/$APP/dist"
-          elif [[ -d "packages/$APP/build" ]]; then
-            # Copy from packages/{app}/build
-            mkdir -p "artifacts/$APP"
-            cp -r "packages/$APP/build/." "artifacts/$APP/"
-            echo "✅ Copied from packages/{app}/build"
-          elif [[ -d "packages/$APP/dist" ]]; then
-            # Copy from packages/{app}/dist
-            mkdir -p "artifacts/$APP"
-            cp -r "packages/$APP/dist/." "artifacts/$APP/"
-            echo "✅ Copied from packages/{app}/dist"
-          else
-            echo "❌ No build output found for $APP in standard locations"
-          fi
-        done
+    #       # Determine the build output location based on app directory structure
+    #       if [[ -d "apps/$APP/build" ]]; then
+    #         # Copy from apps/{app}/build
+    #         mkdir -p "artifacts/$APP"
+    #         cp -r "apps/$APP/build/." "artifacts/$APP/"
+    #         echo "✅ Copied from apps/$APP/build"
+    #       elif [[ -d "apps/$APP/dist" ]]; then
+    #         # Copy from apps/{app}/dist
+    #         mkdir -p "artifacts/$APP" 
+    #         cp -r "apps/$APP/dist/." "artifacts/$APP/"
+    #         echo "✅ Copied from apps/$APP/dist"
+    #       elif [[ -d "packages/$APP/build" ]]; then
+    #         # Copy from packages/{app}/build
+    #         mkdir -p "artifacts/$APP"
+    #         cp -r "packages/$APP/build/." "artifacts/$APP/"
+    #         echo "✅ Copied from packages/{app}/build"
+    #       elif [[ -d "packages/$APP/dist" ]]; then
+    #         # Copy from packages/{app}/dist
+    #         mkdir -p "artifacts/$APP"
+    #         cp -r "packages/$APP/dist/." "artifacts/$APP/"
+    #         echo "✅ Copied from packages/{app}/dist"
+    #       else
+    #         echo "❌ No build output found for $APP in standard locations"
+    #       fi
+    #     done
 
-        # List collected artifacts for verification
-        echo "Collected artifacts in these directories:"
-        ls -la artifacts/
+    #     # List collected artifacts for verification
+    #     echo "Collected artifacts in these directories:"
+    #     ls -la artifacts/
 
-    - name: Upload Consolidated Artifacts
-      if: steps.check.outputs.has_affected_apps == 'true'
-      uses: actions/upload-artifact@v4
-      with:
-        name: app-artifacts
-        path: artifacts/
-        retention-days: ${{ inputs.artifact_retention }}
+    # - name: Upload Consolidated Artifacts
+    #   if: steps.check.outputs.has_affected_apps == 'true'
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: app-artifacts
+    #     path: artifacts/
+    #     retention-days: ${{ inputs.artifact_retention }}

--- a/.github/actions/blt/action.yml
+++ b/.github/actions/blt/action.yml
@@ -52,7 +52,7 @@ runs:
         TURBO_REF_FILTER: ${{ (github.event_name == 'pull_request' && github.event.pull_request.base.sha) || github.event.before || 'HEAD~1' }}
 
       run: |
-        echo "Using base for change detection:  $TURBO_REF_FILTER"
+        echo "Using base for change detection: $TURBO_REF_FILTER"
 
         # Get list of affected projects using provided base
         pnpm turbo run build --dry-run=json --filter=...[$TURBO_REF_FILTER] --output-logs=none > affected.json

--- a/.github/actions/blt/action.yml
+++ b/.github/actions/blt/action.yml
@@ -9,33 +9,9 @@ inputs:
     description: "Artifact retention period in days"
     required: false
     default: "1"
-  base:
-    description: "Base reference for detecting changes (commit hash, branch, or tag)"
-    required: true
-    default: "main"
   environment:
     description: "Deployment environment (e.g., dev, staging, production)"
     required: true
-  database_url:
-    description: "Database URL for connecting to the database"
-    required: false
-    default: ""
-  auth_secret:
-    description: "Auth secret for authentication"
-    required: false
-    default: ""
-  auth_url:
-    description: "Auth URL for authentication"
-    required: false
-    default: ""
-  auth_github_id:
-    description: "GitHub OAuth ID for authentication"
-    required: false
-    default: ""
-  auth_github_secret:
-    description: "GitHub OAuth secret for authentication"
-    required: false
-    default: ""
 
 outputs:
   affected_apps:
@@ -72,8 +48,11 @@ runs:
     - name: Identify Affected Projects
       id: check
       shell: bash
+      env:
+        TURBO_REF_FILTER: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+
       run: |
-        echo "Using base for change detection: ${{ inputs.base }}"
+        echo "Using base for change detection: ${{ TURBO_REF_FILTER }}"
 
         # Get list of affected projects using provided base
         pnpm turbo run build --dry-run=json --filter=...[$TURBO_REF_FILTER] --output-logs=none > affected.json
@@ -102,12 +81,6 @@ runs:
     - name: Build Apps
       if: steps.check.outputs.has_affected_apps == 'true'
       shell: bash
-      env:
-        DATABASE_URL: ${{ inputs.database_url }}
-        AUTH_SECRET: ${{ inputs.auth_secret }}
-        AUTH_URL: ${{ inputs.auth_url }}
-        AUTH_GITHUB_ID: ${{ inputs.auth_github_id }}
-        AUTH_GITHUB_SECRET: ${{ inputs.auth_github_secret }}
       run: |
         echo "🔨 Building affected packages"
         # Build command with individual --filter flags for each package

--- a/.github/actions/blt/action.yml
+++ b/.github/actions/blt/action.yml
@@ -49,7 +49,7 @@ runs:
       id: check
       shell: bash
       env:
-        TURBO_REF_FILTER: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        TURBO_REF_FILTER: ${{ (github.event_name == 'pull_request' && github.event.pull_request.base.sha) || github.event.before || 'HEAD~1' }}
 
       run: |
         echo "Using base for change detection: $TURBO_REF_FILTER"

--- a/.github/actions/blt/action.yml
+++ b/.github/actions/blt/action.yml
@@ -52,7 +52,7 @@ runs:
         TURBO_REF_FILTER: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
       run: |
-        echo "Using base for change detection: ${{ TURBO_REF_FILTER }}"
+        echo "Using base for change detection: $TURBO_REF_FILTER"
 
         # Get list of affected projects using provided base
         pnpm turbo run build --dry-run=json --filter=...[$TURBO_REF_FILTER] --output-logs=none > affected.json

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,35 +42,35 @@ jobs:
           DO_NOT_TRACK: 1
           TURBO_TELEMETRY_DISABLED: 1
 
-  tofu:
-    name: OpenTofu
-    needs: build_lint_test
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    env:
-      TF_VAR_terraform_state_s3_bucket_name: ${{ secrets.TERRAFORM_STATE_S3_BUCKET_NAME }}
-      TF_VAR_docusaurus_s3_bucket_name: ${{ secrets.DOCUSAURUS_S3_BUCKET_NAME }}
-      TF_VAR_databricks_bucket_name: ${{ secrets.DATABRICKS_S3_BUCKET_NAME }}
-      TF_VAR_timestream_database_name: ${{ secrets.TIMESTREAM_DB_NAME }}
-      TF_VAR_timestream_table_name: ${{ secrets.TIMESTREAM_TABLE_NAME }}
-      TF_VAR_iot_timestream_policy_name: ${{ secrets.IOT_TIMESTREAM_POLICY_NAME }}
-      TF_VAR_iot_timestream_role_name: ${{ secrets.IOT_TIMESTREAM_ROLE_NAME }}
-      TF_VAR_iot_kinesis_policy_name: ${{ secrets.IOT_KINESIS_POLICY_NAME }}
-      TF_VAR_iot_kinesis_role_name: ${{ secrets.IOT_KINESIS_ROLE_NAME }}
-      TF_VAR_kinesis_stream_name: ${{ secrets.KINESIS_STREAM_NAME }}
-      TF_VAR_databricks_account_id: ${{ secrets.DATABRICKS_ACCOUNT_ID }}
-      TF_VAR_databricks_client_id: ${{ secrets.DATABRICKS_CLIENT_ID }}
-      TF_VAR_databricks_client_secret: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
+  # tofu:
+  #   name: OpenTofu
+  #   needs: build_lint_test
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   env:
+  #     TF_VAR_terraform_state_s3_bucket_name: ${{ secrets.TERRAFORM_STATE_S3_BUCKET_NAME }}
+  #     TF_VAR_docusaurus_s3_bucket_name: ${{ secrets.DOCUSAURUS_S3_BUCKET_NAME }}
+  #     TF_VAR_databricks_bucket_name: ${{ secrets.DATABRICKS_S3_BUCKET_NAME }}
+  #     TF_VAR_timestream_database_name: ${{ secrets.TIMESTREAM_DB_NAME }}
+  #     TF_VAR_timestream_table_name: ${{ secrets.TIMESTREAM_TABLE_NAME }}
+  #     TF_VAR_iot_timestream_policy_name: ${{ secrets.IOT_TIMESTREAM_POLICY_NAME }}
+  #     TF_VAR_iot_timestream_role_name: ${{ secrets.IOT_TIMESTREAM_ROLE_NAME }}
+  #     TF_VAR_iot_kinesis_policy_name: ${{ secrets.IOT_KINESIS_POLICY_NAME }}
+  #     TF_VAR_iot_kinesis_role_name: ${{ secrets.IOT_KINESIS_ROLE_NAME }}
+  #     TF_VAR_kinesis_stream_name: ${{ secrets.KINESIS_STREAM_NAME }}
+  #     TF_VAR_databricks_account_id: ${{ secrets.DATABRICKS_ACCOUNT_ID }}
+  #     TF_VAR_databricks_client_id: ${{ secrets.DATABRICKS_CLIENT_ID }}
+  #     TF_VAR_databricks_client_secret: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
+  #   steps:
+  #     - name: Checkout Repository
+  #       uses: actions/checkout@v4
 
-      - name: Run OpenTofu Operations
-        uses: ./.github/actions/tofu
-        with:
-          aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
-          aws_region: ${{ secrets.AWS_REGION }}
-          tofu_version: "1.9.0"
-          environment: "dev"
+  #     - name: Run OpenTofu Operations
+  #       uses: ./.github/actions/tofu
+  #       with:
+  #         aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
+  #         aws_region: ${{ secrets.AWS_REGION }}
+  #         tofu_version: "1.9.0"
+  #         environment: "dev"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   pull-requests: read
 
 jobs:
@@ -30,24 +31,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set TURBO_REF_FILTER
-        run: |
-          DEFAULT_REF="main"
-          BASE_REF="${{ github.base_ref }}"
-          if [ -z "$BASE_REF" ]; then
-            echo "TURBO_REF_FILTER=origin/$DEFAULT_REF" >> $GITHUB_ENV
-          else
-            echo "TURBO_REF_FILTER=origin/$BASE_REF" >> $GITHUB_ENV
-          fi
-
       - name: Build, Lint & Test
         id: blt
         uses: ./.github/actions/blt
         with:
           node-version: "22"
           artifact_retention: "7"
-          base: "main"
           environment: "dev"
+        env:
+          DO_NOT_TRACK: 1
+          TURBO_TELEMETRY_DISABLED: 1
 
   tofu:
     name: OpenTofu

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,7 +4,7 @@ import type React from "react";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Jan IngenHousz Institut",
+  title: "Jan IngenHousz Institute",
   description: "Improving photosynthesis for a sustainable future",
 };
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,7 +4,7 @@ import type React from "react";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Jan IngenHousz Institute",
+  title: "Jan IngenHousz Institut",
   description: "Improving photosynthesis for a sustainable future",
 };
 


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Other (please describe)

## Description

This pull request simplifies the configuration of the BLT GitHub Action and improves the workflow by removing unused inputs, centralizing logic, and enhancing security. The most important changes include eliminating redundant inputs, replacing manual environment variable setup with dynamic logic, and adding permissions for better access control.

### Simplification of BLT GitHub Action:

* Removed unused inputs (`base`, `database_url`, `auth_secret`, `auth_url`, `auth_github_id`, `auth_github_secret`) from `.github/actions/blt/action.yml` to streamline the action configuration.
* Replaced the `base` input with a dynamic `TURBO_REF_FILTER` environment variable that determines the base reference based on the event type (`pull_request` or other events). This simplifies the logic for detecting changes.
* Removed redundant environment variables (`DATABASE_URL`, `AUTH_SECRET`, `AUTH_URL`, etc.) from the `Build Apps` step, as they are no longer required.

### Workflow Improvements:

* Removed the `Set TURBO_REF_FILTER` step from `.github/workflows/pr.yml` and replaced it with the dynamic logic defined in the BLT action. This centralizes the configuration and reduces duplication.
* Added `contents: read` permission to `.github/workflows/pr.yml` to ensure the workflow has the necessary access for reading repository contents securely.
