### PR TITLE
fix(mobile): clone macro input to prevent raw scan data mutation

### DIFF
--- a/apps/mobile/src/utils/process-scan/process-scan.test.ts
+++ b/apps/mobile/src/utils/process-scan/process-scan.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { applyMacro } from "./process-scan";
+import { registerPythonMacroRunner } from "./python-macro-runner";
+
+// The raw `.txt` import is resolved by the Metro asset system at runtime;
+// in Node/Vitest it has no loader, so stub it with an opaque module handle.
+vi.mock("./math.lib.js.txt", () => ({
+  default: "mock-math-lib-asset",
+}));
+
+// `Asset.fromModule(...).downloadAsync()` + `new File(path).text()` together
+// load `math.lib.js.txt` into `mathLibSourcePromise`. For these tests we don't
+// exercise math-lib helpers, so resolve with an empty string.
+vi.mock("expo-asset", () => ({
+  Asset: {
+    fromModule: vi.fn(() => ({
+      downloadAsync: vi.fn(() => Promise.resolve()),
+      localUri: "/mock/math.lib.js.txt",
+      uri: "/mock/math.lib.js.txt",
+    })),
+  },
+}));
+
+vi.mock("expo-file-system", () => ({
+  File: vi.fn().mockImplementation(() => ({
+    text: vi.fn(() => Promise.resolve("")),
+  })),
+}));
+
+const encode = (code: string) => Buffer.from(code, "utf8").toString("base64");
+
+describe("applyMacro — input isolation (OJD-1463)", () => {
+  describe("JavaScript macros", () => {
+    it("does not mutate top-level scalar properties on the original sample", async () => {
+      const sample = { meta: "original", phi2: 0.5 };
+      const result = { sample };
+
+      const code = encode(`
+        json.meta = "mutated";
+        json.phi2 = -1;
+        return { ok: true };
+      `);
+
+      const [out] = await applyMacro(result, { code, language: "javascript" });
+
+      // Macro saw its own copy and was free to mutate it.
+      expect(out).toEqual({ ok: true });
+      // Original is untouched.
+      expect(sample).toEqual({ meta: "original", phi2: 0.5 });
+    });
+
+    it("does not mutate array elements on the original sample", async () => {
+      const sample = { data_raw: [1, 2, 3, 4, 5] };
+      const result = { sample };
+
+      const code = encode(`
+        for (var i = 0; i < json.data_raw.length; i++) {
+          json.data_raw[i] = -json.data_raw[i];
+        }
+        json.data_raw.push(999);
+        return { ok: true };
+      `);
+
+      await applyMacro(result, { code, language: "javascript" });
+
+      expect(sample.data_raw).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it("does not mutate nested objects on the original sample", async () => {
+      const sample = {
+        nested: { phi2: 0.5, deep: { value: 42 } },
+      };
+      const result = { sample };
+
+      const code = encode(`
+        json.nested.phi2 = -1;
+        json.nested.deep.value = 0;
+        delete json.nested.deep;
+        return { ok: true };
+      `);
+
+      await applyMacro(result, { code, language: "javascript" });
+
+      expect(sample.nested.phi2).toBe(0.5);
+      expect(sample.nested.deep).toEqual({ value: 42 });
+    });
+
+    it("isolates mutations between sibling samples in a batch", async () => {
+      const sample1 = { data_raw: [1, 2, 3] };
+      const sample2 = { data_raw: [4, 5, 6] };
+      const result = { sample: [sample1, sample2] };
+
+      const code = encode(`
+        json.data_raw[0] = 999;
+        return { first: json.data_raw[0] };
+      `);
+
+      const outputs = await applyMacro(result, { code, language: "javascript" });
+
+      expect(outputs).toEqual([{ first: 999 }, { first: 999 }]);
+      expect(sample1.data_raw).toEqual([1, 2, 3]);
+      expect(sample2.data_raw).toEqual([4, 5, 6]);
+    });
+
+    it("gives the macro a different object reference than the original sample", async () => {
+      const sample = { marker: { tag: "original" } };
+      const result = { sample };
+
+      // Smuggle the `json` reference out of the macro so we can assert on it.
+      let macroSawReference: unknown = null;
+      const code = encode(`
+        json.__capturedBy = "macro";
+        return { capturedRef: json };
+      `);
+
+      const [out] = await applyMacro(result, { code, language: "javascript" });
+      macroSawReference = (out as { capturedRef: unknown }).capturedRef;
+
+      expect(macroSawReference).not.toBe(sample);
+      expect(sample).toEqual({ marker: { tag: "original" } });
+    });
+  });
+
+  describe("Python macros", () => {
+    beforeEach(() => {
+      registerPythonMacroRunner(null);
+    });
+
+    it("does not mutate the original sample even if the Python runner mutates its arg", async () => {
+      const sample = { meta: "original", data_raw: [1, 2, 3] };
+      const result = { sample };
+
+      let receivedRef: unknown = null;
+      registerPythonMacroRunner(async (_code, json) => {
+        receivedRef = json;
+        (json as { meta: string }).meta = "mutated-by-python";
+        (json as { data_raw: number[] }).data_raw[0] = 999;
+        return { ok: true };
+      });
+
+      await applyMacro(result, {
+        code: encode("# python body irrelevant — runner is mocked"),
+        language: "python",
+      });
+
+      // The runner must have received a clone, not the caller's reference.
+      expect(receivedRef).not.toBe(sample);
+      // Original must still be intact.
+      expect(sample).toEqual({ meta: "original", data_raw: [1, 2, 3] });
+    });
+
+    it("isolates mutations between sibling Python samples in a batch", async () => {
+      const sample1 = { data_raw: [1, 2, 3] };
+      const sample2 = { data_raw: [4, 5, 6] };
+      const result = { sample: [sample1, sample2] };
+
+      registerPythonMacroRunner(async (_code, json) => {
+        (json as { data_raw: number[] }).data_raw[0] = 999;
+        return { ok: true };
+      });
+
+      await applyMacro(result, {
+        code: encode("# irrelevant"),
+        language: "python",
+      });
+
+      expect(sample1.data_raw).toEqual([1, 2, 3]);
+      expect(sample2.data_raw).toEqual([4, 5, 6]);
+    });
+  });
+});

--- a/apps/mobile/src/utils/process-scan/process-scan.test.ts
+++ b/apps/mobile/src/utils/process-scan/process-scan.test.ts
@@ -132,11 +132,11 @@ describe("applyMacro — input isolation (OJD-1463)", () => {
       const result = { sample };
 
       let receivedRef: unknown = null;
-      registerPythonMacroRunner(async (_code, json) => {
+      registerPythonMacroRunner((_code, json) => {
         receivedRef = json;
         (json as { meta: string }).meta = "mutated-by-python";
         (json as { data_raw: number[] }).data_raw[0] = 999;
-        return { ok: true };
+        return Promise.resolve({ ok: true });
       });
 
       await applyMacro(result, {
@@ -155,9 +155,9 @@ describe("applyMacro — input isolation (OJD-1463)", () => {
       const sample2 = { data_raw: [4, 5, 6] };
       const result = { sample: [sample1, sample2] };
 
-      registerPythonMacroRunner(async (_code, json) => {
+      registerPythonMacroRunner((_code, json) => {
         (json as { data_raw: number[] }).data_raw[0] = 999;
-        return { ok: true };
+        return Promise.resolve({ ok: true });
       });
 
       await applyMacro(result, {

--- a/apps/mobile/src/utils/process-scan/process-scan.ts
+++ b/apps/mobile/src/utils/process-scan/process-scan.ts
@@ -36,7 +36,7 @@ async function executeMacro(code: string, json: object): Promise<MacroOutput> {
   try {
     // eslint-disable-next-line @typescript-eslint/no-implied-eval
     const fn = new Function("json", macroSource);
-    const output = fn(json);
+    const output = fn(structuredClone(json));
     // console.log("[macro] (JS) output:", JSON.stringify(output));
     return output;
   } catch (err) {
@@ -85,7 +85,7 @@ export async function applyMacro(
       const sample = samples[i];
       console.log("[macro] (Python) input sample", i, JSON.stringify(sample));
       try {
-        const out = await runPython(code, sample);
+        const out = await runPython(code, structuredClone(sample));
         console.log("[macro] (Python) output sample", i, JSON.stringify(out));
         outputs.push(out);
       } catch (err) {


### PR DESCRIPTION
## Summary

- Fixes [OJD-1463](https://linear.app/openjii/issue/OJD-1463/negative-phi2-values): macros were receiving the raw sample by reference and mutating it in place, corrupting downstream reads (e.g. producing negative phi2 values).
- Deep-clone the input via `structuredClone` before invoking either the JS (`executeMacro`) or Python (`runPython`) macro path, so any in-place writes the macro performs stay inside its own copy.
- Adds `apps/mobile/src/utils/process-scan/process-scan.test.ts` covering scalar, array, nested, and multi-sample mutations against both runtimes. The suite fails when the clone is removed and passes with it restored.

## Test plan

- [ ] `pnpm --filter mobile test src/utils/process-scan/process-scan.test.ts` — 7/7 pass
- [ ] Run a protocol on device whose macro touches `data_raw` and confirm phi2 stays in the expected range (no negatives)
- [ ] Re-run a scan that previously reproduced OJD-1463 and confirm the values are correct