### PR TITLE
fix(backend): remove redundant pnpm prune that hangs in Buildx

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -40,7 +40,6 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 COPY --from=pruner /app/out/full/ .
 
 RUN turbo build --filter=${PROJECT}
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm prune --prod --no-optional
 
 # Dependencies stage - create a clean production dependencies directory
 FROM builder AS dependencies


### PR DESCRIPTION
## Summary

Fixes OJD-1406

- Remove the redundant `pnpm prune --prod --no-optional` line from the Docker builder stage that hangs indefinitely when built via `docker/build-push-action` (Buildx)

## Root Cause

`pnpm prune` displays an interactive confirmation prompt (`Proceed? (Y/n)`). Plain `docker build` (used by the deploy workflow) auto-answers this prompt, but Buildx (used by the PR `docker_build_check` job) does not pipe stdin, causing it to block forever on cache misses.

The line has been redundant since June 2025 when the `dependencies` stage was added with `pnpm deploy --prod`. The final runner image only copies `node_modules` from the `dependencies` stage, never from `builder`.

## Test plan

- [ ] PR Docker Build Check passes (this is the job that was hanging)
- [ ] Verify the deploy workflow still builds successfully
