### PR TITLE
fix: revert SG description to avoid re-creation

### DIFF
--- a/infrastructure/modules/vpc/main.tf
+++ b/infrastructure/modules/vpc/main.tf
@@ -226,7 +226,7 @@ resource "aws_security_group" "macro_sandbox_vpc_endpoints" {
   count = var.create_macro_sandbox_resources ? 1 : 0
 
   name        = "${var.environment}-macro-sandbox-vpc-endpoints-sg"
-  description = "SG for ECR and Logs VPC endpoints in isolated subnets"
+  description = "SG for VPC endpoints in isolated subnets - only accepts traffic from macro-sandbox Lambda"
   vpc_id      = aws_vpc.this.id
 
   tags = merge(var.tags, {


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

This pull request makes a minor update to the description of the `aws_security_group.macro_sandbox_vpc_endpoints` resource in `main.tf` to clarify its purpose and the source of allowed traffic.

* Updated the `description` to specify that the security group only accepts traffic from the macro-sandbox Lambda.