### PR TITLE
chore(mobile): restore postinstall and remove redundant CI build step

### DIFF
--- a/.github/workflows/submit-to-google-play.yml
+++ b/.github/workflows/submit-to-google-play.yml
@@ -75,9 +75,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build workspace dependencies
-        run: pnpm turbo run build --filter=mobile...
-
       - name: Set app version from release
         working-directory: apps/mobile
         run: |

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -14,7 +14,8 @@
     "lint": "eslint 'src/**/*' --fix",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "postinstall": "cd ../../packages/api && pnpm run build && cd - && cd ../../packages/transactional && pnpm run build && cd - && cd ../../packages/auth && pnpm run build && cd -"
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity": "catalog:aws-sdk",


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description

Restores mobile's postinstall script that builds workspace dependencies (@repo/api, @repo/transactional, @repo/auth) during pnpm install. This is needed for EAS builds where the workspace packages must be compiled before Metro bundling.

Also removes the now-redundant Build workspace dependencies step from the Google Play submission workflow since pnpm install triggers the postinstall automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined mobile app submission workflow by simplifying the build process.
  * Enhanced dependency management to automatically build required packages during installation, ensuring all necessary components are prepared before mobile app builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->