### PR TITLE
fix(backend): forbid non-owners to update or delete a macro

### DIFF
--- a/apps/backend/src/macros/presentation/macro.controller.ts
+++ b/apps/backend/src/macros/presentation/macro.controller.ts
@@ -83,9 +83,9 @@ export class MacroController {
 
   @TsRestHandler(macroContract.updateMacro)
   @UseGuards(AuthGuard)
-  updateMacro(@CurrentUser() _user: User) {
+  updateMacro(@CurrentUser() user: User) {
     return tsRestHandler(macroContract.updateMacro, async ({ params, body }) => {
-      const result = await this.updateMacroUseCase.execute(params.id, body);
+      const result = await this.updateMacroUseCase.execute(params.id, body, user.id);
 
       if (result.isSuccess()) {
         return {
@@ -100,9 +100,9 @@ export class MacroController {
 
   @TsRestHandler(macroContract.deleteMacro)
   @UseGuards(AuthGuard)
-  deleteMacro(@CurrentUser() _user: User) {
+  deleteMacro(@CurrentUser() user: User) {
     return tsRestHandler(macroContract.deleteMacro, async ({ params }) => {
-      const result = await this.deleteMacroUseCase.execute(params.id);
+      const result = await this.deleteMacroUseCase.execute(params.id, user.id);
 
       if (result.isSuccess()) {
         return {


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Other (please describe)

## Description

This PR adds ownership checks to macro update and delete use cases, ensuring only the creator can modify or remove a macro.

## Checklist

- [x] I have added/updated tests for my changes
- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have tested these changes locally
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
