### PR TITLE
chore: activate macro-sandbox deploy workflow and add missing IAM permissions

### DIFF
--- a/.github/workflows/deploy-macro-sandbox.yml
+++ b/.github/workflows/deploy-macro-sandbox.yml
@@ -1,10 +1,5 @@
 # Macro Sandbox Deployment Workflow
 # Builds 3 Docker images (Python, JS, R) and deploys to Lambda
-#
-# Bootstrap mode (push-bootstrap-images job):
-#   Pushes :latest images to ECR so Terraform can create Lambda functions.
-#   Run once per environment via workflow_dispatch, then uncomment the
-#   build-and-deploy job and comment out push-bootstrap-images.
 
 name: Macro Sandbox Deployment Workflow
 
@@ -40,11 +35,11 @@ permissions:
   contents: read
 
 jobs:
-  push-bootstrap-images:
-    name: Push Bootstrap Images
+  build-and-deploy:
+    name: Build and Deploy Macro Sandbox
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-  
+
     strategy:
       fail-fast: false
       matrix:
@@ -52,172 +47,121 @@ jobs:
           - language: python
             dockerfile: functions/python/Dockerfile
             ecr_repo: macro-sandbox-python
+            function_name: macro-sandbox-python
           - language: javascript
             dockerfile: functions/javascript/Dockerfile
             ecr_repo: macro-sandbox-js
+            function_name: macro-sandbox-js
           - language: r
             dockerfile: functions/r/Dockerfile
             ecr_repo: macro-sandbox-r
-  
+            function_name: macro-sandbox-r
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-  
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Get Checked Out SHA
+        id: get-sha
+        run: |
+          ACTUAL_SHA=$(git rev-parse HEAD)
+          echo "sha=$ACTUAL_SHA" >> $GITHUB_OUTPUT
+          echo "Checked out SHA: $ACTUAL_SHA"
+
+      - name: Capture Deployment Start Time
+        uses: ./.github/actions/capture-dora-start
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
-  
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
-  
-      - name: Build and push :latest image
+
+      - name: Set environment variables
+        run: |
+          echo "ECR_REGISTRY=${{ steps.login-ecr.outputs.registry }}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${{ steps.get-sha.outputs.sha }}" >> $GITHUB_ENV
+          echo "ECR_REPO=${{ matrix.ecr_repo }}-${{ env.ENV }}" >> $GITHUB_ENV
+          echo "FUNCTION_NAME=${{ matrix.function_name }}-${{ env.ENV }}" >> $GITHUB_ENV
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
         working-directory: apps/macro-sandbox
         run: |
           set -euo pipefail
-  
-          IMAGE="${{ steps.login-ecr.outputs.registry }}/${{ matrix.ecr_repo }}-${{ env.ENV }}:latest"
-  
-          echo "🔨 Building ${{ matrix.language }} bootstrap image..."
+
+          FULL_IMAGE="${ECR_REGISTRY}/${ECR_REPO}:${IMAGE_TAG}"
+
+          echo "Building ${{ matrix.language }} macro-sandbox..."
           docker build \
             -f ${{ matrix.dockerfile }} \
-            -t "${IMAGE}" \
+            -t "${FULL_IMAGE}" \
             --platform linux/amd64 \
             .
-  
-          echo "📦 Pushing ${IMAGE}..."
-          docker push "${IMAGE}"
-  
-          echo "✅ ${{ matrix.language }} bootstrap image pushed"
 
-  # build-and-deploy:
-  #   name: Build and Deploy Macro Sandbox
-  #   runs-on: ubuntu-latest
-  #   environment: ${{ inputs.environment }}
+          echo "Pushing ${FULL_IMAGE}..."
+          docker push "${FULL_IMAGE}"
 
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - language: python
-  #           dockerfile: functions/python/Dockerfile
-  #           ecr_repo: macro-sandbox-python
-  #           function_name: macro-sandbox-python
-  #         - language: javascript
-  #           dockerfile: functions/javascript/Dockerfile
-  #           ecr_repo: macro-sandbox-js
-  #           function_name: macro-sandbox-js
-  #         - language: r
-  #           dockerfile: functions/r/Dockerfile
-  #           ecr_repo: macro-sandbox-r
-  #           function_name: macro-sandbox-r
+          echo "image=${FULL_IMAGE}" >> $GITHUB_OUTPUT
+          echo "Image pushed: ${FULL_IMAGE}"
 
-  #   steps:
-  #     - name: Checkout Code
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
-  #         ref: ${{ inputs.ref || github.sha }}
+      - name: Update Lambda function code
+        id: update-lambda
+        run: |
+          set -euo pipefail
 
-  #     - name: Get Checked Out SHA
-  #       id: get-sha
-  #       run: |
-  #         ACTUAL_SHA=$(git rev-parse HEAD)
-  #         echo "sha=$ACTUAL_SHA" >> $GITHUB_OUTPUT
-  #         echo "Checked out SHA: $ACTUAL_SHA"
+          echo "Updating Lambda function: ${FUNCTION_NAME}"
+          aws lambda update-function-code \
+            --function-name "${FUNCTION_NAME}" \
+            --image-uri "${{ steps.build-image.outputs.image }}" \
+            --output json > /dev/null
 
-  #     - name: Capture Deployment Start Time
-  #       uses: ./.github/actions/capture-dora-start
-  #     - name: Configure AWS credentials
-  #       uses: aws-actions/configure-aws-credentials@v4
-  #       with:
-  #         role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-  #         aws-region: ${{ secrets.AWS_REGION }}
+          echo "Waiting for function update to complete..."
+          aws lambda wait function-updated-v2 \
+            --function-name "${FUNCTION_NAME}"
 
-  #     - name: Login to Amazon ECR
-  #       id: login-ecr
-  #       uses: aws-actions/amazon-ecr-login@v2
+          echo "Lambda function updated: ${FUNCTION_NAME}"
 
-  #     - name: Set environment variables
-  #       run: |
-  #         echo "ECR_REGISTRY=${{ steps.login-ecr.outputs.registry }}" >> $GITHUB_ENV
-  #         echo "IMAGE_TAG=${{ steps.get-sha.outputs.sha }}" >> $GITHUB_ENV
-  #         echo "ECR_REPO=${{ matrix.ecr_repo }}-${{ env.ENV }}" >> $GITHUB_ENV
-  #         echo "FUNCTION_NAME=${{ matrix.function_name }}-${{ env.ENV }}" >> $GITHUB_ENV
+      - name: Verify deployment
+        run: |
+          set -euo pipefail
 
-  #     - name: Build, tag, and push image to Amazon ECR
-  #       id: build-image
-  #       working-directory: apps/macro-sandbox
-  #       run: |
-  #         set -euo pipefail
+          CODE_SHA=$(aws lambda get-function-configuration \
+            --function-name "${FUNCTION_NAME}" \
+            --query "CodeSha256" \
+            --output text)
 
-  #         FULL_IMAGE="${ECR_REGISTRY}/${ECR_REPO}:${IMAGE_TAG}"
+          echo "Function: ${FUNCTION_NAME}"
+          echo "  Code SHA: ${CODE_SHA}"
+          echo "  Image: ${{ steps.build-image.outputs.image }}"
 
-  #         echo "🔨 Building ${{ matrix.language }} macro-sandbox..."
-  #         docker build \
-  #           -f ${{ matrix.dockerfile }} \
-  #           -t "${FULL_IMAGE}" \
-  #           --platform linux/amd64 \
-  #           .
+      - name: Publish DORA Metrics
+        if: always()
+        uses: ./.github/actions/publish-dora-metrics
+        with:
+          deployment-outcome: ${{ steps.update-lambda.outcome == 'success' && 'success' || 'failure' }}
+          service: "macro-sandbox-${{ matrix.language }}"
+          environment: ${{ inputs.environment }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
-  #         echo "📦 Pushing ${FULL_IMAGE}..."
-  #         docker push "${FULL_IMAGE}"
+      - name: Deployment Summary
+        if: always()
+        run: |
+          echo "::group::=== ${{ matrix.language }} Deployment Summary ==="
+          echo "Environment: ${{ env.ENV }}"
+          echo "Function: ${FUNCTION_NAME}"
+          echo "Image: ${{ steps.build-image.outputs.image }}"
 
-  #         echo "image=${FULL_IMAGE}" >> $GITHUB_OUTPUT
-  #         echo "✅ Image pushed: ${FULL_IMAGE}"
-
-  #     - name: Update Lambda function code
-  #       id: update-lambda
-  #       run: |
-  #         set -euo pipefail
-
-  #         echo "🚀 Updating Lambda function: ${FUNCTION_NAME}"
-  #         aws lambda update-function-code \
-  #           --function-name "${FUNCTION_NAME}" \
-  #           --image-uri "${{ steps.build-image.outputs.image }}" \
-  #           --output json > /dev/null
-
-  #         echo "⏳ Waiting for function update to complete..."
-  #         aws lambda wait function-updated-v2 \
-  #           --function-name "${FUNCTION_NAME}"
-
-  #         echo "✅ Lambda function updated: ${FUNCTION_NAME}"
-
-  #     - name: Verify deployment
-  #       run: |
-  #         set -euo pipefail
-
-  #         CODE_SHA=$(aws lambda get-function-configuration \
-  #           --function-name "${FUNCTION_NAME}" \
-  #           --query "CodeSha256" \
-  #           --output text)
-
-  #         echo "🔍 Function: ${FUNCTION_NAME}"
-  #         echo "   Code SHA: ${CODE_SHA}"
-  #         echo "   Image: ${{ steps.build-image.outputs.image }}"
-
-  #     - name: Publish DORA Metrics
-  #       if: always()
-  #       uses: ./.github/actions/publish-dora-metrics
-  #       with:
-  #         deployment-outcome: ${{ steps.update-lambda.outcome == 'success' && 'success' || 'failure' }}
-  #         service: "macro-sandbox-${{ matrix.language }}"
-  #         environment: ${{ inputs.environment }}
-  #         aws-region: ${{ secrets.AWS_REGION }}
-
-  #     - name: Deployment Summary
-  #       if: always()
-  #       run: |
-  #         echo "::group::=== ${{ matrix.language }} Deployment Summary ==="
-  #         echo "Environment: ${{ env.ENV }}"
-  #         echo "Function: ${FUNCTION_NAME}"
-  #         echo "Image: ${{ steps.build-image.outputs.image }}"
-
-  #         if [[ "${{ steps.update-lambda.outcome }}" == "success" ]]; then
-  #           echo "✅ ${{ matrix.language }} macro-sandbox deployed successfully"
-  #         else
-  #           echo "❌ ${{ matrix.language }} macro-sandbox deployment failed"
-  #         fi
-  #         echo "::endgroup::"
+          if [[ "${{ steps.update-lambda.outcome }}" == "success" ]]; then
+            echo "${{ matrix.language }} macro-sandbox deployed successfully"
+          else
+            echo "${{ matrix.language }} macro-sandbox deployment failed"
+          fi
+          echo "::endgroup::"

--- a/infrastructure/modules/iam-oidc/README.md
+++ b/infrastructure/modules/iam-oidc/README.md
@@ -100,11 +100,13 @@ These permissions allow Terraform/OpenTofu to enable and manage AWS Inspector v2
 ### Lambda
 - **Function management**: Function configuration and management operations
 - **Code signing**: `lambda:GetFunctionCodeSigningConfig` (Terraform provider reads)
+- **Event invoke configuration**: `lambda:GetFunctionEventInvokeConfig`, `lambda:PutFunctionEventInvokeConfig`, `lambda:UpdateFunctionEventInvokeConfig`, `lambda:DeleteFunctionEventInvokeConfig` (Terraform manages Lambda function event invoke configurations)
 - **Layer management**: `lambda:GetLayerVersion`, `lambda:GetLayerVersionPolicy`, `lambda:ListLayers`, `lambda:ListLayerVersions`, `lambda:PublishLayerVersion` (Terraform provider reads layer metadata before attaching)
 
 ### Other Services
 - **VPC**: Network infrastructure management
 - **CloudFront**: Distribution configuration
+- **CloudWatch Logs**: Log group management, tagging operations, and **metric filter management**: `logs:PutMetricFilter`, `logs:DeleteMetricFilter`, `logs:DescribeMetricFilters` (Terraform manages CloudWatch Logs metric filters)
 - **Timestream**: Database operations
 - **Kinesis**: Stream management
 - **IoT**: Device and policy management

--- a/infrastructure/modules/iam-oidc/main.tf
+++ b/infrastructure/modules/iam-oidc/main.tf
@@ -168,6 +168,11 @@ locals {
         "lambda:GetFunctionConcurrency",
         # Code signing (Terraform provider reads)
         "lambda:GetFunctionCodeSigningConfig",
+        # Event invoke config (Terraform)
+        "lambda:GetFunctionEventInvokeConfig",
+        "lambda:PutFunctionEventInvokeConfig",
+        "lambda:UpdateFunctionEventInvokeConfig",
+        "lambda:DeleteFunctionEventInvokeConfig",
         # Layer management (Terraform provider reads layer metadata before attaching)
         "lambda:GetLayerVersion",
         "lambda:GetLayerVersionPolicy",
@@ -369,6 +374,10 @@ locals {
         "logs:ListTagsForResource",
         "logs:ListTagsLogGroup",
         "logs:TagLogGroup",
+        # Metric filters (Terraform)
+        "logs:PutMetricFilter",
+        "logs:DeleteMetricFilter",
+        "logs:DescribeMetricFilters",
       ]
       resource = "*"
     }


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description

Replace the bootstrap `push-bootstrap-images` job with the actual `build-and-deploy` workflow that builds Docker images, pushes to ECR, and updates Lambda functions via `aws lambda update-function-code`.

Also adds missing IAM permissions to the `GithubActionsDeployAccess` role that were required for Terraform to provision the Lambda event invoke config and CloudWatch metric filters.

### Changes

- **`.github/workflows/deploy-macro-sandbox.yml`** - Remove bootstrap job, activate build-and-deploy job
- **`infrastructure/modules/iam-oidc/main.tf`** - Add `lambda:PutFunctionEventInvokeConfig`, `GetFunctionEventInvokeConfig`, `UpdateFunctionEventInvokeConfig`, `DeleteFunctionEventInvokeConfig` and `logs:PutMetricFilter`, `DeleteMetricFilter`, `DescribeMetricFilters`