### PR TITLE
fix(infra): allow kms:Decrypt for macro-sandbox Lambda env vars

### DIFF
--- a/infrastructure/modules/ecr/main.tf
+++ b/infrastructure/modules/ecr/main.tf
@@ -96,8 +96,7 @@ resource "aws_ecr_repository_policy" "this" {
         }
       ] : [],
       # Lambda service principal needs repo-level access to pull container images.
-      # No sourceArn condition: Lambda does not reliably set it during image init.
-      # Scope is already limited to this specific repository.
+      # Scoped to this specific repository; no additional condition needed.
       var.create_lambda_pull_statement ? [
         {
           Sid    = "AllowLambdaPull",

--- a/infrastructure/modules/macro-lambda/main.tf
+++ b/infrastructure/modules/macro-lambda/main.tf
@@ -89,47 +89,54 @@ resource "aws_iam_role_policy" "lambda_deny" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [{
-      Sid    = "DenyAllDangerousServices"
-      Effect = "Deny"
-      Action = [
-        "s3:*",
-        "rds:*",
-        "rds-data:*",
-        "ssm:*",
-        "iam:*",
-        "sts:AssumeRole",
-        "ecs:*",
-        "dynamodb:*",
-        "sqs:*",
-        "sns:*",
-        "kinesis:*",
-        "kms:*",
-        "secretsmanager:*",
-        "events:*",
-        "states:*",
-        "execute-api:*",
-        "es:*",
-        "elasticache:*",
-        "redshift:*",
-        "kafka:*",
-        "organizations:*",
-        "cloudformation:*",
-        "cloudtrail:*",
-        "route53:*",
-        "elasticloadbalancing:*",
-        "autoscaling:*",
-        "cloudfront:*",
-        "apigateway:*",
-        "cognito-idp:*",
-        "cognito-identity:*",
-        "lambda:*",
-        "ec2:RunInstances",
-        "ec2:TerminateInstances",
-        "ec2:ModifyInstanceAttribute"
-      ]
-      Resource = "*"
-    }]
+    Statement = [
+      {
+        Sid    = "DenyAllDangerousServices"
+        Effect = "Deny"
+        Action = [
+          "s3:*",
+          "rds:*",
+          "rds-data:*",
+          "ssm:*",
+          "iam:*",
+          "sts:AssumeRole",
+          "ecs:*",
+          "dynamodb:*",
+          "sqs:*",
+          "sns:*",
+          "kinesis:*",
+          "secretsmanager:*",
+          "events:*",
+          "states:*",
+          "execute-api:*",
+          "es:*",
+          "elasticache:*",
+          "redshift:*",
+          "kafka:*",
+          "organizations:*",
+          "cloudformation:*",
+          "cloudtrail:*",
+          "route53:*",
+          "elasticloadbalancing:*",
+          "autoscaling:*",
+          "cloudfront:*",
+          "apigateway:*",
+          "cognito-idp:*",
+          "cognito-identity:*",
+          "lambda:*",
+          "ec2:RunInstances",
+          "ec2:TerminateInstances",
+          "ec2:ModifyInstanceAttribute"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid       = "DenyAllKMSExceptDecrypt"
+        Effect    = "Deny"
+        NotAction = ["kms:Decrypt"]
+        Resource  = "*"
+      }
+    ]
   })
 }
 


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Replace blanket kms:* deny with specific KMS action denies, keeping kms:Decrypt allowed. Lambda needs kms:Decrypt to decrypt environment variables at startup. Also update ECR repo policy comment.