### PR TITLE
fix(cicd): resolve YAML syntax error in deploy-macro-sandbox workflow

### DIFF
--- a/.github/workflows/deploy-macro-sandbox.yml
+++ b/.github/workflows/deploy-macro-sandbox.yml
@@ -27,7 +27,7 @@ on:
         type: string
         default: ""
       languages:
-        description: "JSON array of lambda languages to deploy (e.g. '["python","r"]'). Defaults to all."
+        description: "JSON array of lambda languages to deploy (e.g. '[\"python\",\"r\"]'). Defaults to all."
         required: false
         type: string
         default: '["python","javascript","r"]'


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description
Fixes a YAML syntax error on line 29 of `deploy-macro-sandbox.yml` introduced in the previous PR. The `languages` input description contained unescaped double quotes inside a double-quoted string, causing all deploys to dev to fail with:

> Invalid workflow file: You have an error in your yaml syntax on line 29

Escaped the inner quotes in the description string.
<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #
- Related to #
