### PR TITLE
fix(api): Allow protocol with inc_ri

### DIFF
--- a/packages/api/src/schemas/protocol-validator.spec.ts
+++ b/packages/api/src/schemas/protocol-validator.spec.ts
@@ -1128,4 +1128,17 @@ describe("Code to determine error line numbers", () => {
       });
     }
   });
+
+  it("should validate protocol with inc_ri", () => {
+    const envProtocol = [
+      {
+        inc_ri: 1,
+        environmental: [["light_intensity", 0]],
+      },
+    ];
+
+    const result = validateProtocolJson(envProtocol);
+
+    expect(result.success).toBe(true);
+  });
 });

--- a/packages/api/src/schemas/protocol-validator.ts
+++ b/packages/api/src/schemas/protocol-validator.ts
@@ -166,6 +166,7 @@ export const ProtocolSetSchema = z
     message: z.array(z.array(z.string())).optional(), // User messages/prompts
     e_time: z.number().int().optional(),
     hello: z.array(z.number().int()).optional(),
+    inc_ri: z.number().int().optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Other (please describe)

## Description

It should be possible to create protocols with "inc_ri" in it.

## Testing Instructions

Check if you can create the protocol 'Olivia_GH_Protocol'. See https://www.photosynq.org/protocols/olivia_gh_protocol.

## Changes Made

- Add "inc_ri" as an optional integer field.

## Checklist

- [ ] I have added/updated tests for my changes
- [ ] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have tested these changes locally
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code
