### PR TITLE
feat(auth): orcid oauth provider

### DIFF
--- a/apps/web/components/__tests__/login-form.test.tsx
+++ b/apps/web/components/__tests__/login-form.test.tsx
@@ -1,0 +1,312 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import type { Locale } from "@repo/i18n";
+
+import { LoginForm } from "../login-form";
+
+globalThis.React = React;
+
+// Mock Next.js modules
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn(),
+}));
+
+// Mock auth module
+vi.mock("@/lib/auth", () => ({
+  signIn: vi.fn(),
+  providerMap: [
+    { id: "github", name: "GitHub" },
+    { id: "nodemailer", name: "Email" },
+    { id: "orcid", name: "ORCID" },
+  ],
+}));
+
+// Mock AuthError
+vi.mock("@repo/auth/next", () => ({
+  AuthError: class AuthError extends Error {
+    type: string;
+    constructor(type: string) {
+      super(type);
+      this.type = type;
+    }
+  },
+}));
+
+// Mock initTranslations
+vi.mock("@repo/i18n/server", () => ({
+  default: vi.fn(() =>
+    Promise.resolve({
+      t: (key: string) => key,
+    }),
+  ),
+}));
+
+// Mock UI components
+vi.mock("@repo/ui/components", () => ({
+  Button: ({
+    children,
+    type,
+    className,
+    variant,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    variant?: string;
+    children: React.ReactNode;
+  }) => (
+    <button type={type} className={className} data-variant={variant} {...props}>
+      {children}
+    </button>
+  ),
+  Input: ({
+    id,
+    name,
+    type,
+    placeholder,
+    required,
+    ...props
+  }: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input
+      id={id}
+      name={name}
+      type={type}
+      placeholder={placeholder}
+      required={required}
+      {...props}
+    />
+  ),
+  Label: ({
+    htmlFor,
+    children,
+    ...props
+  }: React.LabelHTMLAttributes<HTMLLabelElement> & {
+    children: React.ReactNode;
+  }) => (
+    <label htmlFor={htmlFor} {...props}>
+      {children}
+    </label>
+  ),
+}));
+
+describe("LoginForm", () => {
+  const defaultProps = {
+    callbackUrl: "/dashboard",
+    locale: "en-US" as Locale,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the login form with title and providers", async () => {
+    render(await LoginForm(defaultProps));
+
+    expect(screen.getByText("auth.loginToAccount")).toBeInTheDocument();
+    expect(screen.getByText("auth.continueWith")).toBeInTheDocument();
+    expect(screen.getByText("auth.loginWith-github")).toBeInTheDocument();
+    expect(screen.getByText("auth.loginWith-nodemailer")).toBeInTheDocument();
+    expect(screen.getByText("auth.loginWith-orcid")).toBeInTheDocument();
+  });
+
+  it("renders email input for nodemailer provider", async () => {
+    render(await LoginForm(defaultProps));
+
+    const emailInput = screen.getByLabelText("Email");
+    expect(emailInput).toBeInTheDocument();
+    expect(emailInput).toHaveAttribute("type", "email");
+    expect(emailInput).toHaveAttribute("placeholder", "m@example.com");
+    expect(emailInput).toBeRequired();
+  });
+
+  it("renders provider icons correctly", async () => {
+    render(await LoginForm(defaultProps));
+
+    // Check for GitHub SVG
+    const githubSvg = screen
+      .getByRole("button", { name: /auth\.loginWith-github/i })
+      .querySelector("svg");
+    expect(githubSvg).toBeInTheDocument();
+
+    // Check for ORCID SVG
+    const orcidSvg = screen
+      .getByRole("button", { name: /auth\.loginWith-orcid/i })
+      .querySelector("svg");
+    expect(orcidSvg).toBeInTheDocument();
+  });
+
+  it("renders 'Or continue with' separator after the first provider", async () => {
+    render(await LoginForm(defaultProps));
+
+    const separators = screen.getAllByText("auth.orContinueWith");
+    // Should appear after the first provider (index > 1 condition in the code)
+    expect(separators.length).toBeGreaterThan(0);
+  });
+
+  it("renders all buttons with correct styling", async () => {
+    render(await LoginForm(defaultProps));
+
+    const buttons = screen.getAllByRole("button");
+
+    buttons.forEach((button) => {
+      expect(button).toHaveAttribute("data-variant", "outline");
+      expect(button).toHaveClass("w-full");
+      expect(button).toHaveAttribute("type", "submit");
+    });
+  });
+
+  it("renders provider forms in correct order", async () => {
+    render(await LoginForm(defaultProps));
+
+    const buttons = screen.getAllByRole("button");
+
+    expect(buttons[0]).toHaveTextContent("auth.loginWith-github");
+    expect(buttons[1]).toHaveTextContent("auth.loginWith-nodemailer");
+    expect(buttons[2]).toHaveTextContent("auth.loginWith-orcid");
+  });
+
+  it("renders forms with correct structure", async () => {
+    render(await LoginForm(defaultProps));
+
+    const forms = document.querySelectorAll("form");
+    expect(forms).toHaveLength(3); // One form for each provider
+
+    // Check that each form has a submit button
+    forms.forEach((form) => {
+      const submitButton = form.querySelector('button[type="submit"]');
+      expect(submitButton).toBeInTheDocument();
+    });
+  });
+
+  it("renders with undefined callbackUrl", async () => {
+    const propsWithoutCallback = {
+      ...defaultProps,
+      callbackUrl: undefined,
+    };
+
+    render(await LoginForm(propsWithoutCallback));
+
+    // Should still render all the basic elements
+    expect(screen.getByText("auth.loginToAccount")).toBeInTheDocument();
+    expect(screen.getByText("auth.loginWith-github")).toBeInTheDocument();
+    expect(screen.getByText("auth.loginWith-nodemailer")).toBeInTheDocument();
+    expect(screen.getByText("auth.loginWith-orcid")).toBeInTheDocument();
+  });
+
+  it("renders forms with proper action attributes", async () => {
+    render(await LoginForm(defaultProps));
+
+    const forms = document.querySelectorAll("form");
+
+    // All forms should have action attributes (server actions)
+    forms.forEach((form) => {
+      expect(form).toHaveAttribute("action");
+    });
+  });
+
+  it("renders email input with proper name attribute for form data", async () => {
+    render(await LoginForm(defaultProps));
+
+    const emailInput = screen.getByLabelText("Email");
+    expect(emailInput).toHaveAttribute("name", "email");
+    expect(emailInput).toHaveAttribute("id", "email");
+  });
+
+  it("only renders email input for nodemailer provider", async () => {
+    render(await LoginForm(defaultProps));
+
+    // Should only have one email input (for nodemailer)
+    const emailInputs = screen.getAllByDisplayValue("");
+    const emailTypeInputs = emailInputs.filter((input) => input.getAttribute("type") === "email");
+    expect(emailTypeInputs).toHaveLength(1);
+  });
+
+  it("renders provider buttons with proper submit types", async () => {
+    render(await LoginForm(defaultProps));
+
+    const submitButtons = document.querySelectorAll('button[type="submit"]');
+    expect(submitButtons).toHaveLength(3);
+
+    // Each button should be inside a form
+    submitButtons.forEach((button) => {
+      expect(button.closest("form")).toBeInTheDocument();
+    });
+  });
+
+  it("renders correct provider order with proper separation", async () => {
+    render(await LoginForm(defaultProps));
+
+    const container = document.querySelector(".grid.gap-6");
+    expect(container).toBeInTheDocument();
+
+    // Check that we have the expected structure
+    const children = container?.children;
+    expect(children?.length).toBeGreaterThan(3); // Initial separator + providers + additional separators
+  });
+
+  it("handles different locale", async () => {
+    const propsWithDifferentLocale = {
+      ...defaultProps,
+      locale: "de-DE" as Locale,
+    };
+
+    render(await LoginForm(propsWithDifferentLocale));
+
+    // Should still render (translations will return keys with our mock)
+    expect(screen.getByText("auth.loginToAccount")).toBeInTheDocument();
+    expect(screen.getByText("auth.loginWith-github")).toBeInTheDocument();
+  });
+
+  it("renders with empty string callbackUrl", async () => {
+    const propsWithEmptyCallback = {
+      ...defaultProps,
+      callbackUrl: "",
+    };
+
+    render(await LoginForm(propsWithEmptyCallback));
+
+    // Should still render all elements
+    expect(screen.getByText("auth.loginToAccount")).toBeInTheDocument();
+    expect(screen.getAllByRole("button")).toHaveLength(3);
+  });
+
+  it("renders provider image components correctly", async () => {
+    render(await LoginForm(defaultProps));
+
+    // Check that GitHub icon has the correct path content
+    const githubButton = screen.getByRole("button", { name: /auth\.loginWith-github/i });
+    const githubSvg = githubButton.querySelector("svg");
+    const githubPath = githubSvg?.querySelector("path");
+    expect(githubPath).toHaveAttribute("fill", "currentColor");
+
+    // Check that ORCID icon has the correct path content and fill color
+    const orcidButton = screen.getByRole("button", { name: /auth\.loginWith-orcid/i });
+    const orcidSvg = orcidButton.querySelector("svg");
+    const orcidPath = orcidSvg?.querySelector("path");
+    expect(orcidPath).toHaveAttribute("fill", "#A6CE39");
+  });
+
+  it("renders correct provider map length", async () => {
+    render(await LoginForm(defaultProps));
+
+    // Should have exactly 3 providers as mocked
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(3);
+
+    // Should have exactly 3 forms
+    const forms = document.querySelectorAll("form");
+    expect(forms).toHaveLength(3);
+  });
+
+  it("renders separators correctly based on provider index", async () => {
+    render(await LoginForm(defaultProps));
+
+    // The first separator should be "Continue with"
+    expect(screen.getByText("auth.continueWith")).toBeInTheDocument();
+
+    // Should have at least one "Or continue with" separator (for providers after index 1)
+    const orSeparators = screen.getAllByText("auth.orContinueWith");
+    expect(orSeparators.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/web/components/login-form.tsx
+++ b/apps/web/components/login-form.tsx
@@ -32,7 +32,7 @@ export async function LoginForm({
         </div>
         {providerMap.map((provider, index) => (
           <div key={provider.id}>
-            {index > 0 && (
+            {index > 1 && (
               <div className="after:border-border relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t">
                 <span className="bg-background text-muted-foreground relative z-10 px-2">
                   {t("auth.orContinueWith")}
@@ -95,10 +95,19 @@ function ProviderImage({ id }: { id: string }) {
   switch (id) {
     case "github":
       return (
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="mr-2 h-4 w-4">
           <path
             d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
             fill="currentColor"
+          />
+        </svg>
+      );
+    case "orcid":
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" className="mr-2 h-4 w-4">
+          <path
+            d="M12 0C5.372 0 0 5.372 0 12s5.372 12 12 12 12-5.372 12-12S18.628 0 12 0zM7.369 4.378c.525 0 .947.431.947.947 0 .525-.422.947-.947.947A.943.943 0 0 1 6.422 5.325c0-.516.422-.947.947-.947zm-.722 3.038h1.444v10.041H6.647V7.416zm3.562 0h3.9c3.712 0 5.344 2.653 5.344 5.025 0 2.578-2.016 5.016-5.325 5.016h-3.919V7.416zm1.444 1.303v7.444h2.297c2.359 0 3.588-1.313 3.588-3.722 0-2.2-1.313-3.722-3.588-3.722h-2.297z"
+            fill="#A6CE39"
           />
         </svg>
       );

--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -335,6 +335,8 @@ module "auth_secrets" {
     AUTH_SECRET        = var.auth_secret
     AUTH_GITHUB_ID     = var.github_oauth_client_id
     AUTH_GITHUB_SECRET = var.github_oauth_client_secret
+    AUTH_ORCID_ID      = var.orcid_oauth_client_id
+    AUTH_ORCID_SECRET  = var.orcid_oauth_client_secret
   })
 
   tags = {
@@ -757,6 +759,14 @@ module "backend_ecs" {
     {
       name      = "AUTH_SECRET"
       valueFrom = "${module.auth_secrets.secret_arn}:AUTH_SECRET::"
+    },
+    {
+      name      = "AUTH_ORCID_ID"
+      valueFrom = "${module.auth_secrets.secret_arn}:AUTH_ORCID_ID::"
+    },
+    {
+      name      = "AUTH_ORCID_SECRET"
+      valueFrom = "${module.auth_secrets.secret_arn}:AUTH_ORCID_SECRET::"
     },
     {
       name      = "DATABRICKS_CLIENT_ID"

--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -761,14 +761,6 @@ module "backend_ecs" {
       valueFrom = "${module.auth_secrets.secret_arn}:AUTH_SECRET::"
     },
     {
-      name      = "AUTH_ORCID_ID"
-      valueFrom = "${module.auth_secrets.secret_arn}:AUTH_ORCID_ID::"
-    },
-    {
-      name      = "AUTH_ORCID_SECRET"
-      valueFrom = "${module.auth_secrets.secret_arn}:AUTH_ORCID_SECRET::"
-    },
-    {
       name      = "DATABRICKS_CLIENT_ID"
       valueFrom = "${module.databricks_secrets.secret_arn}:DATABRICKS_CLIENT_ID::"
     },

--- a/infrastructure/env/dev/variables.tf
+++ b/infrastructure/env/dev/variables.tf
@@ -71,6 +71,18 @@ variable "github_oauth_client_secret" {
   sensitive   = true
 }
 
+variable "orcid_oauth_client_id" {
+  description = "ORCID OAuth client ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "orcid_oauth_client_secret" {
+  description = "ORCID OAuth client secret"
+  type        = string
+  sensitive   = true
+}
+
 # Backend x Databricks webhook secrets
 variable "backend_webhook_api_key_id" {
   description = "Databricks webhook API key ID"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -25,6 +25,10 @@
     "./types": {
       "types": "./src/types.d.ts",
       "default": "./dist/types.js"
+    },
+    "./providers/orcid": {
+      "types": "./src/providers/orcid.d.ts",
+      "default": "./dist/providers/orcid.js"
     }
   },
   "private": true,

--- a/packages/auth/src/next.ts
+++ b/packages/auth/src/next.ts
@@ -8,6 +8,7 @@ import { AuthError } from "next-auth";
 import { adapter, lambdaAdapter } from "./adapter";
 import { baseAuthConfig } from "./config";
 import { sendVerificationRequest } from "./email/verificationRequest";
+import ORCID from "./providers/orcid";
 
 interface InitAuthParams {
   authSecrets: Record<string, string>;
@@ -32,6 +33,20 @@ export function initAuth({
       clientSecret: authSecrets.AUTH_GITHUB_SECRET || process.env.AUTH_GITHUB_SECRET,
     }),
   ];
+
+  if (authSecrets.AUTH_ORCID_ID || process.env.AUTH_ORCID_ID) {
+    providers.push(
+      ORCID({
+        clientId: authSecrets.AUTH_ORCID_ID || process.env.AUTH_ORCID_ID,
+        clientSecret: authSecrets.AUTH_ORCID_SECRET || process.env.AUTH_ORCID_SECRET,
+        environment:
+          authSecrets.AUTH_ORCID_ENVIRONMENT === "sandbox" ||
+          process.env.AUTH_ORCID_ENVIRONMENT === "sandbox"
+            ? "sandbox"
+            : "production",
+      }),
+    );
+  }
 
   if (
     (sesSecrets.AUTH_EMAIL_SERVER || process.env.AUTH_EMAIL_SERVER) &&

--- a/packages/auth/src/providers/orcid.ts
+++ b/packages/auth/src/providers/orcid.ts
@@ -1,0 +1,113 @@
+import type { OAuthConfig, OAuthUserConfig } from "@auth/core/providers/oauth";
+
+export interface ORCIDProfile extends Record<string, unknown> {
+  orcid_identifier: {
+    uri: string;
+    path: string;
+    host: string;
+  };
+  person: {
+    name: {
+      "given-names": {
+        value: string;
+      } | null;
+      "family-name": {
+        value: string;
+      } | null;
+      "credit-name": {
+        value: string;
+      } | null;
+    } | null;
+  } | null;
+}
+
+/**
+ * ORCID OAuth provider for Auth.js
+ *
+ * @example
+ * ```ts
+ * import { ORCID } from "@repo/auth/providers/orcid"
+ *
+ * export default NextAuth({
+ *   providers: [
+ *     ORCID({
+ *       clientId: process.env.AUTH_ORCID_ID,
+ *       clientSecret: process.env.AUTH_ORCID_SECRET,
+ *     })
+ *   ]
+ * })
+ * ```
+ *
+ * Resources:
+ * - [ORCID API Tutorial](https://info.orcid.org/documentation/api-tutorials/api-tutorial-get-and-authenticated-orcid-id/)
+ * - [ORCID OAuth Documentation](https://info.orcid.org/documentation/integration-and-api-faq/)
+ */
+export default function ORCID<P extends ORCIDProfile>(
+  options: OAuthUserConfig<P> & {
+    /**
+     * Set to "sandbox" to use ORCID sandbox environment for testing
+     * @default "production"
+     */
+    environment?: "production" | "sandbox";
+  },
+): OAuthConfig<P> {
+  const isProduction = options.environment !== "sandbox";
+  const baseUrl = isProduction ? "https://orcid.org" : "https://sandbox.orcid.org";
+
+  return {
+    id: "orcid",
+    name: "ORCID",
+    type: "oauth",
+    issuer: baseUrl,
+    authorization: {
+      url: `${baseUrl}/oauth/authorize`,
+      params: {
+        scope: "/authenticate",
+        response_type: "code",
+        // Note: redirect_uri is automatically handled by Auth.js
+        // It will be added as: {baseUrl}/api/auth/callback/orcid
+      },
+    },
+    token: `${baseUrl}/oauth/token`,
+    userinfo: {
+      url: `${baseUrl}/v3.0/`,
+      async request({ tokens }: { tokens: { access_token: string } }) {
+        // ORCID requires the bearer token to access user information
+        const tokensObj = tokens as { access_token: string };
+        const response = await fetch(`${baseUrl}/v3.0/${tokensObj.access_token}/record`, {
+          headers: {
+            Authorization: `Bearer ${tokensObj.access_token}`,
+            Accept: "application/json",
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch ORCID profile: ${response.status}`);
+        }
+
+        return (await response.json()) as P;
+      },
+    },
+    client: {
+      token_endpoint_auth_method: "client_secret_post",
+    },
+    profile(profile: P) {
+      const givenName = profile.person?.name?.["given-names"]?.value ?? "";
+      const familyName = profile.person?.name?.["family-name"]?.value ?? "";
+      const fullName = `${givenName} ${familyName}`.trim();
+
+      return {
+        id: profile.orcid_identifier.path,
+        name:
+          profile.person?.name?.["credit-name"]?.value ??
+          (fullName || profile.orcid_identifier.path),
+        email: null, // ORCID doesn't provide email in the basic scope
+        image: null, // ORCID doesn't provide profile images
+        registered: false, // Will be set properly by the auth system
+        // Store the full ORCID iD for future reference
+        orcid: profile.orcid_identifier.uri,
+      };
+    },
+    options,
+  };
+}

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -23,6 +23,8 @@ declare module "@auth/core/types" {
   interface User extends DefaultUser {
     id: string;
     registered: boolean;
+    /** ORCID iD URI if user authenticated with ORCID */
+    orcid?: string;
     // Example on how to extend the User type
     // role?: "admin" | "user";
   }

--- a/packages/i18n/locales/de-DE/common.json
+++ b/packages/i18n/locales/de-DE/common.json
@@ -197,6 +197,7 @@
     "loginWith": "Anmelden mit {{provider}}",
     "loginWith-github": "Mit GitHub anmelden",
     "loginWith-nodemailer": "Mit E-Mail anmelden",
+    "loginWith-orcid": "Mit ORCID anmelden",
     "verifyRequest": "Wir haben Ihnen per E-Mail einen Anmeldelink gesendet",
     "verifyRequestDetails": "Wir haben Ihnen eine E-Mail an Ihre E-Mail-Adresse gesendet. Tippen Sie auf die Schaltfläche in der E-Mail, um fortzufahren.",
     "verifyRequestDetailsJunk": "Wenn Sie die E-Mail nicht sehen, überprüfen Sie Ihren Spam- oder Junk-Ordner.",

--- a/packages/i18n/locales/en-US/common.json
+++ b/packages/i18n/locales/en-US/common.json
@@ -203,6 +203,7 @@
     "loginWith": "Sign in with {{provider}}",
     "loginWith-github": "Sign in with GitHub",
     "loginWith-nodemailer": "Sign in with Email",
+    "loginWith-orcid": "Sign in with ORCID",
     "verifyRequest": "We emailed you a sign in link",
     "verifyRequestDetails": "We sent you an email to your email address. Tap the button in the email to continue.",
     "verifyRequestDetailsJunk": "If you don’t see the email, check your spam or junk folder.",

--- a/packages/i18n/locales/nl-NL/common.json
+++ b/packages/i18n/locales/nl-NL/common.json
@@ -151,6 +151,9 @@
     "loginToAccount": "Log in op je account",
     "continueWith": "Doorgaan met",
     "loginWith": "Inloggen met {{provider}}",
+    "loginWith-github": "Inloggen met GitHub",
+    "loginWith-nodemailer": "Inloggen met e-mail",
+    "loginWith-orcid": "Inloggen met ORCID",
     "account": "Account",
     "userMenu": "Gebruikersmenu",
     "signingOut": "Uitloggen..."


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Other (please describe)

## Description

Adds ORCID OAuth authentication support to the application, enabling researchers to sign in using their ORCID credentials alongside existing GitHub and email authentication methods.

### 🔧 Core Features
- **ORCID OAuth Provider Integration**
  - Custom ORCID provider implementation with production and sandbox environment support
  - Proper token handling and user profile extraction from ORCID API
  - Support for ORCID iD persistence in user profiles
- **Multi-language Support**
  - Added ORCID login translations for English, German, and Dutch locales
  - Consistent messaging across all supported authentication providers
- **UI Enhancements**
  - Added ORCID icon/logo to login form with proper styling
  - Fixed provider separator logic to improve visual hierarchy
  - Maintained consistent button styling across all providers

### 🏗 Architecture Implementation
- Built custom ORCID provider following Auth.js OAuth patterns
- Extended user type definitions to include optional ORCID iD field
- Environment-aware configuration supporting both production and sandbox ORCID endpoints
- Proper error handling for ORCID API responses and token validation