### PR TITLE
fix(cicd): skips cov upload if no tests were ran

### DIFF
--- a/.github/actions/test-packages/action.yml
+++ b/.github/actions/test-packages/action.yml
@@ -17,26 +17,35 @@ runs:
   using: "composite"
   steps:
     - name: Run Tests
+      id: run-tests
       shell: bash
       run: |
         echo "🧪 Testing affected packages"
 
         AFFECTED_APPS='${{ inputs.affected_apps }}'
-
-        # Parse apps into array to construct command
         APPS=($(echo $AFFECTED_APPS | jq -r '.[]'))
 
-        # Test command string
         TEST_CMD="pnpm turbo run test"
         for APP in "${APPS[@]}"; do
           TEST_CMD="$TEST_CMD --filter=$APP"
         done
 
         echo "Running: $TEST_CMD"
-        eval "$TEST_CMD"
+
+        OUTPUT=$(eval "$TEST_CMD" 2>&1)
+        EXIT_CODE=$?
+        echo "$OUTPUT"
+
+        if echo "$OUTPUT" | grep -q "No tasks were executed"; then
+          echo "has_coverage=false" >> $GITHUB_OUTPUT
+        else
+          echo "has_coverage=true" >> $GITHUB_OUTPUT
+        fi
+
+        exit $EXIT_CODE
 
     - name: Upload coverage to Codecov
-      if: inputs.skip-coverage != 'true'
+      if: inputs.skip-coverage != 'true' && steps.run-tests.outputs.has_coverage == 'true'
       uses: codecov/codecov-action@v5
       with:
         token: ${{ inputs.codecov-token }}


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Fixes a CI/CD failure where Codecov upload step would fail with "No coverage reports found" error when testing affected packages that have no test suites configured.

### 🐛 Problem

When running tests on affected packages, some packages may not have tests configured. The test command would complete successfully with "No tasks were executed", but the workflow would still attempt to upload coverage reports to Codecov, causing the pipeline to fail.

