### PR TITLE
feat(ci): skip tofu plan when no infrastructure changes detected

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,6 +28,7 @@ jobs:
     outputs:
       affected_apps: ${{ steps.detect.outputs.affected_apps }}
       has_affected_apps: ${{ steps.detect.outputs.has_affected_apps }}
+      has_infra_changes: ${{ steps.infra.outputs.has_infra_changes }}
     env:
       DO_NOT_TRACK: 1
       TURBO_TELEMETRY_DISABLED: 1
@@ -45,6 +46,24 @@ jobs:
       - name: Detect Affected Packages
         id: detect
         uses: ./.github/actions/detect-affected-packages
+
+      - name: Detect Infrastructure Changes
+        id: infra
+        shell: bash
+        env:
+          BASE_SHA: ${{ (github.event_name == 'pull_request' &&
+            github.event.pull_request.base.sha) || github.event.before ||
+            'HEAD~1' }}
+        run: |
+          echo "Using base for infra change detection: $BASE_SHA"
+          if git diff --quiet "$BASE_SHA"...HEAD -- 'infrastructure/'; then
+            echo "has_infra_changes=false" >> $GITHUB_OUTPUT
+            echo "No infrastructure changes detected"
+          else
+            echo "has_infra_changes=true" >> $GITHUB_OUTPUT
+            echo "Infrastructure changes detected:"
+            git diff --name-only "$BASE_SHA"...HEAD -- 'infrastructure/'
+          fi
 
   build_lint_test:
     name: Build, Lint, & Test
@@ -106,10 +125,11 @@ jobs:
     name: OpenTofu (Plan)
     needs: detect
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && needs.detect.outputs.has_infra_changes
+      == 'true'
     strategy:
       matrix:
-        environment: [dev, prod]
+        environment: [ dev, prod ]
       fail-fast: false
     environment: ${{ matrix.environment }}
     concurrency:


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

This pull request updates the GitHub Actions workflow to improve detection and handling of infrastructure changes in pull requests. The main enhancement is that infrastructure-related jobs will now only run when relevant files have been modified, making the CI process more efficient.

**Infrastructure Change Detection:**

* Added a new step (`Detect Infrastructure Changes`) to the workflow that checks if any files in the `infrastructure/` directory have changed compared to the base branch, and sets the `has_infra_changes` output accordingly.
* The output `has_infra_changes` is now included in the workflow outputs, making it available for subsequent jobs.

**Conditional Job Execution:**

* Modified the `OpenTofu (Plan)` job to only run if there are infrastructure changes, using the new `has_infra_changes` output as a condition.