### PR TITLE
chore(cicd): skips code coverage uploads on dependabot PRs

### DIFF
--- a/.github/actions/test-packages/action.yml
+++ b/.github/actions/test-packages/action.yml
@@ -8,6 +8,10 @@ inputs:
   codecov-token:
     description: "Codecov token for uploading coverage"
     required: true
+  skip-coverage:
+    description: "Skip coverage upload (e.g., for Dependabot PRs)"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -32,6 +36,7 @@ runs:
         eval "$TEST_CMD"
 
     - name: Upload coverage to Codecov
+      if: inputs.skip-coverage != 'true'
       uses: codecov/codecov-action@v5
       with:
         token: ${{ inputs.codecov-token }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           affected_apps: ${{ steps.detect.outputs.affected_apps }}
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          skip-coverage: ${{ github.actor == 'dependabot[bot]' }}
 
       - name: Save coverage artifacts for main branch upload
         if: steps.detect.outputs.has_affected_apps == 'true'


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description

Skips coverage uploads for Dependabot PRs to reduce CI noise and avoid unnecessary Codecov API calls.

### Changes

- **Added skip-coverage parameter** to test-packages action with default "false"
- **Added conditional logic** to skip Codecov upload when parameter is "true" 
- **Auto-detects Dependabot PRs** in workflow using `github.actor == 'dependabot[bot]'`