### PR TITLE
chore(infra): remove AllowTFTesterPush statement from ECR repository policy

### DIFF
--- a/infrastructure/modules/ecr/main.tf
+++ b/infrastructure/modules/ecr/main.tf
@@ -95,30 +95,6 @@ resource "aws_ecr_repository_policy" "this" {
           }
         }
       ] : [],
-      [
-        {
-          Sid    = "AllowTFTesterPush",
-          Effect = "Allow",
-          Principal = {
-            AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/terraform-tester-${var.environment}"
-          },
-          # CI/CD pipeline permissions for building and pushing images
-          Action = [
-            "ecr:GetAuthorizationToken", # Get temporary credentials
-            "ecr:PutImage",              # Push complete images
-            "ecr:InitiateLayerUpload",   # Start layer upload
-            "ecr:UploadLayerPart",       # Upload layer chunks
-            "ecr:CompleteLayerUpload",   # Finalize layer upload
-            "ecr:TagResource",           # Add tags to images
-            "ecr:DescribeImages"         # List and describe images
-          ],
-          Condition = {
-            Bool = {
-              "aws:SecureTransport" = "true"
-            }
-          }
-        }
-      ]
     )
   })
 }


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description

This pull request removes a policy statement from the ECR repository policy in the Terraform module. The deleted statement previously allowed a specific IAM user to push images to the ECR repository.