### PR TITLE
fix(mobile): allow install on Android devices without USB host (OJD-1464)

### DIFF
--- a/patches/react-native-usb-serialport-for-android.patch
+++ b/patches/react-native-usb-serialport-for-android.patch
@@ -31,3 +31,13 @@ diff --git a/android/build.gradle b/android/build.gradle
  }
  
  dependencies {
+diff --git a/android/src/main/AndroidManifest.xml b/android/src/main/AndroidManifest.xml
+index b88623856198359153c479f17413321f18b7b9bd..57636d24e79f9b8020fe172c2256670f791a20ae 100644
+--- a/android/src/main/AndroidManifest.xml
++++ b/android/src/main/AndroidManifest.xml
+@@ -1,4 +1,4 @@
+ <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+           package="com.bastengao.usbserialport">
+-    <uses-feature android:name="android.hardware.usb.host" />
++    <uses-feature android:name="android.hardware.usb.host" android:required="false" />
+ </manifest>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,7 +108,7 @@ patchedDependencies:
     hash: 96812310a27a5ba65b9a67eab72ae6b1a1aa5e5b29107190ea75147ed5fe467a
     path: patches/@better-auth__expo@1.5.6.patch
   react-native-usb-serialport-for-android:
-    hash: 31811a12742cd056af7e4b2a51aad7cd18865488fff2380ae09d7a063b330dbb
+    hash: eb6f43839c09154480e4be78153e9f36fcf27e90193169b73475274b0d61e64b
     path: patches/react-native-usb-serialport-for-android.patch
 
 importers:
@@ -628,7 +628,7 @@ importers:
         version: 2.3.3(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
       react-native-usb-serialport-for-android:
         specifier: ^0.5.0
-        version: 0.5.0(patch_hash=31811a12742cd056af7e4b2a51aad7cd18865488fff2380ae09d7a063b330dbb)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
+        version: 0.5.0(patch_hash=eb6f43839c09154480e4be78153e9f36fcf27e90193169b73475274b0d61e64b)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
       react-native-vector-icons:
         specifier: ^10.3.0
         version: 10.3.0
@@ -1187,7 +1187,7 @@ importers:
         version: 1.73.0-rc.13(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))
       react-native-usb-serialport-for-android:
         specifier: ^0.5.0
-        version: 0.5.0(patch_hash=31811a12742cd056af7e4b2a51aad7cd18865488fff2380ae09d7a063b330dbb)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
+        version: 0.5.0(patch_hash=eb6f43839c09154480e4be78153e9f36fcf27e90193169b73475274b0d61e64b)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -27729,7 +27729,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@22.19.15)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.13.3(@types/node@22.19.15)(typescript@5.9.3))(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.5.0)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(msw@2.13.3(@types/node@25.5.0)(typescript@5.9.3))(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -37077,7 +37077,7 @@ snapshots:
       react: 19.2.4
       react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4)
 
-  react-native-usb-serialport-for-android@0.5.0(patch_hash=31811a12742cd056af7e4b2a51aad7cd18865488fff2380ae09d7a063b330dbb)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4):
+  react-native-usb-serialport-for-android@0.5.0(patch_hash=eb6f43839c09154480e4be78153e9f36fcf27e90193169b73475274b0d61e64b)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4)


### PR DESCRIPTION
## Summary
- Users with Android phones that lack USB host hardware (common on unlocked / budget / prepaid devices) cannot install the OpenJII app from Google Play even though their OS version exceeds the advertised Android 7 minimum — Play rejects with an ambiguous "feature is missing" error (Linear [OJD-1464](https://linear.app/openjii/issue/OJD-1464) / GitHub #1318).
- Root cause: `react-native-usb-serialport-for-android@0.5.0` declares `<uses-feature android:name="android.hardware.usb.host" />` in its library manifest without `android:required="false"`. The manifest merger propagates this into the app AAB as a *required* hardware feature, and Play filters installs on devices that don't advertise USB host.
- Fix: extend the existing pnpm patch with a third hunk that rewrites the library's manifest to `<uses-feature android:name="android.hardware.usb.host" android:required="false" />`. This is purely a Play install-filter change — runtime USB access is unaffected.
- USB is one of three MultispeQ 2 connection paths (BLE, Bluetooth Classic, USB serial), so it should be optional.

## Test plan
- [x] `pnpm install` — patch applies cleanly, no "patch did not apply" errors
- [x] Patched library manifest at `apps/mobile/node_modules/react-native-usb-serialport-for-android/android/src/main/AndroidManifest.xml` contains `android:required="false"`
- [x] Existing patch hunks still apply (`setDTR(true)` / `setRTS(true)` in `UsbSerialportForAndroidModule.java`, `jcenter()` removal in `android/build.gradle`)
- [x] `./gradlew :app:processDebugManifest --rerun-tasks` — merged manifest at `apps/mobile/android/app/build/intermediates/merged_manifests/debug/processDebugManifest/AndroidManifest.xml` carries `android:required="false"` on the `uses-feature` line
- [ ] Cut next `mobile-v*` tag and confirm the EAS production AAB, inspected with `bundletool dump manifest`, shows `required='false'` on the USB host feature
- [ ] In Play Console → App bundle explorer → Device catalog, confirm devices without USB host are no longer excluded
- [ ] Direct-install on the reporter's Android 11 device via Play Store succeeds; BLE and Bluetooth Classic connections to MultispeQ 2 work
- [ ] Follow-up on OJD-1464 / #1318 with the shipped version

## Follow-up (separate ticket, out of scope here)
Several other implicit hardware requirements could still filter out some device classes and should be audited / marked optional where safe:
- `android.hardware.camera` (implicit from `CAMERA` permission via `expo-camera`)
- `android.hardware.bluetooth_le` (via `react-native-ble-plx`)
- `android.hardware.location.gps` (implicit from `ACCESS_FINE_LOCATION`)

Also consider adding runtime USB-host detection + a small "Cable not available on this device — use Bluetooth" inline note in `connection-setup.tsx` to make the non-USB experience explicit. Not required for the current bug fix since `UsbSerialManager.list()` returns `[]` on non-USB devices (same degradation as iOS today).