### PR TITLE
fix: ASCII-only SG descriptions, add flow log IAM permissions

### DIFF
--- a/infrastructure/modules/iam-oidc/main.tf
+++ b/infrastructure/modules/iam-oidc/main.tf
@@ -451,6 +451,10 @@ locals {
         "ec2:DeleteVpcEndpoints",
         "ec2:DescribeVpcEndpoints",
         "ec2:ModifyVpcEndpoint",
+        # VPC Flow Logs
+        "ec2:CreateFlowLogs",
+        "ec2:DeleteFlowLogs",
+        "ec2:DescribeFlowLogs",
         # Tags
         "ec2:CreateTags",
         "ec2:DeleteTags",

--- a/infrastructure/modules/vpc/main.tf
+++ b/infrastructure/modules/vpc/main.tf
@@ -195,7 +195,7 @@ resource "aws_security_group" "macro_sandbox_lambda" {
   count = var.create_macro_sandbox_resources ? 1 : 0
 
   name        = "${var.environment}-macro-sandbox-lambda-sg"
-  description = "Lambda macro execution — no inbound, HTTPS to VPC endpoints only"
+  description = "Lambda macro execution - no inbound, HTTPS to VPC endpoints only"
   vpc_id      = aws_vpc.this.id
 
   tags = merge(var.tags, {
@@ -226,7 +226,7 @@ resource "aws_security_group" "macro_sandbox_vpc_endpoints" {
   count = var.create_macro_sandbox_resources ? 1 : 0
 
   name        = "${var.environment}-macro-sandbox-vpc-endpoints-sg"
-  description = "SG for VPC endpoints in isolated subnets — only accepts traffic from macro-sandbox Lambda"
+  description = "SG for VPC endpoints in isolated subnets - only accepts traffic from macro-sandbox Lambda"
   vpc_id      = aws_vpc.this.id
 
   tags = merge(var.tags, {


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description

This pull request introduces a small update to the IAM policy and makes minor wording adjustments to security group descriptions. The main change is the addition of permissions for managing VPC Flow Logs, which enhances observability in the VPC. There are also minor formatting changes to security group descriptions for consistency.

IAM Policy Updates:
* Added permissions for `ec2:CreateFlowLogs`, `ec2:DeleteFlowLogs`, and `ec2:DescribeFlowLogs` to support VPC Flow Logs management.

Security Group Description Formatting:
* Updated the descriptions in `aws_security_group.macro_sandbox_lambda` and `aws_security_group.macro_sandbox_vpc_endpoints` to use hyphens instead of em dashes for consistency. [[1]](diffhunk://#diff-d67a6ebef3071e7bffcd92c9e06e764809581b907f38743bc89936302065222cL198-R198) [[2]](diffhunk://#diff-d67a6ebef3071e7bffcd92c9e06e764809581b907f38743bc89936302065222cL229-R229)