### PR TITLE
fix(cicd): Update OIDC role to create AWS Inspector

### DIFF
--- a/infrastructure/modules/iam-oidc/README.md
+++ b/infrastructure/modules/iam-oidc/README.md
@@ -93,6 +93,7 @@ The IAM role includes permissions for the following AWS services and operations:
 - **Disable scanning**: `inspector2:Disable`
 - **Read current account status** (plan/refresh): `inspector2:BatchGetAccountStatus`
 - **Provider reads during plan**: `inspector2:ListAccountPermissions`
+- **Service-linked role creation** (first-time enablement): `iam:CreateServiceLinkedRole` - Limited to the AWS Inspector v2 service-linked role ARN (`arn:aws:iam::*:role/aws-service-role/inspector2.amazonaws.com/AWSServiceRoleForAmazonInspector2`)
 
 These permissions allow Terraform/OpenTofu to enable and manage AWS Inspector v2 for vulnerability scanning of ECR images and Lambda functions. All actions apply to resource scope `*` (account-level enablement).
 

--- a/infrastructure/modules/iam-oidc/main.tf
+++ b/infrastructure/modules/iam-oidc/main.tf
@@ -974,6 +974,14 @@ locals {
       ]
       resource = "*"
     }
+
+    # ── Inspector v2: service-linked role creation (first-time enablement) ──
+    inspector2-slr = {
+      actions = [
+        "iam:CreateServiceLinkedRole",
+      ]
+      resource = "arn:aws:iam::*:role/aws-service-role/inspector2.amazonaws.com/AWSServiceRoleForAmazonInspector2"
+    }
   }
 
   # Combine all service permissions into comprehensive policy statements


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description
Add `iam:CreateServiceLinkedRole` to OIDC role
<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #
- Related to #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added IAM permission requirements for AWS Inspector v2 initial enablement

* **Infrastructure**
  * Extended IAM policy configuration to support AWS Inspector v2 service-linked role creation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->