### PR TITLE
fix(mobile): debug-friendly raw measurements (no gzip, copy JSON)

### DIFF
--- a/apps/docs/docs/001-introduction/key-features.md
+++ b/apps/docs/docs/001-introduction/key-features.md
@@ -17,7 +17,7 @@ This page highlights the main capabilities of the openJII platform. For detailed
 - **Redesigned measurement flow:** guided flows with auto-advance, smart skipping, and animated progress for rapid field data collection.
 - **QR code scanning:** scan QR codes to populate answers in OpenEndedQuestion inputs, or to apply a MultipleChoiceQuestion option. Uses the device camera for faster data entry compared to manual typing. Requires camera permissions.
 - **Question-only flows:** collect survey data and field observations without a sensor measurement.
-- **Offline-first:** capture data offline with on-device gzip compression; sync when network is available. User sessions are maintained during temporary network drops. After login, all experiment data is prefetched and cached so measurements can run completely offline.
+- **Offline-first:** capture data offline; sync when network is available. User sessions are maintained during temporary network drops. After login, all experiment data is prefetched and cached so measurements can run completely offline.
 - **Comments & annotations:** add comments to measurements via swipe actions.
 - **Local export:** save measurements locally as JSON for backup or external analysis.
 - **Python macros:** run Python post-processing macros on-device via embedded Pyodide runtime.

--- a/apps/docs/docs/006-for-developers/001-developers-guide/system-architecture-data-pipeline.md
+++ b/apps/docs/docs/006-for-developers/001-developers-guide/system-architecture-data-pipeline.md
@@ -138,4 +138,4 @@ The `@repo/iot` package provides a layered architecture for sensor communication
 - **Many-to-many protocol/macro compatibility**: Join table linking protocols and macros independently
 - **Invitation system**: Email-based invitations with auto-acceptance on first sign-in
 - **On-device macro execution**: Python macros run via embedded Pyodide in mobile app
-- **Compression throughout**: gzip+base64 for MQTT payloads, gzip for on-device storage
+- **Measurements**: MQTT transmission uses gzip+base64 encoding; on-device SQLite storage uses plain JSON strings

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -49,6 +49,7 @@
     "expo-asset": "~55.0.14",
     "expo-audio": "~55.0.13",
     "expo-camera": "~55.0.15",
+    "expo-clipboard": "~55.0.13",
     "expo-constants": "~55.0.13",
     "expo-device": "~55.0.14",
     "expo-file-system": "~55.0.16",

--- a/apps/mobile/src/components/measurement-result/measurement-result.tsx
+++ b/apps/mobile/src/components/measurement-result/measurement-result.tsx
@@ -1,8 +1,11 @@
 import { clsx } from "clsx";
-import { ChevronRight, MessageCircle } from "lucide-react-native";
+import * as Clipboard from "expo-clipboard";
+import { ChevronRight, Copy, MessageCircle } from "lucide-react-native";
 import React, { useState } from "react";
 import { useAsync } from "react-async-hook";
 import { View, Text, TouchableOpacity, ActivityIndicator } from "react-native";
+import { toast } from "sonner-native";
+import { Button } from "~/components/Button";
 import { TabBar } from "~/components/TabBar";
 import { useTheme } from "~/hooks/use-theme";
 import { applyMacro } from "~/utils/process-scan/process-scan";
@@ -46,10 +49,31 @@ export function MeasurementResult({
       ?.map((output) => output.messages)
       .filter((msg): msg is MacroMessageGroup => msg !== undefined) ?? [];
 
+  const handleCopyRawJson = async () => {
+    try {
+      await Clipboard.setStringAsync(JSON.stringify(rawMeasurement, null, 2));
+      toast.success("Copied raw JSON to clipboard");
+    } catch {
+      toast.error("Could not copy to clipboard");
+    }
+  };
+
   const renderRawContent = () => (
-    <Text className={clsx("font-mono text-sm leading-5", classes.text)}>
-      {JSON.stringify(rawMeasurement, null, 2)}
-    </Text>
+    <View className="gap-2">
+      <View className="flex-row justify-end">
+        <Button
+          title="Copy JSON"
+          variant="outline"
+          size="sm"
+          icon={<Copy size={14} color={colors.primary.dark} />}
+          iconPosition="left"
+          onPress={handleCopyRawJson}
+        />
+      </View>
+      <Text className={clsx("font-mono text-sm leading-5", classes.text)}>
+        {JSON.stringify(rawMeasurement, null, 2)}
+      </Text>
+    </View>
   );
 
   const renderProcessedContent = () => {

--- a/apps/mobile/src/services/measurements-storage.ts
+++ b/apps/mobile/src/services/measurements-storage.ts
@@ -2,7 +2,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { eq, and, lt } from "drizzle-orm";
 import { Duration } from "luxon";
 import { v4 as uuidv4 } from "uuid";
-import { compressForStorage, decompressFromStorage } from "~/utils/storage-compression";
+import { decompressFromStorage } from "~/utils/storage-compression";
 
 import { db } from "./db/client";
 import { measurements } from "./db/schema";
@@ -47,7 +47,7 @@ async function migrateLegacyEntries(): Promise<void> {
             id,
             status,
             topic: parsed.topic,
-            measurementResult: compressForStorage(parsed.measurementResult),
+            measurementResult: JSON.stringify(parsed.measurementResult),
             experimentName: parsed.metadata.experimentName,
             protocolName: parsed.metadata.protocolName,
             timestamp: parsed.metadata.timestamp,
@@ -92,7 +92,7 @@ export async function saveMeasurement(
       id: uuidv4(),
       status,
       topic: upload.topic,
-      measurementResult: compressForStorage(upload.measurementResult),
+      measurementResult: JSON.stringify(upload.measurementResult),
       experimentName: upload.metadata.experimentName,
       protocolName: upload.metadata.protocolName,
       timestamp: upload.metadata.timestamp,
@@ -130,7 +130,7 @@ export async function updateMeasurement(key: string, data: Measurement): Promise
     db.update(measurements)
       .set({
         topic: data.topic,
-        measurementResult: compressForStorage(data.measurementResult),
+        measurementResult: JSON.stringify(data.measurementResult),
         experimentName: data.metadata.experimentName,
         protocolName: data.metadata.protocolName,
         timestamp: data.metadata.timestamp,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -488,6 +488,9 @@ importers:
       expo-camera:
         specifier: ~55.0.15
         version: 55.0.15(@types/emscripten@1.41.5)(expo@55.0.15)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
+      expo-clipboard:
+        specifier: ~55.0.13
+        version: 55.0.13(expo@55.0.15)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
       expo-constants:
         specifier: ~55.0.13
         version: 55.0.14(expo@55.0.15)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(typescript@5.9.3)
@@ -11060,6 +11063,13 @@ packages:
       react-native-web:
         optional: true
 
+  expo-clipboard@55.0.13:
+    resolution: {integrity: sha512-PrOmmuVsGW4bAkNQmGKtxMXj3invsfN+jfIKmQxHwE/dn7ODqwFWviUTa+PMUjP3XZmYCDLyu/i0GLeu7HF9Ew==}
+    peerDependencies:
+      expo: '*'
+      react: 19.2.4
+      react-native: '*'
+
   expo-constants@55.0.14:
     resolution: {integrity: sha512-l23QVQCYBPKT5zbxxZdJeuhiunadvWdjcQ9+GC8h+02jCoLmWRk20064nCINnQTP3Hf+uLPteUiwYrJd0e446w==}
     peerDependencies:
@@ -20222,7 +20232,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.2(zod@3.25.76)
+      better-call: 1.3.2(zod@4.3.6)
       jose: 6.2.2
       kysely: 0.28.14
       nanostores: 1.2.0
@@ -27443,7 +27453,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(@vitest/ui@3.2.4)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -27508,7 +27518,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(@vitest/ui@3.2.4)(jiti@1.21.7)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -28374,7 +28384,7 @@ snapshots:
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.3.2(zod@3.25.76)
+      better-call: 1.3.2(zod@4.3.6)
       defu: 6.1.7
       jose: 6.2.2
       kysely: 0.28.14
@@ -28391,15 +28401,6 @@ snapshots:
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
-
-  better-call@1.3.2(zod@3.25.76):
-    dependencies:
-      '@better-auth/utils': 0.3.1
-      '@better-fetch/fetch': 1.1.21
-      rou3: 0.7.12
-      set-cookie-parser: 3.1.0
-    optionalDependencies:
-      zod: 3.25.76
 
   better-call@1.3.2(zod@4.3.6):
     dependencies:
@@ -30939,6 +30940,12 @@ snapshots:
       react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4)
     transitivePeerDependencies:
       - '@types/emscripten'
+
+  expo-clipboard@55.0.13(expo@55.0.15)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4):
+    dependencies:
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@6.1.2)(expo-router@55.0.12)(react-dom@19.2.4(react@19.2.4))(react-native-webview@13.16.0(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      react: 19.2.4
+      react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4)
 
   expo-constants@55.0.14(expo@55.0.15)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary
- Stop gzipping measurement results before writing to SQLite. Rows are now stored as plain JSON strings; the `gz:`-prefix-aware reader is kept so pending uploads from older installs still decode.
- Add a **Copy JSON** button to the Raw data tab in the measurement preview (uses `expo-clipboard`). Makes it easy to grab the raw payload off-device when debugging why the phone and cloud macros produce different results on the same measurement.

MQTT sample compression is unchanged — the wire payload is still gzipped.

## Test plan
- [ ] Take a measurement → raw data tab shows a "Copy JSON" button; tapping it shows a toast and pastes valid JSON elsewhere.
- [ ] Fresh install: save a measurement, kill the app, reopen → measurement still visible in Recent.
- [ ] Upgrade path: install the previous build, create a failed upload, upgrade to this build → the legacy gzipped row still decodes and uploads.
- [ ] Verify MQTT payload still has `_sample_encoding: "gzip+base64"` (cloud side continues to ungzip).