### PR TITLE
fix(ui): show display name instead of identifier in export modal

### DIFF
--- a/apps/web/components/experiment-data/data-export-modal/__tests__/data-export-modal.test.tsx
+++ b/apps/web/components/experiment-data/data-export-modal/__tests__/data-export-modal.test.tsx
@@ -56,10 +56,18 @@ vi.mock("../steps/export-list-step", () => ({
   ),
 }));
 
-// Mock translation
+// Mock translation — append interpolation params so we can assert on them
 vi.mock("@repo/i18n/client", () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string, params?: Record<string, string>) => {
+      if (params) {
+        const serialized = Object.entries(params)
+          .map(([k, v]) => `${k}:${v}`)
+          .join(",");
+        return `${key}|${serialized}`;
+      }
+      return key;
+    },
   }),
 }));
 
@@ -255,5 +263,17 @@ describe("DataExportModal", () => {
   it("renders dialog header correctly", () => {
     renderModal();
     expect(screen.getByTestId("dialog-header")).toBeInTheDocument();
+  });
+
+  it("shows displayName in description when provided", () => {
+    renderModal({ displayName: "My Experiment Data" });
+    const description = screen.getByTestId("dialog-description");
+    expect(description).toHaveTextContent("tableName:My Experiment Data");
+  });
+
+  it("falls back to tableName in description when displayName is not provided", () => {
+    renderModal();
+    const description = screen.getByTestId("dialog-description");
+    expect(description).toHaveTextContent("tableName:raw_data");
   });
 });

--- a/apps/web/components/experiment-data/data-export-modal/data-export-modal.tsx
+++ b/apps/web/components/experiment-data/data-export-modal/data-export-modal.tsx
@@ -20,6 +20,7 @@ import { ExportListStep } from "./steps/export-list-step";
 interface DataExportModalProps {
   experimentId: string;
   tableName: string;
+  displayName?: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
@@ -29,6 +30,7 @@ export type CreationStatus = "idle" | "creating" | "success";
 export function DataExportModal({
   experimentId,
   tableName,
+  displayName,
   open,
   onOpenChange,
 }: DataExportModalProps) {
@@ -93,7 +95,7 @@ export function DataExportModal({
             {t("experimentData.exportModal.title")}
           </DialogTitle>
           <DialogDescription>
-            {t("experimentData.exportModal.description", { tableName })}
+            {t("experimentData.exportModal.description", { tableName: displayName ?? tableName })}
           </DialogDescription>
         </DialogHeader>
 

--- a/apps/web/components/experiment-data/experiment-data-table.tsx
+++ b/apps/web/components/experiment-data/experiment-data-table.tsx
@@ -437,6 +437,7 @@ export function ExperimentDataTable({
         <DataExportModal
           experimentId={experimentId}
           tableName={tableName}
+          displayName={displayName}
           open={downloadModalOpen}
           onOpenChange={setDownloadModalOpen}
         />


### PR DESCRIPTION
## Summary
- The export data modal description was showing the technical table identifier (often a UUID) instead of the human-readable display name
- Added optional `displayName` prop to `DataExportModal` and threaded it from `ExperimentDataTable`
- Falls back to `tableName` when `displayName` is not provided

## Test plan
- [x] Added test: shows `displayName` in description when provided
- [x] Added test: falls back to `tableName` when `displayName` is omitted
- [x] All 14 existing tests continue to pass
