### PR TITLE
feat: improve account deletion UX with ownership transfer for archived experiments

### DIFF
--- a/apps/backend/src/experiments/application/use-cases/experiment-members/update-experiment-member-role.spec.ts
+++ b/apps/backend/src/experiments/application/use-cases/experiment-members/update-experiment-member-role.spec.ts
@@ -88,7 +88,7 @@ describe("UpdateExperimentMemberRoleUseCase", () => {
     expect(result.error.code).toBe("FORBIDDEN");
   });
 
-  it("should return FORBIDDEN when attempting to update member roles in an archived experiment", async () => {
+  it("should allow updating member roles in an archived experiment", async () => {
     // Create an experiment and archive it
     const { experiment } = await testApp.createExperiment({
       name: "Archived Update Role Test",
@@ -102,12 +102,12 @@ describe("UpdateExperimentMemberRoleUseCase", () => {
     });
     await testApp.addExperimentMember(experiment.id, memberId, "member");
 
-    // Attempt to update role as the creator/admin
+    // Attempt to update role as the creator/admin — should succeed
     const result = await useCase.execute(experiment.id, memberId, "admin", testUserId);
 
-    expect(result.isSuccess()).toBe(false);
-    assertFailure(result);
-    expect(result.error.code).toBe("FORBIDDEN");
+    expect(result.isSuccess()).toBe(true);
+    assertSuccess(result);
+    expect(result.value.role).toBe("admin");
   });
 
   it("should return BAD_REQUEST when attempting to demote the last admin", async () => {

--- a/apps/backend/src/experiments/application/use-cases/experiment-members/update-experiment-member-role.ts
+++ b/apps/backend/src/experiments/application/use-cases/experiment-members/update-experiment-member-role.ts
@@ -50,15 +50,6 @@ export class UpdateExperimentMemberRoleUseCase {
           return failure(AppError.notFound(`Experiment with ID ${experimentId} not found`));
         }
 
-        if (experiment.status === "archived") {
-          this.logger.warn({
-            msg: "Experiment is archived",
-            operation: "update-experiment-member-role",
-            experimentId,
-          });
-          return failure(AppError.forbidden("Cannot update member roles in archived experiments"));
-        }
-
         if (!isAdmin) {
           this.logger.warn({
             msg: "User attempted to update member roles without admin privileges",

--- a/apps/backend/src/experiments/presentation/experiment-members.controller.spec.ts
+++ b/apps/backend/src/experiments/presentation/experiment-members.controller.spec.ts
@@ -675,7 +675,7 @@ describe("ExperimentMembersController", () => {
         });
     });
 
-    it("should return 403 when updating role in archived experiment", async () => {
+    it("should allow updating role in archived experiment", async () => {
       // Create an archived experiment
       const { experiment } = await testApp.createExperiment({
         name: "Test Archived Experiment",
@@ -689,20 +689,13 @@ describe("ExperimentMembersController", () => {
       });
       await testApp.addExperimentMember(experiment.id, memberId, "member");
 
-      // Try to update role
+      // Update role — should succeed
       const path = testApp.resolvePath(contract.experiments.updateExperimentMemberRole.path, {
         id: experiment.id,
         memberId: memberId,
       });
 
-      await testApp
-        .patch(path)
-        .withAuth(testUserId)
-        .send({ role: "admin" })
-        .expect(StatusCodes.FORBIDDEN)
-        .expect(({ body }: { body: ErrorResponse }) => {
-          expect(body.message).toContain("Cannot update member roles in archived experiments");
-        });
+      await testApp.patch(path).withAuth(testUserId).send({ role: "admin" }).expect(StatusCodes.OK);
     });
 
     it("should return 401 if not authenticated", async () => {

--- a/apps/backend/src/users/application/use-cases/bulk-transfer-admin/bulk-transfer-admin.spec.ts
+++ b/apps/backend/src/users/application/use-cases/bulk-transfer-admin/bulk-transfer-admin.spec.ts
@@ -1,0 +1,211 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+import {
+  success,
+  failure,
+  AppError,
+  assertSuccess,
+  assertFailure,
+} from "../../../../common/utils/fp-utils";
+import type { ExperimentMemberRepository } from "../../../../experiments/core/repositories/experiment-member.repository";
+import type { UserRepository } from "../../../core/repositories/user.repository";
+import { BulkTransferAdminUseCase } from "./bulk-transfer-admin";
+
+describe("BulkTransferAdminUseCase", () => {
+  let useCase: BulkTransferAdminUseCase;
+  let userRepository: {
+    findOne: ReturnType<typeof vi.fn>;
+    findByEmail: ReturnType<typeof vi.fn>;
+    getExperimentsWhereOnlyAdmin: ReturnType<typeof vi.fn>;
+  };
+  let experimentMemberRepository: {
+    getMemberRole: ReturnType<typeof vi.fn>;
+    addMembers: ReturnType<typeof vi.fn>;
+    updateMemberRole: ReturnType<typeof vi.fn>;
+  };
+
+  const mockUser = { id: "user-1", email: "owner@example.com" };
+  const mockTarget = { id: "user-2", email: "colleague@example.com" };
+
+  beforeEach(() => {
+    userRepository = {
+      findOne: vi.fn(),
+      findByEmail: vi.fn(),
+      getExperimentsWhereOnlyAdmin: vi.fn(),
+    };
+    experimentMemberRepository = {
+      getMemberRole: vi.fn(),
+      addMembers: vi.fn(),
+      updateMemberRole: vi.fn(),
+    };
+    useCase = new BulkTransferAdminUseCase(
+      userRepository as unknown as UserRepository,
+      experimentMemberRepository as unknown as ExperimentMemberRepository,
+    );
+  });
+
+  it("should transfer admin to a non-member by adding them", async () => {
+    userRepository.findOne.mockResolvedValue(success(mockUser));
+    userRepository.findByEmail.mockResolvedValue(success(mockTarget));
+    userRepository.getExperimentsWhereOnlyAdmin.mockResolvedValue(
+      success([{ id: "exp-1", name: "Test", status: "active" }]),
+    );
+    experimentMemberRepository.getMemberRole.mockResolvedValue(success(null));
+    experimentMemberRepository.addMembers.mockResolvedValue(success([]));
+
+    const result = await useCase.execute("user-1", "colleague@example.com");
+
+    assertSuccess(result);
+    expect(result.value.transferred).toBe(1);
+    expect(experimentMemberRepository.addMembers).toHaveBeenCalledWith("exp-1", [
+      { userId: "user-2", role: "admin" },
+    ]);
+  });
+
+  it("should promote existing member to admin", async () => {
+    userRepository.findOne.mockResolvedValue(success(mockUser));
+    userRepository.findByEmail.mockResolvedValue(success(mockTarget));
+    userRepository.getExperimentsWhereOnlyAdmin.mockResolvedValue(
+      success([{ id: "exp-1", name: "Test", status: "active" }]),
+    );
+    experimentMemberRepository.getMemberRole.mockResolvedValue(success("member"));
+    experimentMemberRepository.updateMemberRole.mockResolvedValue(success({ role: "admin" }));
+
+    const result = await useCase.execute("user-1", "colleague@example.com");
+
+    assertSuccess(result);
+    expect(result.value.transferred).toBe(1);
+    expect(experimentMemberRepository.updateMemberRole).toHaveBeenCalledWith(
+      "exp-1",
+      "user-2",
+      "admin",
+    );
+  });
+
+  it("should skip transfer when target is already admin", async () => {
+    userRepository.findOne.mockResolvedValue(success(mockUser));
+    userRepository.findByEmail.mockResolvedValue(success(mockTarget));
+    userRepository.getExperimentsWhereOnlyAdmin.mockResolvedValue(
+      success([{ id: "exp-1", name: "Test", status: "active" }]),
+    );
+    experimentMemberRepository.getMemberRole.mockResolvedValue(success("admin"));
+
+    const result = await useCase.execute("user-1", "colleague@example.com");
+
+    assertSuccess(result);
+    expect(result.value.transferred).toBe(1);
+    expect(experimentMemberRepository.addMembers).not.toHaveBeenCalled();
+    expect(experimentMemberRepository.updateMemberRole).not.toHaveBeenCalled();
+  });
+
+  it("should handle multiple blocking experiments", async () => {
+    userRepository.findOne.mockResolvedValue(success(mockUser));
+    userRepository.findByEmail.mockResolvedValue(success(mockTarget));
+    userRepository.getExperimentsWhereOnlyAdmin.mockResolvedValue(
+      success([
+        { id: "exp-1", name: "Active", status: "active" },
+        { id: "exp-2", name: "Archived", status: "archived" },
+      ]),
+    );
+    experimentMemberRepository.getMemberRole.mockResolvedValue(success(null));
+    experimentMemberRepository.addMembers.mockResolvedValue(success([]));
+
+    const result = await useCase.execute("user-1", "colleague@example.com");
+
+    assertSuccess(result);
+    expect(result.value.transferred).toBe(2);
+    expect(experimentMemberRepository.addMembers).toHaveBeenCalledTimes(2);
+  });
+
+  it("should return 0 transferred when no blocking experiments", async () => {
+    userRepository.findOne.mockResolvedValue(success(mockUser));
+    userRepository.findByEmail.mockResolvedValue(success(mockTarget));
+    userRepository.getExperimentsWhereOnlyAdmin.mockResolvedValue(success([]));
+
+    const result = await useCase.execute("user-1", "colleague@example.com");
+
+    assertSuccess(result);
+    expect(result.value.transferred).toBe(0);
+  });
+
+  it("should return NOT_FOUND when current user does not exist", async () => {
+    userRepository.findOne.mockResolvedValue(success(null));
+
+    const result = await useCase.execute("user-1", "colleague@example.com");
+
+    assertFailure(result);
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should return NOT_FOUND when target email does not exist", async () => {
+    userRepository.findOne.mockResolvedValue(success(mockUser));
+    userRepository.findByEmail.mockResolvedValue(success(null));
+
+    const result = await useCase.execute("user-1", "nobody@example.com");
+
+    assertFailure(result);
+    expect(result.error.code).toBe("NOT_FOUND");
+    expect(result.error.message).toContain("nobody@example.com");
+  });
+
+  it("should return BAD_REQUEST when transferring to self", async () => {
+    userRepository.findOne.mockResolvedValue(success(mockUser));
+    userRepository.findByEmail.mockResolvedValue(success(mockUser)); // same user
+
+    const result = await useCase.execute("user-1", "owner@example.com");
+
+    assertFailure(result);
+    expect(result.error.code).toBe("BAD_REQUEST");
+    expect(result.error.message).toContain("yourself");
+  });
+
+  it("should continue on getMemberRole failure and not count it as transferred", async () => {
+    userRepository.findOne.mockResolvedValue(success(mockUser));
+    userRepository.findByEmail.mockResolvedValue(success(mockTarget));
+    userRepository.getExperimentsWhereOnlyAdmin.mockResolvedValue(
+      success([{ id: "exp-1", name: "Test", status: "active" }]),
+    );
+    experimentMemberRepository.getMemberRole.mockResolvedValue(
+      failure(AppError.internal("DB error")),
+    );
+
+    const result = await useCase.execute("user-1", "colleague@example.com");
+
+    assertSuccess(result);
+    expect(result.value.transferred).toBe(0);
+  });
+
+  it("should continue on addMembers failure and not count it as transferred", async () => {
+    userRepository.findOne.mockResolvedValue(success(mockUser));
+    userRepository.findByEmail.mockResolvedValue(success(mockTarget));
+    userRepository.getExperimentsWhereOnlyAdmin.mockResolvedValue(
+      success([{ id: "exp-1", name: "Test", status: "active" }]),
+    );
+    experimentMemberRepository.getMemberRole.mockResolvedValue(success(null));
+    experimentMemberRepository.addMembers.mockResolvedValue(
+      failure(AppError.internal("Insert failed")),
+    );
+
+    const result = await useCase.execute("user-1", "colleague@example.com");
+
+    assertSuccess(result);
+    expect(result.value.transferred).toBe(0);
+  });
+
+  it("should continue on updateMemberRole failure and not count it as transferred", async () => {
+    userRepository.findOne.mockResolvedValue(success(mockUser));
+    userRepository.findByEmail.mockResolvedValue(success(mockTarget));
+    userRepository.getExperimentsWhereOnlyAdmin.mockResolvedValue(
+      success([{ id: "exp-1", name: "Test", status: "active" }]),
+    );
+    experimentMemberRepository.getMemberRole.mockResolvedValue(success("member"));
+    experimentMemberRepository.updateMemberRole.mockResolvedValue(
+      failure(AppError.internal("Update failed")),
+    );
+
+    const result = await useCase.execute("user-1", "colleague@example.com");
+
+    assertSuccess(result);
+    expect(result.value.transferred).toBe(0);
+  });
+});

--- a/apps/backend/src/users/application/use-cases/bulk-transfer-admin/bulk-transfer-admin.ts
+++ b/apps/backend/src/users/application/use-cases/bulk-transfer-admin/bulk-transfer-admin.ts
@@ -1,0 +1,123 @@
+import { Injectable, Logger } from "@nestjs/common";
+
+import { success, Result, failure, AppError } from "../../../../common/utils/fp-utils";
+import { ExperimentMemberRepository } from "../../../../experiments/core/repositories/experiment-member.repository";
+import { UserRepository } from "../../../core/repositories/user.repository";
+
+@Injectable()
+export class BulkTransferAdminUseCase {
+  private readonly logger = new Logger(BulkTransferAdminUseCase.name);
+
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly experimentMemberRepository: ExperimentMemberRepository,
+  ) {}
+
+  async execute(userId: string, email: string): Promise<Result<{ transferred: number }>> {
+    this.logger.log({
+      msg: "Starting bulk admin transfer",
+      operation: "bulkTransferAdmin",
+      userId,
+      targetEmail: email,
+    });
+
+    // Verify current user exists
+    const userResult = await this.userRepository.findOne(userId);
+    if (userResult.isFailure()) return userResult as unknown as Result<{ transferred: number }>;
+    if (!userResult.value) {
+      return failure(AppError.notFound(`User with ID ${userId} not found`));
+    }
+
+    // Resolve target user by email
+    const targetResult = await this.userRepository.findByEmail(email);
+    if (targetResult.isFailure()) return targetResult as unknown as Result<{ transferred: number }>;
+    if (!targetResult.value) {
+      return failure(AppError.notFound(`No user found with email ${email}`));
+    }
+
+    const newAdminUserId = targetResult.value.id;
+
+    if (userId === newAdminUserId) {
+      return failure(AppError.badRequest("Cannot transfer admin rights to yourself"));
+    }
+
+    // Get all experiments where current user is the only admin
+    const blockingResult = await this.userRepository.getExperimentsWhereOnlyAdmin(userId);
+    if (blockingResult.isFailure())
+      return blockingResult as unknown as Result<{ transferred: number }>;
+
+    const blockingExperiments = blockingResult.value;
+
+    if (blockingExperiments.length === 0) {
+      return success({ transferred: 0 });
+    }
+
+    let transferred = 0;
+
+    for (const experiment of blockingExperiments) {
+      // Check if new admin is already a member
+      const roleResult = await this.experimentMemberRepository.getMemberRole(
+        experiment.id,
+        newAdminUserId,
+      );
+
+      if (roleResult.isFailure()) {
+        this.logger.error({
+          msg: "Failed to check member role",
+          operation: "bulkTransferAdmin",
+          experimentId: experiment.id,
+          error: roleResult.error,
+        });
+        continue;
+      }
+
+      if (roleResult.value === null) {
+        // Not a member yet, add them as admin
+        const addResult = await this.experimentMemberRepository.addMembers(experiment.id, [
+          { userId: newAdminUserId, role: "admin" },
+        ]);
+
+        if (addResult.isFailure()) {
+          this.logger.error({
+            msg: "Failed to add new admin member",
+            operation: "bulkTransferAdmin",
+            experimentId: experiment.id,
+            error: addResult.error,
+          });
+          continue;
+        }
+      } else if (roleResult.value !== "admin") {
+        // Already a member but not admin, promote them
+        const updateResult = await this.experimentMemberRepository.updateMemberRole(
+          experiment.id,
+          newAdminUserId,
+          "admin",
+        );
+
+        if (updateResult.isFailure()) {
+          this.logger.error({
+            msg: "Failed to promote member to admin",
+            operation: "bulkTransferAdmin",
+            experimentId: experiment.id,
+            error: updateResult.error,
+          });
+          continue;
+        }
+      }
+      // If already admin, nothing to do
+
+      transferred++;
+    }
+
+    this.logger.log({
+      msg: "Bulk admin transfer completed",
+      operation: "bulkTransferAdmin",
+      userId,
+      newAdminUserId,
+      transferred,
+      total: blockingExperiments.length,
+    });
+
+    return success({ transferred });
+  }
+}

--- a/apps/backend/src/users/application/use-cases/delete-user/delete-user.ts
+++ b/apps/backend/src/users/application/use-cases/delete-user/delete-user.ts
@@ -38,51 +38,54 @@ export class DeleteUserUseCase {
       }
 
       // Check if user is the only admin of any experiments
-      const adminCheckResult = await this.userRepository.isOnlyAdminOfAnyExperiments(id);
+      const adminCheckResult = await this.userRepository.getExperimentsWhereOnlyAdmin(id);
 
-      return adminCheckResult.chain(async (isOnlyAdmin: boolean) => {
-        if (isOnlyAdmin) {
-          this.logger.warn({
-            msg: "Cannot delete user - only admin of experiments",
-            errorCode: ErrorCodes.USER_IS_ONLY_ADMIN,
+      return adminCheckResult.chain(
+        async (blockingExperiments: { id: string; name: string; status: string }[]) => {
+          if (blockingExperiments.length > 0) {
+            this.logger.warn({
+              msg: "Cannot delete user - only admin of experiments",
+              errorCode: ErrorCodes.USER_IS_ONLY_ADMIN,
+              operation: "deleteUser",
+              userId: id,
+              blockingExperiments: blockingExperiments.map((e) => e.id),
+            });
+            return failure(
+              AppError.forbidden(
+                `Cannot delete account - you are the only admin of one or more experiments. Please transfer admin rights before deleting.`,
+              ),
+            );
+          }
+
+          // Soft delete
+          this.logger.log({
+            msg: "Soft-deleting user",
             operation: "deleteUser",
             userId: id,
           });
-          return failure(
-            AppError.forbidden(
-              `Cannot delete account - you are the only admin of one or more experiments. Please assign other admins before deleting.`,
-            ),
-          );
-        }
+          const deleteResult = await this.userRepository.delete(id);
 
-        // Soft delete
-        this.logger.log({
-          msg: "Soft-deleting user",
-          operation: "deleteUser",
-          userId: id,
-        });
-        const deleteResult = await this.userRepository.delete(id);
+          if (deleteResult.isFailure()) {
+            return deleteResult;
+          }
 
-        if (deleteResult.isFailure()) {
-          return deleteResult;
-        }
+          this.logger.log({
+            msg: "User soft-deleted successfully",
+            operation: "deleteUser",
+            userId: id,
+            status: "success",
+          });
 
-        this.logger.log({
-          msg: "User soft-deleted successfully",
-          operation: "deleteUser",
-          userId: id,
-          status: "success",
-        });
+          this.logger.log({
+            msg: "User deletion completed",
+            operation: "deleteUser",
+            userId: id,
+            status: "success",
+          });
 
-        this.logger.log({
-          msg: "User deletion completed",
-          operation: "deleteUser",
-          userId: id,
-          status: "success",
-        });
-
-        return success(undefined);
-      });
+          return success(undefined);
+        },
+      );
     });
   }
 }

--- a/apps/backend/src/users/application/use-cases/get-deletion-check/get-deletion-check.spec.ts
+++ b/apps/backend/src/users/application/use-cases/get-deletion-check/get-deletion-check.spec.ts
@@ -1,0 +1,83 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+import {
+  success,
+  failure,
+  AppError,
+  assertSuccess,
+  assertFailure,
+} from "../../../../common/utils/fp-utils";
+import type { UserRepository } from "../../../core/repositories/user.repository";
+import { GetDeletionCheckUseCase } from "./get-deletion-check";
+
+describe("GetDeletionCheckUseCase", () => {
+  let useCase: GetDeletionCheckUseCase;
+  let userRepository: {
+    findOne: ReturnType<typeof vi.fn>;
+    getExperimentsWhereOnlyAdmin: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    userRepository = {
+      findOne: vi.fn(),
+      getExperimentsWhereOnlyAdmin: vi.fn(),
+    };
+    useCase = new GetDeletionCheckUseCase(userRepository as unknown as UserRepository);
+  });
+
+  it("should return canDelete true when user has no blocking experiments", async () => {
+    userRepository.findOne.mockResolvedValue(success({ id: "user-1", email: "test@example.com" }));
+    userRepository.getExperimentsWhereOnlyAdmin.mockResolvedValue(success([]));
+
+    const result = await useCase.execute("user-1");
+
+    assertSuccess(result);
+    expect(result.value.canDelete).toBe(true);
+    expect(result.value.blockingExperiments).toEqual([]);
+  });
+
+  it("should return canDelete false with blocking experiments", async () => {
+    const blocking = [
+      { id: "exp-1", name: "Active Experiment", status: "active" },
+      { id: "exp-2", name: "Archived Experiment", status: "archived" },
+    ];
+    userRepository.findOne.mockResolvedValue(success({ id: "user-1", email: "test@example.com" }));
+    userRepository.getExperimentsWhereOnlyAdmin.mockResolvedValue(success(blocking));
+
+    const result = await useCase.execute("user-1");
+
+    assertSuccess(result);
+    expect(result.value.canDelete).toBe(false);
+    expect(result.value.blockingExperiments).toEqual(blocking);
+  });
+
+  it("should return NOT_FOUND when user does not exist", async () => {
+    userRepository.findOne.mockResolvedValue(success(null));
+
+    const result = await useCase.execute("non-existent");
+
+    assertFailure(result);
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should propagate repository failure from findOne", async () => {
+    userRepository.findOne.mockResolvedValue(failure(AppError.internal("DB error")));
+
+    const result = await useCase.execute("user-1");
+
+    assertFailure(result);
+    expect(result.error.message).toBe("DB error");
+  });
+
+  it("should propagate repository failure from getExperimentsWhereOnlyAdmin", async () => {
+    userRepository.findOne.mockResolvedValue(success({ id: "user-1", email: "test@example.com" }));
+    userRepository.getExperimentsWhereOnlyAdmin.mockResolvedValue(
+      failure(AppError.internal("Query failed")),
+    );
+
+    const result = await useCase.execute("user-1");
+
+    assertFailure(result);
+    expect(result.error.message).toBe("Query failed");
+  });
+});

--- a/apps/backend/src/users/application/use-cases/get-deletion-check/get-deletion-check.ts
+++ b/apps/backend/src/users/application/use-cases/get-deletion-check/get-deletion-check.ts
@@ -1,0 +1,46 @@
+import { Injectable, Logger } from "@nestjs/common";
+
+import { success, Result, failure, AppError } from "../../../../common/utils/fp-utils";
+import { UserDto } from "../../../core/models/user.model";
+import { UserRepository } from "../../../core/repositories/user.repository";
+
+interface DeletionCheckResult {
+  canDelete: boolean;
+  blockingExperiments: { id: string; name: string; status: string }[];
+}
+
+@Injectable()
+export class GetDeletionCheckUseCase {
+  private readonly logger = new Logger(GetDeletionCheckUseCase.name);
+
+  constructor(private readonly userRepository: UserRepository) {}
+
+  async execute(id: string): Promise<Result<DeletionCheckResult>> {
+    const userResult = await this.userRepository.findOne(id);
+
+    return userResult.chain(async (user: UserDto | null) => {
+      if (!user) {
+        return failure(AppError.notFound(`User with ID ${id} not found`));
+      }
+
+      const blockingResult = await this.userRepository.getExperimentsWhereOnlyAdmin(id);
+
+      return blockingResult.chain(
+        (blockingExperiments: { id: string; name: string; status: string }[]) => {
+          this.logger.log({
+            msg: "Deletion check completed",
+            operation: "getDeletionCheck",
+            userId: id,
+            canDelete: blockingExperiments.length === 0,
+            blockingCount: blockingExperiments.length,
+          });
+
+          return success({
+            canDelete: blockingExperiments.length === 0,
+            blockingExperiments,
+          });
+        },
+      );
+    });
+  }
+}

--- a/apps/backend/src/users/core/repositories/user.repository.spec.ts
+++ b/apps/backend/src/users/core/repositories/user.repository.spec.ts
@@ -316,23 +316,23 @@ describe("UserRepository", () => {
     });
   });
 
-  describe("isOnlyAdminOfAnyExperiments", () => {
-    it("should return false when user is not an admin of any experiments", async () => {
+  describe("getExperimentsWhereOnlyAdmin", () => {
+    it("should return empty array when user is not an admin of any experiments", async () => {
       // Arrange
       const userId = await testApp.createTestUser({
         email: "nonadmin@example.com",
       });
 
       // Act
-      const result = await repository.isOnlyAdminOfAnyExperiments(userId);
+      const result = await repository.getExperimentsWhereOnlyAdmin(userId);
 
       // Assert
       expect(result.isSuccess()).toBe(true);
       assertSuccess(result);
-      expect(result.value).toBe(false);
+      expect(result.value).toEqual([]);
     });
 
-    it("should return false when user is admin but other admins exist", async () => {
+    it("should return empty array when user is admin but other admins exist", async () => {
       // Arrange
       const admin1Id = await testApp.createTestUser({
         email: "admin1@example.com",
@@ -350,15 +350,15 @@ describe("UserRepository", () => {
       await testApp.addExperimentMember(experiment.id, admin2Id, "admin");
 
       // Act
-      const result = await repository.isOnlyAdminOfAnyExperiments(admin1Id);
+      const result = await repository.getExperimentsWhereOnlyAdmin(admin1Id);
 
       // Assert
       expect(result.isSuccess()).toBe(true);
       assertSuccess(result);
-      expect(result.value).toBe(false);
+      expect(result.value).toEqual([]);
     });
 
-    it("should return true when user is the only admin of an experiment", async () => {
+    it("should return experiment details when user is the only admin", async () => {
       // Arrange
       const soloAdminId = await testApp.createTestUser({
         email: "soloadmin@example.com",
@@ -376,15 +376,20 @@ describe("UserRepository", () => {
       await testApp.addExperimentMember(experiment.id, memberId, "member");
 
       // Act
-      const result = await repository.isOnlyAdminOfAnyExperiments(soloAdminId);
+      const result = await repository.getExperimentsWhereOnlyAdmin(soloAdminId);
 
       // Assert
       expect(result.isSuccess()).toBe(true);
       assertSuccess(result);
-      expect(result.value).toBe(true);
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]).toMatchObject({
+        id: experiment.id,
+        name: "Solo Admin Experiment",
+        status: "active",
+      });
     });
 
-    it("should return true when user is sole admin of at least one experiment among many", async () => {
+    it("should return only the experiment where user is sole admin among many", async () => {
       // Arrange
       const userId = await testApp.createTestUser({
         email: "multiadmin@example.com",
@@ -394,7 +399,7 @@ describe("UserRepository", () => {
       });
 
       // Experiment 1: user is sole admin
-      await testApp.createExperiment({
+      const { experiment: experiment1 } = await testApp.createExperiment({
         name: "Sole Admin Experiment",
         userId: userId,
       });
@@ -407,15 +412,16 @@ describe("UserRepository", () => {
       await testApp.addExperimentMember(experiment2.id, otherAdminId, "admin");
 
       // Act
-      const result = await repository.isOnlyAdminOfAnyExperiments(userId);
+      const result = await repository.getExperimentsWhereOnlyAdmin(userId);
 
       // Assert
       expect(result.isSuccess()).toBe(true);
       assertSuccess(result);
-      expect(result.value).toBe(true);
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0].id).toBe(experiment1.id);
     });
 
-    it("should return false when user is only a member, not an admin", async () => {
+    it("should return empty array when user is only a member, not an admin", async () => {
       // Arrange
       const adminId = await testApp.createTestUser({
         email: "admin@example.com",
@@ -433,12 +439,38 @@ describe("UserRepository", () => {
       await testApp.addExperimentMember(experiment.id, memberId, "member");
 
       // Act
-      const result = await repository.isOnlyAdminOfAnyExperiments(memberId);
+      const result = await repository.getExperimentsWhereOnlyAdmin(memberId);
 
       // Assert
       expect(result.isSuccess()).toBe(true);
       assertSuccess(result);
-      expect(result.value).toBe(false);
+      expect(result.value).toEqual([]);
+    });
+
+    it("should include archived experiments where user is sole admin", async () => {
+      // Arrange
+      const userId = await testApp.createTestUser({
+        email: "archiveadmin@example.com",
+      });
+
+      const { experiment } = await testApp.createExperiment({
+        name: "Archived Solo Experiment",
+        userId: userId,
+        status: "archived",
+      });
+
+      // Act
+      const result = await repository.getExperimentsWhereOnlyAdmin(userId);
+
+      // Assert
+      expect(result.isSuccess()).toBe(true);
+      assertSuccess(result);
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0]).toMatchObject({
+        id: experiment.id,
+        name: "Archived Solo Experiment",
+        status: "archived",
+      });
     });
   });
 

--- a/apps/backend/src/users/core/repositories/user.repository.ts
+++ b/apps/backend/src/users/core/repositories/user.repository.ts
@@ -13,6 +13,7 @@ import {
   sessions,
   // authenticators table removed - Better Auth uses accounts table
   experimentMembers,
+  experiments,
   sql,
   isNull,
 } from "@repo/database";
@@ -147,7 +148,9 @@ export class UserRepository {
     );
   }
 
-  async isOnlyAdminOfAnyExperiments(userId: string): Promise<Result<boolean>> {
+  async getExperimentsWhereOnlyAdmin(
+    userId: string,
+  ): Promise<Result<{ id: string; name: string; status: string }[]>> {
     return tryCatch(async () => {
       // Find all experiments where this user is an admin
       const adminRows = await this.database
@@ -156,10 +159,11 @@ export class UserRepository {
         .where(and(eq(experimentMembers.userId, userId), eq(experimentMembers.role, "admin")));
 
       if (adminRows.length === 0) {
-        return false;
+        return [];
       }
 
-      // For each experiment, check how many admins exist. If any has exactly 1 admin, return true.
+      const blocking: { id: string; name: string; status: string }[] = [];
+
       for (const row of adminRows) {
         const admins = await this.database
           .select()
@@ -172,11 +176,19 @@ export class UserRepository {
           );
 
         if (admins.length === 1) {
-          return true;
+          const exp = await this.database
+            .select({ id: experiments.id, name: experiments.name, status: experiments.status })
+            .from(experiments)
+            .where(eq(experiments.id, row.experimentId))
+            .limit(1);
+
+          if (exp.length > 0) {
+            blocking.push(exp[0]);
+          }
         }
       }
 
-      return false;
+      return blocking;
     });
   }
 

--- a/apps/backend/src/users/presentation/user.controller.ts
+++ b/apps/backend/src/users/presentation/user.controller.ts
@@ -8,8 +8,10 @@ import { contract } from "@repo/api";
 
 import { formatDates, formatDatesList } from "../../common/utils/date-formatter";
 import { handleFailure } from "../../common/utils/fp-utils";
+import { BulkTransferAdminUseCase } from "../application/use-cases/bulk-transfer-admin/bulk-transfer-admin";
 import { CreateUserProfileUseCase } from "../application/use-cases/create-user-profile/create-user-profile";
 import { DeleteUserUseCase } from "../application/use-cases/delete-user/delete-user";
+import { GetDeletionCheckUseCase } from "../application/use-cases/get-deletion-check/get-deletion-check";
 import { GetUserProfileUseCase } from "../application/use-cases/get-user-profile/get-user-profile";
 import { GetUserUseCase } from "../application/use-cases/get-user/get-user";
 import { SearchUsersUseCase } from "../application/use-cases/search-users/search-users";
@@ -19,11 +21,13 @@ export class UserController {
   private readonly logger = new Logger(UserController.name);
 
   constructor(
+    private readonly bulkTransferAdminUseCase: BulkTransferAdminUseCase,
     private readonly createUserProfileUseCase: CreateUserProfileUseCase,
-    private readonly searchUsersUseCase: SearchUsersUseCase,
+    private readonly deleteUserUseCase: DeleteUserUseCase,
+    private readonly getDeletionCheckUseCase: GetDeletionCheckUseCase,
     private readonly getUserUseCase: GetUserUseCase,
     private readonly getUserProfileUseCase: GetUserProfileUseCase,
-    private readonly deleteUserUseCase: DeleteUserUseCase,
+    private readonly searchUsersUseCase: SearchUsersUseCase,
   ) {}
 
   @TsRestHandler(contract.users.deleteUser)
@@ -41,6 +45,38 @@ export class UserController {
         return {
           status: StatusCodes.NO_CONTENT,
           body: null,
+        };
+      }
+
+      return handleFailure(result, this.logger);
+    });
+  }
+
+  @TsRestHandler(contract.users.getDeletionCheck)
+  getDeletionCheck() {
+    return tsRestHandler(contract.users.getDeletionCheck, async ({ params }) => {
+      const result = await this.getDeletionCheckUseCase.execute(params.id);
+
+      if (result.isSuccess()) {
+        return {
+          status: StatusCodes.OK,
+          body: result.value,
+        };
+      }
+
+      return handleFailure(result, this.logger);
+    });
+  }
+
+  @TsRestHandler(contract.users.bulkTransferAdmin)
+  bulkTransferAdmin() {
+    return tsRestHandler(contract.users.bulkTransferAdmin, async ({ params, body }) => {
+      const result = await this.bulkTransferAdminUseCase.execute(params.id, body.email);
+
+      if (result.isSuccess()) {
+        return {
+          status: StatusCodes.OK,
+          body: result.value,
         };
       }
 

--- a/apps/backend/src/users/user.module.ts
+++ b/apps/backend/src/users/user.module.ts
@@ -6,9 +6,11 @@ import { EmailAdapter } from "../common/modules/email/services/email.adapter";
 import { EmailModule } from "../common/modules/email/services/email.module";
 import { ExperimentModule } from "../experiments/experiment.module";
 import { AcceptPendingInvitationsUseCase } from "./application/use-cases/accept-pending-invitations/accept-pending-invitations";
+import { BulkTransferAdminUseCase } from "./application/use-cases/bulk-transfer-admin/bulk-transfer-admin";
 import { CreateInvitationUseCase } from "./application/use-cases/create-invitation/create-invitation";
 import { CreateUserProfileUseCase } from "./application/use-cases/create-user-profile/create-user-profile";
 import { DeleteUserUseCase } from "./application/use-cases/delete-user/delete-user";
+import { GetDeletionCheckUseCase } from "./application/use-cases/get-deletion-check/get-deletion-check";
 import { GetInvitationsUseCase } from "./application/use-cases/get-invitations/get-invitations";
 import { GetUserProfileUseCase } from "./application/use-cases/get-user-profile/get-user-profile";
 import { GetUserUseCase } from "./application/use-cases/get-user/get-user";
@@ -45,7 +47,9 @@ import { UserController } from "./presentation/user.controller";
     },
 
     // Use case providers
+    BulkTransferAdminUseCase,
     DeleteUserUseCase,
+    GetDeletionCheckUseCase,
     GetUserUseCase,
     SearchUsersUseCase,
     CreateUserProfileUseCase,

--- a/apps/web/components/account-settings/danger-zone-card.test.tsx
+++ b/apps/web/components/account-settings/danger-zone-card.test.tsx
@@ -12,12 +12,29 @@ import { DangerZoneCard } from "./danger-zone-card";
 globalThis.React = React;
 
 // ---------- Hoisted mocks ----------
-const { updateProfileSpy, deleteAccountSpy, handleLogoutSpy, toastSpy } = vi.hoisted(() => {
+const {
+  updateProfileSpy,
+  deleteAccountSpy,
+  handleLogoutSpy,
+  toastSpy,
+  bulkTransferSpy,
+  mockDeletionCheckData,
+} = vi.hoisted(() => {
   return {
     updateProfileSpy: vi.fn<(arg: { body: CreateUserProfileBody }) => unknown>(),
     deleteAccountSpy: vi.fn<(arg: { params: { id: string } }) => Promise<void>>(),
     handleLogoutSpy: vi.fn<(arg: { redirectTo: string }) => Promise<void>>(),
     toastSpy: vi.fn<(arg: { description: string; variant?: string }) => void>(),
+    bulkTransferSpy:
+      vi.fn<(arg: { params: { id: string }; body: { email: string } }) => Promise<unknown>>(),
+    mockDeletionCheckData: {
+      current: null as {
+        body: {
+          canDelete: boolean;
+          blockingExperiments: { id: string; name: string; status: string }[];
+        };
+      } | null,
+    },
   };
 });
 
@@ -42,6 +59,26 @@ vi.mock("~/hooks/auth/useSignOut/useSignOut", () => ({
 
 vi.mock("~/app/actions/auth", () => ({
   handleLogout: (arg: { redirectTo: string }) => handleLogoutSpy(arg),
+}));
+
+// Mock tsr for getDeletionCheck and bulkTransferAdmin
+vi.mock("~/lib/tsr", () => ({
+  tsr: {
+    users: {
+      getDeletionCheck: {
+        useQuery: () => ({
+          data: mockDeletionCheckData.current,
+          refetch: vi.fn().mockResolvedValue(undefined),
+        }),
+      },
+      bulkTransferAdmin: {
+        useMutation: () => ({
+          mutateAsync: bulkTransferSpy,
+          isPending: false,
+        }),
+      },
+    },
+  },
 }));
 
 let isPendingUpdate = false;
@@ -139,6 +176,7 @@ describe("<DangerZoneCard />", () => {
     vi.clearAllMocks();
     isPendingUpdate = false;
     isDeletingUser = false;
+    mockDeletionCheckData.current = null;
   });
 
   describe("Rendering", () => {
@@ -389,7 +427,135 @@ describe("<DangerZoneCard />", () => {
       expect(screen.getByText("dangerZone.delete.warningPreserveList.content")).toBeInTheDocument();
     });
 
+    it("disables delete button when there are blocking experiments", async () => {
+      mockDeletionCheckData.current = {
+        body: {
+          canDelete: false,
+          blockingExperiments: [{ id: "exp-1", name: "My Experiment", status: "active" }],
+        },
+      };
+
+      const user = userEvent.setup();
+      renderComponent();
+
+      await user.click(screen.getByRole("button", { name: "dangerZone.delete.button" }));
+
+      const input = screen.getByPlaceholderText("dangerZone.delete.confirmPlaceholder");
+      await user.type(input, "dangerZone.delete.confirmWord");
+
+      const dialogContents = screen.getAllByTestId("dialog-content");
+      const dialogContent = dialogContents[1];
+      const confirmBtn = within(dialogContent).getByRole("button", {
+        name: "dangerZone.delete.buttonConfirm",
+      });
+
+      // Should be disabled because canDelete is false
+      expect(confirmBtn).toBeDisabled();
+    });
+
+    it("shows blocking experiments with transfer UI", async () => {
+      mockDeletionCheckData.current = {
+        body: {
+          canDelete: false,
+          blockingExperiments: [
+            { id: "exp-1", name: "My Experiment", status: "active" },
+            { id: "exp-2", name: "Archived Experiment", status: "archived" },
+          ],
+        },
+      };
+
+      const user = userEvent.setup();
+      renderComponent();
+
+      await user.click(screen.getByRole("button", { name: "dangerZone.delete.button" }));
+
+      // Should show blocking experiments section
+      expect(screen.getByText("dangerZone.delete.blockingTitle")).toBeInTheDocument();
+      expect(screen.getByText("My Experiment")).toBeInTheDocument();
+      expect(screen.getByText("Archived Experiment")).toBeInTheDocument();
+
+      // Should show transfer input and button
+      expect(
+        screen.getByPlaceholderText("dangerZone.delete.transferPlaceholder"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "dangerZone.delete.transferButton" }),
+      ).toBeInTheDocument();
+    });
+
+    it("calls bulkTransfer with email when transfer button is clicked", async () => {
+      mockDeletionCheckData.current = {
+        body: {
+          canDelete: false,
+          blockingExperiments: [{ id: "exp-1", name: "My Experiment", status: "active" }],
+        },
+      };
+      bulkTransferSpy.mockResolvedValueOnce({ body: { transferred: 1 } });
+
+      const user = userEvent.setup();
+      renderComponent({ userId: "user-123" });
+
+      await user.click(screen.getByRole("button", { name: "dangerZone.delete.button" }));
+
+      const emailInput = screen.getByPlaceholderText("dangerZone.delete.transferPlaceholder");
+      await user.type(emailInput, "colleague@example.com");
+
+      const transferBtn = screen.getByRole("button", {
+        name: "dangerZone.delete.transferButton",
+      });
+      await user.click(transferBtn);
+
+      await waitFor(() => {
+        expect(bulkTransferSpy).toHaveBeenCalledWith({
+          params: { id: "user-123" },
+          body: { email: "colleague@example.com" },
+        });
+      });
+
+      await waitFor(() => {
+        expect(toastSpy).toHaveBeenCalledWith({
+          description: "dangerZone.delete.transferSuccess",
+        });
+      });
+    });
+
+    it("shows error toast when transfer fails", async () => {
+      mockDeletionCheckData.current = {
+        body: {
+          canDelete: false,
+          blockingExperiments: [{ id: "exp-1", name: "My Experiment", status: "active" }],
+        },
+      };
+      bulkTransferSpy.mockRejectedValueOnce({
+        body: { message: "No user found with email bad@example.com" },
+      });
+
+      const user = userEvent.setup();
+      renderComponent();
+
+      await user.click(screen.getByRole("button", { name: "dangerZone.delete.button" }));
+
+      const emailInput = screen.getByPlaceholderText("dangerZone.delete.transferPlaceholder");
+      await user.type(emailInput, "bad@example.com");
+
+      const transferBtn = screen.getByRole("button", {
+        name: "dangerZone.delete.transferButton",
+      });
+      await user.click(transferBtn);
+
+      await waitFor(() => {
+        expect(toastSpy).toHaveBeenCalledWith({
+          description: "No user found with email bad@example.com",
+          variant: "destructive",
+        });
+      });
+    });
+
     it("requires confirmation word to enable delete button", async () => {
+      mockDeletionCheckData.current = {
+        body: { canDelete: true, blockingExperiments: [] },
+      };
+
       const user = userEvent.setup();
       renderComponent();
 
@@ -416,6 +582,10 @@ describe("<DangerZoneCard />", () => {
     });
 
     it("calls deleteAccount with correct userId when deleting", async () => {
+      mockDeletionCheckData.current = {
+        body: { canDelete: true, blockingExperiments: [] },
+      };
+
       const user = userEvent.setup();
       const userId = "user-456";
       renderComponent({ userId });
@@ -438,6 +608,10 @@ describe("<DangerZoneCard />", () => {
     });
 
     it("shows success toast and logs out after deletion", async () => {
+      mockDeletionCheckData.current = {
+        body: { canDelete: true, blockingExperiments: [] },
+      };
+
       const user = userEvent.setup();
       renderComponent();
 
@@ -465,6 +639,9 @@ describe("<DangerZoneCard />", () => {
     });
 
     it("handles deletion errors and shows error toast", async () => {
+      mockDeletionCheckData.current = {
+        body: { canDelete: true, blockingExperiments: [] },
+      };
       deleteAccountSpy.mockRejectedValueOnce({
         body: { message: "Network error", code: "NETWORK_ERROR" },
       });

--- a/apps/web/components/account-settings/danger-zone-card.tsx
+++ b/apps/web/components/account-settings/danger-zone-card.tsx
@@ -5,11 +5,13 @@ import { useState } from "react";
 import { useSignOut } from "~/hooks/auth/useSignOut/useSignOut";
 import { useCreateUserProfile } from "~/hooks/profile/useCreateUserProfile/useCreateUserProfile";
 import { useDeleteUser } from "~/hooks/profile/useDeleteUser/useDeleteUser";
+import { tsr } from "~/lib/tsr";
 import { parseApiError } from "~/util/apiError";
 
 import type { CreateUserProfileBody } from "@repo/api";
 import { useTranslation } from "@repo/i18n";
 import {
+  Badge,
   Button,
   Card,
   CardHeader,
@@ -31,11 +33,34 @@ interface DangerZoneCardProps {
   userId: string;
 }
 
+const statusVariantMap: Record<string, "default" | "secondary" | "destructive" | "outline"> = {
+  active: "default",
+  archived: "secondary",
+  stale: "outline",
+  published: "default",
+};
+
 export function DangerZoneCard({ profile, userId }: DangerZoneCardProps) {
   const { t } = useTranslation("account");
   const [openModal, setOpenModal] = useState<"deactivate" | "delete" | null>(null);
   const [confirmation, setConfirmation] = useState("");
+  const [transferEmail, setTransferEmail] = useState("");
   const signOut = useSignOut();
+
+  // Fetch deletion check when dialog opens
+  const { data: deletionCheck, refetch: refetchDeletionCheck } =
+    tsr.users.getDeletionCheck.useQuery({
+      queryData: { params: { id: userId } },
+      queryKey: ["deletionCheck", userId],
+      enabled: openModal === "delete",
+    });
+
+  const blockingExperiments = deletionCheck?.body.blockingExperiments ?? [];
+  const canDelete = deletionCheck?.body.canDelete ?? false;
+
+  // Bulk transfer mutation
+  const { mutateAsync: bulkTransfer, isPending: isTransferring } =
+    tsr.users.bulkTransferAdmin.useMutation();
 
   const { mutate: updateProfile, isPending } = useCreateUserProfile({
     onSuccess: async () => {
@@ -51,6 +76,7 @@ export function DangerZoneCard({ profile, userId }: DangerZoneCardProps) {
   const handleClose = () => {
     setOpenModal(null);
     setConfirmation("");
+    setTransferEmail("");
   };
 
   // Deactivate handler - only supports deactivation from the UI
@@ -88,9 +114,35 @@ export function DangerZoneCard({ profile, userId }: DangerZoneCardProps) {
     }
   };
 
+  const handleTransfer = async () => {
+    try {
+      await bulkTransfer({
+        params: { id: userId },
+        body: { email: transferEmail },
+      });
+      toast({ description: t("dangerZone.delete.transferSuccess") });
+      setTransferEmail("");
+      await refetchDeletionCheck();
+    } catch (err) {
+      toast({
+        description: parseApiError(err)?.message ?? t("dangerZone.delete.transferError"),
+        variant: "destructive",
+      });
+    }
+  };
+
   const actionLabel = isPending
     ? t("dangerZone.deactivate.buttonSaving")
     : t("dangerZone.deactivate.buttonConfirm");
+
+  const statusLabel = (status: string) => {
+    const key = `dangerZone.delete.status${status.charAt(0).toUpperCase() + status.slice(1)}` as
+      | "dangerZone.delete.statusActive"
+      | "dangerZone.delete.statusArchived"
+      | "dangerZone.delete.statusStale"
+      | "dangerZone.delete.statusPublished";
+    return t(key);
+  };
 
   return (
     <Card className="border-destructive/40 mt-8 rounded-md">
@@ -163,7 +215,7 @@ export function DangerZoneCard({ profile, userId }: DangerZoneCardProps) {
                 <p className="text-muted-foreground text-sm">
                   {t("dangerZone.deactivate.confirmPrompt")}{" "}
                   <span className="text-destructive font-semibold">
-                    "{t("dangerZone.deactivate.confirmWord")}"
+                    &quot;{t("dangerZone.deactivate.confirmWord")}&quot;
                   </span>{" "}
                   {t("dangerZone.deactivate.confirmSuffix")}
                 </p>
@@ -203,6 +255,7 @@ export function DangerZoneCard({ profile, userId }: DangerZoneCardProps) {
               if (!v) handleClose();
               else {
                 setConfirmation("");
+                setTransferEmail("");
                 setOpenModal("delete");
               }
             }}
@@ -220,6 +273,51 @@ export function DangerZoneCard({ profile, userId }: DangerZoneCardProps) {
                   {t("dangerZone.delete.dialogDescription")}
                 </DialogDescription>
               </DialogHeader>
+
+              {/* Blocking experiments section */}
+              {blockingExperiments.length > 0 && (
+                <div className="border-warning/30 bg-muted mt-3 rounded-md border p-3 text-sm">
+                  <div className="mb-2 flex items-start gap-2">
+                    <AlertTriangle className="text-warning mt-0.5 h-5 w-5 shrink-0" />
+                    <p className="font-medium">{t("dangerZone.delete.blockingTitle")}</p>
+                  </div>
+                  <ul className="mb-3 space-y-1.5 pl-7">
+                    {blockingExperiments.map((exp) => (
+                      <li key={exp.id} className="flex items-center gap-2">
+                        <span className="text-foreground">{exp.name}</span>
+                        <Badge variant={statusVariantMap[exp.status] ?? "outline"}>
+                          {statusLabel(exp.status)}
+                        </Badge>
+                      </li>
+                    ))}
+                  </ul>
+                  <p className="text-muted-foreground pl-7">
+                    {t("dangerZone.delete.blockingDescription")}
+                  </p>
+                  <div className="mt-3 space-y-2 pl-7">
+                    <label className="text-foreground text-sm font-medium">
+                      {t("dangerZone.delete.transferLabel")}
+                    </label>
+                    <div className="flex gap-2">
+                      <Input
+                        type="email"
+                        placeholder={t("dangerZone.delete.transferPlaceholder")}
+                        value={transferEmail}
+                        onChange={(e) => setTransferEmail(e.target.value)}
+                      />
+                      <Button
+                        size="sm"
+                        onClick={handleTransfer}
+                        disabled={!transferEmail || isTransferring}
+                      >
+                        {isTransferring
+                          ? t("dangerZone.delete.transferring")
+                          : t("dangerZone.delete.transferButton")}
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              )}
 
               {/* Red warning box */}
               <div className="border-destructive/30 bg-muted mt-3 rounded-md border p-3 text-sm">
@@ -249,7 +347,7 @@ export function DangerZoneCard({ profile, userId }: DangerZoneCardProps) {
                 <p className="text-muted-foreground text-sm">
                   {t("dangerZone.delete.confirmPrompt")}{" "}
                   <span className="text-destructive font-semibold">
-                    "{t("dangerZone.delete.confirmWord")}"
+                    &quot;{t("dangerZone.delete.confirmWord")}&quot;
                   </span>{" "}
                   {t("dangerZone.delete.confirmSuffix")}
                 </p>
@@ -267,7 +365,9 @@ export function DangerZoneCard({ profile, userId }: DangerZoneCardProps) {
                 <Button
                   variant="destructive"
                   onClick={handleDelete}
-                  disabled={confirmation !== t("dangerZone.delete.confirmWord") || isDeleting}
+                  disabled={
+                    confirmation !== t("dangerZone.delete.confirmWord") || isDeleting || !canDelete
+                  }
                 >
                   {isDeleting
                     ? t("dangerZone.delete.buttonDeleting")

--- a/packages/api/src/contracts/user.contract.ts
+++ b/packages/api/src/contracts/user.contract.ts
@@ -19,6 +19,9 @@ import {
   zUpdateInvitationRoleBody,
   zInvitationIdPathParam,
   zListInvitationsQuery,
+  zDeletionCheckResponse,
+  zBulkTransferAdminBody,
+  zBulkTransferAdminResponse,
 } from "../schemas/user.schema";
 
 const c = initContract();
@@ -84,6 +87,35 @@ export const userContract = c.router({
     },
     summary: "Delete a user",
     description: "Deletes a user by their ID if allowed",
+  },
+
+  getDeletionCheck: {
+    method: "GET",
+    path: "/api/v1/users/:id/deletion-check",
+    pathParams: zUserIdPathParam,
+    responses: {
+      200: zDeletionCheckResponse,
+      404: zErrorResponse,
+    },
+    summary: "Check if user can be deleted",
+    description:
+      "Returns whether the user can be deleted and lists any experiments blocking deletion",
+  },
+
+  bulkTransferAdmin: {
+    method: "POST",
+    path: "/api/v1/users/:id/transfer-experiments",
+    pathParams: zUserIdPathParam,
+    body: zBulkTransferAdminBody,
+    responses: {
+      200: zBulkTransferAdminResponse,
+      400: zErrorResponse,
+      403: zErrorResponse,
+      404: zErrorResponse,
+    },
+    summary: "Bulk transfer experiment admin rights",
+    description:
+      "Transfers admin rights on all experiments where the user is the sole admin to the specified new admin user",
   },
 
   getUserMetadata: {

--- a/packages/api/src/schemas/user.schema.ts
+++ b/packages/api/src/schemas/user.schema.ts
@@ -114,6 +114,31 @@ export type UserMetadataWebhookResponse = z.infer<typeof zUserMetadataWebhookRes
 export type WebhookSuccessResponse = z.infer<typeof zWebhookSuccessResponse>;
 export type WebhookErrorResponse = z.infer<typeof zWebhookErrorResponse>;
 
+// --- Deletion Check Schemas ---
+export const zBlockingExperiment = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  status: z.string(),
+});
+
+export const zDeletionCheckResponse = z.object({
+  canDelete: z.boolean(),
+  blockingExperiments: z.array(zBlockingExperiment),
+});
+
+export const zBulkTransferAdminBody = z.object({
+  email: z.string().email().describe("Email of the user to transfer admin rights to"),
+});
+
+export const zBulkTransferAdminResponse = z.object({
+  transferred: z.number().describe("Number of experiments transferred"),
+});
+
+export type BlockingExperiment = z.infer<typeof zBlockingExperiment>;
+export type DeletionCheckResponse = z.infer<typeof zDeletionCheckResponse>;
+export type BulkTransferAdminBody = z.infer<typeof zBulkTransferAdminBody>;
+export type BulkTransferAdminResponse = z.infer<typeof zBulkTransferAdminResponse>;
+
 // --- Invitation Schemas ---
 export const zInvitationStatus = z.enum(["pending", "accepted", "revoked"]);
 export const zInvitationResourceType = z.enum(["platform", "experiment"]);

--- a/packages/i18n/locales/en-US/account.json
+++ b/packages/i18n/locales/en-US/account.json
@@ -90,7 +90,19 @@
       "confirmPlaceholder": "Type 'delete' here",
       "buttonDeleting": "Deleting...",
       "buttonConfirm": "Delete Account",
-      "successMessage": "Account deleted. Your personal data has been erased."
+      "successMessage": "Account deleted. Your personal data has been erased.",
+      "blockingTitle": "You are the sole admin of these experiments:",
+      "blockingDescription": "Transfer admin rights before you can delete your account.",
+      "transferLabel": "Transfer all to:",
+      "transferPlaceholder": "colleague@example.com",
+      "transferButton": "Transfer Admin Rights",
+      "transferring": "Transferring...",
+      "transferSuccess": "Admin rights transferred successfully. You can now delete your account.",
+      "transferError": "Failed to transfer admin rights.",
+      "statusActive": "Active",
+      "statusArchived": "Archived",
+      "statusStale": "Stale",
+      "statusPublished": "Published"
     },
     "cancel": "Cancel"
   }


### PR DESCRIPTION
## Summary

- Remove archive restriction on experiment member role updates — admins can now transfer roles on archived experiments without unarchiving first
- Add `GET /api/v1/users/:id/deletion-check` endpoint that returns which experiments block deletion (with name + status)
- Add `POST /api/v1/users/:id/transfer-experiments` endpoint for bulk admin transfer via email
- Update delete account dialog to show blocking experiments and a "Transfer All" email input when deletion is blocked
- Delete button is disabled until all blocking experiments are resolved

## Test plan

### Backend
- [ ] **Deletion check returns blocking experiments**: Create a user who is the sole admin of 2+ experiments (one active, one archived). Call `GET /users/:id/deletion-check` and verify both experiments are returned with correct names and statuses.
- [ ] **Deletion check returns canDelete: true when no blockers**: Create a user who is not admin of any experiments. Verify `canDelete: true` and empty `blockingExperiments`.
- [ ] **Bulk transfer via email**: Call `POST /users/:id/transfer-experiments` with a valid colleague email. Verify admin rights are transferred on all blocking experiments and response shows correct `transferred` count.
- [ ] **Bulk transfer — target user not found**: Call with a non-existent email. Verify 404 error with clear message.
- [ ] **Bulk transfer — transfer to self**: Call with the user's own email. Verify 400 error.
- [ ] **Bulk transfer — target already a member**: Transfer to a user who is already a member (not admin) of some blocking experiments. Verify they are promoted to admin.
- [ ] **Bulk transfer — target already admin**: Transfer to a user who is already admin of a blocking experiment. Verify no error and correct count.
- [ ] **Role update on archived experiment**: Update a member's role on an archived experiment. Verify it succeeds (previously returned 403).
- [ ] **Delete account after transfer**: After bulk transferring, call deletion check again to verify `canDelete: true`, then delete the account.

### Frontend
- [ ] **Delete dialog shows blocking experiments**: Open delete dialog as a user who is sole admin of experiments. Verify the experiment names and status badges are displayed.
- [ ] **Delete dialog shows archived experiments**: Verify archived experiments appear in the blocking list with an "Archived" badge.
- [ ] **Transfer input and button visible**: When blocking experiments exist, verify the email input and "Transfer Admin Rights" button are shown.
- [ ] **Transfer button disabled without email**: Verify the transfer button is disabled when the email input is empty.
- [ ] **Successful transfer refreshes the list**: Enter a valid email, click transfer. Verify success toast and the blocking experiments list updates.
- [ ] **Transfer error shows toast**: Enter an invalid email, click transfer. Verify a destructive toast with the error message.
- [ ] **Delete button disabled when blocked**: Verify the "Delete Account" confirm button is disabled when there are blocking experiments, even after typing "delete".
- [ ] **Delete button enabled after transfer**: After successfully transferring all blocking experiments, verify the delete button becomes enabled.
- [ ] **Full flow**: Transfer all experiments → type "delete" → confirm deletion → verify sign-out and redirect.

### Edge cases
- [ ] **User with only archived experiments blocking deletion**: Verify archived-only experiments show up and can be transferred.
- [ ] **Large number of blocking experiments**: User is sole admin of 10+ experiments. Verify all are listed and bulk transfer handles all.
- [ ] **Concurrent admin changes**: Another admin is added to a blocking experiment externally. Verify deletion check reflects the updated state.

Closes OJD-1420

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deletion eligibility check to inform users which experiments block account deletion.
  * Introduced bulk admin rights transfer feature for seamless account deletion workflow.

* **Bug Fixes**
  * Removed restriction preventing admin role updates in archived experiments; role changes now allowed with proper admin privilege verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->