### PR TITLE
chore: disable postinstall scripts and allowlist build dependencies

### DIFF
--- a/.github/workflows/submit-to-google-play.yml
+++ b/.github/workflows/submit-to-google-play.yml
@@ -31,7 +31,6 @@ jobs:
       github.event_name == 'workflow_call' ||
       startsWith(github.event.release.tag_name, 'mobile-v')
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -61,7 +60,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: "22"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -75,6 +74,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
+      - name: Build workspace dependencies
+        run: pnpm turbo run build --filter=mobile...
 
       - name: Set app version from release
         working-directory: apps/mobile

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -14,8 +14,7 @@
     "lint": "eslint 'src/**/*' --fix",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest",
-    "postinstall": "cd ../../packages/api && pnpm run build && cd - &&  cd ../../packages/transactional && pnpm run build && cd - && cd ../../packages/auth && pnpm run build && cd -"
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity": "catalog:aws-sdk",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "db:generate": "turbo --filter database db:generate",
     "db:studio": "turbo --filter database db:studio",
     "db:setup": "turbo db:setup",
-    "postinstall": "pnpm lint:ws",
     "typecheck": "turbo run typecheck",
     "ui-add": "turbo run ui-add",
     "dev:fb": "turbo run dev --filter=backend --filter=web"
@@ -45,6 +44,10 @@
     "node": ">=22"
   },
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "@swc/core",
+      "turbo"
+    ],
     "overrides": {
       "react": "catalog:react19",
       "react-dom": "catalog:react19"

--- a/turbo.json
+++ b/turbo.json
@@ -38,6 +38,7 @@
       "dependsOn": ["^check-types"]
     },
     "dev": {
+      "dependsOn": ["^build"],
       "env": ["NEXT_PUBLIC_ENABLE_DEVTOOLS"],
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description

This pull request introduces several improvements to the build and deployment workflow for the mobile app, primarily focusing on dependency management and build reliability. The most significant change is the shift from building dependencies during `postinstall` scripts to explicitly building them as a separate step in the CI workflow, which should make builds more predictable and maintainable. Additional changes clean up redundant scripts and update configuration for better consistency.

**Build and Dependency Management Improvements:**

* Added a dedicated step in the `.github/workflows/submit-to-google-play.yml` workflow to build workspace dependencies for the mobile app using `pnpm turbo run build --filter=mobile...`, replacing previous reliance on `postinstall` scripts.
* Removed `postinstall` scripts from both `apps/mobile/package.json` and the root `package.json`, reducing side effects during dependency installation and improving clarity. [[1]](diffhunk://#diff-179bbaeea9e8295a4abee862073776f87f7dc3c78066c787b8fcdb8be71d5d83L17-R17) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L29)
* Updated `turbo.json` to ensure that the `dev` task depends on the `build` task, which enforces correct build order and prevents runtime errors due to missing builds.

**Configuration and Consistency Updates:**

* Added the `onlyBuiltDependencies` field to the root `package.json`'s `pnpm` configuration to ensure that only specific dependencies (`@swc/core`, `turbo`) are built, optimizing install times and resource usage.
* Minor formatting changes in the workflow YAML for consistency (e.g., quoting the Node.js version).