### PR TITLE
fix(mobile): resolve lint warnings and formatting issues

### DIFF
--- a/apps/mobile/src/app/(auth)/login.tsx
+++ b/apps/mobile/src/app/(auth)/login.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
 import { useRouter } from "expo-router";
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import {
   View,
   Text,
@@ -54,7 +54,25 @@ export default function LoginScreen() {
   const [otp, setOTP] = useState("");
   const [error, setError] = useState("");
   const [countdown, setCountdown] = useState(0);
+  const handleOTPVerify = useCallback(async () => {
+    setError("");
+    if (otp?.length !== 6) {
+      setError("Please enter a valid 6-digit code");
+      return;
+    }
 
+    const result = await verifyEmailOTP(email, otp);
+    if (result?.error) {
+      setError(
+        "The code you entered is invalid or has expired. Please try again or request a new one.",
+      );
+      return;
+    }
+
+    // Check if user is registered (similar to web app)
+    // For now, just navigate to tabs - registration flow can be added later
+    router.replace("(tabs)");
+  }, [otp, email, verifyEmailOTP, router]);
   useEffect(() => {
     if (countdown > 0) {
       const timer = setTimeout(() => setCountdown(countdown - 1), 1000);
@@ -66,7 +84,7 @@ export default function LoginScreen() {
     if (otp.length === 6 && !verifyLoading) {
       void handleOTPVerify();
     }
-  }, [otp, verifyLoading]);
+  }, [otp, verifyLoading, handleOTPVerify]);
 
   async function handleGitHubLogin() {
     setError("");
@@ -95,26 +113,6 @@ export default function LoginScreen() {
 
     setShowOTPInput(true);
     setCountdown(RESEND_COOLDOWN_SECONDS);
-  }
-
-  async function handleOTPVerify() {
-    setError("");
-    if (otp?.length !== 6) {
-      setError("Please enter a valid 6-digit code");
-      return;
-    }
-
-    const result = await verifyEmailOTP(email, otp);
-    if (result?.error) {
-      setError(
-        "The code you entered is invalid or has expired. Please try again or request a new one.",
-      );
-      return;
-    }
-
-    // Check if user is registered (similar to web app)
-    // For now, just navigate to tabs - registration flow can be added later
-    router.replace("(tabs)");
   }
 
   async function handleResendCode() {

--- a/apps/mobile/src/hooks/__tests__/use-measurement-upload.test.ts
+++ b/apps/mobile/src/hooks/__tests__/use-measurement-upload.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+import { useMeasurementUpload } from "../use-measurement-upload";
+
 // Use vi.hoisted so mock fns are available inside vi.mock factories
 const {
   mockInvalidateQueries,
@@ -69,8 +71,6 @@ vi.mock("react-async-hook", () => ({
     return { loading: false, execute: fn };
   },
 }));
-
-import { useMeasurementUpload } from "../use-measurement-upload";
 
 const baseArgs = {
   rawMeasurement: { data: 1 },
@@ -181,9 +181,7 @@ describe("useMeasurementUpload", () => {
 
     await saveButton.onPress();
 
-    expect(mockToastError).toHaveBeenCalledWith(
-      "Could not save measurement. Please try again.",
-    );
+    expect(mockToastError).toHaveBeenCalledWith("Could not save measurement. Please try again.");
 
     vi.restoreAllMocks();
   });

--- a/apps/mobile/src/screens/measurement-flow-screen/components/measurement-flow-container.tsx
+++ b/apps/mobile/src/screens/measurement-flow-screen/components/measurement-flow-container.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { useFlowAnswersStore } from "~/stores/use-flow-answers-store";
 import { useMeasurementFlowStore } from "~/stores/use-measurement-flow-store";
 
@@ -71,25 +71,28 @@ export function MeasurementFlowContainer() {
     isRememberAnswerEnabled,
   ]);
 
-  const seedNextIterationAnswer = (node: FlowNode, answerValue: string) => {
-    const content = node.content as QuestionContent | undefined;
-    if (!content) return;
+  const seedNextIterationAnswer = useCallback(
+    (node: FlowNode, answerValue: string) => {
+      const content = node.content as QuestionContent | undefined;
+      if (!content) return;
 
-    if (content.kind === "multi_choice" && isAutoincrementEnabled(node.id)) {
-      const options = content.options ?? [];
-      if (!options.length) return;
-      const currentIndex = options.indexOf(answerValue);
-      if (currentIndex < 0) return;
-      const nextIndex = (currentIndex + 1) % options.length;
-      const nextValue = options[nextIndex];
-      setAnswer(iterationCount + 1, node.id, nextValue);
-      return;
-    }
+      if (content.kind === "multi_choice" && isAutoincrementEnabled(node.id)) {
+        const options = content.options ?? [];
+        if (!options.length) return;
+        const currentIndex = options.indexOf(answerValue);
+        if (currentIndex < 0) return;
+        const nextIndex = (currentIndex + 1) % options.length;
+        const nextValue = options[nextIndex];
+        setAnswer(iterationCount + 1, node.id, nextValue);
+        return;
+      }
 
-    if (isRememberAnswerEnabled(node.id)) {
-      setAnswer(iterationCount + 1, node.id, answerValue);
-    }
-  };
+      if (isRememberAnswerEnabled(node.id)) {
+        setAnswer(iterationCount + 1, node.id, answerValue);
+      }
+    },
+    [isAutoincrementEnabled, isRememberAnswerEnabled, setAnswer, iterationCount],
+  );
 
   // Auto-skip a question only when we first land on it and it already has an answer
   // (e.g. from "remember answer" or when revisiting). Do not skip when the user
@@ -110,13 +113,11 @@ export function MeasurementFlowContainer() {
   }, [
     currentFlowStep,
     iterationCount,
-    currentNode?.id,
+    currentNode,
     showingOverview,
     returnToOverviewAfterEdit,
     getAnswer,
-    setAnswer,
-    isAutoincrementEnabled,
-    isRememberAnswerEnabled,
+    seedNextIterationAnswer,
     nextStep,
   ]);
 

--- a/apps/mobile/src/services/__tests__/export-measurements.test.ts
+++ b/apps/mobile/src/services/__tests__/export-measurements.test.ts
@@ -1,4 +1,7 @@
+import * as Sharing from "expo-sharing";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { exportSingleMeasurementToFile } from "../export-measurements";
 
 const mockCreate = vi.fn();
 const mockWrite = vi.fn();
@@ -23,9 +26,6 @@ vi.mock("~/services/failed-uploads-storage", () => ({
 vi.mock("~/services/successful-uploads-storage", () => ({
   getSuccessfulUploadsWithKeys: vi.fn().mockResolvedValue([]),
 }));
-
-import * as Sharing from "expo-sharing";
-import { exportSingleMeasurementToFile } from "../export-measurements";
 
 const mockMeasurement = {
   topic: "test/topic",

--- a/apps/mobile/src/services/__tests__/failed-uploads-storage.test.ts
+++ b/apps/mobile/src/services/__tests__/failed-uploads-storage.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
 import { saveFailedUpload, getFailedUploadsWithKeys } from "../failed-uploads-storage";
 
 vi.mock("@react-native-async-storage/async-storage", () => ({
@@ -71,9 +72,7 @@ describe("failed-uploads-storage", () => {
 
     it("skips entries with invalid JSON", async () => {
       vi.mocked(AsyncStorage.getAllKeys).mockResolvedValue(["FAILED_UPLOAD_abc"]);
-      vi.mocked(AsyncStorage.multiGet).mockResolvedValue([
-        ["FAILED_UPLOAD_abc", "not-valid-json"],
-      ]);
+      vi.mocked(AsyncStorage.multiGet).mockResolvedValue([["FAILED_UPLOAD_abc", "not-valid-json"]]);
 
       const result = await getFailedUploadsWithKeys();
       expect(result).toHaveLength(0);


### PR DESCRIPTION
## Summary
- Fix `react-hooks/exhaustive-deps` warnings by wrapping handlers in `useCallback`
- Auto-fix prettier formatting in test files

## Test plan
- [ ] Verify mobile app builds without lint warnings
- [ ] Verify test files pass formatting checks