### PR TITLE
fix(infra): fixes service principal grants not being applied to external locations

### DIFF
--- a/infrastructure/modules/databricks/external-location/main.tf
+++ b/infrastructure/modules/databricks/external-location/main.tf
@@ -26,11 +26,8 @@ resource "databricks_grants" "this" {
 
   external_location = databricks_external_location.this.id
 
-  dynamic "grant" {
-    for_each = each.value.privileges
-    content {
-      principal  = each.value.principal
-      privileges = [grant.value]
-    }
+  grant {
+    principal  = each.value.principal
+    privileges = each.value.privileges
   }
 }


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

This pull request simplifies how privileges are assigned to principals in the `databricks_grants` resource for external locations. Instead of using a dynamic block to iterate over privileges, it now assigns the entire privileges list directly to each principal, making the configuration more concise and easier to read.

**Terraform configuration simplification:**

* Refactored the `databricks_grants` resource in `main.tf` to remove the `dynamic "grant"` block and assign the full `privileges` list directly to each principal within a single `grant` block.