### PR TITLE
fix(data): cast VARIANT columns to string for CSV export

### DIFF
--- a/apps/data/src/tasks/data_export_task.py
+++ b/apps/data/src/tasks/data_export_task.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from typing import Optional
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import to_json, col, lit
-from pyspark.sql.types import StructType, ArrayType, MapType
+from pyspark.sql.types import StructType, ArrayType, MapType, VariantType
 from pyspark.dbutils import DBUtils
 
 # Import openjii utilities
@@ -107,12 +107,10 @@ def export_data(df):
             # CSV doesn't support complex types (structs, arrays, maps, variants)
             # Convert them to JSON strings
             for field in df.schema.fields:
-                type_name = field.dataType.typeName()
                 if isinstance(field.dataType, (StructType, ArrayType, MapType)):
                     df = df.withColumn(field.name, to_json(col(field.name)))
-                elif type_name == "variant":
-                    # VARIANT is a Databricks-specific type; cast to string
-                    # which produces a JSON representation
+                elif isinstance(field.dataType, VariantType):
+                    # VARIANT already stores JSON; cast to string for CSV compatibility
                     df = df.withColumn(field.name, col(field.name).cast("string"))
             
             df.coalesce(1).write.mode("overwrite").option("header", True).csv(OUTPUT_PATH)


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

This pull request improves the CSV export functionality in the `export_data` function by enhancing support for complex data types, specifically addressing the handling of Parquet-specific `VARIANT` types.