### PR TITLE
fix(mobile, web): update auto-proceeded summary to display only the first answer

### DIFF
--- a/apps/docs/docs/003-data-platform/002-web-platform/0013-create-add-experiment.md
+++ b/apps/docs/docs/003-data-platform/002-web-platform/0013-create-add-experiment.md
@@ -42,6 +42,7 @@ How to build the flow:
 Notes:
 - For now, a valid flow should include at least one Measurement node and one Analysis node. More advanced flow options will be added over time.
 - Unconnected nodes are ignored when the flow runs.
+- If your flow includes a question asking for a plant identifier, place it **first** among the Question nodes. The mobile app displays the answer to the first ID question as a contextual banner on subsequent questions, helping field operators confirm which plot they are measuring.
 
 ![Measurement flow example](image-1.png)
 

--- a/apps/mobile/src/screens/measurement-flow-screen/components/flow-nodes/question-node/auto-proceeded-summary.tsx
+++ b/apps/mobile/src/screens/measurement-flow-screen/components/flow-nodes/question-node/auto-proceeded-summary.tsx
@@ -45,14 +45,16 @@ export function AutoProceededSummary({ currentNodeId, iterationCount }: AutoProc
 
   const firstManualNodeId = getCachedFirstManualNodeId(iterationCount);
 
-  const autoProceededWithAnswers = flowNodes
-    .filter((n) => n.type === "question" && isAutoincrementEnabled(n.id))
-    .filter((n) => !!getAnswer(iterationCount, n.id)?.trim());
+  const firstAutoProceededWithPlot = flowNodes.find(
+    (n) =>
+      n.type === "question" &&
+      isAutoincrementEnabled(n.id) &&
+      !!getAnswer(iterationCount, n.id)?.trim() &&
+      /(plot)/i.test(`${n.name ?? ""} ${n.content?.text ?? ""}`),
+  );
 
   const show =
-    iterationCount > 0 &&
-    autoProceededWithAnswers.length > 0 &&
-    firstManualNodeId === currentNodeId;
+    iterationCount > 0 && !!firstAutoProceededWithPlot && firstManualNodeId === currentNodeId;
 
   if (!show) return null;
 
@@ -71,21 +73,17 @@ export function AutoProceededSummary({ currentNodeId, iterationCount }: AutoProc
         Your current plot
       </Text>
 
-      {autoProceededWithAnswers.map((n) => (
-        <View key={n.id}>
-          <View className="flex-row items-center gap-1">
-            <Text
-              numberOfLines={1}
-              ellipsizeMode="tail"
-              className={clsx("flex-shrink text-base font-semibold", classes.text)}
-            >
-              {getAnswer(iterationCount, n.id)}
-            </Text>
+      <View className="flex-row items-center gap-1">
+        <Text
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          className={clsx("flex-shrink text-base font-semibold", classes.text)}
+        >
+          {getAnswer(iterationCount, firstAutoProceededWithPlot.id)}
+        </Text>
 
-            <Repeat2 size={16} color={colors.neutral.black} />
-          </View>
-        </View>
-      ))}
+        <Repeat2 size={16} color={colors.neutral.black} />
+      </View>
     </View>
   );
 }

--- a/apps/mobile/src/screens/measurement-flow-screen/components/flow-nodes/question-node/auto-proceeded-summary.tsx
+++ b/apps/mobile/src/screens/measurement-flow-screen/components/flow-nodes/question-node/auto-proceeded-summary.tsx
@@ -45,16 +45,14 @@ export function AutoProceededSummary({ currentNodeId, iterationCount }: AutoProc
 
   const firstManualNodeId = getCachedFirstManualNodeId(iterationCount);
 
-  const firstAutoProceededWithPlot = flowNodes.find(
+  const firstAutoProceeded = flowNodes.find(
     (n) =>
       n.type === "question" &&
       isAutoincrementEnabled(n.id) &&
-      !!getAnswer(iterationCount, n.id)?.trim() &&
-      /(plot)/i.test(`${n.name ?? ""} ${n.content?.text ?? ""}`),
+      !!getAnswer(iterationCount, n.id)?.trim(),
   );
 
-  const show =
-    iterationCount > 0 && !!firstAutoProceededWithPlot && firstManualNodeId === currentNodeId;
+  const show = iterationCount > 0 && !!firstAutoProceeded && firstManualNodeId === currentNodeId;
 
   if (!show) return null;
 
@@ -79,7 +77,7 @@ export function AutoProceededSummary({ currentNodeId, iterationCount }: AutoProc
           ellipsizeMode="tail"
           className={clsx("flex-shrink text-base font-semibold", classes.text)}
         >
-          {getAnswer(iterationCount, firstAutoProceededWithPlot.id)}
+          {getAnswer(iterationCount, firstAutoProceeded.id)}
         </Text>
 
         <Repeat2 size={16} color={colors.neutral.black} />

--- a/apps/web/components/question-card/question-card.tsx
+++ b/apps/web/components/question-card/question-card.tsx
@@ -63,8 +63,8 @@ export function QuestionCard({
         </div>
 
         {/* Plot / ID question hint */}
-        <p className="from-jii-medium-green/10 to-jii-dark-green/10 text-jii-dark-green mb-4 rounded-lg bg-gradient-to-r px-3 py-2 text-xs">
-          💡 If this is a <strong>plant identifier</strong> question, place it{" "}
+        <p className="from-jii-medium-green/10 to-jii-dark-green/10 text-jii-dark-green mb-6 rounded-lg bg-gradient-to-r px-3 py-2 text-xs">
+          Note: If this is a <strong>plant identifier</strong> question, place it{" "}
           <strong>first</strong> in the flow. The mobile app will show it as a confirmation banner
           throughout the iteration.
         </p>

--- a/apps/web/components/question-card/question-card.tsx
+++ b/apps/web/components/question-card/question-card.tsx
@@ -62,6 +62,13 @@ export function QuestionCard({
           />
         </div>
 
+        {/* Plot / ID question hint */}
+        <p className="from-jii-medium-green/10 to-jii-dark-green/10 text-jii-dark-green mb-4 rounded-lg bg-gradient-to-r px-3 py-2 text-xs">
+          💡 If this is a <strong>plant identifier</strong> question, place it{" "}
+          <strong>first</strong> in the flow. The mobile app will show it as a confirmation banner
+          throughout the iteration.
+        </p>
+
         {/* Required Toggle */}
         <div className="mb-6">
           <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 p-4">


### PR DESCRIPTION
Refs: OJD-1435

## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

This PR updates AutoProceededSummary banner to only display the answer for the first auto-proceeded question. Previously, the banner rendered all auto-proceeded answers.

## Checklist

- [ ] I have added/updated tests for my changes
- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have tested these changes locally
- [x] My changes generate no new warnings
- [x] I have reviewed my own code
