### PR TITLE
chore(data): retain records with null device_id in silver layer

### DIFF
--- a/apps/data/src/pipelines/centrum_pipeline.py
+++ b/apps/data/src/pipelines/centrum_pipeline.py
@@ -55,7 +55,7 @@ sensor_schema = StructType([
     StructField("topic", StringType(), False),
     StructField("device_name", StringType(), True),
     StructField("device_version", StringType(), True),
-    StructField("device_id", StringType(), False),
+    StructField("device_id", StringType(), True),
     StructField("device_battery", DoubleType(), True),
     StructField("device_firmware", StringType(), True),
     StructField("sample", StringType(), True),


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description

This pull request makes a small update to the data cleaning pipeline by modifying how the validity of `device_id` is enforced. The change ensures that records without a `device_id` are now flagged as invalid rather than being dropped automatically.