### PR TITLE
fix(infra): skip macro-sandbox deploy when no languages detected

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -169,7 +169,7 @@ jobs:
       always() &&
       needs.detect-changes.result == 'success' &&
       contains('success,skipped', needs.deploy-infrastructure.result) &&
-      (inputs.deploy_all || contains(inputs.deploy_app, 'macro-sandbox') || (inputs.deploy_app == '' && contains(fromJSON(needs.detect-changes.outputs.affected_apps), 'macro-sandbox')))
+      (inputs.deploy_all || contains(inputs.deploy_app, 'macro-sandbox') || (inputs.deploy_app == '' && contains(fromJSON(needs.detect-changes.outputs.affected_apps), 'macro-sandbox') && needs.detect-changes.outputs.macro_sandbox_languages != '[]'))
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -18,7 +18,7 @@ on:
                 type: boolean
                 default: false
             deploy_app:
-                description: "Comma-separated apps to force deploy (e.g. web,backend). Leave empty for change detection. Options: web, backend, migration, databricks, docs"
+                description: "Comma-separated apps to force deploy (e.g. web,backend). Leave empty for change detection. Options: web, backend, migration, databricks, docs, macro-sandbox"
                 required: false
                 type: string
                 default: ""


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

This pull request makes targeted improvements to the deployment workflow for the `macro-sandbox` app, ensuring deployments only occur when relevant languages are detected, and updates documentation for deployment options.