### PR TITLE
fix(mobile): add @repo/iot to postinstall build step

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -16,7 +16,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
-    "postinstall": "cd ../../packages/api && pnpm run build && cd - && cd ../../packages/transactional && pnpm run build && cd - && cd ../../packages/auth && pnpm run build && cd -"
+    "postinstall": "cd ../../packages/api && pnpm run build && cd - && cd ../../packages/transactional && pnpm run build && cd - && cd ../../packages/auth && pnpm run build && cd - && cd ../../packages/iot && pnpm run build && cd -"
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity": "catalog:aws-sdk",


### PR DESCRIPTION
## Summary
- Add `@repo/iot` to the mobile app's `postinstall` script so its `dist/` is compiled before Metro bundles
- Fixes EAS build failure: `@repo/iot/dist/index.js` not found

## Test plan
- [ ] Verify EAS Android build succeeds
- [ ] Verify local `pnpm install` in `apps/mobile` builds the iot package