### PR TITLE
fix(mobile): suppress time sync warnings when offline (OJD-1429)

### DIFF
--- a/apps/mobile/src/utils/time-sync.test.ts
+++ b/apps/mobile/src/utils/time-sync.test.ts
@@ -13,6 +13,13 @@ vi.mock("@react-native-async-storage/async-storage", () => ({
   },
 }));
 
+let mockIsInternetReachable = true;
+vi.mock("expo-network", () => ({
+  getNetworkStateAsync: vi.fn(() =>
+    Promise.resolve({ isInternetReachable: mockIsInternetReachable }),
+  ),
+}));
+
 vi.mock("expo-location", () => ({
   requestForegroundPermissionsAsync: vi.fn(() => Promise.resolve({ status: "granted" })),
   getCurrentPositionAsync: vi.fn(() =>
@@ -79,6 +86,7 @@ describe("time-sync", () => {
     mockRemove.mockClear();
     mockServerUtcMs = Date.now();
     getTimeCallCount = 0;
+    mockIsInternetReachable = true;
 
     // Clean up any leftover state from previous tests
     for (const key of Object.keys(mockAsyncStorage)) {
@@ -561,6 +569,77 @@ describe("time-sync", () => {
       await Promise.all([p1, p2, p3]);
       expect(resolvedCount).toBe(3);
       expect(getTimeSyncState().isSynced).toBe(true);
+    });
+  });
+
+  describe("offline behavior", () => {
+    it("should skip sync entirely when device is offline", async () => {
+      mockIsInternetReachable = false;
+
+      const { startTimeSync, getTimeSyncState } = await import("./time-sync");
+
+      startTimeSync();
+      await vi.advanceTimersByTimeAsync(50);
+
+      // No sync should have happened — server was never called
+      expect(getTimeCallCount).toBe(0);
+      expect(getTimeSyncState().isSynced).toBe(false);
+    });
+
+    it("should not show any toast when offline", async () => {
+      mockIsInternetReachable = false;
+
+      const { startTimeSync } = await import("./time-sync");
+      const { toast } = await import("sonner-native");
+      (toast.warning as ReturnType<typeof vi.fn>).mockClear();
+
+      startTimeSync();
+      await vi.advanceTimersByTimeAsync(50);
+
+      expect(toast.warning).not.toHaveBeenCalled();
+    });
+
+    it("should not increment missedPings when offline", async () => {
+      const { startTimeSync, getTimeSyncState } = await import("./time-sync");
+
+      // Start online with a successful sync
+      mockServerUtcMs = Date.now();
+      startTimeSync();
+      await vi.advanceTimersByTimeAsync(50);
+      expect(getTimeSyncState().missedPings).toBe(0);
+
+      // Go offline and trigger foreground syncs
+      mockIsInternetReachable = false;
+
+      for (let i = 0; i < 5; i++) {
+        await advancePastDebounce();
+        capturedAppStateHandler?.("active");
+        await vi.advanceTimersByTimeAsync(50);
+      }
+
+      // missedPings should still be 0 — offline syncs were skipped, not failed
+      expect(getTimeSyncState().missedPings).toBe(0);
+    });
+
+    it("should sync successfully when connectivity returns", async () => {
+      mockIsInternetReachable = false;
+
+      const { startTimeSync, getTimeSyncState } = await import("./time-sync");
+
+      startTimeSync();
+      await vi.advanceTimersByTimeAsync(50);
+      expect(getTimeSyncState().isSynced).toBe(false);
+
+      // Come back online
+      mockIsInternetReachable = true;
+      mockServerUtcMs = Date.now() + 3000;
+
+      await advancePastDebounce();
+      capturedAppStateHandler?.("active");
+      await vi.advanceTimersByTimeAsync(50);
+
+      expect(getTimeSyncState().isSynced).toBe(true);
+      expect(getTimeCallCount).toBe(1);
     });
   });
 });

--- a/apps/mobile/src/utils/time-sync.ts
+++ b/apps/mobile/src/utils/time-sync.ts
@@ -2,6 +2,7 @@ import tzLookup from "@photostructure/tz-lookup";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Debouncer } from "@tanstack/pacer";
 import * as Location from "expo-location";
+import * as Network from "expo-network";
 import { DateTime } from "luxon";
 import { AppState } from "react-native";
 import type { AppStateStatus } from "react-native";
@@ -110,6 +111,12 @@ async function fetchServerTime(): Promise<number> {
 }
 
 async function performSync(isInitial = false): Promise<void> {
+  const networkState = await Network.getNetworkStateAsync();
+  if (!networkState.isInternetReachable) {
+    console.log("[time-sync] Skipping sync — device is offline");
+    return;
+  }
+
   try {
     const timezone = await resolveTimezone();
     const beforeFetch = Date.now();


### PR DESCRIPTION
## Summary
- Skip `performSync()` entirely when the device has no internet — avoids confusing "Time sync lost" / "Unable to synchronize time" toasts when users are in the field without connectivity
- Uses `expo-network` (`getNetworkStateAsync`) to check `isInternetReachable` before doing any GPS/network work
- Sync resumes automatically on next foreground event once connectivity returns

Closes OJD-1429

## Test plan
- [x] All 25 time-sync tests pass (4 new offline-specific tests added)
- [ ] On device: enable airplane mode → foreground app → no toast shown
- [ ] On device: disable airplane mode → foreground app → sync completes normally
- [ ] Long field session without connectivity → no "Time sync lost" toast accumulation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Time synchronization now detects offline status and gracefully defers sync operations until connectivity is restored, improving app stability in varying network conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->