### PR TITLE
fix(auth): use CID attachment for QR code in verification emails

### DIFF
--- a/packages/auth/src/email/verificationRequest.ts
+++ b/packages/auth/src/email/verificationRequest.ts
@@ -27,24 +27,18 @@ export async function sendVerificationRequest(params: {
 
   const { host } = new URL(url);
   const transport = createTransport(provider.server);
-  const qrCodeDataUrl = await QRCode.toDataURL(url, {
+  const qrCodeBuffer = await QRCode.toBuffer(url, {
     width: 200,
     margin: 1,
     errorCorrectionLevel: "M",
   });
 
-  const emailHtml = await render(
-    VerificationRequest({ url, host, senderName: "openJII", qrCodeDataUrl }),
-    {},
-  );
-  const emailText = await render(
-    VerificationRequest({ url, host, senderName: "openJII", qrCodeDataUrl }),
-    {
-      plainText: true,
-    },
-  );
+  const emailHtml = await render(VerificationRequest({ url, host, senderName: "openJII" }), {});
+  const emailText = await render(VerificationRequest({ url, host, senderName: "openJII" }), {
+    plainText: true,
+  });
 
-  const result = transport.sendMail({
+  const result = await transport.sendMail({
     to: identifier,
     from: {
       name: "openJII",
@@ -53,9 +47,15 @@ export async function sendVerificationRequest(params: {
     subject: `Sign in to the openJII Platform`,
     html: emailHtml,
     text: emailText,
+    attachments: [
+      {
+        filename: "qrcode.png",
+        content: qrCodeBuffer,
+        cid: "qrcode",
+      },
+    ],
   });
 
-  // Cast result to extended type to handle optional rejected/pending properties
   const extendedResult = result as ExtendedSentMessageInfo;
   const rejected: string[] = extendedResult.rejected ?? [];
   const pending: string[] = extendedResult.pending ?? [];

--- a/packages/transactional/src/emails/verification-request.tsx
+++ b/packages/transactional/src/emails/verification-request.tsx
@@ -17,15 +17,9 @@ interface VerificationRequestProps {
   url: string;
   host: string;
   senderName: string;
-  qrCodeDataUrl: string;
 }
 
-export const VerificationRequest = ({
-  url,
-  host,
-  senderName,
-  qrCodeDataUrl,
-}: VerificationRequestProps) => {
+export const VerificationRequest = ({ url, host, senderName }: VerificationRequestProps) => {
   return (
     <Html>
       <Tailwind>
@@ -62,7 +56,7 @@ export const VerificationRequest = ({
               </Text>
               <Section className="mb-6 text-center">
                 <Img
-                  src={qrCodeDataUrl}
+                  src="cid:qrcode"
                   alt="QR Code"
                   width="200"
                   height="200"


### PR DESCRIPTION
Gmail's webmail client blocks base64 data URL images for security reasons, causing the QR code to appear broken. This change switches from embedding the QR code as a base64 data URL to using a CID (Content-ID) inline attachment, which is supported across all major email clients.

Changes:
- Generate QR code as buffer instead of data URL
- Attach QR code as inline attachment with CID reference
- Reference attachment via cid:qrcode in email template
- Add missing await to sendMail call