### PR TITLE
fix(web): Firefox clipboard paste timeout + metadata docs

### DIFF
--- a/apps/docs/docs/003-data-platform/002-web-platform/001-overview.md
+++ b/apps/docs/docs/003-data-platform/002-web-platform/001-overview.md
@@ -11,6 +11,7 @@ The openJII Web Platform (https://openjii.org/) provides a secure, scalable envi
 - **Scalable data layer:** Centralized `centrum` schema with medallion architecture (Bronze–Silver–Gold) for efficient ingestion, storage, and querying of large time-series and sensor datasets.
 - **Secure authentication & access control:** Email login via 6-digit OTP code, ORCID and GitHub sign-in, plus [role-based access](./roles) and configurable visibility (Public/Private). See [Register](./0012-register.md) to create an account.
 - **Experiment management:** Create, edit and version experiments; add members, locations, metadata and tags; set visibility and embargo periods — see [Create / Edit Experiment](./0013-create-add-experiment.md).
+- **Metadata:** Attach plot or plant metadata (genotype, treatment, harvest date, etc.) to your measurements via CSV, Excel, or clipboard — see [Metadata](./0017-metadata.md).
 - **User invitations:** Invite collaborators by email — pending invitations are automatically accepted when the invitee creates an account.
 - **Protocol-macro compatibility:** Many-to-many linking between protocols and macros, with sort order and preferred badges — see [Protocols / Macros](./0014-protocol.md).
 - **Visual measurement flows:** Drag-and-drop flow editor (Instruction, Question, Measurement, Analysis nodes). Supports question-only flows for survey data collection.

--- a/apps/docs/docs/003-data-platform/002-web-platform/0017-metadata.md
+++ b/apps/docs/docs/003-data-platform/002-web-platform/0017-metadata.md
@@ -12,14 +12,14 @@ Sensor data alone tells you *what* was measured, but not *why* or *under which c
 
 ### Common examples
 
-| Column | Purpose | Example values |
-|:---|:---|:---|
-| `plant_id` | Unique identifier per plant or plot | `P001`, `P002`, `A-12` |
-| `genotype` | Genetic background or cultivar | `Col-0`, `Ler`, `Nipponbare` |
-| `treatment` | Experimental condition | `control`, `drought`, `high-light` |
-| `block` | Field or greenhouse block | `B1`, `B2` |
-| `sowing_date` | Date the plant was sown | `2025-03-15` |
-| `harvest_date` | Date of harvest or final measurement | `2025-06-20` |
+| Column         | Purpose                              | Example values                     |
+| :------------- | :----------------------------------- | :--------------------------------- |
+| `plant_id`     | Unique identifier per plant or plot  | `P001`, `P002`, `A-12`             |
+| `genotype`     | Genetic background or cultivar       | `Col-0`, `Ler`, `Nipponbare`       |
+| `treatment`    | Experimental condition               | `control`, `drought`, `high-light` |
+| `block`        | Field or greenhouse block            | `B1`, `B2`                         |
+| `sowing_date`  | Date the plant was sown              | `2025-03-15`                       |
+| `harvest_date` | Date of harvest or final measurement | `2025-06-20`                       |
 
 You can add any columns that are relevant to your experiment. There is no fixed schema.
 

--- a/apps/docs/docs/003-data-platform/002-web-platform/0017-metadata.md
+++ b/apps/docs/docs/003-data-platform/002-web-platform/0017-metadata.md
@@ -1,0 +1,62 @@
+# Metadata
+
+Metadata turns raw sensor readings into meaningful, analysable data. By attaching information such as genotype, treatment group, or planting date to each measurement, you make it possible to filter, compare, and draw conclusions from your experiment.
+
+## Why metadata matters
+
+Sensor data alone tells you *what* was measured, but not *why* or *under which conditions*. Metadata bridges that gap:
+
+- **Filter and group:** Compare genotypes, treatments (e.g. stress vs. control), or time points side by side.
+- **Enable analysis:** Most statistical analyses require at least one grouping variable. Without metadata you cannot run an ANOVA, build a regression, or produce meaningful plots.
+- **Support FAIR and open data:** The [FAIR principles](../../introduction/glossary-terminology#fair-principles) (Findable, Accessible, Interoperable, Reusable) require that data is described with rich metadata so that other researchers can discover, understand, and reuse it. Adding context now saves everyone time later.
+
+### Common examples
+
+| Column | Purpose | Example values |
+|:---|:---|:---|
+| `plant_id` | Unique identifier per plant or plot | `P001`, `P002`, `A-12` |
+| `genotype` | Genetic background or cultivar | `Col-0`, `Ler`, `Nipponbare` |
+| `treatment` | Experimental condition | `control`, `drought`, `high-light` |
+| `block` | Field or greenhouse block | `B1`, `B2` |
+| `sowing_date` | Date the plant was sown | `2025-03-15` |
+| `harvest_date` | Date of harvest or final measurement | `2025-06-20` |
+
+You can add any columns that are relevant to your experiment. There is no fixed schema.
+
+## How it works
+
+When you save metadata, the platform joins it to your measurement data using a shared **identifier column** (for example `plant_id` that matches an answer to one of your experiment's [Questions](./0013-create-add-experiment.md)). The joined columns then appear alongside sensor readings in the **Data** tab and in all exports.
+
+## Import metadata
+
+1. Open your experiment and go to the **Data** tab.
+2. Click **Upload Data** and choose **Plot/Plant Metadata**.
+3. In the Import Metadata dialog you have three ways to bring data in:
+
+   - **Upload a file** — drag-and-drop or browse for a CSV, TSV, or Excel file (.xlsx, .xls).
+   - **Paste from Clipboard** — copy a range from a spreadsheet (Excel, Google Sheets, etc.) and click **Paste from Clipboard**.
+   - **Keyboard paste** — press **Ctrl+V** (or **Cmd+V** on Mac) directly in the dialog.
+
+4. After import you will see a table preview. Review the data and use the editing tools to make adjustments if needed (see below).
+5. Choose the **Identifier column** — the column whose values match an existing Question in your measurement flow.
+6. Optionally link the identifier to a specific **Question** so the platform knows how to join.
+7. Click **Save Metadata**.
+
+After saving, metadata columns will appear in the Data tab and be included in exports on the next processing interval.
+
+## Edit metadata
+
+Once data is imported you can refine it before saving:
+
+- **Add or remove rows** using the row controls.
+- **Add or remove columns** by clicking the column header menu.
+- **Rename columns** by clicking a column header.
+- **Mark the identifier column** — this tells the platform which column to use for joining.
+- **Replace or clear** the imported data to start over.
+
+## Tips
+
+- Use short, consistent column names — they become column headers in exports and plots.
+- Make sure your identifier values exactly match the answers recorded during measurement (e.g. if the mobile app records `P001`, use `P001` in metadata, not `p001` or `Plant 001`).
+- You can update metadata at any time by uploading a new version; the old version will be replaced.
+- Keep one metadata table per logical grouping. For example, one table for genotype information and another for harvest data if they come from different sources.

--- a/apps/web/components/metadata-table/utils/parse-metadata-import.test.ts
+++ b/apps/web/components/metadata-table/utils/parse-metadata-import.test.ts
@@ -284,7 +284,7 @@ describe("parseClipboard", () => {
     const resultPromise = parseClipboard();
 
     // Advance past the timeout
-    await vi.advanceTimersByTimeAsync(3500);
+    await vi.advanceTimersByTimeAsync(31_000);
 
     const result = await resultPromise;
 

--- a/apps/web/components/metadata-table/utils/parse-metadata-import.ts
+++ b/apps/web/components/metadata-table/utils/parse-metadata-import.ts
@@ -2,7 +2,7 @@ import Papa from "papaparse";
 
 import type { MetadataColumn, MetadataRow } from "../types";
 
-const CLIPBOARD_TIMEOUT_MS = 3000;
+const CLIPBOARD_TIMEOUT_MS = 30_000;
 const DELIMITED_EXTENSIONS = new Set(["csv", "tsv", "txt"]);
 const EXCEL_EXTENSIONS = new Set(["xlsx", "xls"]);
 


### PR DESCRIPTION
## Summary
- **Bug fix:** Firefox shows a mandatory "Paste" confirmation popup before granting `navigator.clipboard.readText()` access. The previous 3-second timeout was too short — it fired before the user could confirm, causing a spurious "Could not read clipboard" error. Increased timeout from 3s to 30s so it only acts as a safety net for truly hung APIs.
- **Docs:** Added a user-facing metadata documentation page covering why metadata matters (FAIR principles, open data, enabling analysis), common examples (genotype, treatment, block), and step-by-step instructions for importing and editing. Linked from the web platform overview.

## Test plan
- [ ] Open the Edit Metadata modal in **Firefox**, click "Add new" → "Paste from Clipboard" — rows should appear without an error message
- [ ] Verify the same flow still works in Chrome/Safari (no popup, immediate paste)
- [ ] Existing unit tests pass (`parse-metadata-import.test.ts` — 45 tests)
- [ ] Docs build successfully and the new Metadata page renders at the expected URL