### PR TITLE
fix(backend): adds transitive dependency expo-secure-store

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -43,6 +43,7 @@
     "better-auth": "^1.4.12",
     "busboy": "^1.6.0",
     "drizzle-zod": "^0.5.1",
+    "expo-secure-store": "~15.0.8",
     "expo-web-browser": "~15.0.9",
     "http-status-codes": "^2.3.0",
     "nodemailer": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       drizzle-zod:
         specifier: ^0.5.1
         version: 0.5.1(drizzle-orm@0.41.0(@opentelemetry/api@1.9.0)(kysely@0.28.10)(postgres@3.4.8))(zod@3.25.76)
+      expo-secure-store:
+        specifier: ~15.0.8
+        version: 15.0.8(expo@54.0.31)
       expo-web-browser:
         specifier: ~15.0.9
         version: 15.0.10(expo@54.0.31)(react-native@0.81.5(@babel/core@7.28.6)(@types/react@19.2.9)(react@19.1.0))
@@ -589,7 +592,7 @@ importers:
         version: 8.0.0
       eslint:
         specifier: 'catalog:'
-        version: 9.39.2(jiti@1.21.7)
+        version: 9.39.2(jiti@2.6.1)
       expo-dev-client:
         specifier: ~6.0.18
         version: 6.0.20(expo@54.0.31)
@@ -657,7 +660,7 @@ importers:
         version: 0.507.0(react@19.1.0)
       next:
         specifier: 'catalog:'
-        version: 15.5.9(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.5.9(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       posthog-js:
         specifier: 'catalog:'
         version: 1.332.0
@@ -1307,7 +1310,7 @@ importers:
         version: 22.19.7
       eslint:
         specifier: 'catalog:'
-        version: 9.39.2(jiti@2.6.1)
+        version: 9.39.2(jiti@1.21.7)
       prettier:
         specifier: 'catalog:'
         version: 3.5.3
@@ -22191,7 +22194,7 @@ snapshots:
 
   '@graphql-tools/schema@10.0.30(graphql@16.12.0)':
     dependencies:
-      '@graphql-tools/merge': 9.1.6(graphql@16.12.0)
+      '@graphql-tools/merge': 9.1.7(graphql@16.12.0)
       '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
       graphql: 16.12.0
       tslib: 2.8.1


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

This pull request primarily updates project dependencies, including the addition of a new package and several version bumps. The most significant change is the introduction of the `expo-secure-store` package, which is now included in both the `package.json` and lockfile. Other changes involve minor dependency updates and adjustments.

Primarily due to:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for 'expo-secure-store@15.0.8(expo@54.0.31)' in pnpm-lock.yaml
1.656 
1.656 This issue is probably caused by a badly resolved merge conflict.
1.656 To fix the lockfile, run 'pnpm install --no-frozen-lockfile'.
------
Dockerfile:37
--------------------
  35 |     
  36 |     # First install the dependencies (as they change less often)
  37 | >>> RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
  38 |     
  39 |     # Copy source code of isolated subworkspace
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c pnpm install --frozen-lockfile" did not complete successfully: exit code: 1
Error: Process completed with exit code 1.
```
