### PR TITLE
fix(email): lower casing for "openJII" in verification emails

### DIFF
--- a/packages/auth/src/email/verificationRequest.ts
+++ b/packages/auth/src/email/verificationRequest.ts
@@ -34,11 +34,11 @@ export async function sendVerificationRequest(params: {
   });
 
   const emailHtml = await render(
-    VerificationRequest({ url, host, senderName: "OpenJII", qrCodeDataUrl }),
+    VerificationRequest({ url, host, senderName: "openJII", qrCodeDataUrl }),
     {},
   );
   const emailText = await render(
-    VerificationRequest({ url, host, senderName: "OpenJII", qrCodeDataUrl }),
+    VerificationRequest({ url, host, senderName: "openJII", qrCodeDataUrl }),
     {
       plainText: true,
     },
@@ -47,10 +47,10 @@ export async function sendVerificationRequest(params: {
   const result = transport.sendMail({
     to: identifier,
     from: {
-      name: "OpenJII",
+      name: "openJII",
       address: provider.from,
     },
-    subject: `Sign in to the OpenJII Platform`,
+    subject: `Sign in to the openJII Platform`,
     html: emailHtml,
     text: emailText,
   });

--- a/packages/transactional/src/emails/verification-request.tsx
+++ b/packages/transactional/src/emails/verification-request.tsx
@@ -32,7 +32,7 @@ export const VerificationRequest = ({
         <Head />
         <Body className="mx-auto my-auto bg-gray-50 font-sans" style={{ color: "#374151" }}>
           <Container className="mx-auto my-[40px] w-[580px] rounded-lg border border-solid border-gray-200 bg-white shadow-sm">
-            <Preview>Sign in to your OpenJII account</Preview>
+            <Preview>Sign in to your openJII account</Preview>
 
             {/* Header */}
             <Section className="rounded-t-lg bg-[#005e5e] px-8 py-6">
@@ -45,7 +45,7 @@ export const VerificationRequest = ({
                 Confirm your email address
               </Text>
               <Text className="mb-8 text-center text-[16px] leading-relaxed text-gray-600">
-                Click the button below to verify your email address and sign in to your OpenJII
+                Click the button below to verify your email address and sign in to your openJII
                 account.
               </Text>
               <Section className="mb-8 text-center">


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Other (please describe)

## Description

This PR updates the branding in verification emails to use the correct lowercase format "openJII".

## Checklist

- [x] I have added/updated tests for my changes
- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have tested these changes locally
- [x] My changes generate no new warnings
- [x] I have reviewed my own code