### PR TITLE
fix(api,web): share canonical label sanitizer and harden duplicate check

### DIFF
--- a/apps/web/components/experiment-data/metadata-upload-modal/steps/metadata-upload-step.tsx
+++ b/apps/web/components/experiment-data/metadata-upload-modal/steps/metadata-upload-step.tsx
@@ -29,6 +29,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { sanitizeQuestionLabel } from "@repo/api/schemas/experiment.schema";
 import type { ExperimentMetadata } from "@repo/api/schemas/experiment.schema";
 import { useTranslation } from "@repo/i18n/client";
 import { Button } from "@repo/ui/components/button";
@@ -44,25 +45,6 @@ import {
   SelectValue,
 } from "@repo/ui/components/select";
 import { cn } from "@repo/ui/lib/utils";
-
-/**
- * Sanitize a question label to match the pipeline's `questions_data` key format.
- * Must stay in sync with `sanitize_label` in centrum_pipeline.py.
- */
-function sanitizeQuestionLabel(label: string): string {
-  if (!label) return "question_empty";
-
-  let s = label.toLowerCase();
-  s = s.replace(/[ ,;{}()\n\t=.]+/g, "_");
-  s = s.replace(/^_+|_+$/g, "");
-  s = s.replace(/_+/g, "_");
-
-  if (!s || /^\d/.test(s)) {
-    s = `question_${s}`;
-  }
-
-  return s;
-}
 
 type SaveStatus = "idle" | "saving" | "saved";
 

--- a/apps/web/components/react-flow/__tests__/node-content.test.tsx
+++ b/apps/web/components/react-flow/__tests__/node-content.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@/test/test-utils";
+import { Position } from "@xyflow/react";
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+
+import { NodeContent } from "../node-content";
+
+vi.mock("../node-config", () => ({
+  nodeTypeColorMap: {
+    QUESTION: { border: "border-red-500", bg: "bg-red-50", icon: <span data-testid="icon" /> },
+    INSTRUCTION: { border: "border-blue-500", bg: "bg-blue-50", icon: <span data-testid="icon" /> },
+    MEASUREMENT: {
+      border: "border-green-500",
+      bg: "bg-green-50",
+      icon: <span data-testid="icon" />,
+    },
+    ANALYSIS: {
+      border: "border-yellow-500",
+      bg: "bg-yellow-50",
+      icon: <span data-testid="icon" />,
+    },
+  },
+}));
+
+vi.mock("../node-handles", () => ({
+  NodeHandles: () => <div data-testid="node-handles" />,
+}));
+
+const baseProps = {
+  nodeType: "QUESTION" as const,
+  hasInput: true,
+  hasOutput: true,
+  inputPosition: Position.Left,
+  outputPosition: Position.Right,
+};
+
+describe("NodeContent", () => {
+  it("renders the title when provided", () => {
+    render(<NodeContent {...baseProps} title="Plot number" />);
+    expect(screen.getByText("Plot number")).toBeInTheDocument();
+    expect(screen.queryByText("flow.untitledNode")).not.toBeInTheDocument();
+  });
+
+  it("renders the untitled placeholder when title is empty", () => {
+    render(<NodeContent {...baseProps} title="" />);
+    expect(screen.getByText("flow.untitledNode")).toBeInTheDocument();
+  });
+
+  it("shows the start indicator when isStartNode is true", () => {
+    render(<NodeContent {...baseProps} title="Q" isStartNode />);
+    expect(screen.getByText("start")).toBeInTheDocument();
+  });
+
+  it("does not show the start indicator by default", () => {
+    render(<NodeContent {...baseProps} title="Q" />);
+    expect(screen.queryByText("start")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/react-flow/node-content.tsx
+++ b/apps/web/components/react-flow/node-content.tsx
@@ -60,12 +60,18 @@ export function NodeContent({
           </div>
           {/* Label inside the node */}
           <div className="text-center">
-            <span
-              className="text-md inline-block max-w-[250px] truncate font-medium text-slate-700"
-              title={title}
-            >
-              {title}
-            </span>
+            {title ? (
+              <span
+                className="text-md inline-block max-w-[250px] truncate font-medium text-slate-700"
+                title={title}
+              >
+                {title}
+              </span>
+            ) : (
+              <span className="text-md inline-block max-w-[250px] truncate font-medium italic text-slate-400">
+                {t("flow.untitledNode")}
+              </span>
+            )}
           </div>
         </div>
       </div>

--- a/apps/web/components/react-flow/node-utils.tsx
+++ b/apps/web/components/react-flow/node-utils.tsx
@@ -31,14 +31,15 @@ export function toPosition(pos?: string | Position): Position | undefined {
   }
 }
 
-// Factory for a new node with minimal placeholder spec (validated/enriched elsewhere)
+// Factory for a new node with minimal placeholder spec (validated/enriched elsewhere).
 export function createNewNode(
   type: string,
   position: { x: number; y: number },
   title?: string,
 ): Node {
   const cfg = nodeTypeColorMap[type as keyof typeof nodeTypeColorMap];
-  const displayTitle = title ?? `${type.charAt(0)}${type.slice(1).toLowerCase()} Node`;
+  const defaultTitle =
+    type === "QUESTION" ? "" : `${type.charAt(0)}${type.slice(1).toLowerCase()} Node`;
   const stepSpecification =
     DEFAULT_STEP_SPECIFICATIONS[type as keyof typeof DEFAULT_STEP_SPECIFICATIONS];
   return {
@@ -48,7 +49,7 @@ export function createNewNode(
     sourcePosition: cfg.defaultSourcePosition,
     targetPosition: cfg.defaultTargetPosition,
     data: {
-      title: displayTitle,
+      title: title ?? defaultTitle,
       description: type === "INSTRUCTION" ? "" : undefined,
       stepSpecification,
       isStartNode: false,

--- a/apps/web/components/side-panel-flow/side-panel-flow.tsx
+++ b/apps/web/components/side-panel-flow/side-panel-flow.tsx
@@ -207,8 +207,13 @@ export function ExperimentSidePanel({
                 onChange={handleTitleChange}
                 placeholder={t("sidePanelFlow.labelPlaceholder")}
                 disabled={isDisabled}
+                required={displayNodeType === "QUESTION"}
+                aria-required={displayNodeType === "QUESTION"}
                 className="focus:border-jii-dark-green focus:ring-jii-dark-green w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-opacity-50 disabled:cursor-not-allowed disabled:bg-gray-100"
               />
+              {displayNodeType === "QUESTION" && (
+                <p className="mt-1.5 text-xs text-gray-500">{t("sidePanelFlow.labelHint")}</p>
+              )}
             </CardContent>
           </Card>
 

--- a/packages/api/src/schemas/experiment.schema.spec.ts
+++ b/packages/api/src/schemas/experiment.schema.spec.ts
@@ -410,6 +410,36 @@ describe("Experiment Schema", () => {
       expect(zFlowGraph.parse(graph)).toEqual(graph);
     });
 
+    it("zFlowGraph rejects question labels that collide after canonicalization", () => {
+      // "Question Node" and "QUESTION-node!" both reduce to `question_node`,
+      // i.e. the same pipeline column key.
+      const graph = {
+        nodes: [
+          {
+            id: "n1",
+            type: "question",
+            name: "Question Node",
+            content: { kind: "yes_no", text: "a?", required: false },
+            isStart: true,
+          },
+          {
+            id: "n2",
+            type: "question",
+            name: "QUESTION-node!",
+            content: { kind: "yes_no", text: "b?", required: false },
+            isStart: false,
+          },
+        ],
+        edges: [{ id: "e1", source: "n1", target: "n2", label: null }],
+      };
+      const result = zFlowGraph.safeParse(graph);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find((i) => i.path.join(".") === "nodes.1.name");
+        expect(issue?.message).toContain("QUESTION-node!");
+      }
+    });
+
     it("zFlow and zUpsertFlowBody valid", () => {
       const graph = {
         nodes: [

--- a/packages/api/src/schemas/experiment.schema.ts
+++ b/packages/api/src/schemas/experiment.schema.ts
@@ -420,6 +420,20 @@ export const zFlowEdge = z.object({
   label: z.string().max(64, "Edge label must be 64 characters or less").optional().nullable(),
 });
 
+/**
+ * Canonicalize a flow node label to the column key the data pipeline emits
+ * for `questions_data`. Allowlist: lowercase ASCII letters, digits, underscore;
+ * everything else collapses to `_`. Mirrors `sanitize_label` in
+ * apps/data/src/pipelines/centrum_pipeline.py — keep them in sync.
+ */
+export function sanitizeQuestionLabel(label: string): string {
+  if (!label) return "question_empty";
+  let s = label.toLowerCase().replace(/[^a-z0-9_]+/g, "_");
+  s = s.replace(/^_+|_+$/g, "");
+  if (!s || /^\d/.test(s)) s = `question_${s}`;
+  return s;
+}
+
 export const zFlowGraph = z
   .object({
     nodes: z.array(zFlowNode).min(1, "At least one node is required to create a flow"),
@@ -439,10 +453,14 @@ export const zFlowGraph = z
     // Reject duplicate question-node labels. Only question nodes need this:
     // their labels become column keys in `questions_data`, so duplicates collide
     // and lose answers downstream. Other node types' labels are display-only.
+    // Compare on the canonicalized form so labels that only differ by
+    // punctuation/whitespace (and would collapse to the same column key)
+    // are also caught.
     const seen = new Map<string, number>();
     graph.nodes.forEach((node, index) => {
       if (node.type !== "question") return;
-      if (seen.has(node.name)) {
+      const canonical = sanitizeQuestionLabel(node.name);
+      if (seen.has(canonical)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: `Question node label "${node.name}" must be unique`,
@@ -450,7 +468,7 @@ export const zFlowGraph = z
         });
         return;
       }
-      seen.set(node.name, index);
+      seen.set(canonical, index);
     });
   });
 

--- a/packages/i18n/locales/de-DE/experiments.json
+++ b/packages/i18n/locales/de-DE/experiments.json
@@ -61,7 +61,8 @@
       "title": "Datenspaltenname",
       "description": "Diese Bezeichnung wird zu einer Spalte in Ihrer Datenanalyse:",
       "defaultColumnName": "frage_name"
-    }
+    },
+    "untitledNode": "(Ohne Titel)"
   },
   "overview": "Übersicht",
   "data": "Daten",
@@ -164,6 +165,7 @@
     "nodePanel": "Knoten-Panel",
     "label": "Bezeichnung",
     "labelPlaceholder": "Knotentitel eingeben...",
+    "labelHint": "Muss innerhalb dieses Flows eindeutig sein.",
     "nodeProperties": "Knoteneigenschaften",
     "startNode": "Startknoten",
     "startNodeLimit": "Auf einen pro Flow begrenzt",

--- a/packages/i18n/locales/en-US/experiments.json
+++ b/packages/i18n/locales/en-US/experiments.json
@@ -79,7 +79,8 @@
       "title": "Data Column Name",
       "description": "This label will become a column in your data analysis:",
       "defaultColumnName": "question_name"
-    }
+    },
+    "untitledNode": "(Untitled)"
   },
   "overview": "Overview",
   "data": "Data",
@@ -189,6 +190,7 @@
     "nodePanel": "Node Panel",
     "label": "Label",
     "labelPlaceholder": "Enter node title...",
+    "labelHint": "Must be unique within this flow.",
     "nodeProperties": "Node Properties",
     "startNode": "Start Node",
     "startNodeLimit": "Limited to one per flow",


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

This pull request refactors and improves the handling of question label sanitization and uniqueness validation for experiment flow nodes. The main changes ensure that labels are consistently canonicalized across the codebase and that duplicate labels (after canonicalization) are properly rejected, preventing downstream data pipeline issues.