### PR TITLE
chore: dedupe axios to 1.15.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8583,9 +8583,6 @@ packages:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
 
-  axios@1.14.0:
-    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
-
   axios@1.15.0:
     resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
@@ -26349,7 +26346,7 @@ snapshots:
       '@swagger-api/apidom-core': 1.9.0
       '@swagger-api/apidom-error': 1.9.0
       '@types/ramda': 0.30.2
-      axios: 1.14.0
+      axios: 1.15.0
       minimatch: 10.2.4
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
@@ -28017,14 +28014,6 @@ snapshots:
 
   axe-core@4.11.1: {}
 
-  axios@1.14.0:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
@@ -29103,7 +29092,7 @@ snapshots:
     dependencies:
       '@contentful/content-source-maps': 0.11.44
       '@contentful/rich-text-types': 16.8.5
-      axios: 1.14.0
+      axios: 1.15.0
       contentful-resolve-response: 1.9.8
       contentful-sdk-core: 9.4.5
       json-stringify-safe: 5.0.1
@@ -34883,7 +34872,7 @@ snapshots:
   node-red-admin@4.1.3:
     dependencies:
       ansi-colors: 4.1.3
-      axios: 1.14.0
+      axios: 1.15.0
       bcryptjs: 3.0.2
       cli-table: 0.3.11
       enquirer: 2.4.1


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description

This pull request updates the `axios` dependency from version 1.14.0 to 1.15.0 throughout the `pnpm-lock.yaml` file. This ensures that all packages relying on `axios` use the latest version, which may include bug fixes, security patches, and new features.