### PR TITLE
feat(mobile): prefetch experiment data on login for offline use

### DIFF
--- a/apps/mobile/src/app/(auth)/login.tsx
+++ b/apps/mobile/src/app/(auth)/login.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
+import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import React, { useState, useEffect, useCallback } from "react";
 import {
@@ -24,6 +25,7 @@ import { useLoginFlow } from "~/hooks/use-login";
 import { useMultiTapReveal } from "~/hooks/use-multi-tap-reveal";
 import { useSession } from "~/hooks/use-session";
 import { useTheme } from "~/hooks/use-theme";
+import { prefetchOfflineData } from "~/services/prefetch-offline-data";
 import { markSessionActive } from "~/services/session-persistence";
 import { getEnvVar } from "~/stores/environment-store";
 import { EnvironmentSelector } from "~/widgets/environment-selector";
@@ -35,6 +37,7 @@ export default function LoginScreen() {
   const { colors } = theme;
 
   const router = useRouter();
+  const queryClient = useQueryClient();
   const webBaseUrl = getEnvVar("NEXT_AUTH_URI");
   const {
     startGitHubLogin,
@@ -86,7 +89,8 @@ export default function LoginScreen() {
 
     void markSessionActive();
     router.replace("(tabs)");
-  }, [otp, email, verifyEmailOTP, router]);
+    void prefetchOfflineData(queryClient);
+  }, [otp, email, verifyEmailOTP, router, queryClient]);
   useEffect(() => {
     if (countdown > 0) {
       const timer = setTimeout(() => setCountdown(countdown - 1), 1000);
@@ -105,6 +109,7 @@ export default function LoginScreen() {
     await startGitHubLogin();
     void markSessionActive();
     router.replace("(tabs)");
+    void prefetchOfflineData(queryClient);
   }
 
   async function handleOrcidLogin() {
@@ -112,6 +117,7 @@ export default function LoginScreen() {
     await startOrcidLogin();
     void markSessionActive();
     router.replace("(tabs)");
+    void prefetchOfflineData(queryClient);
   }
 
   async function handleEmailSubmit() {

--- a/apps/mobile/src/components/configured-query-client-provider.tsx
+++ b/apps/mobile/src/components/configured-query-client-provider.tsx
@@ -36,6 +36,7 @@ const defaultOptions = {
   queries: {
     staleTime: 0,
     gcTime: Infinity,
+    networkMode: "offlineFirst" as const,
     refetchOnMount: false,
     refetchOnReconnect: true,
     refetchOnWindowFocus: false,
@@ -75,7 +76,7 @@ export function ConfiguredQueryClientProvider({ children }) {
       client={queryClientRef.current}
       persistOptions={{
         persister: asyncStoragePersister,
-        maxAge: 1000 * 60 * 60 * 24 * 7, // 7 days
+        maxAge: Infinity,
       }}
     >
       {children}

--- a/apps/mobile/src/services/prefetch-offline-data.ts
+++ b/apps/mobile/src/services/prefetch-offline-data.ts
@@ -1,0 +1,94 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { uniq } from "lodash";
+import { tsr } from "~/api/tsr";
+import type { FlowNode } from "~/screens/measurement-flow-screen/types";
+
+/**
+ * Prefetches all experiment data needed for offline use.
+ * Called after login to ensure measurements can run without network.
+ */
+export async function prefetchOfflineData(queryClient: QueryClient): Promise<void> {
+  // 1. Fetch all user experiments
+  const experimentsResponse = await queryClient.fetchQuery({
+    queryKey: ["experiments"],
+    queryFn: async () => {
+      const response = await tsr.experiments.listExperiments.query({
+        query: { filter: "member" },
+      });
+      return response;
+    },
+    staleTime: Infinity,
+  });
+
+  const experiments = (experimentsResponse?.body ?? []) as { id: string }[];
+
+  // 2. For each experiment, fetch the flow and extract protocol/macro IDs
+  const allProtocolIds: string[] = [];
+  const allMacroIds: string[] = [];
+
+  await Promise.all(
+    experiments.map(async (experiment: { id: string }) => {
+      // Fetch experiment flow
+      const flowResponse: any = await queryClient.fetchQuery({
+        queryKey: ["experiment-flow", experiment.id],
+        queryFn: async () => {
+          const response = await tsr.experiments.getFlow.query({
+            params: { id: experiment.id },
+          });
+          return response;
+        },
+        staleTime: Infinity,
+      });
+
+      const nodes = flowResponse?.body?.graph?.nodes ?? [];
+
+      // Collect protocol IDs from measurement nodes
+      const protocolIds = nodes
+        .filter((node: FlowNode) => node.type === "measurement" && node.content?.protocolId)
+        .map((node: FlowNode) => node.content.protocolId as string);
+
+      // Collect macro IDs from analysis nodes
+      const macroIds = nodes
+        .filter((node: FlowNode) => node.type === "analysis" && node.content?.macroId)
+        .map((node: FlowNode) => node.content.macroId as string);
+
+      allProtocolIds.push(...protocolIds);
+      allMacroIds.push(...macroIds);
+    }),
+  );
+
+  // 3. Fetch all unique protocols and macros
+  const uniqueProtocolIds = uniq(allProtocolIds);
+  const uniqueMacroIds = uniq(allMacroIds);
+
+  await Promise.all([
+    ...uniqueProtocolIds.map((protocolId) =>
+      queryClient.prefetchQuery({
+        queryKey: ["protocol", protocolId],
+        queryFn: async () => {
+          const response = await tsr.protocols.getProtocol.query({
+            params: { id: protocolId },
+          });
+          return { body: response.body };
+        },
+        staleTime: Infinity,
+      }),
+    ),
+    ...uniqueMacroIds.map((macroId) =>
+      queryClient.prefetchQuery({
+        queryKey: ["macro", macroId],
+        queryFn: async () => {
+          const response = await tsr.macros.getMacro.query({
+            params: { id: macroId },
+          });
+          return { body: response.body };
+        },
+        staleTime: Infinity,
+      }),
+    ),
+  ]);
+
+  console.log(
+    `[prefetch] Cached ${experiments.length} experiments, ${uniqueProtocolIds.length} protocols, ${uniqueMacroIds.length} macros for offline use`,
+  );
+}

--- a/apps/mobile/src/services/prefetch-offline-data.ts
+++ b/apps/mobile/src/services/prefetch-offline-data.ts
@@ -8,6 +8,17 @@ import type { FlowNode } from "~/screens/measurement-flow-screen/types";
  * Called after login to ensure measurements can run without network.
  */
 export async function prefetchOfflineData(queryClient: QueryClient): Promise<void> {
+  try {
+    await _prefetchOfflineData(queryClient);
+  } catch (err) {
+    console.error(
+      "[prefetch] Failed to prefetch offline data:",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+async function _prefetchOfflineData(queryClient: QueryClient): Promise<void> {
   // 1. Fetch all user experiments
   const experimentsResponse = await queryClient.fetchQuery({
     queryKey: ["experiments"],
@@ -53,7 +64,9 @@ export async function prefetchOfflineData(queryClient: QueryClient): Promise<voi
         allProtocolIds.push(...protocolIds);
         allMacroIds.push(...macroIds);
       } catch (err) {
-        throw new Error(`Flow fetch failed for experiment ${experiment.id}: ${err}`);
+        throw new Error(
+          `Flow fetch failed for experiment ${experiment.id}: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     }),
   );

--- a/apps/mobile/src/services/prefetch-offline-data.ts
+++ b/apps/mobile/src/services/prefetch-offline-data.ts
@@ -28,35 +28,44 @@ export async function prefetchOfflineData(queryClient: QueryClient): Promise<voi
 
   const flowResults = await Promise.allSettled(
     experiments.map(async (experiment: { id: string }) => {
-      const flowResponse: any = await queryClient.fetchQuery({
-        queryKey: ["experiment-flow", experiment.id],
-        queryFn: async () => {
-          const response = await tsr.experiments.getFlow.query({
-            params: { id: experiment.id },
-          });
-          return response;
-        },
-        staleTime: 0,
-      });
+      try {
+        const flowResponse: any = await queryClient.fetchQuery({
+          queryKey: ["experiment-flow", experiment.id],
+          queryFn: async () => {
+            const response = await tsr.experiments.getFlow.query({
+              params: { id: experiment.id },
+            });
+            return response;
+          },
+          staleTime: 0,
+        });
 
-      const nodes = flowResponse?.body?.graph?.nodes ?? [];
+        const nodes = flowResponse?.body?.graph?.nodes ?? [];
 
-      const protocolIds = nodes
-        .filter((node: FlowNode) => node.type === "measurement" && node.content?.protocolId)
-        .map((node: FlowNode) => node.content.protocolId as string);
+        const protocolIds = nodes
+          .filter((node: FlowNode) => node.type === "measurement" && node.content?.protocolId)
+          .map((node: FlowNode) => node.content.protocolId as string);
 
-      const macroIds = nodes
-        .filter((node: FlowNode) => node.type === "analysis" && node.content?.macroId)
-        .map((node: FlowNode) => node.content.macroId as string);
+        const macroIds = nodes
+          .filter((node: FlowNode) => node.type === "analysis" && node.content?.macroId)
+          .map((node: FlowNode) => node.content.macroId as string);
 
-      allProtocolIds.push(...protocolIds);
-      allMacroIds.push(...macroIds);
+        allProtocolIds.push(...protocolIds);
+        allMacroIds.push(...macroIds);
+      } catch (err) {
+        throw new Error(`Flow fetch failed for experiment ${experiment.id}: ${err}`);
+      }
     }),
   );
 
-  const flowFailures = flowResults.filter((r) => r.status === "rejected");
+  const flowFailures = flowResults.filter(
+    (r): r is PromiseRejectedResult => r.status === "rejected",
+  );
   if (flowFailures.length > 0) {
-    console.warn(`[prefetch] ${flowFailures.length} experiment flow(s) failed to prefetch`);
+    console.warn(
+      `[prefetch] ${flowFailures.length}/${experiments.length} experiment flow(s) failed:`,
+      flowFailures.map((r) => r.reason?.message ?? String(r.reason)),
+    );
   }
 
   // 3. Fetch all unique protocols and macros
@@ -92,10 +101,15 @@ export async function prefetchOfflineData(queryClient: QueryClient): Promise<voi
 
   const assetFailures = assetResults.filter((r) => r.status === "rejected");
   if (assetFailures.length > 0) {
-    console.warn(`[prefetch] ${assetFailures.length} protocol/macro(s) failed to prefetch`);
+    console.warn(
+      `[prefetch] ${assetFailures.length}/${uniqueProtocolIds.length + uniqueMacroIds.length} protocol/macro(s) failed to prefetch`,
+    );
   }
 
+  const flowsCached = experiments.length - flowFailures.length;
+  const assetsCached = uniqueProtocolIds.length + uniqueMacroIds.length - assetFailures.length;
+
   console.log(
-    `[prefetch] Cached ${experiments.length} experiments, ${uniqueProtocolIds.length} protocols, ${uniqueMacroIds.length} macros for offline use`,
+    `[prefetch] Cached ${flowsCached}/${experiments.length} experiments, ${assetsCached}/${uniqueProtocolIds.length + uniqueMacroIds.length} protocols+macros`,
   );
 }

--- a/apps/mobile/src/services/prefetch-offline-data.ts
+++ b/apps/mobile/src/services/prefetch-offline-data.ts
@@ -17,7 +17,7 @@ export async function prefetchOfflineData(queryClient: QueryClient): Promise<voi
       });
       return response;
     },
-    staleTime: Infinity,
+    staleTime: 0,
   });
 
   const experiments = (experimentsResponse?.body ?? []) as { id: string }[];
@@ -26,9 +26,8 @@ export async function prefetchOfflineData(queryClient: QueryClient): Promise<voi
   const allProtocolIds: string[] = [];
   const allMacroIds: string[] = [];
 
-  await Promise.all(
+  const flowResults = await Promise.allSettled(
     experiments.map(async (experiment: { id: string }) => {
-      // Fetch experiment flow
       const flowResponse: any = await queryClient.fetchQuery({
         queryKey: ["experiment-flow", experiment.id],
         queryFn: async () => {
@@ -37,17 +36,15 @@ export async function prefetchOfflineData(queryClient: QueryClient): Promise<voi
           });
           return response;
         },
-        staleTime: Infinity,
+        staleTime: 0,
       });
 
       const nodes = flowResponse?.body?.graph?.nodes ?? [];
 
-      // Collect protocol IDs from measurement nodes
       const protocolIds = nodes
         .filter((node: FlowNode) => node.type === "measurement" && node.content?.protocolId)
         .map((node: FlowNode) => node.content.protocolId as string);
 
-      // Collect macro IDs from analysis nodes
       const macroIds = nodes
         .filter((node: FlowNode) => node.type === "analysis" && node.content?.macroId)
         .map((node: FlowNode) => node.content.macroId as string);
@@ -57,11 +54,16 @@ export async function prefetchOfflineData(queryClient: QueryClient): Promise<voi
     }),
   );
 
+  const flowFailures = flowResults.filter((r) => r.status === "rejected");
+  if (flowFailures.length > 0) {
+    console.warn(`[prefetch] ${flowFailures.length} experiment flow(s) failed to prefetch`);
+  }
+
   // 3. Fetch all unique protocols and macros
   const uniqueProtocolIds = uniq(allProtocolIds);
   const uniqueMacroIds = uniq(allMacroIds);
 
-  await Promise.all([
+  const assetResults = await Promise.allSettled([
     ...uniqueProtocolIds.map((protocolId) =>
       queryClient.prefetchQuery({
         queryKey: ["protocol", protocolId],
@@ -71,7 +73,7 @@ export async function prefetchOfflineData(queryClient: QueryClient): Promise<voi
           });
           return { body: response.body };
         },
-        staleTime: Infinity,
+        staleTime: 0,
       }),
     ),
     ...uniqueMacroIds.map((macroId) =>
@@ -83,10 +85,15 @@ export async function prefetchOfflineData(queryClient: QueryClient): Promise<voi
           });
           return { body: response.body };
         },
-        staleTime: Infinity,
+        staleTime: 0,
       }),
     ),
   ]);
+
+  const assetFailures = assetResults.filter((r) => r.status === "rejected");
+  if (assetFailures.length > 0) {
+    console.warn(`[prefetch] ${assetFailures.length} protocol/macro(s) failed to prefetch`);
+  }
 
   console.log(
     `[prefetch] Cached ${experiments.length} experiments, ${uniqueProtocolIds.length} protocols, ${uniqueMacroIds.length} macros for offline use`,


### PR DESCRIPTION
## Summary

After login, all experiment data is prefetched into the React Query cache so measurements can run offline. Depends on OJD-563 (#1189) for auth/session fixes.

### Changes
- **Prefetch service** (`prefetch-offline-data.ts`): After login (email, GitHub, ORCID), fetches all experiments, flows, protocols, and macros into cache. Uses `Promise.allSettled` so partial failures don't abort the batch.
- **Query client config**: `networkMode: "offlineFirst"` as default — serves cached data immediately when offline, refetches in background when online. Persister `maxAge` changed from 7 days to `Infinity`.
- **Login integration**: All three auth methods trigger `prefetchOfflineData` after successful login.
- **staleTime: 0**: Prefetched data refreshes when online (not locked to Infinity).

Closes OJD-1418

## Files changed

| File | Change |
|------|--------|
| `services/prefetch-offline-data.ts` | New — prefetches experiments, flows, protocols, macros |
| `components/configured-query-client-provider.tsx` | `offlineFirst` networkMode, `Infinity` maxAge |
| `app/(auth)/login.tsx` | Prefetch calls after each auth method |

## Test plan

### Scenario 1: Login prefetch
- [ ] Log in with internet
- [ ] Check console logs for `[prefetch] Cached X experiments, Y protocols, Z macros`
- [ ] Verify numbers match your expected experiment/protocol/macro count

### Scenario 2: Offline measurement after login
- [ ] Log in, wait a few seconds for prefetch
- [ ] Turn off internet
- [ ] Navigate to Measure tab, select an experiment
- [ ] Verify flow loads from cache, start a measurement

### Scenario 3: App restart while offline
- [ ] Log in, wait for prefetch, force-close app
- [ ] Turn off internet, reopen app
- [ ] Verify experiment data is still available from persisted cache

### Scenario 4: Data refreshes when online
- [ ] Log in, use the app
- [ ] Make a change to experiment data on the web platform
- [ ] Return to the app — verify data updates in the background

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced offline support: login now triggers background prefetch of experiments, protocols, and analysis assets so content is cached for offline use and faster loads.
* **Chores**
  * Query behavior updated to prefer offline-first access and persisted cache no longer expires, improving reliability when offline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->