### PR TITLE
fix(cicd): Update OIDC role with kms permission

### DIFF
--- a/infrastructure/modules/iam-oidc/README.md
+++ b/infrastructure/modules/iam-oidc/README.md
@@ -80,6 +80,8 @@ The IAM role includes permissions for the following AWS services and operations:
 - **Selection management**: `CreateBackupSelection`, `DeleteBackupSelection`, `GetBackupSelection`, `ListBackupSelections`
 - **Tagging**: `TagResource`, `UntagResource`, `ListTags`
 - **Policy and notification management**: `GetBackupVaultAccessPolicy`, `PutBackupVaultAccessPolicy`, `DeleteBackupVaultAccessPolicy`, `GetBackupVaultNotifications`
+- **Grant management operations**: `kms:CreateGrant`, `kms:ListGrants`, `kms:RevokeGrant` (required by AWS Backup's CreateBackupVault to establish ongoing encryption access for the vault)
+
 
 ### Other Services
 - **VPC**: Network infrastructure management

--- a/infrastructure/modules/iam-oidc/main.tf
+++ b/infrastructure/modules/iam-oidc/main.tf
@@ -341,6 +341,11 @@ locals {
         "kms:GenerateDataKey",
         "kms:GenerateDataKeyWithoutPlaintext",
         "kms:Decrypt",
+        # Required by CreateBackupVault — AWS Backup calls CreateGrant on the
+        # KMS key to establish ongoing encryption access for the vault
+        "kms:CreateGrant",
+        "kms:ListGrants",
+        "kms:RevokeGrant",
       ]
       resource = "*"
     }


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description
Add missing kms permission to OIDC role 

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #
- Related to #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated IAM permissions documentation for AWS KMS to include newly supported grant-management operations required for AWS Backup vault encryption access.

* **Configuration**
  * Expanded the IAM role's KMS permissions to support additional grant-management operations: CreateGrant, ListGrants, and RevokeGrant, enabling more comprehensive AWS Backup vault encryption with enhanced key management and access control capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->