### PR TITLE
feat: add data layout with provisioning status handling

### DIFF
--- a/apps/web/app/[locale]/platform/experiments/[id]/data/__tests__/layout.test.tsx
+++ b/apps/web/app/[locale]/platform/experiments/[id]/data/__tests__/layout.test.tsx
@@ -1,0 +1,383 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import type { Locale } from "@repo/i18n";
+
+import DataLayout from "../layout";
+
+// Global React for JSX in mocks
+globalThis.React = React;
+
+// -------------------
+// Mocks
+// -------------------
+
+// Mock React's use function for async params
+const mockUse = vi.fn();
+vi.mock("react", async () => {
+  const actual = await vi.importActual("react");
+  return {
+    ...actual,
+    use: (promise: Promise<unknown>) => mockUse(promise),
+  };
+});
+
+// Mock useExperiment hook
+const mockUseExperiment = vi.fn();
+vi.mock("@/hooks/experiment/useExperiment/useExperiment", () => ({
+  useExperiment: (id: string) => mockUseExperiment(id),
+}));
+
+// Mock i18n
+vi.mock("@repo/i18n/client", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+// Mock error display component
+vi.mock("@/components/error-display", () => ({
+  ErrorDisplay: ({ error, title }: { error: Error; title: string }) => (
+    <div data-testid="error-display">
+      <h2>{title}</h2>
+      <p>{error.message}</p>
+    </div>
+  ),
+}));
+
+// Mock UI components
+vi.mock("@repo/ui/components", () => {
+  const Alert = ({
+    children,
+    variant,
+    className,
+  }: React.PropsWithChildren<{ variant?: string; className?: string }>) => (
+    <div data-testid="alert" data-variant={variant} className={className}>
+      {children}
+    </div>
+  );
+
+  const AlertTitle = ({ children }: React.PropsWithChildren) => (
+    <h3 data-testid="alert-title">{children}</h3>
+  );
+
+  const AlertDescription = ({ children }: React.PropsWithChildren) => (
+    <div data-testid="alert-description">{children}</div>
+  );
+
+  const TooltipProvider = ({ children }: React.PropsWithChildren) => (
+    <div data-testid="tooltip-provider">{children}</div>
+  );
+
+  const Tooltip = ({ children }: React.PropsWithChildren) => (
+    <div data-testid="tooltip">{children}</div>
+  );
+
+  const TooltipTrigger = ({
+    children,
+    asChild: _asChild,
+  }: React.PropsWithChildren<{ asChild?: boolean }>) => {
+    return (
+      <div data-testid="tooltip-trigger" className="ml-2 inline h-4 w-4 cursor-help">
+        {children}
+      </div>
+    );
+  };
+
+  const TooltipContent = ({ children }: React.PropsWithChildren) => (
+    <div data-testid="tooltip-content">{children}</div>
+  );
+
+  return {
+    Alert,
+    AlertTitle,
+    AlertDescription,
+    TooltipProvider,
+    Tooltip,
+    TooltipTrigger,
+    TooltipContent,
+  };
+});
+
+// Mock Lucide icons
+vi.mock("lucide-react", () => ({
+  AlertTriangle: (props: React.ComponentProps<"div">) => (
+    <div data-testid="alert-triangle-icon" {...props} />
+  ),
+  Info: (props: React.ComponentProps<"div">) => <div data-testid="info-icon" {...props} />,
+  Loader2: (props: React.ComponentProps<"div">) => <div data-testid="loader2-icon" {...props} />,
+}));
+
+// -------------------
+// Test Data
+// -------------------
+const mockParams = { id: "test-experiment-id", locale: "en-US" as Locale };
+
+const createMockExperiment = (status: string) => ({
+  data: {
+    body: {
+      id: "test-experiment-id",
+      name: "Test Experiment",
+      status,
+      createdAt: "2023-01-01T00:00:00Z",
+      updatedAt: "2023-01-01T00:00:00Z",
+    },
+  },
+  isLoading: false,
+  error: null,
+});
+
+// -------------------
+// Helpers
+// -------------------
+function renderDataLayout({
+  children = <div data-testid="child-content">Child Content</div>,
+  experimentStatus = "active",
+  isLoading = false,
+  error = null,
+}: {
+  children?: React.ReactNode;
+  experimentStatus?: string;
+  isLoading?: boolean;
+  error?: Error | null;
+} = {}) {
+  // Mock the async params
+  mockUse.mockReturnValue(mockParams);
+
+  // Mock useExperiment hook response
+  if (error) {
+    mockUseExperiment.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error,
+    });
+  } else if (isLoading) {
+    mockUseExperiment.mockReturnValue({
+      data: null,
+      isLoading: true,
+      error: null,
+    });
+  } else {
+    mockUseExperiment.mockReturnValue(createMockExperiment(experimentStatus));
+  }
+
+  return render(<DataLayout params={Promise.resolve(mockParams)}>{children}</DataLayout>);
+}
+
+// -------------------
+// Tests
+// -------------------
+describe("<DataLayout />", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Loading State", () => {
+    it("shows loading message when data is loading", () => {
+      renderDataLayout({ isLoading: true });
+
+      expect(screen.getByText("loading")).toBeInTheDocument();
+      expect(screen.queryByTestId("child-content")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Error State", () => {
+    it("shows error display when there is an error", () => {
+      const error = new Error("Failed to fetch experiment");
+      renderDataLayout({ error });
+
+      expect(screen.getByTestId("error-display")).toBeInTheDocument();
+      expect(screen.getByText("failedToLoad")).toBeInTheDocument();
+      expect(screen.getByText("Failed to fetch experiment")).toBeInTheDocument();
+      expect(screen.queryByTestId("child-content")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("No Data State", () => {
+    it("shows not found message when no data is returned", () => {
+      mockUse.mockReturnValue(mockParams);
+      mockUseExperiment.mockReturnValue({
+        data: null,
+        isLoading: false,
+        error: null,
+      });
+
+      render(
+        <DataLayout params={Promise.resolve(mockParams)}>
+          <div data-testid="child-content">Child Content</div>
+        </DataLayout>,
+      );
+
+      expect(screen.getByText("notFound")).toBeInTheDocument();
+      expect(screen.queryByTestId("child-content")).not.toBeInTheDocument();
+    });
+
+    it("shows not found message when experiment body is missing", () => {
+      mockUse.mockReturnValue(mockParams);
+      mockUseExperiment.mockReturnValue({
+        data: { body: null },
+        isLoading: false,
+        error: null,
+      });
+
+      render(
+        <DataLayout params={Promise.resolve(mockParams)}>
+          <div data-testid="child-content">Child Content</div>
+        </DataLayout>,
+      );
+
+      expect(screen.getByText("notFound")).toBeInTheDocument();
+      expect(screen.queryByTestId("child-content")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Active State", () => {
+    it("renders children when experiment status is active", () => {
+      renderDataLayout({ experimentStatus: "active" });
+
+      expect(screen.getByTestId("child-content")).toBeInTheDocument();
+      expect(screen.getByText("Child Content")).toBeInTheDocument();
+      expect(screen.queryByTestId("alert")).not.toBeInTheDocument();
+    });
+
+    it("renders children when experiment status is completed", () => {
+      renderDataLayout({ experimentStatus: "completed" });
+
+      expect(screen.getByTestId("child-content")).toBeInTheDocument();
+      expect(screen.queryByTestId("alert")).not.toBeInTheDocument();
+    });
+
+    it("renders children when experiment status is unknown", () => {
+      renderDataLayout({ experimentStatus: "unknown" });
+
+      expect(screen.getByTestId("child-content")).toBeInTheDocument();
+      expect(screen.queryByTestId("alert")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Provisioning State", () => {
+    it("shows provisioning alert and blocks children when status is provisioning", () => {
+      renderDataLayout({ experimentStatus: "provisioning" });
+
+      // Should show alert instead of children
+      expect(screen.queryByTestId("child-content")).not.toBeInTheDocument();
+
+      // Should show the alert with correct styling
+      const alert = screen.getByTestId("alert");
+      expect(alert).toBeInTheDocument();
+      expect(alert).toHaveAttribute("data-variant", "default");
+
+      // Should show correct title and description
+      expect(screen.getByTestId("alert-title")).toHaveTextContent(
+        "experimentData.provisioning.title",
+      );
+      expect(screen.getByTestId("alert-description")).toHaveTextContent(
+        "experimentData.provisioning.description",
+      );
+
+      // Should show loader icon
+      expect(screen.getByTestId("loader2-icon")).toBeInTheDocument();
+
+      // Should show header content
+      expect(screen.getByText("experimentData.title")).toBeInTheDocument();
+      expect(screen.getByText("experimentData.description")).toBeInTheDocument();
+    });
+
+    it("shows tooltip for provisioning state", () => {
+      renderDataLayout({ experimentStatus: "provisioning" });
+
+      // Should show tooltip components
+      expect(screen.getByTestId("tooltip-provider")).toBeInTheDocument();
+      expect(screen.getByTestId("tooltip")).toBeInTheDocument();
+      expect(screen.getByTestId("tooltip-trigger")).toBeInTheDocument();
+      expect(screen.getByTestId("tooltip-content")).toBeInTheDocument();
+
+      // Should show info icon in tooltip trigger
+      expect(screen.getByTestId("info-icon")).toBeInTheDocument();
+
+      // Should show correct tooltip text
+      expect(screen.getByText("experimentData.provisioning.tooltip")).toBeInTheDocument();
+    });
+  });
+
+  describe("Provisioning Failed State", () => {
+    it("shows provisioning failed alert and blocks children when status is provisioning_failed", () => {
+      renderDataLayout({ experimentStatus: "provisioning_failed" });
+
+      // Should show alert instead of children
+      expect(screen.queryByTestId("child-content")).not.toBeInTheDocument();
+
+      // Should show the alert with correct styling
+      const alert = screen.getByTestId("alert");
+      expect(alert).toBeInTheDocument();
+      expect(alert).toHaveAttribute("data-variant", "destructive");
+
+      // Should show correct title and description
+      expect(screen.getByTestId("alert-title")).toHaveTextContent(
+        "experimentData.provisioningFailed.title",
+      );
+      expect(screen.getByTestId("alert-description")).toHaveTextContent(
+        "experimentData.provisioningFailed.description",
+      );
+
+      // Should show alert triangle icon
+      expect(screen.getByTestId("alert-triangle-icon")).toBeInTheDocument();
+
+      // Should show header content
+      expect(screen.getByText("experimentData.title")).toBeInTheDocument();
+      expect(screen.getByText("experimentData.description")).toBeInTheDocument();
+    });
+
+    it("does not show tooltip for provisioning_failed state", () => {
+      renderDataLayout({ experimentStatus: "provisioning_failed" });
+
+      // Should not show tooltip components
+      expect(screen.queryByTestId("tooltip-provider")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("tooltip")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("info-icon")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Hook Integration", () => {
+    it("calls useExperiment with correct experiment ID", () => {
+      renderDataLayout();
+
+      expect(mockUseExperiment).toHaveBeenCalledWith("test-experiment-id");
+    });
+
+    it("calls use function with params promise", () => {
+      renderDataLayout();
+
+      expect(mockUse).toHaveBeenCalledWith(expect.any(Promise));
+    });
+  });
+
+  describe("Tooltip Interaction", () => {
+    it("only shows tooltip for provisioning state, not for other states", () => {
+      // Test provisioning state has tooltip
+      const { rerender } = renderDataLayout({ experimentStatus: "provisioning" });
+      expect(screen.getByTestId("tooltip-provider")).toBeInTheDocument();
+
+      // Test active state doesn't have tooltip
+      mockUseExperiment.mockReturnValue(createMockExperiment("active"));
+      rerender(
+        <DataLayout params={Promise.resolve(mockParams)}>
+          <div data-testid="child-content">Child Content</div>
+        </DataLayout>,
+      );
+      expect(screen.queryByTestId("tooltip-provider")).not.toBeInTheDocument();
+
+      // Test provisioning_failed state doesn't have tooltip
+      mockUseExperiment.mockReturnValue(createMockExperiment("provisioning_failed"));
+      rerender(
+        <DataLayout params={Promise.resolve(mockParams)}>
+          <div data-testid="child-content">Child Content</div>
+        </DataLayout>,
+      );
+      expect(screen.queryByTestId("tooltip-provider")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/app/[locale]/platform/experiments/[id]/data/layout.tsx
+++ b/apps/web/app/[locale]/platform/experiments/[id]/data/layout.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { ErrorDisplay } from "@/components/error-display";
+import { useExperiment } from "@/hooks/experiment/useExperiment/useExperiment";
+import { AlertCircle, InfoIcon } from "lucide-react";
+import { use, useMemo } from "react";
+import * as React from "react";
+
+import type { Locale } from "@repo/i18n";
+import { useTranslation } from "@repo/i18n/client";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@repo/ui/components";
+
+interface DataLayoutProps {
+  children: React.ReactNode;
+  params: Promise<{ id: string; locale: Locale }>;
+}
+
+export default function DataLayout({ children, params }: DataLayoutProps) {
+  const { id } = use(params);
+  const { data, isLoading, error } = useExperiment(id);
+  const { t } = useTranslation("experiments");
+
+  // Memoize experiment status checks and message - must be called before any early returns
+  const experiment = data?.body;
+
+  const isProvisioningState = useMemo(
+    () => experiment?.status === "provisioning" || experiment?.status === "provisioning_failed",
+    [experiment?.status],
+  );
+
+  const message = useMemo(() => {
+    if (!experiment) return null;
+
+    if (experiment.status === "provisioning") {
+      return {
+        title: t("experimentData.provisioning.title"),
+        description: t("experimentData.provisioning.description"),
+        icon: <InfoIcon className="h-4 w-4" />,
+        variant: "default" as const,
+      };
+    } else {
+      return {
+        title: t("experimentData.provisioningFailed.title"),
+        description: t("experimentData.provisioningFailed.description"),
+        icon: <AlertCircle className="h-4 w-4" />,
+        variant: "destructive" as const,
+      };
+    }
+  }, [experiment, t]);
+
+  if (isLoading) {
+    return <div>{t("loading")}</div>;
+  }
+
+  if (error) {
+    return <ErrorDisplay error={error} title={t("failedToLoad")} />;
+  }
+
+  if (!data || !experiment) {
+    return <div>{t("notFound")}</div>;
+  }
+
+  if (!isProvisioningState) {
+    return <>{children}</>;
+  }
+
+  // At this point we know experiment exists and is in provisioning state, so message won't be null
+  if (!message) {
+    return <div>{t("notFound")}</div>;
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-start justify-between">
+        <div>
+          <h4 className="text-lg font-medium">{t("experimentData.title")}</h4>
+          <p className="text-muted-foreground text-sm">{t("experimentData.description")}</p>
+        </div>
+      </div>
+
+      <Alert variant={message.variant}>
+        {message.icon}
+        <AlertTitle>{message.title}</AlertTitle>
+        <AlertDescription>
+          {message.description}
+          {experiment.status === "provisioning" && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <InfoIcon className="ml-2 inline h-4 w-4 cursor-help" />
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>{t("experimentData.provisioning.tooltip")}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+}

--- a/apps/web/app/[locale]/platform/experiments/[id]/data/layout.tsx
+++ b/apps/web/app/[locale]/platform/experiments/[id]/data/layout.tsx
@@ -2,7 +2,7 @@
 
 import { ErrorDisplay } from "@/components/error-display";
 import { useExperiment } from "@/hooks/experiment/useExperiment/useExperiment";
-import { AlertCircle, InfoIcon } from "lucide-react";
+import { AlertTriangle, Info, Loader2 } from "lucide-react";
 import { use, useMemo } from "react";
 import * as React from "react";
 
@@ -43,17 +43,23 @@ export default function DataLayout({ children, params }: DataLayoutProps) {
       return {
         title: t("experimentData.provisioning.title"),
         description: t("experimentData.provisioning.description"),
-        icon: <InfoIcon className="h-4 w-4" />,
+        icon: Loader2,
         variant: "default" as const,
+        tooltipText: t("experimentData.provisioning.tooltip"),
       };
-    } else {
+    }
+
+    if (experiment.status === "provisioning_failed") {
       return {
         title: t("experimentData.provisioningFailed.title"),
         description: t("experimentData.provisioningFailed.description"),
-        icon: <AlertCircle className="h-4 w-4" />,
+        icon: AlertTriangle,
         variant: "destructive" as const,
+        tooltipText: t("experimentData.provisioningFailed.tooltip"),
       };
     }
+
+    return null;
   }, [experiment, t]);
 
   if (isLoading) {
@@ -68,13 +74,8 @@ export default function DataLayout({ children, params }: DataLayoutProps) {
     return <div>{t("notFound")}</div>;
   }
 
-  if (!isProvisioningState) {
+  if (!isProvisioningState || !message) {
     return <>{children}</>;
-  }
-
-  // At this point we know experiment exists and is in provisioning state, so message won't be null
-  if (!message) {
-    return <div>{t("notFound")}</div>;
   }
 
   return (
@@ -87,7 +88,7 @@ export default function DataLayout({ children, params }: DataLayoutProps) {
       </div>
 
       <Alert variant={message.variant}>
-        {message.icon}
+        <message.icon className="h-4 w-4" />
         <AlertTitle>{message.title}</AlertTitle>
         <AlertDescription>
           {message.description}
@@ -95,7 +96,7 @@ export default function DataLayout({ children, params }: DataLayoutProps) {
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <InfoIcon className="ml-2 inline h-4 w-4 cursor-help" />
+                  <Info className="ml-2 inline h-4 w-4 cursor-help" />
                 </TooltipTrigger>
                 <TooltipContent>
                   <p>{t("experimentData.provisioning.tooltip")}</p>

--- a/packages/i18n/locales/de-DE/experiments.json
+++ b/packages/i18n/locales/de-DE/experiments.json
@@ -63,7 +63,16 @@
   "experimentData": {
     "title": "Experimentdaten",
     "description": "Anzeigen und Verwalten von Daten, die mit diesem Experiment verbunden sind.",
-    "uploadData": "Daten hochladen"
+    "uploadData": "Daten hochladen",
+    "provisioning": {
+      "title": "Experiment wird vorbereitet",
+      "description": "Die Experiment-Infrastruktur wird derzeit eingerichtet. Der Datenzugang wird verfügbar sein, sobald die Bereitstellung abgeschlossen ist.",
+      "tooltip": "Während der Bereitstellung erstellt das System Datenbankschemas, richtet Daten-Pipelines ein und konfiguriert Zugriffsberechtigungen. Dieser Prozess dauert normalerweise einige Minuten."
+    },
+    "provisioningFailed": {
+      "title": "Experiment-Setup fehlgeschlagen",
+      "description": "Es gab ein Problem beim Einrichten der Experiment-Infrastruktur. Bitte kontaktieren Sie den Support oder versuchen Sie, das Experiment neu zu erstellen."
+    }
   },
   "experiment": "Experiment",
   "experimentId": "Experiment-ID",

--- a/packages/i18n/locales/en-US/experiments.json
+++ b/packages/i18n/locales/en-US/experiments.json
@@ -63,7 +63,16 @@
   "experimentData": {
     "title": "Experiment Data",
     "description": "View and manage data associated with this experiment.",
-    "uploadData": "Upload Data"
+    "uploadData": "Upload Data",
+    "provisioning": {
+      "title": "Experiment is Being Prepared",
+      "description": "The experiment infrastructure is currently being set up. Data access will be available once provisioning is complete.",
+      "tooltip": "During provisioning, the system is creating database schemas, setting up data pipelines, and configuring access permissions. This process usually takes a few minutes."
+    },
+    "provisioningFailed": {
+      "title": "Experiment Setup Failed",
+      "description": "There was an issue setting up the experiment infrastructure. Please contact support or try recreating the experiment."
+    }
   },
   "experiment": "Experiment",
   "experimentId": "Experiment ID",

--- a/packages/i18n/locales/nl-NL/experiments.json
+++ b/packages/i18n/locales/nl-NL/experiments.json
@@ -56,7 +56,16 @@
   "experimentData": {
     "title": "Experimentgegevens",
     "description": "Bekijk en beheer gegevens die bij dit experiment horen.",
-    "uploadData": "Gegevens uploaden"
+    "uploadData": "Gegevens uploaden",
+    "provisioning": {
+      "title": "Experiment wordt voorbereid",
+      "description": "De experimentinfrastructuur wordt momenteel opgezet. Gegevenstoegang wordt beschikbaar zodra de inrichting is voltooid.",
+      "tooltip": "Tijdens het inrichten maakt het systeem databaseschema's aan, stelt gegevenspijplijnen in en configureert toegangsrechten. Dit proces duurt meestal enkele minuten."
+    },
+    "provisioningFailed": {
+      "title": "Experiment-instelling mislukt",
+      "description": "Er was een probleem bij het opzetten van de experimentinfrastructuur. Neem contact op met de ondersteuning of probeer het experiment opnieuw aan te maken."
+    }
   },
   "experiment": "Experiment",
   "experimentId": "Experiment-ID",


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [x] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Other (please describe)

## Description

- Add layout component for experiment data pages that checks provisioning status
- Show informative alerts when experiment is in provisioning or provisioning_failed state
- Prevent data queries during provisioning with user-friendly messaging
- Add tooltip explaining provisioning process to users
- Optimize with useMemo for performance on status checks and message creation
- Add translation keys for provisioning states in en, de, and nl locales

Closes: [ticket-number] (if applicable)
<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #
- Related to #

## Testing Instructions

<!-- Provide steps to test your changes and any relevant environments tested -->

- [ ] Test case 1
- [ ] Test case 2

## Changes Made

<!-- List the key changes made in this PR -->

-
-

## Checklist

- [ ] I have added/updated tests for my changes
- [ ] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have tested these changes locally
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code

## Screenshots/Recordings

<!-- If applicable, add screenshots or recordings to demonstrate your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
