### PR TITLE
chore(backend): excludes vitest config from nest build

### DIFF
--- a/apps/backend/tsconfig.build.json
+++ b/apps/backend/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "vitest.config.mts"]
 }


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Other (please describe)

## Description

Excludes the `vitest.config.mts` file from the NestJS backend build process.

### 🔧 Core Change
- Updated `tsconfig.build.json` in `apps/backend` to add `vitest.config.mts` to the `exclude` array.
- Prevents the build process from including test configuration files. Having a .ts file in the root of the backend projects restructures the `/dist` output, and realistically `vitest.config.mts` is irrelevant to the build and not included in the final docker image regardless.
