### PR TITLE
fix(ui): resolves React.Children.only crashes in Button component

### DIFF
--- a/packages/ui/src/components/button.test.tsx
+++ b/packages/ui/src/components/button.test.tsx
@@ -83,4 +83,22 @@ describe("Button", () => {
     expect(button.className).toContain("h-9");
     expect(button.className).toContain("w-9");
   });
+
+  it("shows loading spinner when isLoading is true", () => {
+    const { container } = render(<Button isLoading>Click me</Button>);
+    const spinner = container.querySelector(".animate-spin");
+    expect(spinner).toBeTruthy();
+    const button = screen.getByRole("button") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  it("does not show loading spinner when asChild is true", () => {
+    const { container } = render(
+      <Button asChild isLoading>
+        <span>Click me</span>
+      </Button>,
+    );
+    const spinner = container.querySelector(".animate-spin");
+    expect(spinner).toBeNull();
+  });
 });

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -58,8 +58,14 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={isLoading || props.disabled}
         {...props}
       >
-        {isLoading && <Loader2 className="animate-spin" />}
-        {children}
+        {asChild ? (
+          children
+        ) : (
+          <>
+            {isLoading && <Loader2 className="animate-spin" />}
+            {children}
+          </>
+        )}
       </Comp>
     );
   },


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Fixes a React "Children.only" error when using the Button component with `asChild` and `isLoading` props together.

```
 ⨯ [Error: React.Children.only expected to receive a single React element child.] {
  digest: '937592146'
}
```
