### PR TITLE
fix(mobile): send cancel command (-1+) when aborting measurement

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -30,6 +30,7 @@
     "@react-navigation/native-stack": "^7.14.10",
     "@repo/api": "workspace:*",
     "@repo/auth": "workspace:*",
+    "@repo/iot": "workspace:*",
     "@shopify/react-native-skia": "2.4.18",
     "@tanstack/pacer": "^0.19.0",
     "@tanstack/query-async-storage-persister": "catalog:react-query",

--- a/apps/mobile/src/screens/measurement-flow-screen/components/flow-nodes/measurement-node/measurement-node.tsx
+++ b/apps/mobile/src/screens/measurement-flow-screen/components/flow-nodes/measurement-node/measurement-node.tsx
@@ -61,6 +61,11 @@ export function MeasurementNode({ content }: MeasurementNodeProps) {
     navigateToQuestionFromOverview(flowStepIndex);
   };
 
+  const handleCancelMeasurement = () => {
+    void cancelCommand();
+    resetScan();
+  };
+
   const handleStartScan = async () => {
     if (!device) {
       toast.error("Not connected to sensor");
@@ -133,10 +138,7 @@ export function MeasurementNode({ content }: MeasurementNodeProps) {
 
             <Button
               title="Cancel Measurement"
-              onPress={() => {
-                void cancelCommand();
-                resetScan();
-              }}
+              onPress={handleCancelMeasurement}
               style={{ height: 44 }}
             />
           </View>

--- a/apps/mobile/src/screens/measurement-flow-screen/components/flow-nodes/measurement-node/measurement-node.tsx
+++ b/apps/mobile/src/screens/measurement-flow-screen/components/flow-nodes/measurement-node/measurement-node.tsx
@@ -33,6 +33,7 @@ export function MeasurementNode({ content }: MeasurementNodeProps) {
     reset: resetScan,
     result: scanResult,
     error: scanError,
+    cancelCommand,
   } = useScanner();
   const { data: device } = useConnectedDevice();
   const { nextStep, setScanResult, setProtocolId, navigateToQuestionFromOverview } =
@@ -130,7 +131,14 @@ export function MeasurementNode({ content }: MeasurementNodeProps) {
               </Text>
             </View>
 
-            <Button title="Cancel Measurement" onPress={resetScan} style={{ height: 44 }} />
+            <Button
+              title="Cancel Measurement"
+              onPress={() => {
+                void cancelCommand();
+                resetScan();
+              }}
+              style={{ height: 44 }}
+            />
           </View>
         </View>
       );

--- a/apps/mobile/src/services/multispeq-communication/multispeq-command-executor.test.ts
+++ b/apps/mobile/src/services/multispeq-communication/multispeq-command-executor.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Emitter } from "~/utils/emitter";
+
+import { MultispeqCommandExecutor } from "./multispeq-command-executor";
+import type { MultispeqStreamEvents } from "./multispeq-stream-events";
+
+/**
+ * Wrap an Emitter as a fake device: every command sent via "sendCommandToDevice"
+ * is captured so the test can drive a corresponding "receivedReplyFromDevice"
+ * reply at a chosen moment.
+ */
+function createFakeDevice() {
+  const emitter = new Emitter<MultispeqStreamEvents>();
+  const sentCommands: (string | object)[] = [];
+  const destroyed = vi.fn();
+
+  emitter.on("sendCommandToDevice", (cmd) => {
+    sentCommands.push(cmd);
+  });
+  emitter.on("destroy", () => {
+    destroyed();
+  });
+
+  const reply = (data: object | string, checksum = "") =>
+    emitter.emit("receivedReplyFromDevice", { data, checksum });
+
+  return { emitter, sentCommands, destroyed, reply };
+}
+
+describe("MultispeqCommandExecutor", () => {
+  let device: ReturnType<typeof createFakeDevice>;
+  let executor: MultispeqCommandExecutor;
+
+  beforeEach(() => {
+    device = createFakeDevice();
+    executor = new MultispeqCommandExecutor(device.emitter);
+  });
+
+  it("sends the command to the device and resolves with the next reply", async () => {
+    const pending = executor.execute("hello");
+
+    expect(device.sentCommands).toEqual(["hello"]);
+
+    await device.reply({ ok: true });
+
+    await expect(pending).resolves.toEqual({ ok: true });
+  });
+
+  it("forwards object commands unchanged", async () => {
+    const protocol = [{ pulses: [1, 2, 3] }];
+    const pending = executor.execute(protocol);
+
+    expect(device.sentCommands[0]).toBe(protocol);
+
+    await device.reply("raw-string-reply");
+    await expect(pending).resolves.toBe("raw-string-reply");
+  });
+
+  describe("preemption (cancel race)", () => {
+    it("a follow-up execute() rejects the in-flight call with 'Superseded by new execute call'", async () => {
+      const original = executor.execute("long-running");
+      const cancel = executor.execute("-1+");
+
+      await expect(original).rejects.toThrow("Superseded by new execute call");
+
+      // The pending cancel must still be live and resolve from the next reply.
+      await device.reply({ cancelled: true });
+      await expect(cancel).resolves.toEqual({ cancelled: true });
+    });
+
+    it("only the latest execute() receives the next reply (no double-resolve)", async () => {
+      const original = executor.execute("long-running");
+      const cancel = executor.execute("-1+");
+
+      // Swallow the original rejection so it doesn't surface as unhandled.
+      const originalSettled = original.catch((err: Error) => err);
+
+      await device.reply({ from: "device" });
+
+      await expect(cancel).resolves.toEqual({ from: "device" });
+      const originalErr = await originalSettled;
+      expect(originalErr).toBeInstanceOf(Error);
+      expect((originalErr as Error).message).toBe("Superseded by new execute call");
+
+      // Both commands were written to the wire.
+      expect(device.sentCommands).toEqual(["long-running", "-1+"]);
+    });
+
+    it("a reply that arrives with no in-flight execute() does not leak into the next call", async () => {
+      // Simulate a stray reply (e.g. the device's response to a previous
+      // cancel that arrived after the executor had already settled).
+      await device.reply({ stray: true });
+
+      // The next execute() must wait for its own reply, NOT pick up the stray.
+      const pending = executor.execute("hello");
+      let settled = false;
+      void pending.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+
+      // Yield the microtask queue — without the regression fix the executor
+      // would have already resolved from the emitter's history buffer.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      await device.reply({ fresh: true });
+      await expect(pending).resolves.toEqual({ fresh: true });
+    });
+  });
+
+  describe("destroy", () => {
+    it("rejects an in-flight execute() with 'Executor destroyed'", async () => {
+      const pending = executor.execute("hello");
+
+      await executor.destroy();
+
+      await expect(pending).rejects.toThrow("Executor destroyed");
+      expect(device.destroyed).toHaveBeenCalledTimes(1);
+    });
+
+    it("unregisters the reply listener so post-destroy replies do nothing", async () => {
+      await executor.destroy();
+
+      // After destroy() the executor should no longer be subscribed; emitting
+      // a reply must not throw, and a fresh executor should not pick it up
+      // from history.
+      await device.reply({ late: true });
+
+      // Re-attach a fresh executor on the same emitter and verify the stale
+      // reply does not surface.
+      const next = new MultispeqCommandExecutor(device.emitter);
+      const pending = next.execute("hello");
+
+      let settled = false;
+      void pending.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      await device.reply({ ok: true });
+      await expect(pending).resolves.toEqual({ ok: true });
+    });
+  });
+
+  describe("write failures", () => {
+    it("rejects the execute() promise when the device write fails", async () => {
+      const failing = new Emitter<MultispeqStreamEvents>();
+      failing.on("sendCommandToDevice", () => {
+        throw new Error("BT write failed");
+      });
+      // Suppress the emitter's default console.log error sink for this test.
+      failing.onError(vi.fn());
+
+      const exec = new MultispeqCommandExecutor(failing);
+      await expect(exec.execute("hello")).rejects.toThrow("BT write failed");
+    });
+  });
+});

--- a/apps/mobile/src/services/multispeq-communication/multispeq-command-executor.ts
+++ b/apps/mobile/src/services/multispeq-communication/multispeq-command-executor.ts
@@ -8,21 +8,55 @@ export interface IMultispeqCommandExecutor {
 }
 
 export class MultispeqCommandExecutor implements IMultispeqCommandExecutor {
-  constructor(private readonly emitter: Emitter<MultispeqStreamEvents>) {}
+  private currentResolve?: (data: object | string) => void;
+  private currentReject?: (reason: unknown) => void;
+  private readonly handler = (payload: { data: object | string; checksum: string }) => {
+    const resolve = this.currentResolve;
+    this.currentResolve = undefined;
+    this.currentReject = undefined;
+    resolve?.(payload.data);
+  };
 
-  async execute(command: string | object) {
-    await this.emitter.emit("sendCommandToDevice", command);
+  constructor(private readonly emitter: Emitter<MultispeqStreamEvents>) {
+    // Single permanent listener: prevents the emitter's history buffer from
+    // trapping replies that arrive between command/response pairs and avoids
+    // multiple in-flight execute() calls each registering their own handler
+    // (which would resolve from the same payload).
+    this.emitter.on("receivedReplyFromDevice", this.handler);
+  }
 
-    return new Promise<object | string>((resolve) => {
-      const handler = (payload: { data: object | string; checksum: string }) => {
-        resolve(payload.data);
-        this.emitter.off("receivedReplyFromDevice", handler);
-      };
-      this.emitter.on("receivedReplyFromDevice", handler);
+  execute(command: string | object): Promise<object | string> {
+    // Preempt any in-flight execute() so a follow-up call (e.g. cancel) does
+    // not race against a stale handler. The previous caller's awaited promise
+    // rejects; the new call becomes the sole owner of the next reply.
+    if (this.currentReject) {
+      const reject = this.currentReject;
+      this.currentResolve = undefined;
+      this.currentReject = undefined;
+      reject(new Error("Superseded by new execute call"));
+    }
+
+    return new Promise<object | string>((resolve, reject) => {
+      this.currentResolve = resolve;
+      this.currentReject = reject;
+      this.emitter.emit("sendCommandToDevice", command).catch((err: unknown) => {
+        if (this.currentReject === reject) {
+          this.currentResolve = undefined;
+          this.currentReject = undefined;
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      });
     });
   }
 
   destroy() {
+    this.emitter.off("receivedReplyFromDevice", this.handler);
+    if (this.currentReject) {
+      const reject = this.currentReject;
+      this.currentResolve = undefined;
+      this.currentReject = undefined;
+      reject(new Error("Executor destroyed"));
+    }
     return this.emitter.emit("destroy");
   }
 }

--- a/apps/mobile/src/services/scan-manager/scan-manager.ts
+++ b/apps/mobile/src/services/scan-manager/scan-manager.ts
@@ -3,7 +3,7 @@ import { useDeviceConnectionStore } from "~/hooks/use-device-connection-store";
 import { useScannerCommandExecutor } from "~/services/scan-manager/use-scanner-command-executor";
 
 export function useScanner() {
-  const { executeCommand } = useScannerCommandExecutor();
+  const { executeCommand, cancelCommand } = useScannerCommandExecutor();
 
   const { setBatteryLevel } = useDeviceConnectionStore();
 
@@ -36,5 +36,6 @@ export function useScanner() {
     error,
     result,
     executeCommand,
+    cancelCommand,
   };
 }

--- a/apps/mobile/src/services/scan-manager/use-scanner-command-executor.ts
+++ b/apps/mobile/src/services/scan-manager/use-scanner-command-executor.ts
@@ -1,7 +1,7 @@
 import { useScannerCommandExecutorStore } from "~/stores/use-scanner-command-executor-store";
 
 export function useScannerCommandExecutor() {
-  const { commandResponse, reset, isExecuting, error, executeCommand } =
+  const { commandResponse, reset, isExecuting, error, executeCommand, cancelCommand } =
     useScannerCommandExecutorStore();
 
   return {
@@ -10,5 +10,6 @@ export function useScannerCommandExecutor() {
     isExecuting,
     error,
     executeCommand,
+    cancelCommand,
   };
 }

--- a/apps/mobile/src/stores/use-scanner-command-executor-store.test.ts
+++ b/apps/mobile/src/stores/use-scanner-command-executor-store.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { IMultispeqCommandExecutor } from "~/services/multispeq-communication/multispeq-command-executor";
+import type { Device } from "~/types/device";
+
+import { useScannerCommandExecutorStore } from "./use-scanner-command-executor-store";
+
+// `@repo/iot` pulls in driver code we don't need at unit-test time — stub the
+// only constant the store reads.
+vi.mock("@repo/iot", () => ({
+  MULTISPEQ_CONSOLE: {
+    CANCEL: "-1+",
+  },
+}));
+
+// Replace the executor factory so the store never touches react-native or BT.
+const createMultispeqCommandExecutor = vi.fn();
+vi.mock("~/services/scan-manager/utils/create-multispeq-command-executor", () => ({
+  createMultispeqCommandExecutor: (device: Device | undefined) =>
+    createMultispeqCommandExecutor(device),
+}));
+
+interface ExecuteCall {
+  command: string | object;
+  resolve: (data: object | string) => void;
+  reject: (err: Error) => void;
+}
+
+interface ControllableExecutor extends IMultispeqCommandExecutor {
+  /** All execute() calls in the order they were issued. */
+  calls: ExecuteCall[];
+  destroyCalls: () => number;
+}
+
+function createControllableExecutor(): ControllableExecutor {
+  const calls: ExecuteCall[] = [];
+  let destroyed = 0;
+
+  return {
+    calls,
+    execute(command: string | object) {
+      return new Promise<object | string>((resolve, reject) => {
+        calls.push({ command, resolve, reject });
+      });
+    },
+    destroy() {
+      destroyed++;
+      return Promise.resolve();
+    },
+    destroyCalls: () => destroyed,
+  };
+}
+
+const FAKE_DEVICE: Device = { type: "bluetooth-classic", name: "fake", id: "fake-id" };
+
+async function attachExecutor(): Promise<ControllableExecutor> {
+  const exec = createControllableExecutor();
+  createMultispeqCommandExecutor.mockResolvedValueOnce(exec);
+  await useScannerCommandExecutorStore.getState().setDevice(FAKE_DEVICE);
+  return exec;
+}
+
+function resetStore() {
+  useScannerCommandExecutorStore.setState({
+    commandExecutor: undefined,
+    commandResponse: undefined,
+    isExecuting: false,
+    isCancelled: false,
+    error: undefined,
+    isInitializing: false,
+  });
+}
+
+describe("useScannerCommandExecutorStore", () => {
+  beforeEach(() => {
+    createMultispeqCommandExecutor.mockReset();
+    resetStore();
+  });
+
+  describe("executeCommand", () => {
+    it("resolves with the executor result and clears execution state", async () => {
+      const exec = await attachExecutor();
+
+      const pending = useScannerCommandExecutorStore.getState().executeCommand("hello");
+      expect(useScannerCommandExecutorStore.getState().isExecuting).toBe(true);
+      expect(exec.calls[0]?.command).toBe("hello");
+
+      exec.calls[0].resolve({ ok: true });
+      await expect(pending).resolves.toEqual({ ok: true });
+
+      const state = useScannerCommandExecutorStore.getState();
+      expect(state.isExecuting).toBe(false);
+      expect(state.commandResponse).toEqual({ ok: true });
+      expect(state.error).toBeUndefined();
+    });
+
+    it("throws and sets error when no executor is attached", async () => {
+      await expect(
+        useScannerCommandExecutorStore.getState().executeCommand("hello"),
+      ).rejects.toThrow("Command executor not initialized");
+      expect(useScannerCommandExecutorStore.getState().error?.message).toMatch(
+        "Command executor not initialized",
+      );
+    });
+
+    it("propagates underlying executor errors verbatim when not cancelled", async () => {
+      const exec = await attachExecutor();
+      const pending = useScannerCommandExecutorStore.getState().executeCommand("hello");
+
+      exec.calls[0].reject(new Error("BT write failed"));
+
+      await expect(pending).rejects.toThrow("BT write failed");
+      expect(useScannerCommandExecutorStore.getState().error?.message).toBe("BT write failed");
+      expect(useScannerCommandExecutorStore.getState().isExecuting).toBe(false);
+    });
+  });
+
+  describe("cancelCommand", () => {
+    it("sends MULTISPEQ_CONSOLE.CANCEL and surfaces 'Measurement cancelled' to the in-flight executeCommand", async () => {
+      const exec = await attachExecutor();
+
+      // Start an in-flight measurement so cancelCommand has something to abort.
+      const pendingScan = useScannerCommandExecutorStore.getState().executeCommand("protocol");
+
+      const cancelPromise = useScannerCommandExecutorStore.getState().cancelCommand();
+
+      const stateMidCancel = useScannerCommandExecutorStore.getState();
+      expect(stateMidCancel.isCancelled).toBe(true);
+      expect(stateMidCancel.isExecuting).toBe(false);
+
+      // Two execute() calls: the original protocol + the cancel.
+      expect(exec.calls).toHaveLength(2);
+      expect(exec.calls[0]?.command).toBe("protocol");
+      expect(exec.calls[1]?.command).toBe("-1+");
+
+      // The real executor preempts the in-flight call with "Superseded by new
+      // execute call" when a follow-up execute() arrives. Mirror that here.
+      exec.calls[0].reject(new Error("Superseded by new execute call"));
+      exec.calls[1].resolve({ cancelled: true });
+
+      await expect(cancelPromise).resolves.toBeUndefined();
+
+      // executeCommand must surface "Measurement cancelled" (NOT "Superseded")
+      // because cancelCommand set isCancelled=true before the preemption fired.
+      await expect(pendingScan).rejects.toThrow("Measurement cancelled");
+      expect(useScannerCommandExecutorStore.getState().error?.message).toBe(
+        "Measurement cancelled",
+      );
+    });
+
+    it("is a no-op (resolves) when no executor is attached", async () => {
+      await expect(
+        useScannerCommandExecutorStore.getState().cancelCommand(),
+      ).resolves.toBeUndefined();
+
+      expect(useScannerCommandExecutorStore.getState().isCancelled).toBe(true);
+      expect(useScannerCommandExecutorStore.getState().isExecuting).toBe(false);
+      expect(useScannerCommandExecutorStore.getState().error).toBeUndefined();
+    });
+
+    it("logs, sets store error, and rethrows when the cancel write fails", async () => {
+      const exec = await attachExecutor();
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
+
+      const cancelPromise = useScannerCommandExecutorStore.getState().cancelCommand();
+      exec.calls[0].reject(new Error("write to BT failed"));
+
+      await expect(cancelPromise).rejects.toThrow("write to BT failed");
+
+      expect(useScannerCommandExecutorStore.getState().error?.message).toBe("write to BT failed");
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Failed to send cancel command",
+        expect.any(Error),
+      );
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});

--- a/apps/mobile/src/stores/use-scanner-command-executor-store.ts
+++ b/apps/mobile/src/stores/use-scanner-command-executor-store.ts
@@ -100,7 +100,14 @@ export const useScannerCommandExecutorStore = create<ScannerCommandExecutorStore
       set({ commandResponse: result, isExecuting: false, error: undefined });
       return result;
     } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
+      // If cancelCommand preempted this execute() the underlying executor
+      // rejects with a "superseded" error — surface the user-facing reason
+      // instead so callers see a coherent cancellation message.
+      const error = get().isCancelled
+        ? new Error("Measurement cancelled")
+        : err instanceof Error
+          ? err
+          : new Error(String(err));
       set({ error, isExecuting: false });
       throw error;
     }
@@ -109,8 +116,16 @@ export const useScannerCommandExecutorStore = create<ScannerCommandExecutorStore
   cancelCommand: async () => {
     set({ isCancelled: true, isExecuting: false });
     const { commandExecutor } = get();
-    if (commandExecutor) {
+    if (!commandExecutor) {
+      return;
+    }
+    try {
       await commandExecutor.execute(MULTISPEQ_CONSOLE.CANCEL);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      console.error("Failed to send cancel command", error);
+      set({ error });
+      throw error;
     }
   },
 

--- a/apps/mobile/src/stores/use-scanner-command-executor-store.ts
+++ b/apps/mobile/src/stores/use-scanner-command-executor-store.ts
@@ -3,10 +3,13 @@ import type { IMultispeqCommandExecutor } from "~/services/multispeq-communicati
 import { createMultispeqCommandExecutor } from "~/services/scan-manager/utils/create-multispeq-command-executor";
 import type { Device } from "~/types/device";
 
+import { MULTISPEQ_CONSOLE } from "@repo/iot";
+
 interface ScannerCommandExecutorStore {
   commandExecutor: IMultispeqCommandExecutor | undefined;
   commandResponse: string | object | undefined;
   isExecuting: boolean;
+  isCancelled: boolean;
   error: Error | undefined;
   isInitializing: boolean;
 
@@ -15,6 +18,9 @@ interface ScannerCommandExecutorStore {
 
   // Execute a command
   executeCommand: (command: string | object) => Promise<string | object | undefined>;
+
+  // Send cancel command (-1+) to stop a running operation on the device
+  cancelCommand: () => Promise<void>;
 
   // Reset state
   reset: () => void;
@@ -27,6 +33,7 @@ export const useScannerCommandExecutorStore = create<ScannerCommandExecutorStore
   commandExecutor: undefined,
   commandResponse: undefined,
   isExecuting: false,
+  isCancelled: false,
   error: undefined,
   isInitializing: false,
 
@@ -83,10 +90,13 @@ export const useScannerCommandExecutorStore = create<ScannerCommandExecutorStore
       throw error;
     }
 
-    set({ isExecuting: true, error: undefined });
+    set({ isExecuting: true, isCancelled: false, error: undefined });
 
     try {
       const result = await commandExecutor.execute(command);
+      if (get().isCancelled) {
+        throw new Error("Measurement cancelled");
+      }
       set({ commandResponse: result, isExecuting: false, error: undefined });
       return result;
     } catch (err) {
@@ -96,8 +106,16 @@ export const useScannerCommandExecutorStore = create<ScannerCommandExecutorStore
     }
   },
 
+  cancelCommand: async () => {
+    set({ isCancelled: true, isExecuting: false });
+    const { commandExecutor } = get();
+    if (commandExecutor) {
+      await commandExecutor.execute(MULTISPEQ_CONSOLE.CANCEL);
+    }
+  },
+
   reset: () => {
-    set({ commandResponse: undefined, error: undefined, isExecuting: false });
+    set({ commandResponse: undefined, error: undefined, isExecuting: false, isCancelled: false });
   },
 
   destroy: async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,6 +431,9 @@ importers:
       '@repo/auth':
         specifier: workspace:*
         version: link:../../packages/auth
+      '@repo/iot':
+        specifier: workspace:*
+        version: link:../../packages/iot
       '@shopify/react-native-skia':
         specifier: 2.4.18
         version: 2.4.18(react-native-reanimated@4.2.3(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
* **New Features**
  * Cancel action now explicitly stops active device operations before clearing scan state, making cancellation more reliable.

* **Bug Fixes**
  * Command executor now enforces a single in-flight command and properly rejects superseded or destroyed requests.

* **Tests**
  * Added unit tests covering command execution, cancellation races, destroy behavior, and write failure handling.

* **Chores**
  * Added IoT workspace dependency to the mobile app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->