### PR TITLE
fix(transactional): include OTP code in email preview for iOS auto-fill

### DIFF
--- a/packages/transactional/src/emails/otp-email.tsx
+++ b/packages/transactional/src/emails/otp-email.tsx
@@ -24,7 +24,7 @@ export const OtpEmail = ({ otp, senderName, host }: OtpEmailProps) => {
         <Head />
         <Body className="mx-auto my-auto bg-gray-50 font-sans" style={{ color: "#374151" }}>
           <Container className="mx-auto my-[40px] w-[580px] rounded-lg border border-solid border-gray-200 bg-white shadow-sm">
-            <Preview>Your openJII login code</Preview>
+            <Preview>Your login code is {otp}</Preview>
 
             {/* Header */}
             <Section className="rounded-t-lg bg-[#005e5e] px-8 py-6">


### PR DESCRIPTION
## Description:
Apple Mail's OTP detection was incorrectly identifying "openJII" as the
code instead of the 6-digit number. Including the actual code in the
email preview text allows iOS to properly detect and suggest the OTP
for auto-fill on iPhone/iPad.

@oebe tested already