### PR TITLE
fix: adds pipeline_id & schema_name to prod experiment provisioning job

### DIFF
--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -331,9 +331,9 @@ module "pipeline_scheduler" {
   source = "../../modules/databricks/job"
 
   name        = "Pipeline-Scheduler-PROD"
-  description = "Orchestrates central pipeline execution followed by all experiment pipelines every 15 minutes between 9am and 9pm"
+  description = "Orchestrates central pipeline execution followed by all experiment pipelines every 15 minutes between 6am and 6pm"
 
-  # Schedule: Every 15 minutes (0, 15, 30, 45) between 9am and 9pm (UTC)
+  # Schedule: Every 15 minutes (0, 15, 30, 45) between 6am and 6pm (UTC)
   # Format: "seconds minutes hours day-of-month month day-of-week"
   schedule = "0 0,15,30,45 6-18 * * ?"
 
@@ -369,7 +369,7 @@ module "pipeline_scheduler" {
       parameters = {
         "catalog_name"            = module.databricks_catalog.catalog_name,
         "central_schema"          = "centrum",
-        "experiment_status_table" = "experiment_status"
+        "experiment_status_table" = "experiment_status",
         "environment"             = upper(var.environment)
       }
 
@@ -446,6 +446,9 @@ module "centrum_backup_job" {
   # Configure Slack notifications
   webhook_notifications = {
     on_failure = [
+      module.slack_notification_destination.notification_destination_id
+    ]
+    on_start = [
       module.slack_notification_destination.notification_destination_id
     ]
   }
@@ -614,7 +617,7 @@ module "enriched_tables_refresh_job" {
 module "ambyte_processing_job" {
   source = "../../modules/databricks/job"
 
-  name        = "Ambyte-Processing-Job-PRPD"
+  name        = "Ambyte-Processing-Job-PROD"
   description = "Processes raw ambyte trace files and saves them in the respective volume in parquet format"
 
   max_concurrent_runs           = 1 # Limit concurrent runs when queueing is enabled
@@ -647,10 +650,12 @@ module "ambyte_processing_job" {
 
       parameters = {
         EXPERIMENT_ID     = "{{EXPERIMENT_ID}}"
+        EXPERIMENT_NAME   = "{{EXPERIMENT_NAME}}"
         EXPERIMENT_SCHEMA = "{{EXPERIMENT_SCHEMA}}"
         UPLOAD_DIRECTORY  = "{{UPLOAD_DIRECTORY}}"
         YEAR_PREFIX       = "{{YEAR_PREFIX}}"
         CATALOG_NAME      = module.databricks_catalog.catalog_name
+        ENVIRONMENT       = upper(var.environment)
       }
     }
   ]


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

This pull request adds two new environment variables to the `experiment_provisioning_job` module configuration. These variables will provide downstream access to the `pipeline_id` and `schema_name` generated by the experiment pipeline creation task.

**Enhancements to job configuration:**

* Added `pipeline_id` and `schema_name` environment variables to the `experiment_provisioning_job` module, sourcing their values from the results of the `experiment_pipeline_create` task.