### PR TITLE
feat(data): reworks experiment pipeline

### DIFF
--- a/infrastructure/notebooks/pipelines/experiment_pipeline.py
+++ b/infrastructure/notebooks/pipelines/experiment_pipeline.py
@@ -2,13 +2,13 @@
 # DBTITLE 1,OpenJII Experiment Pipeline
 # Implementation of experiment-specific medallion architecture pipeline
 # Processes data from central silver layer into experiment-specific bronze/silver/gold tables
-# Includes raw ambyte data processing capabilities
 
 # COMMAND ----------
 
 import dlt
 from pyspark.sql import functions as F
 from pyspark.sql.window import Window
+from pyspark.sql.types import StringType, TimestampType, DoubleType
 from pyspark.sql.types import StringType, TimestampType, DoubleType, StructType, StructField, IntegerType, FloatType, BooleanType, ArrayType
 from pyspark.sql import SparkSession
 from delta.tables import DeltaTable
@@ -38,9 +38,8 @@ CENTRAL_SILVER_TABLE = spark.conf.get("CENTRAL_SILVER_TABLE", "clean_data")
 YEAR_PREFIX = "2025"
 
 # Output table names
-BRONZE_TABLE = "bronze_data_exp"
-SILVER_TABLE = "silver_data_exp"
-GOLD_TABLE = "gold_data_exp"
+DEVICE_TABLE = "device"
+SAMPLE_TABLE = "sample"
 RAW_AMBYTE_TABLE = "raw_ambyte_data"
 
 spark = SparkSession.builder.getOrCreate()
@@ -49,164 +48,86 @@ print(f"Processing experiment: {EXPERIMENT_ID}")
 print(f"Using experiment schema: {EXPERIMENT_SCHEMA}")
 print(f"Reading from central schema: {CENTRAL_SCHEMA}.{CENTRAL_SILVER_TABLE}")
 
+# COMMAND ----------
+
+# DBTITLE 1,Device Table
+@dlt.table(
+    name=DEVICE_TABLE,
+    comment="Device metadata from MultispeQ measurements",
+    table_properties={
+        "quality": "bronze",
+        "pipelines.autoOptimize.managed": "true"
+    }
+)
+def device():
+    """Extract device metadata from central silver table filtered for MultispeQ data"""
+    return (
+        spark.read.table(f"{CATALOG_NAME}.{CENTRAL_SCHEMA}.{CENTRAL_SILVER_TABLE}")
+        .filter(F.col("experiment_id") == EXPERIMENT_ID)  # Filter for specific experiment
+        .select(
+            F.col("device_name"),
+            F.col("device_version"),
+            F.col("device_id"),
+            F.col("device_battery"),
+            F.col("device_firmware"),
+            F.current_timestamp().alias("processed_timestamp")
+        )
+        .dropDuplicates(["device_id", "device_firmware"])
+    )
 
 # COMMAND ----------
 
-# DBTITLE 1,Bronze Layer - Experiment Data Extraction
+# DBTITLE 1,Sample Table (Core Table)
 @dlt.table(
-    name=BRONZE_TABLE,
-    comment=f"Bronze layer: Experiment-specific data for {EXPERIMENT_ID} from central Silver tier",
+    name=SAMPLE_TABLE,
+    comment="Core sample table containing references to measurement sets",
     table_properties={
         "quality": "bronze",
         "pipelines.autoOptimize.managed": "true",
         "delta.enableChangeDataFeed": "true"
     }
 )
-def experiment_bronze():
-    """
-    Reads data from central schema Silver layer that matches the experiment ID.
-    This creates an experiment-specific snapshot as the foundation for scientific analysis.
-    """
-    # Read from central Silver tier, filtering for this experiment only
+def sample():
+    """Extract sample metadata and create references to measurement sets from central silver table"""
     return (
-        spark.readStream.table(f"{CATALOG_NAME}.{CENTRAL_SCHEMA}.{CENTRAL_SILVER_TABLE}")
-        .filter(F.col("experiment_id") == EXPERIMENT_ID)
-        .withColumn("experiment_import_timestamp", F.current_timestamp())
-    )
-
-# COMMAND ----------
-
-# DBTITLE 1,Experiment Silver Layer - Specialized Processing
-@dlt.table(
-    name=SILVER_TABLE,
-    comment=f"Silver layer: Experiment-specific processed data for {EXPERIMENT_ID}",
-    table_properties={
-        "quality": "silver",
-        "pipelines.autoOptimize.managed": "true"
-    }
-)
-@dlt.expect_or_fail("valid_measurement", "measurement_value IS NOT NULL")
-def experiment_silver():
-    """
-    Applies experiment-specific transformations and quality checks.
-    This is where scientific protocol-specific processing happens.
-    """
-    return (
-        dlt.read(BRONZE_TABLE)
-        # Add experiment-specific fields and transformations
-        .withColumn("experiment_specific_flag", 
-                   F.when(F.col("measurement_value") > 100, "high")
-                    .when(F.col("measurement_value") < 0, "error")
-                    .otherwise("normal"))
-        
-        # Apply experiment-specific quality check
-        .withColumn("experiment_quality_check", 
-                   (F.col("quality_check_passed") == True) & 
-                   (F.col("measurement_value").between(-100, 1000)))
-                   
-        # Add processing metadata
-        .withColumn("experiment_processed_timestamp", F.current_timestamp())
-        .withColumn("experiment_process_date", F.to_date(F.col("experiment_processed_timestamp")))
-    )
-
-# COMMAND ----------
-
-# DBTITLE 1,Experiment Gold Layer - Scientific Analytics
-@dlt.table(
-    name=GOLD_TABLE,
-    comment=f"Gold layer: Experiment-specific analytics for {EXPERIMENT_ID}",
-    table_properties={
-        "quality": "gold"
-    }
-)
-def experiment_gold():
-    """
-    Creates experiment-specific aggregations and metrics for scientific analysis.
-    These are tailored to the scientific questions being investigated.
-    """
-    return (
-        dlt.read(SILVER_TABLE)
-        .where("experiment_quality_check = true")  # Use experiment-specific quality check
-        .groupBy(
-            "date",
-            "device_id",
-            "sensor_id",
-            "plant_id",
-            "measurement_type"
+        spark.read.table(f"{CATALOG_NAME}.{CENTRAL_SCHEMA}.{CENTRAL_SILVER_TABLE}")
+        .filter(F.col("experiment_id") == EXPERIMENT_ID)  # Filter for specific experiment
+        .select(
+            F.col("device_id"),
+            F.col("device_name"),
+            F.explode(F.from_json(F.col("sample"), "array<string>")).alias("sample_data_str")
         )
-        .agg(
-            # Standard aggregations
-            F.count("*").alias("reading_count"),
-            F.avg("standardized_value").alias("avg_value"),
-            F.min("standardized_value").alias("min_value"),
-            F.max("standardized_value").alias("max_value"),
-            F.stddev("standardized_value").alias("stddev_value"),
-            
-            # Experiment-specific metrics
-            F.expr("percentile(standardized_value, 0.95)").alias("p95_value"),
-            F.expr("percentile(standardized_value, 0.05)").alias("p05_value"),
-            
-            # Count by experiment-specific flag
-            F.sum(F.when(F.col("experiment_specific_flag") == "high", 1).otherwise(0)).alias("high_value_count"),
-            F.sum(F.when(F.col("experiment_specific_flag") == "error", 1).otherwise(0)).alias("error_value_count")
+        .select(
+            F.col("device_id"),
+            F.col("device_name"),
+            F.get_json_object(F.col("sample_data_str"), "$.v_arrays").alias("v_arrays"),
+            F.get_json_object(F.col("sample_data_str"), "$.set_repeats").cast("int").alias("set_repeats"),
+            F.get_json_object(F.col("sample_data_str"), "$.protocol_id").alias("protocol_id"),
+            F.when(F.get_json_object(F.col("sample_data_str"), "$.set").isNotNull(), 
+                   F.from_json(F.get_json_object(F.col("sample_data_str"), "$.set"), "array<string>"))
+            .otherwise(
+                # Extract all fields except v_arrays, set_repeats, and protocol_id as JSON strings
+                F.expr("""
+                    transform(
+                        filter(
+                            map_keys(from_json(sample_data_str, 'map<string,string>')),
+                            key -> key NOT IN ('v_arrays', 'set_repeats', 'protocol_id')
+                        ),
+                        key -> to_json(map(key, get_json_object(sample_data_str, concat('$.', key))))
+                    )
+                """)
+            ).alias("measurement_sets"),
+            F.hash(F.col("device_id"), F.col("sample_data_str")).alias("sample_id"),
+            F.current_timestamp().alias("processed_timestamp")
+        )
+        .withColumn("measurement_set_types", 
+            F.when(F.col("measurement_sets").isNotNull(),
+                   F.when(F.expr("size(filter(transform(measurement_sets, x -> get_json_object(x, '$.label')), label -> label is not null)) > 0"),
+                          F.expr("transform(measurement_sets, x -> get_json_object(x, '$.label'))"))
+                   .otherwise(F.lit(None)))
+            .otherwise(F.array())
         )
     )
-
-# COMMAND ----------
-
-# DBTITLE 1,Experiment Daily Trends
-@dlt.table(
-    name="daily_trends",
-    comment=f"Gold layer: Daily trends for experiment {EXPERIMENT_ID}",
-    table_properties={
-        "quality": "gold" 
-    }
-)
-def daily_trends():
-    """
-    Creates experiment-specific daily trend analysis
-    """
-    return (
-        dlt.read(SILVER_TABLE)
-        .where("experiment_quality_check = true")
-        .groupBy("date", "device_type", "measurement_type")
-        .agg(
-            F.count("*").alias("reading_count"),
-            F.avg("standardized_value").alias("daily_avg"),
-            F.max("standardized_value").alias("daily_max"),
-            F.min("standardized_value").alias("daily_min")
-        )
-    )
-
-# COMMAND ----------
-
-# DBTITLE 1,Experiment Status
-@dlt.table(
-    name="experiment_status",
-    comment=f"System table: Processing status for experiment {EXPERIMENT_ID}",
-    table_properties={
-        "quality": "system"
-    }
-)
-def experiment_status():
-    """
-    Tracking table for experiment processing status
-    """
-    from datetime import datetime
-    
-    status_df = spark.createDataFrame([
-        {
-            "experiment_id": EXPERIMENT_ID,
-            "experiment_schema": EXPERIMENT_SCHEMA,
-            "pipeline_name": "experiment_pipeline",
-            "execution_timestamp": datetime.now(),
-            "source_schema": CENTRAL_SCHEMA,
-            "source_table": CENTRAL_SILVER_TABLE,
-            "status": "completed"
-        }
-    ])
-    
-    return status_df
 
 # COMMAND ----------
 


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Other (please describe)

## Description

Refactors the experiment pipeline notebook to introduce a new data model and streamline processing for MultispeQ experiment data.

### 🆕 Key Changes

- **Device and Sample Tables**
  - Replaces previous bronze, silver, and gold tables with two focused tables: `device` (device metadata) and `sample` (core sample data with measurement set references).
  - Device table extracts and deduplicates device metadata from the central silver table.
  - Sample table parses and structures sample metadata, including measurement sets and protocol references.

- **Simplified Processing Flow**
  - Removes layered bronze/silver/gold approach in favor of direct extraction and transformation.
  - Drops experiment-specific aggregations and analytics from the pipeline, focusing on core data extraction and structuring.

- **Code Structure**
  - All logic is now contained in two main DLT table functions: `device` and `sample`.
  - Legacy tables and daily trend/status tracking tables have been removed for clarity and maintainability.

### 🏗 Architectural Notes

- The pipeline now reads directly from the central silver table, filtering by experiment ID.
- Device and sample extraction logic is separated for clarity and future extensibility.
- Data is deduplicated and structured at the point of ingestion, reducing downstream complexity.
