### PR TITLE
fix: ignore managed rules for `/ingest` routes

### DIFF
--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -1166,13 +1166,7 @@ module "opennext_waf" {
   log_retention_days = 30
   enable_bot_control = true
 
-  large_body_bypass_routes = [
-    {
-      search_string         = "/ingest"
-      positional_constraint = "STARTS_WITH"
-      method                = "POST"
-    }
-  ]
+  managed_rules_excluded_paths = ["/ingest"]
 
   tags = {
     Environment = var.environment

--- a/infrastructure/env/dr/main.tf
+++ b/infrastructure/env/dr/main.tf
@@ -539,13 +539,7 @@ module "opennext_waf" {
   rate_limit         = 2500
   log_retention_days = 30
 
-  large_body_bypass_routes = [
-    {
-      search_string         = "/ingest"
-      positional_constraint = "STARTS_WITH"
-      method                = "POST"
-    }
-  ]
+  managed_rules_excluded_paths = ["/ingest"]
 
   tags = {
     Environment = var.environment

--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -1125,13 +1125,7 @@ module "opennext_waf" {
   log_retention_days = 30
   enable_bot_control = true
 
-  large_body_bypass_routes = [
-    {
-      search_string         = "/ingest"
-      positional_constraint = "STARTS_WITH"
-      method                = "POST"
-    }
-  ]
+  managed_rules_excluded_paths = ["/ingest"]
 
   tags = {
     Environment = var.environment

--- a/infrastructure/modules/waf/main.tf
+++ b/infrastructure/modules/waf/main.tf
@@ -3,6 +3,16 @@ provider "aws" {
   region = "us-east-1"
 }
 
+# Pre-compute scope-down data so both managed rule groups share identical logic.
+# The list is non-empty only when managed_rules_excluded_paths is set, driving
+# the dynamic "scope_down_statement" for_each in each rule.
+locals {
+  managed_rules_scope_down_statement = length(var.managed_rules_excluded_paths) > 0 ? [{
+    single_path = length(var.managed_rules_excluded_paths) == 1 ? [var.managed_rules_excluded_paths[0]] : []
+    multi_paths = length(var.managed_rules_excluded_paths) >= 2 ? var.managed_rules_excluded_paths : []
+  }] : []
+}
+
 # Web Application Firewall (WAF) v2 for comprehensive application-layer protection
 # WAF inspects HTTP/HTTPS requests before they reach the ALB
 # Provides protection against common web exploits and application-layer attacks
@@ -77,14 +87,16 @@ resource "aws_wafv2_web_acl" "main" {
           }
         }
 
-        # Exclude configured paths from this rule group entirely via scope-down
+        # Exclude configured paths from this rule group entirely via scope-down.
+        # Uses local.managed_rules_scope_down_statement so both managed rule groups
+        # share identical scope-down logic without duplication.
         dynamic "scope_down_statement" {
-          for_each = length(var.managed_rules_excluded_paths) > 0 ? [1] : []
+          for_each = local.managed_rules_scope_down_statement
           content {
             not_statement {
               statement {
                 dynamic "byte_match_statement" {
-                  for_each = length(var.managed_rules_excluded_paths) == 1 ? [var.managed_rules_excluded_paths[0]] : []
+                  for_each = scope_down_statement.value.single_path
                   content {
                     search_string         = byte_match_statement.value
                     positional_constraint = "STARTS_WITH"
@@ -99,10 +111,10 @@ resource "aws_wafv2_web_acl" "main" {
                 }
 
                 dynamic "or_statement" {
-                  for_each = length(var.managed_rules_excluded_paths) >= 2 ? [1] : []
+                  for_each = length(scope_down_statement.value.multi_paths) >= 2 ? [1] : []
                   content {
                     dynamic "statement" {
-                      for_each = var.managed_rules_excluded_paths
+                      for_each = scope_down_statement.value.multi_paths
                       content {
                         byte_match_statement {
                           search_string         = statement.value
@@ -150,14 +162,16 @@ resource "aws_wafv2_web_acl" "main" {
         name        = "AWSManagedRulesKnownBadInputsRuleSet"
         vendor_name = "AWS"
 
-        # Exclude configured paths from this rule group entirely via scope-down
+        # Exclude configured paths from this rule group entirely via scope-down.
+        # Uses local.managed_rules_scope_down_statement so both managed rule groups
+        # share identical scope-down logic without duplication.
         dynamic "scope_down_statement" {
-          for_each = length(var.managed_rules_excluded_paths) > 0 ? [1] : []
+          for_each = local.managed_rules_scope_down_statement
           content {
             not_statement {
               statement {
                 dynamic "byte_match_statement" {
-                  for_each = length(var.managed_rules_excluded_paths) == 1 ? [var.managed_rules_excluded_paths[0]] : []
+                  for_each = scope_down_statement.value.single_path
                   content {
                     search_string         = byte_match_statement.value
                     positional_constraint = "STARTS_WITH"
@@ -172,10 +186,10 @@ resource "aws_wafv2_web_acl" "main" {
                 }
 
                 dynamic "or_statement" {
-                  for_each = length(var.managed_rules_excluded_paths) >= 2 ? [1] : []
+                  for_each = length(scope_down_statement.value.multi_paths) >= 2 ? [1] : []
                   content {
                     dynamic "statement" {
-                      for_each = var.managed_rules_excluded_paths
+                      for_each = scope_down_statement.value.multi_paths
                       content {
                         byte_match_statement {
                           search_string         = statement.value

--- a/infrastructure/modules/waf/main.tf
+++ b/infrastructure/modules/waf/main.tf
@@ -76,6 +76,53 @@ resource "aws_wafv2_web_acl" "main" {
             name = "SizeRestrictions_BODY"
           }
         }
+
+        # Exclude configured paths from this rule group entirely via scope-down
+        dynamic "scope_down_statement" {
+          for_each = length(var.managed_rules_excluded_paths) > 0 ? [1] : []
+          content {
+            not_statement {
+              statement {
+                dynamic "byte_match_statement" {
+                  for_each = length(var.managed_rules_excluded_paths) == 1 ? [var.managed_rules_excluded_paths[0]] : []
+                  content {
+                    search_string         = byte_match_statement.value
+                    positional_constraint = "STARTS_WITH"
+                    field_to_match {
+                      uri_path {}
+                    }
+                    text_transformation {
+                      priority = 0
+                      type     = "LOWERCASE"
+                    }
+                  }
+                }
+
+                dynamic "or_statement" {
+                  for_each = length(var.managed_rules_excluded_paths) >= 2 ? [1] : []
+                  content {
+                    dynamic "statement" {
+                      for_each = var.managed_rules_excluded_paths
+                      content {
+                        byte_match_statement {
+                          search_string         = statement.value
+                          positional_constraint = "STARTS_WITH"
+                          field_to_match {
+                            uri_path {}
+                          }
+                          text_transformation {
+                            priority = 0
+                            type     = "LOWERCASE"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
 
@@ -102,6 +149,53 @@ resource "aws_wafv2_web_acl" "main" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesKnownBadInputsRuleSet"
         vendor_name = "AWS"
+
+        # Exclude configured paths from this rule group entirely via scope-down
+        dynamic "scope_down_statement" {
+          for_each = length(var.managed_rules_excluded_paths) > 0 ? [1] : []
+          content {
+            not_statement {
+              statement {
+                dynamic "byte_match_statement" {
+                  for_each = length(var.managed_rules_excluded_paths) == 1 ? [var.managed_rules_excluded_paths[0]] : []
+                  content {
+                    search_string         = byte_match_statement.value
+                    positional_constraint = "STARTS_WITH"
+                    field_to_match {
+                      uri_path {}
+                    }
+                    text_transformation {
+                      priority = 0
+                      type     = "LOWERCASE"
+                    }
+                  }
+                }
+
+                dynamic "or_statement" {
+                  for_each = length(var.managed_rules_excluded_paths) >= 2 ? [1] : []
+                  content {
+                    dynamic "statement" {
+                      for_each = var.managed_rules_excluded_paths
+                      content {
+                        byte_match_statement {
+                          search_string         = statement.value
+                          positional_constraint = "STARTS_WITH"
+                          field_to_match {
+                            uri_path {}
+                          }
+                          text_transformation {
+                            priority = 0
+                            type     = "LOWERCASE"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
 

--- a/infrastructure/modules/waf/variables.tf
+++ b/infrastructure/modules/waf/variables.tf
@@ -32,6 +32,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "managed_rules_excluded_paths" {
+  description = "List of URI path prefixes to exclude from all managed rule groups via scope-down. Use for trusted proxied origins (e.g. PostHog /ingest) whose payloads would otherwise trigger false positives."
+  type        = list(string)
+  default     = []
+}
+
 variable "large_body_bypass_routes" {
   description = "List of route configurations that should bypass the SizeRestrictions_BODY rule from AWSManagedRulesCommonRuleSet"
   type = list(object({


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description

This pull request updates how certain routes are excluded from AWS WAF managed rule groups, specifically to improve maintainability and flexibility when bypassing rules for trusted paths like `/ingest`. The change replaces the previous `large_body_bypass_routes` mechanism with a new `managed_rules_excluded_paths` variable, and updates the WAF module logic to use this variable to scope-down managed rule groups accordingly.

Key changes:

**Configuration and Variable Updates:**
- Added a new variable `managed_rules_excluded_paths` to the WAF module, allowing a list of URI path prefixes to be excluded from all managed rule groups. This replaces the previous approach using `large_body_bypass_routes`. (`infrastructure/modules/waf/variables.tf`)
- Updated environment configuration files (`dev`, `dr`, `prod`) to use `managed_rules_excluded_paths = ["/ingest"]` instead of the old `large_body_bypass_routes` block. (`infrastructure/env/dev/main.tf`, `infrastructure/env/dr/main.tf`, `infrastructure/env/prod/main.tf`) [[1]](diffhunk://#diff-f6672b4c785f679251f4f9dbd2e79d208b1486eb63bcb0db45be92c90197d13eL1169-R1169) [[2]](diffhunk://#diff-9c8c625a5871130e7868dc1b5eff888dcd589681cb8929a4e1957749cdc2e8e7L542-R542) [[3]](diffhunk://#diff-09bdb85c9d5378e633e10f5979c6492282ffbbcc94a9d2c4f4d660bb7a6af4d9L1128-R1128)

**WAF Rule Logic Enhancements:**
- Modified the WAF module to apply a scope-down statement to managed rule groups (`SizeRestrictions_BODY` and `AWSManagedRulesKnownBadInputsRuleSet`), excluding any paths specified in `managed_rules_excluded_paths`. This is done dynamically, supporting one or multiple excluded paths, and applies a `NOT` statement with a `byte_match_statement` or an `or_statement` as appropriate. (`infrastructure/modules/waf/main.tf`) [[1]](diffhunk://#diff-4e4a9fabd9aa74c6964e1c4390f53721a7879c153aad0f4ee25464c7da2a799aR79-R125) [[2]](diffhunk://#diff-4e4a9fabd9aa74c6964e1c4390f53721a7879c153aad0f4ee25464c7da2a799aR152-R198)

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #
- Related to #

## Testing Instructions

<!-- Provide steps to test your changes and any relevant environments tested -->

- [ ] open website
- [ ] see no blocked request on /ingest/X

## Changes Made

<!-- List the key changes made in this PR -->

-
-

## Checklist

- [x] I have added/updated tests for my changes
- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have tested these changes locally
- [x] My changes generate no new warnings
- [x] I have reviewed my own code

## Screenshots/Recordings

<!-- If applicable, add screenshots or recordings to demonstrate your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated WAF configuration across environments to replace the previous route-specific large-body bypass with a simplified path-based exclusion for the /ingest endpoint.
  * Added support for configuring one or more URI path prefixes to be excluded from managed WAF rule evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->