### PR TITLE
feat(mobile): register ESP32-C3 USB Serial/JTAG VID/PID with CdcAcmSerialDriver (OJD-1475)

### DIFF
--- a/patches/react-native-usb-serialport-for-android.patch
+++ b/patches/react-native-usb-serialport-for-android.patch
@@ -1,8 +1,28 @@
 diff --git a/android/src/main/java/com/bastengao/usbserialport/UsbSerialportForAndroidModule.java b/android/src/main/java/com/bastengao/usbserialport/UsbSerialportForAndroidModule.java
-index 7e2028288172afdfb08e6ac0d4d07b69d5885902..a9180b049afd7d8e48900964365bb4d0783a8769 100644
 --- a/android/src/main/java/com/bastengao/usbserialport/UsbSerialportForAndroidModule.java
 +++ b/android/src/main/java/com/bastengao/usbserialport/UsbSerialportForAndroidModule.java
-@@ -153,6 +153,9 @@ public class UsbSerialportForAndroidModule extends ReactContextBaseJavaModule im
+@@ -18,6 +18,8 @@
+ import com.facebook.react.bridge.WritableMap;
+ import com.facebook.react.module.annotations.ReactModule;
+ import com.facebook.react.modules.core.DeviceEventManagerModule;
++import com.hoho.android.usbserial.driver.CdcAcmSerialDriver;
++import com.hoho.android.usbserial.driver.ProbeTable;
+ import com.hoho.android.usbserial.driver.UsbSerialDriver;
+ import com.hoho.android.usbserial.driver.UsbSerialPort;
+ import com.hoho.android.usbserial.driver.UsbSerialProber;
+@@ -129,7 +131,10 @@
+             return;
+         }
+
+-        UsbSerialDriver driver = UsbSerialProber.getDefaultProber().probeDevice(device);
++        ProbeTable customTable = UsbSerialProber.getDefaultProbeTable();
++        customTable.addProduct(0x303A, 0x1001, CdcAcmSerialDriver.class); // ESP32-C3/S3 USB Serial/JTAG
++        UsbSerialProber prober = new UsbSerialProber(customTable);
++        UsbSerialDriver driver = prober.probeDevice(device);
+         if (driver == null) {
+             promise.reject(CODE_DRIVER_NOT_FOND, "no driver for device");
+             return;
+@@ -153,6 +158,9 @@ public class UsbSerialportForAndroidModule extends ReactContextBaseJavaModule im
          try {
              port.open(connection);
              port.setParameters(baudRate, dataBits, stopBits, parity);
@@ -21,7 +41,7 @@ diff --git a/android/build.gradle b/android/build.gradle
              mavenCentral()
 -            jcenter()
          }
- 
+
          dependencies {
 @@ -51,7 +50,6 @@ repositories {
      maven { url 'https://jitpack.io' }
@@ -29,5 +49,5 @@ diff --git a/android/build.gradle b/android/build.gradle
      mavenCentral()
 -    jcenter()
  }
- 
+
  dependencies {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,7 +108,7 @@ patchedDependencies:
     hash: 96812310a27a5ba65b9a67eab72ae6b1a1aa5e5b29107190ea75147ed5fe467a
     path: patches/@better-auth__expo@1.5.6.patch
   react-native-usb-serialport-for-android:
-    hash: 31811a12742cd056af7e4b2a51aad7cd18865488fff2380ae09d7a063b330dbb
+    hash: 5fabf343421faf246ae24e07311177ed9bb428b21f019b8585ca22bc121591b3
     path: patches/react-native-usb-serialport-for-android.patch
 
 importers:
@@ -628,7 +628,7 @@ importers:
         version: 2.3.3(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
       react-native-usb-serialport-for-android:
         specifier: ^0.5.0
-        version: 0.5.0(patch_hash=31811a12742cd056af7e4b2a51aad7cd18865488fff2380ae09d7a063b330dbb)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
+        version: 0.5.0(patch_hash=5fabf343421faf246ae24e07311177ed9bb428b21f019b8585ca22bc121591b3)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
       react-native-vector-icons:
         specifier: ^10.3.0
         version: 10.3.0
@@ -1199,7 +1199,7 @@ importers:
         version: 1.73.0-rc.13(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))
       react-native-usb-serialport-for-android:
         specifier: ^0.5.0
-        version: 0.5.0(patch_hash=31811a12742cd056af7e4b2a51aad7cd18865488fff2380ae09d7a063b330dbb)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
+        version: 0.5.0(patch_hash=5fabf343421faf246ae24e07311177ed9bb428b21f019b8585ca22bc121591b3)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@repo/eslint-config':
         specifier: workspace:*
@@ -37328,7 +37328,7 @@ snapshots:
       react: 19.2.4
       react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4)
 
-  react-native-usb-serialport-for-android@0.5.0(patch_hash=31811a12742cd056af7e4b2a51aad7cd18865488fff2380ae09d7a063b330dbb)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4):
+  react-native-usb-serialport-for-android@0.5.0(patch_hash=5fabf343421faf246ae24e07311177ed9bb428b21f019b8585ca22bc121591b3)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.4)


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

This pull request updates the `react-native-usb-serialport-for-android` package with a custom patch to add support for ESP32-C3/S3 USB Serial/JTAG devices. The changes involve modifying the USB serial driver probing logic to recognize these devices, and updating the patch references in the dependency lock file.

Support for ESP32-C3/S3 devices:

* Modified `UsbSerialportForAndroidModule.java` to add a custom entry in the `ProbeTable` for devices with vendor ID `0x303A` and product ID `0x1001`, enabling support for ESP32-C3/S3 USB Serial/JTAG devices.

Dependency and lockfile updates:

* Updated the patch hash for `react-native-usb-serialport-for-android` in `pnpm-lock.yaml` to reference the new patch that includes ESP32-C3/S3 support. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL111-R111) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL631-R631) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1202-R1202) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL37331-R37331)

## Related Issues

-  #1359 