### PR TITLE
chore(api): label no longer required in multi protocol set

### DIFF
--- a/packages/api/src/schemas/protocol-validator.spec.ts
+++ b/packages/api/src/schemas/protocol-validator.spec.ts
@@ -347,7 +347,7 @@ describe("Comprehensive Protocol JSON Validator", () => {
         expect(isMultiProtocolSet(result.data[0])).toBe(true);
 
         if (isMultiProtocolSet(result.data[0])) {
-          const protocolSet = result.data[0]._protocol_set_ as ProtocolSet[];
+          const protocolSet = result.data[0]._protocol_set_ as unknown as ProtocolSet[];
           expect(protocolSet).toHaveLength(4);
           expect(protocolSet[0].label).toBe("no_leaf_baseline");
           expect(protocolSet[1].label).toBe("DIRK_ECS");
@@ -997,7 +997,7 @@ describe("Code to determine error line numbers", () => {
     const protocol: unknown = JSON.parse(code);
     const result = validateProtocolJson(protocol);
     expect(result.success).toBe(false);
-    expect(result.error?.length).toBe(3);
+    expect(result.error?.length).toBe(2);
     if (result.error !== undefined) {
       const errorInfo1 = findProtocolErrorLine(code, result.error[0]);
       expect(errorInfo1).toStrictEqual({
@@ -1005,9 +1005,7 @@ describe("Code to determine error line numbers", () => {
         message: "Item 'averages': Number must be greater than 0",
       });
       const errorInfo2 = findProtocolErrorLine(code, result.error[1]);
-      expect(errorInfo2).toStrictEqual({ line: 31, message: "Item 'label': Required" });
-      const errorInfo3 = findProtocolErrorLine(code, result.error[2]);
-      expect(errorInfo3).toStrictEqual({
+      expect(errorInfo2).toStrictEqual({
         line: 30,
         message: "Item 'averages': Number must be greater than 0",
       });

--- a/packages/api/src/schemas/protocol-validator.ts
+++ b/packages/api/src/schemas/protocol-validator.ts
@@ -169,15 +169,10 @@ export const ProtocolSetSchema = z
   })
   .strict();
 
-// Schema for protocols within a multi-protocol set (requires label)
-const ProtocolSetWithLabelSchema = ProtocolSetSchema.extend({
-  label: z.string(), // Required for multi-protocol sets
-}).strict();
-
 // Single and multi-protocol set schema
 export const ProtocolJsonSchema = z.array(
   ProtocolSetSchema.extend({
-    _protocol_set_: z.array(ProtocolSetWithLabelSchema).min(1).optional(),
+    _protocol_set_: z.array(ProtocolSetSchema).min(1).optional(),
   }).strict(),
 );
 


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Other (please describe)

## Description

The field is now no longer required in multi protocol sets.

## Related Issues

- Related to #456

## Testing Instructions

You should now be able to save the 4 provided protocols without getting an error about a missing Label field.

## Changes Made

- Changed protocol validation so that the field label in multi-protocol set is no longer required

## Checklist

- [ ] I have added/updated tests for my changes
- [ ] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have tested these changes locally
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
