### PR TITLE
fix(data,api): preserve answers for duplicate question labels (OJD-1474)

### DIFF
--- a/apps/data/src/pipelines/centrum_pipeline.py
+++ b/apps/data/src/pipelines/centrum_pipeline.py
@@ -511,16 +511,25 @@ def experiment_raw_data():
         def sanitize_questions_array(questions_array):
             if questions_array is None or len(questions_array) == 0:
                 return []
-            
+
             result = []
+            # Disambiguate duplicate sanitized labels within the same payload by
+            # appending a 1-based occurrence suffix (e.g. label, label_2, label_3).
+            # Without this, downstream map_from_arrays collapses duplicates and
+            # only the last answer survives.
+            label_counts: dict[str, int] = {}
             for q in questions_array:
                 if q:
+                    base_label = sanitize_label(q.get('question_label'))
+                    count = label_counts.get(base_label, 0) + 1
+                    label_counts[base_label] = count
+                    label = base_label if count == 1 else f"{base_label}_{count}"
                     result.append({
-                        'question_label': sanitize_label(q.get('question_label')),
+                        'question_label': label,
                         'question_answer': q.get('question_answer')
                     })
             return result
-        
+
         return questions.apply(sanitize_questions_array)
     
     return (
@@ -543,11 +552,8 @@ def experiment_raw_data():
                     parse_json(
                         to_json(
                             map_from_arrays(
-                                array_distinct(transform(questions_sanitized, q -> q.question_label)),
-                                transform(
-                                    array_distinct(transform(questions_sanitized, q -> q.question_label)),
-                                    label -> element_at(filter(questions_sanitized, q -> q.question_label = label), -1).question_answer
-                                )
+                                transform(questions_sanitized, q -> q.question_label),
+                                transform(questions_sanitized, q -> q.question_answer)
                             )
                         )
                     )

--- a/apps/data/src/pipelines/centrum_pipeline.py
+++ b/apps/data/src/pipelines/centrum_pipeline.py
@@ -512,22 +512,41 @@ def experiment_raw_data():
             if questions_array is None or len(questions_array) == 0:
                 return []
 
+            # Disambiguate duplicate sanitized labels so downstream
+            # map_from_arrays doesn't collapse them and lose answers.
+            # Strategy:
+            #   - unique label in row -> bare label
+            #   - label collides, texts differ -> "<label>__<text>"
+            #   - label and text both collide -> positional fallback "_2", "_3"
+            # The text-based suffix gives stable, meaningful column names
+            # across rows whenever question_text differs between duplicates.
+            base_labels = [
+                sanitize_label(q.get('question_label')) if q else None
+                for q in questions_array
+            ]
+            label_total: dict[str, int] = {}
+            for bl in base_labels:
+                if bl is not None:
+                    label_total[bl] = label_total.get(bl, 0) + 1
+
+            key_counts: dict[str, int] = {}
             result = []
-            # Disambiguate duplicate sanitized labels within the same payload by
-            # appending a 1-based occurrence suffix (e.g. label, label_2, label_3).
-            # Without this, downstream map_from_arrays collapses duplicates and
-            # only the last answer survives.
-            label_counts: dict[str, int] = {}
-            for q in questions_array:
-                if q:
-                    base_label = sanitize_label(q.get('question_label'))
-                    count = label_counts.get(base_label, 0) + 1
-                    label_counts[base_label] = count
-                    label = base_label if count == 1 else f"{base_label}_{count}"
-                    result.append({
-                        'question_label': label,
-                        'question_answer': q.get('question_answer')
-                    })
+            for i, q in enumerate(questions_array):
+                if not q:
+                    continue
+                base = base_labels[i]
+                if label_total.get(base, 0) <= 1:
+                    key = base
+                else:
+                    text_part = sanitize_label(q.get('question_text'))
+                    candidate = f"{base}__{text_part}"
+                    count = key_counts.get(candidate, 0) + 1
+                    key_counts[candidate] = count
+                    key = candidate if count == 1 else f"{candidate}_{count}"
+                result.append({
+                    'question_label': key,
+                    'question_answer': q.get('question_answer')
+                })
             return result
 
         return questions.apply(sanitize_questions_array)

--- a/apps/data/src/pipelines/centrum_pipeline.py
+++ b/apps/data/src/pipelines/centrum_pipeline.py
@@ -486,26 +486,22 @@ def experiment_raw_data():
         def sanitize_label(label):
             if not label:
                 return "question_empty"
-            
-            # Convert to lowercase
-            sanitized = label.lower()
-            
-            # Replace invalid characters with underscores
-            invalid_chars = ' ,;{}()\n\t=.'
-            for char in invalid_chars:
-                sanitized = sanitized.replace(char, '_')
-            
-            # Remove leading/trailing underscores
-            sanitized = sanitized.strip('_')
-            
-            # Collapse multiple underscores to single
+
+            # Allowlist: lowercase ASCII letters, digits, underscore.
+            # Anything else collapses to a single underscore so the result is
+            # safe as a Spark identifier and as a JSON/VARIANT key, regardless
+            # of where it gets rendered downstream (SQL, CSV, Excel, UI).
+            sanitized = ''.join(
+                c if (c == '_' or (c.isascii() and c.isalnum())) else '_'
+                for c in label.lower()
+            )
             while '__' in sanitized:
                 sanitized = sanitized.replace('__', '_')
-            
-            # Ensure it's not empty and doesn't start with a number
+            sanitized = sanitized.strip('_')
+
             if not sanitized or sanitized[0].isdigit():
                 sanitized = f"question_{sanitized}"
-            
+
             return sanitized
         
         def sanitize_questions_array(questions_array):

--- a/apps/data/src/pipelines/centrum_pipeline.py
+++ b/apps/data/src/pipelines/centrum_pipeline.py
@@ -512,10 +512,13 @@ def experiment_raw_data():
             # map_from_arrays doesn't collapse them and lose answers.
             # Strategy:
             #   - unique label in row -> bare label
-            #   - label collides, texts differ -> "<label>__<text>"
-            #   - label and text both collide -> positional fallback "_2", "_3"
-            # The text-based suffix gives stable, meaningful column names
-            # across rows whenever question_text differs between duplicates.
+            #   - label collides, sanitized text differs from sanitized label
+            #       -> "<label>__<text>"
+            #   - label collides but text adds nothing (empty, or same as label
+            #       after sanitization, e.g. uncustomized default)
+            #       -> positional fallback "_2", "_3" on bare label
+            #   - label and text both collide
+            #       -> positional fallback on the combined "<label>__<text>" key
             base_labels = [
                 sanitize_label(q.get('question_label')) if q else None
                 for q in questions_array
@@ -534,8 +537,12 @@ def experiment_raw_data():
                 if label_total.get(base, 0) <= 1:
                     key = base
                 else:
-                    text_part = sanitize_label(q.get('question_text'))
-                    candidate = f"{base}__{text_part}"
+                    text = q.get('question_text')
+                    text_part = sanitize_label(text) if text else None
+                    if not text_part or text_part == base:
+                        candidate = base
+                    else:
+                        candidate = f"{base}__{text_part}"
                     count = key_counts.get(candidate, 0) + 1
                     key_counts[candidate] = count
                     key = candidate if count == 1 else f"{candidate}_{count}"

--- a/packages/api/src/schemas/experiment.schema.spec.ts
+++ b/packages/api/src/schemas/experiment.schema.spec.ts
@@ -356,6 +356,35 @@ describe("Experiment Schema", () => {
       expect(() => zFlowGraph.parse(twoStart)).toThrow();
     });
 
+    it("zFlowGraph rejects duplicate node labels", () => {
+      const graph = {
+        nodes: [
+          {
+            id: "n1",
+            type: "question",
+            name: "Question Node",
+            content: { kind: "yes_no", text: "ok?", required: false },
+            isStart: true,
+          },
+          {
+            id: "n2",
+            type: "question",
+            name: "Question Node",
+            content: { kind: "yes_no", text: "again?", required: false },
+            isStart: false,
+          },
+        ],
+        edges: [{ id: "e1", source: "n1", target: "n2", label: null }],
+      };
+      const result = zFlowGraph.safeParse(graph);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find((i) => i.path.join(".") === "nodes.1.name");
+        expect(issue?.message).toContain("Question Node");
+        expect(issue?.message).toContain("unique");
+      }
+    });
+
     it("zFlow and zUpsertFlowBody valid", () => {
       const graph = {
         nodes: [

--- a/packages/api/src/schemas/experiment.schema.spec.ts
+++ b/packages/api/src/schemas/experiment.schema.spec.ts
@@ -356,7 +356,7 @@ describe("Experiment Schema", () => {
       expect(() => zFlowGraph.parse(twoStart)).toThrow();
     });
 
-    it("zFlowGraph rejects duplicate node labels", () => {
+    it("zFlowGraph rejects duplicate question-node labels", () => {
       const graph = {
         nodes: [
           {
@@ -383,6 +383,31 @@ describe("Experiment Schema", () => {
         expect(issue?.message).toContain("Question Node");
         expect(issue?.message).toContain("unique");
       }
+    });
+
+    it("zFlowGraph allows duplicate labels across node types", () => {
+      // Only question-node labels become column keys downstream — other types
+      // can share labels with each other or with a question without conflict.
+      const graph = {
+        nodes: [
+          {
+            id: "n1",
+            type: "question",
+            name: "Plot",
+            content: { kind: "open_ended", text: "Which plot?", required: false },
+            isStart: true,
+          },
+          {
+            id: "n2",
+            type: "instruction",
+            name: "Plot",
+            content: { text: "Walk to the plot." },
+            isStart: false,
+          },
+        ],
+        edges: [{ id: "e1", source: "n1", target: "n2", label: null }],
+      };
+      expect(zFlowGraph.parse(graph)).toEqual(graph);
     });
 
     it("zFlow and zUpsertFlowBody valid", () => {

--- a/packages/api/src/schemas/experiment.schema.ts
+++ b/packages/api/src/schemas/experiment.schema.ts
@@ -436,14 +436,16 @@ export const zFlowGraph = z
       });
     }
 
-    // Reject duplicate node labels. The data pipeline derives column keys from
-    // these names; without uniqueness, columns collide across rows.
+    // Reject duplicate question-node labels. Only question nodes need this:
+    // their labels become column keys in `questions_data`, so duplicates collide
+    // and lose answers downstream. Other node types' labels are display-only.
     const seen = new Map<string, number>();
     graph.nodes.forEach((node, index) => {
+      if (node.type !== "question") return;
       if (seen.has(node.name)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: `Node label "${node.name}" must be unique`,
+          message: `Question node label "${node.name}" must be unique`,
           path: ["nodes", index, "name"],
         });
         return;

--- a/packages/api/src/schemas/experiment.schema.ts
+++ b/packages/api/src/schemas/experiment.schema.ts
@@ -435,6 +435,21 @@ export const zFlowGraph = z
         path: ["nodes"],
       });
     }
+
+    // Reject duplicate node labels. The data pipeline derives column keys from
+    // these names; without uniqueness, columns collide across rows.
+    const seen = new Map<string, number>();
+    graph.nodes.forEach((node, index) => {
+      if (seen.has(node.name)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Node label "${node.name}" must be unique`,
+          path: ["nodes", index, "name"],
+        });
+        return;
+      }
+      seen.set(node.name, index);
+    });
   });
 
 export const zFlow = z.object({


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Fixes OJD-1474. Question answers were being lost when an experiment flow contained multiple question nodes that sanitized to the same column key. The pipeline ran `array_distinct` over labels and re-joined answers with `element_at(..., -1)`, so colliding labels collapsed to a single column holding only the last answer.

#### Pipeline (`centrum_pipeline.py`):
- Drop the `array_distinct` + `element_at` reconstruction in the SQL expression and feed `map_from_arrays` parallel label/answer arrays produced by the Python sanitizer, so disambiguation happens in one place.
- `sanitize_questions_array` now disambiguates colliding sanitized labels: unique labels stay bare, collisions with differing `question_text` become `<label>__<text>`, and full duplicates fall back to positional `_2`, `_3` suffixes. This keeps column names stable and meaningful across rows.
- `sanitize_label` switches from a denylist of invalid characters to an ASCII-alphanumeric-plus-underscore allowlist, so non-ASCII characters and any unanticipated punctuation are coerced safely for use as Spark identifiers and JSON/VARIANT keys.

#### API schema (`experiment.schema.ts`):
- `zFlowGraph` now rejects duplicate node `name` values with an issue attached to the offending node, preventing authors from creating flows whose questions would alias to the same downstream column in the first place.

## Related Issues

- #1160 , #1356 
