### PR TITLE
fix: validate a user is online before replacing the route to `/callback`

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -36,11 +36,31 @@ pnpm start
 
 To run the app on an Android device or emulator:
 
+Make sure you have an Android device connected or an emulator running.
+
 ```bash
 pnpm run android
 ```
 
-Make sure you have an Android device connected or an emulator running.
+#### Known issues
+
+```
+› Opening on Android...
+CommandError: No development build (com.openjii.app) for this project is installed. Install a development build on the target device and try again.
+```
+
+To install the first development built on the phone you can run `pnpm run android`, once a development build is present you can run `pnpm start` as well and press `a` to run the dev-app on your connected android device.
+
+---
+
+
+#### ⁉️ Debug on android
+
+To debug an interal test version of the application you can attach the phone  and run:
+
+```bash
+npx react-native log-android
+```
 
 ### 🍏 Run on iOS
 

--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -8,19 +8,33 @@ import { useSession } from "~/hooks/use-session";
 import { useTheme } from "~/hooks/use-theme";
 import { DevIndicator } from "~/widgets/dev-indicator";
 import { DeviceConnectionWidget } from "~/widgets/device-connection-widget";
+import { onlineManager } from "@tanstack/react-query";
 
 export default function TabLayout() {
   const theme = useTheme();
   const { colors } = theme;
   const insets = useSafeAreaInsets();
   const router = useRouter();
-  const { session, isLoaded } = useSession();
+  const { session, isLoaded, error } = useSession();
 
   useEffect(() => {
-    if (isLoaded && !session) {
-      router.replace("/callback");
-    }
-  }, [isLoaded, session, router]);
+    // Prevent user from being kicked out when network drops
+    if(!onlineManager.isOnline()) return 
+
+    // Check if the session error is a network error
+    // Even though we are back online, the session fetch might not have been (re)fetched yet
+    const isNetworkError = !!error && error.status === undefined // Network errors do not have a status
+    if(isNetworkError) return
+
+    // Give better auth time to load
+    if(!isLoaded) return
+
+    // Hooray, we have a session
+    if(session) return
+
+    // No session is present > kick out user
+    router.replace("/callback");
+  }, [isLoaded, session, router, error?.status]);
 
   return (
     <View style={{ flex: 1 }}>


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description

Prevent offline users being kicked out due to not having a session

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #1122
- Related to #

## Testing Instructions

<!-- Provide steps to test your changes and any relevant environments tested -->

- [ ] Sign in
- [ ] Turn off the internet on the phone

## Changes Made
* Enhanced session handling in `apps/mobile/src/app/(tabs)/_layout.tsx` to prevent users from being logged out due to temporary network drops. The logic now checks for network connectivity and distinguishes between network errors and actual authentication issues before redirecting to the callback route.

## Checklist

- [ ] I have added/updated tests for my changes
- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have tested these changes locally
- [x] My changes generate no new warnings
- [x] I have reviewed my own code

## Screenshots/Recordings

<!-- If applicable, add screenshots or recordings to demonstrate your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
