### PR TITLE
fix(web): add disabled prop to ProtocolSearchWithDropdown and MeasurementPanel components

### DIFF
--- a/apps/web/components/protocol-search-with-dropdown.tsx
+++ b/apps/web/components/protocol-search-with-dropdown.tsx
@@ -19,6 +19,7 @@ export interface ProtocolSearchWithDropdownProps {
   onSearchChange: (value: string) => void;
   onAddProtocol: (protocolId: string) => void | Promise<void>;
   isAddingProtocol: boolean;
+  disabled?: boolean;
 }
 
 export function ProtocolSearchWithDropdown({
@@ -30,6 +31,7 @@ export function ProtocolSearchWithDropdown({
   onSearchChange,
   onAddProtocol,
   isAddingProtocol,
+  disabled = false,
 }: ProtocolSearchWithDropdownProps) {
   const [open, setOpen] = useState(false);
   const { t } = useTranslation("common");
@@ -62,6 +64,7 @@ export function ProtocolSearchWithDropdown({
           role="combobox"
           aria-expanded={open}
           className="w-full justify-between p-0"
+          disabled={disabled}
         >
           <div className="flex w-full items-center gap-3 px-3 py-2.5">
             {selectedProtocol ? (

--- a/apps/web/components/side-panel-flow/measurement-panel.tsx
+++ b/apps/web/components/side-panel-flow/measurement-panel.tsx
@@ -54,6 +54,7 @@ export function MeasurementPanel({
           onSearchChange={setProtocolSearch}
           onAddProtocol={handleAddProtocol}
           isAddingProtocol={false}
+          disabled={disabled}
         />
       </CardContent>
     </Card>


### PR DESCRIPTION
- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Other (please describe)

## Description

This PR fixes a bug where the protocol dropdown in the experiment overview remained interactive when it should have been disabled. The fix adds support for a disabled prop that is properly propagated through the component hierarchy.

## Checklist

- [x] I have added/updated tests for my changes
- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have tested these changes locally
- [x] My changes generate no new warnings
- [x] I have reviewed my own code