### PR TITLE
chore: sets all job compute environments to v4

### DIFF
--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -489,7 +489,7 @@ module "ambyte_processing_job" {
     {
       environment_key = "ambyte_processing"
       spec = {
-        environment_version = "1"
+        environment_version = "4"
         dependencies = [
           "/Workspace/Shared/.bundle/open-jii/${var.environment}/artifacts/.internal/ambyte-0.1.0-py3-none-any.whl"
         ]
@@ -611,7 +611,7 @@ module "data_export_job" {
     {
       environment_key = "data_exporting"
       spec = {
-        environment_version = "1"
+        environment_version = "4"
         dependencies = [
           "/Workspace/Shared/.bundle/open-jii/${var.environment}/artifacts/.internal/openjii-0.1.0-py3-none-any.whl"
         ]

--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -492,7 +492,7 @@ module "ambyte_processing_job" {
     {
       environment_key = "ambyte_processing"
       spec = {
-        environment_version = "1"
+        environment_version = "4"
         dependencies = [
           "/Workspace/Shared/.bundle/open-jii/${var.environment}/artifacts/.internal/ambyte-0.1.0-py3-none-any.whl"
         ]
@@ -614,7 +614,7 @@ module "data_export_job" {
     {
       environment_key = "data_exporting"
       spec = {
-        environment_version = "1"
+        environment_version = "4"
         dependencies = [
           "/Workspace/Shared/.bundle/open-jii/${var.environment}/artifacts/.internal/openjii-0.1.0-py3-none-any.whl"
         ]

--- a/infrastructure/modules/databricks/job/variables.tf
+++ b/infrastructure/modules/databricks/job/variables.tf
@@ -153,7 +153,7 @@ variable "environments" {
   type = list(object({
     environment_key = string
     spec = object({
-      environment_version = optional(string, "1")
+      environment_version = optional(string, "4")
       dependencies        = list(string)
     })
   }))


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description

This pull request updates the default and configured environment versions for Databricks jobs across both development and production infrastructure. The main change is increasing the `environment_version` from `1` to `4` to ensure jobs use the latest environment specification.
