### PR TITLE
fix(web): extend navigation light mode to include FAQ and Policies pages

### DIFF
--- a/apps/web/components/unified-navbar/unified-navbar.tsx
+++ b/apps/web/components/unified-navbar/unified-navbar.tsx
@@ -170,7 +170,9 @@ export function UnifiedNavbar({ locale, session }: UnifiedNavbarProps) {
     pathname === `/` ||
     pathname === `/${locale}` ||
     pathname.startsWith(`/${locale}/about`) ||
-    pathname.startsWith(`/${locale}/blog`);
+    pathname.startsWith(`/${locale}/blog`) ||
+    pathname.startsWith(`/${locale}/faq`) ||
+    pathname.startsWith(`/${locale}/policies`);
 
   return (
     <header


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Other (please describe)

## Description

This PR fixes an issue where the UnifiedNavbar failed to display in light mode on the Policies and FAQ pages.

## Checklist

- [x] I have added/updated tests for my changes
- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have tested these changes locally
- [x] My changes generate no new warnings
- [x] I have reviewed my own code