### PR TITLE
chore(infra): provisions volume for legacy data

### DIFF
--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -587,6 +587,28 @@ module "data_imports_volume" {
   depends_on = [module.databricks_catalog]
 }
 
+module "data_legacy_volume" {
+  source = "../../modules/databricks/volume"
+
+  catalog_name = module.databricks_catalog.catalog_name
+  schema_name  = "centrum"
+  volume_name  = "data-legacy"
+  comment      = "Managed volume for experiment legacy data"
+
+  grants = {
+    node_service_principal = {
+      principal  = module.node_service_principal.service_principal_application_id
+      privileges = ["READ_VOLUME", "WRITE_VOLUME"]
+    }
+  }
+
+  providers = {
+    databricks.workspace = databricks.workspace
+  }
+
+  depends_on = [module.databricks_catalog]
+}
+
 module "data_export_job" {
   source = "../../modules/databricks/job"
 

--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -590,6 +590,28 @@ module "data_imports_volume" {
   depends_on = [module.databricks_catalog]
 }
 
+module "data_legacy_volume" {
+  source = "../../modules/databricks/volume"
+
+  catalog_name = module.databricks_catalog.catalog_name
+  schema_name  = "centrum"
+  volume_name  = "data-legacy"
+  comment      = "Managed volume for experiment legacy data"
+
+  grants = {
+    node_service_principal = {
+      principal  = module.node_service_principal.service_principal_application_id
+      privileges = ["READ_VOLUME", "WRITE_VOLUME"]
+    }
+  }
+
+  providers = {
+    databricks.workspace = databricks.workspace
+  }
+
+  depends_on = [module.databricks_catalog]
+}
+
 module "data_export_job" {
   source = "../../modules/databricks/job"
 


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description

This pull request adds a new managed Databricks volume for experiment legacy data to both the development and production environments. The new volume is configured with appropriate access grants for the node service principal.