### PR TITLE
fix: enhance VARIANT schema transformation for from_json compatibility

### DIFF
--- a/apps/backend/src/common/modules/databricks/services/query-builder/query-builder.base.spec.ts
+++ b/apps/backend/src/common/modules/databricks/services/query-builder/query-builder.base.spec.ts
@@ -114,6 +114,14 @@ describe("QueryBuilder Base", () => {
       expect(transformed).toBe("STRUCT<a: STRING, b: STRUCT<c: INT>>");
     });
 
+    it("should coerce VOID fields to STRING for from_json", () => {
+      const schema = "OBJECT<phi2: DOUBLE, messages: OBJECT<text: STRING>, dead: VOID>";
+      const transformed = builder.transformSchemaForFromJson(schema);
+      expect(transformed).toBe(
+        "STRUCT<phi2: DOUBLE, messages: STRUCT<text: STRING>, dead: STRING>",
+      );
+    });
+
     it("should build variant query", () => {
       const query = builder
         .from("events")

--- a/apps/backend/src/common/modules/databricks/services/query-builder/query-builder.base.ts
+++ b/apps/backend/src/common/modules/databricks/services/query-builder/query-builder.base.ts
@@ -33,21 +33,20 @@ export abstract class BaseQueryBuilder {
   }
 
   /**
-   * Transform VARIANT schema from schema_of_variant_agg() to from_json() compatible schema.
-   * Replaces OBJECT<...> with STRUCT<...> for DDL compatibility.
+   * Transform a VARIANT schema string from schema_of_variant_agg() into one that from_json() accepts.
+   *
+   * - OBJECT< → STRUCT<: schema_of_variant_agg uses Spark's VARIANT DDL (OBJECT); from_json wants STRUCT.
+   * - VOID → STRING: schema_of_variant_agg emits VOID for fields that exist on the JSON but are
+   *   null across every aggregated row, and from_json rejects VOID inside a STRUCT. Coercing to
+   *   STRING is safe — those fields parse back as null.
    *
    * Example:
-   * Input:  "OBJECT<phi2: DOUBLE, messages: OBJECT<text: STRING>>"
-   * Output: "STRUCT<phi2: DOUBLE, messages: STRUCT<text: STRING>>"
+   *   Input:  "OBJECT<phi2: DOUBLE, messages: OBJECT<text: STRING>, dead: VOID>"
+   *   Output: "STRUCT<phi2: DOUBLE, messages: STRUCT<text: STRING>, dead: STRING>"
    */
   transformSchemaForFromJson(variantSchema: string): string {
-    if (!variantSchema) {
-      return "";
-    }
-
-    // Replace all occurrences of OBJECT with STRUCT
-    // This handles nested OBJECT types as well
-    return variantSchema.replace(/OBJECT</g, "STRUCT<");
+    if (!variantSchema) return "";
+    return variantSchema.replace(/OBJECT</g, "STRUCT<").replace(/\bVOID\b/g, "STRING");
   }
 }
 

--- a/apps/backend/src/common/modules/databricks/services/query-builder/query-builder.base.ts
+++ b/apps/backend/src/common/modules/databricks/services/query-builder/query-builder.base.ts
@@ -46,7 +46,9 @@ export abstract class BaseQueryBuilder {
    */
   transformSchemaForFromJson(variantSchema: string): string {
     if (!variantSchema) return "";
-    return variantSchema.replace(/OBJECT</g, "STRUCT<").replace(/\bVOID\b/g, "STRING");
+    // ": VOID" is unambiguous as a type token: DDL field identifiers can't contain
+    // ":" or spaces, so this only matches the type position, never a field name.
+    return variantSchema.replaceAll("OBJECT<", "STRUCT<").replaceAll(": VOID", ": STRING");
   }
 }
 

--- a/apps/data/src/lib/openjii/openjii/helpers.py
+++ b/apps/data/src/lib/openjii/openjii/helpers.py
@@ -210,10 +210,14 @@ def load_experiment_table(experiment_id, table_name, catalog_name, schema_name="
     spark = SparkSession.builder.getOrCreate()
     metadata = get_table_metadata(experiment_id, table_name, catalog_name, schema_name=schema_name)
     
-    # Normalize variant schemas for from_json compatibility (OBJECT → STRUCT)
-    # Normalize variant schemas for from_json compatibility (OBJECT → STRUCT, VOID → STRING)
+    # Normalize variant schemas for from_json compatibility (OBJECT → STRUCT, VOID → STRING).
+    # VOID is matched only after ": " so we hit the type position and not a field identifier
+    # that happens to contain the substring (e.g. "avoid"). DDL identifiers can't contain ":"
+    # or spaces, so ": VOID" is unambiguous.
     def normalize_schema(schema):
-        return schema.replace("OBJECT<", "STRUCT<").replace("VOID", "STRING") if schema else None
+        if not schema:
+            return None
+        return schema.replace("OBJECT<", "STRUCT<").replace(": VOID", ": STRING")
     
     macro_schema = normalize_schema(metadata["macro_schema"])
     questions_schema = normalize_schema(metadata["questions_schema"])

--- a/apps/data/src/lib/openjii/openjii/helpers.py
+++ b/apps/data/src/lib/openjii/openjii/helpers.py
@@ -211,8 +211,9 @@ def load_experiment_table(experiment_id, table_name, catalog_name, schema_name="
     metadata = get_table_metadata(experiment_id, table_name, catalog_name, schema_name=schema_name)
     
     # Normalize variant schemas for from_json compatibility (OBJECT → STRUCT)
+    # Normalize variant schemas for from_json compatibility (OBJECT → STRUCT, VOID → STRING)
     def normalize_schema(schema):
-        return schema.replace("OBJECT<", "STRUCT<") if schema else None
+        return schema.replace("OBJECT<", "STRUCT<").replace("VOID", "STRING") if schema else None
     
     macro_schema = normalize_schema(metadata["macro_schema"])
     questions_schema = normalize_schema(metadata["questions_schema"])


### PR DESCRIPTION
## Type of PR

- [x] Bug Fix

## Description

Processed-data tables backed by VARIANT columns failed to open when any aggregated field was null across every row. `schema_of_variant_agg()` emits `VOID` for those fields, and `from_json()` rejects `VOID` inside a `STRUCT`, so the load query errored out before returning rows.

This PR extends the existing VARIANT schema transform to coerce `VOID` → `STRING` in addition to the existing `OBJECT<` → `STRUCT<` rewrite. Coercing to `STRING` is safe — the affected fields parse back as `null`.

## Related Issues

- Closes OJD-1434

## Changes Made

- `apps/backend/.../query-builder.base.ts`: `transformSchemaForFromJson` now also replaces `\bVOID\b` with `STRING`. Tightened the JSDoc to explain both rewrites and the reasoning behind the VOID coercion.
- `apps/data/.../openjii/helpers.py`: mirror the same `VOID` → `STRING` normalization in `load_experiment_table` so notebook loads stay consistent with the backend.
- `apps/backend/.../query-builder.base.spec.ts`: added a test covering a schema with a `VOID` field (matching the JSDoc example) to lock in the new behavior.

## Testing Instructions

- [x] `pnpm vitest run src/common/modules/databricks/services/query-builder/query-builder.base.spec.ts` (24 passed)
- [ ] Open a processed-data table that previously failed (one with an all-null variant field) and confirm it loads with the affected field surfaced as `null`.

## Checklist

- [x] I have added/updated tests for my changes
- [x] My code follows the project's style guidelines
- [x] I have tested these changes locally
- [x] My changes generate no new warnings
- [x] I have reviewed my own code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved schema transformation to correctly convert VOID-typed fields to STRING type during JSON parsing operations, ensuring proper data handling and compatibility across backend data processing services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->