### PR TITLE
fix(web): reject unknown locales in locale layout

### DIFF
--- a/apps/web/app/[locale]/layout.tsx
+++ b/apps/web/app/[locale]/layout.tsx
@@ -8,7 +8,7 @@ import { isFeatureFlagEnabled } from "~/lib/posthog-server";
 
 import { FEATURE_FLAGS } from "@repo/analytics";
 import { ContentfulPreviewProvider } from "@repo/cms/contentful";
-import { defaultLocale, namespaces } from "@repo/i18n";
+import { defaultLocale, isKnownLocale, namespaces } from "@repo/i18n";
 import initTranslations from "@repo/i18n/server";
 import { cn } from "@repo/ui/lib/utils";
 
@@ -49,6 +49,11 @@ const allowedOriginList = ["https://app.contentful.com", "https://app.eu.content
 
 export default async function LocaleLayout({ children, params }: LocaleLayoutProps) {
   const { locale } = await params;
+
+  if (!isKnownLocale(locale)) {
+    notFound();
+  }
+
   const { isEnabled: preview } = await draftMode();
 
   // Check multi-language feature flag

--- a/apps/web/test/setup.ts
+++ b/apps/web/test/setup.ts
@@ -51,6 +51,7 @@ vi.mock("@repo/i18n", () => ({
   }),
   defaultLocale: "en-US",
   locales: ["en-US"],
+  isKnownLocale: (locale: string) => ["en-US", "de-DE"].includes(locale),
   namespaces: ["common", "questionCard", "registration", "settings", "experiments"],
   createInstance: vi.fn(() => ({
     use: vi.fn().mockReturnThis(),


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

This pull request improves the locale handling in the `apps/web/app/[locale]/layout.tsx` file by adding a validation step to ensure that only known locales are accepted. If an unknown locale is provided, the user is shown a 404 page.