### PR TITLE
fix(ui): prevent Quill toolbar from closing edit mode on blur

### DIFF
--- a/packages/ui/src/components/rich-textarea.test.tsx
+++ b/packages/ui/src/components/rich-textarea.test.tsx
@@ -8,6 +8,7 @@ import { RichTextarea } from "./rich-textarea";
 
 const mockToolbarContainer = {
   addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
 };
 
 // Mock react-quilljs
@@ -39,6 +40,8 @@ describe("RichTextarea", () => {
     mockQuillInstance.off.mockClear();
     mockQuillInstance.enable.mockClear();
     mockQuillInstance.getModule.mockClear();
+    mockToolbarContainer.addEventListener.mockClear();
+    mockToolbarContainer.removeEventListener.mockClear();
   });
 
   it("renders the editor container", () => {
@@ -214,5 +217,22 @@ describe("RichTextarea", () => {
       // Verify preventDefault was called
       expect(mockEvent.preventDefault).toHaveBeenCalled();
     }
+  });
+  it("removes toolbar mousedown listener on unmount", () => {
+    const removeEventListener = vi.fn();
+
+    // Override container to include removeEventListener
+    mockToolbarContainer.removeEventListener = removeEventListener;
+
+    const { unmount } = render(<RichTextarea value="" onChange={mockOnChange} />);
+
+    // Get the registered handler
+    const mousedownHandler = mockToolbarContainer.addEventListener.mock.calls.find(
+      (call) => call[0] === "mousedown",
+    )?.[1];
+
+    unmount();
+
+    expect(removeEventListener).toHaveBeenCalledWith("mousedown", mousedownHandler);
   });
 });

--- a/packages/ui/src/components/rich-textarea.tsx
+++ b/packages/ui/src/components/rich-textarea.tsx
@@ -50,9 +50,20 @@ export function RichTextarea({
     if (!quill) return;
 
     const toolbar = quill.getModule("toolbar") as { container: HTMLElement };
-    toolbar.container.addEventListener("mousedown", (e) => {
+
+    const preventFocus = (e: MouseEvent) => {
       e.preventDefault();
-    });
+    };
+
+    toolbar.container.addEventListener("mousedown", preventFocus);
+
+    return () => {
+      toolbar.container.removeEventListener("mousedown", preventFocus);
+    };
+  }, [quill]);
+
+  useEffect(() => {
+    if (!quill) return;
 
     // Set initial value if provided
     if (value && quill.root.innerHTML !== value) {


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

This PR prevents Quill toolbar interactions from unintentionally closing edit mode by stopping toolbar mousedown events from stealing focus using this [fix](https://github.com/slab/quill/issues/1290#:~:text=Problem%3A%20loses%20selection,4).

## Checklist

- [x] I have added/updated tests for my changes
- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have tested these changes locally
- [x] My changes generate no new warnings
- [x] I have reviewed my own code