### PR TITLE
fix: allow ECS and migration tasks to reach VPC endpoints

### DIFF
--- a/infrastructure/modules/vpc/main.tf
+++ b/infrastructure/modules/vpc/main.tf
@@ -226,7 +226,7 @@ resource "aws_security_group" "macro_sandbox_vpc_endpoints" {
   count = var.create_macro_sandbox_resources ? 1 : 0
 
   name        = "${var.environment}-macro-sandbox-vpc-endpoints-sg"
-  description = "SG for VPC endpoints in isolated subnets - only accepts traffic from macro-sandbox Lambda"
+  description = "SG for ECR and Logs VPC endpoints in isolated subnets"
   vpc_id      = aws_vpc.this.id
 
   tags = merge(var.tags, {
@@ -246,6 +246,32 @@ resource "aws_security_group_rule" "vpc_endpoint_ingress_from_macro_sandbox" {
   source_security_group_id = aws_security_group.macro_sandbox_lambda[0].id
   security_group_id        = aws_security_group.macro_sandbox_vpc_endpoints[0].id
   description              = "Allow Lambda macro-sandbox to reach VPC endpoints"
+}
+
+# Allow ECS tasks to reach the VPC endpoints (private_dns_enabled is VPC-wide)
+resource "aws_security_group_rule" "vpc_endpoint_ingress_from_ecs" {
+  count = (var.create_macro_sandbox_resources && var.create_ecs_resources) ? 1 : 0
+
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.ecs_sg[0].id
+  security_group_id        = aws_security_group.macro_sandbox_vpc_endpoints[0].id
+  description              = "Allow ECS tasks to reach ECR and Logs VPC endpoints"
+}
+
+# Allow migration tasks to reach the VPC endpoints (private_dns_enabled is VPC-wide)
+resource "aws_security_group_rule" "vpc_endpoint_ingress_from_migration" {
+  count = (var.create_macro_sandbox_resources && var.create_migration_resources) ? 1 : 0
+
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.migration_task_sg[0].id
+  security_group_id        = aws_security_group.macro_sandbox_vpc_endpoints[0].id
+  description              = "Allow migration tasks to reach ECR and Logs VPC endpoints"
 }
 # ---------------
 # Public Subnets


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

This pull request updates the security group configuration for VPC endpoints in the macro sandbox environment, mainly to allow additional AWS services (ECS tasks and migration tasks) to access ECR and Logs VPC endpoints. The changes clarify the security group's purpose and expand ingress rules to support these services.

**Security group description update:**

* Updated the description of the `aws_security_group.macro_sandbox_vpc_endpoints` resource to clarify that it is for ECR and Logs VPC endpoints, not just Lambda access.

**Ingress rule additions:**

* Added a new ingress rule to allow ECS tasks (via their security group) to access the ECR and Logs VPC endpoints when both macro sandbox and ECS resources are enabled.
* Added a new ingress rule to allow migration tasks (via their security group) to access the ECR and Logs VPC endpoints when both macro sandbox and migration resources are enabled.