### PR TITLE
fix(infra): add Contentful environment variables for backend service

### DIFF
--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -1616,6 +1616,14 @@ module "backend_ecs" {
       name      = "EMAIL_FROM"
       valueFrom = "${module.ses_secrets.secret_arn}:BACKEND_EMAIL_FROM::"
     },
+    {
+      name      = "CONTENTFUL_SPACE_ID"
+      valueFrom = "${module.contentful_secrets.secret_arn}:CONTENTFUL_SPACE_ID::"
+    },
+    {
+      name      = "CONTENTFUL_ACCESS_TOKEN"
+      valueFrom = "${module.contentful_secrets.secret_arn}:CONTENTFUL_ACCESS_TOKEN::"
+    },
   ]
 
   # Environment variables for the backend service

--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -1575,6 +1575,14 @@ module "backend_ecs" {
       name      = "EMAIL_FROM"
       valueFrom = "${module.ses_secrets.secret_arn}:BACKEND_EMAIL_FROM::"
     },
+    {
+      name      = "CONTENTFUL_SPACE_ID"
+      valueFrom = "${module.contentful_secrets.secret_arn}:CONTENTFUL_SPACE_ID::"
+    },
+    {
+      name      = "CONTENTFUL_ACCESS_TOKEN"
+      valueFrom = "${module.contentful_secrets.secret_arn}:CONTENTFUL_ACCESS_TOKEN::"
+    },
   ]
 
   # Environment variables for the backend service


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

The backend needs Contentful credentials to fetch email templates. References the existing contentful_secrets module in both dev and prod.