### PR TITLE
fix(data): use RFC 4180 escape for CSV exports

### DIFF
--- a/apps/data/src/tasks/data_export_task.py
+++ b/apps/data/src/tasks/data_export_task.py
@@ -113,7 +113,7 @@ def export_data(df):
                     # VARIANT already stores JSON; cast to string for CSV compatibility
                     df = df.withColumn(field.name, col(field.name).cast("string"))
             
-            df.coalesce(1).write.mode("overwrite").option("header", True).csv(OUTPUT_PATH)
+            df.coalesce(1).write.mode("overwrite").option("header", True).option("escape", '"').csv(OUTPUT_PATH)
         elif FORMAT == "ndjson":
             # Write as newline-delimited JSON (NDJSON/JSONL)
             # Each line is a valid JSON object, which is standard for big data exports


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

This pull request updates the CSV export functionality in the `export_data` function to improve compatibility with data containing special characters. The most important change is the addition of an option to escape double quotes in CSV output.