### PR TITLE
fix(mobile/ci): unblock OTA fingerprint + bundler resolution

### DIFF
--- a/.github/workflows/mobile-preview-ota.yml
+++ b/.github/workflows/mobile-preview-ota.yml
@@ -98,7 +98,7 @@ jobs:
         id: fp
         working-directory: apps/mobile
         run: |
-          HASH=$(pnpm exec expo-updates fingerprint:generate --json 2>/dev/null | jq -r .hash)
+          HASH=$(pnpm exec expo-updates fingerprint:generate --platform android | jq -r .hash)
           if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
             echo "::error::Failed to compute fingerprint"
             exit 1

--- a/.github/workflows/mobile-promote.yml
+++ b/.github/workflows/mobile-promote.yml
@@ -83,7 +83,7 @@ jobs:
         id: fp
         working-directory: apps/mobile
         run: |
-          HASH=$(pnpm exec expo-updates fingerprint:generate --json 2>/dev/null | jq -r .hash)
+          HASH=$(pnpm exec expo-updates fingerprint:generate --platform android | jq -r .hash)
           if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
             echo "::error::Failed to compute fingerprint"
             exit 1

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -128,7 +128,7 @@ jobs:
         id: fp
         working-directory: apps/mobile
         run: |
-          HASH=$(pnpm exec expo-updates fingerprint:generate --json 2>/dev/null | jq -r .hash)
+          HASH=$(pnpm exec expo-updates fingerprint:generate --platform android | jq -r .hash)
           if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
             echo "::error::Failed to compute fingerprint"
             exit 1

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+public-hoist-pattern[]=*babel*
+public-hoist-pattern[]=babel-preset-expo
+public-hoist-pattern[]=nativewind

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -8,7 +8,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "prebuild": "expo prebuild",
-    "build-apk": "echo 'node-linker=hoisted' > .npmrc && dotenv -- eas build -p android --profile preview --local && rm .npmrc",
+    "build-apk": "dotenv -- eas build -p android --profile preview --local",
     "build-aab-locally": "dotenv -- eas build -p android --profile internal --local",
     "submit-to-google-play": "eas build -p android --profile internal --clear-cache --non-interactive --auto-submit",
     "update:preview": "eas update --branch preview",


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description

Fixes two CI failures in the mobile release pipeline introduced alongside the new multi-stage OTA flow (#1372):

1. `expo-updates fingerprint:generate --json` errored with `Unknown or unexpected option: --json`. The `2>/dev/null` in the workflow swallowed it, so the step exited with a misleading "Failed to compute fingerprint". Removed `--json` (output is already JSON), added required `--platform android`, and dropped the stderr suppression so future CLI breakage stays visible.
2. `eas update`'s bundler step failed with `Cannot find module 'babel-preset-expo'` (and similar for `nativewind/babel`). Cause: pnpm's strict isolation hides Babel preset/plugin packages that aren't direct deps in `apps/mobile/package.json`. Added a repo-root `.npmrc` with narrow `public-hoist-pattern[]` entries so only Babel + nativewind get hoisted to the root `node_modules`. Strict isolation preserved everywhere else. Also dropped the redundant temp `.npmrc` workaround from the `build-apk` script.

## Related Issues

- Closes #
- Related to #1372

## Testing Instructions

- [x] Locally: `pnpm exec expo-updates fingerprint:generate --platform android | jq -r .hash` returns a valid hash
- [x] Locally: `node -e "require.resolve('babel-preset-expo', {paths: ['apps/mobile']})"` resolves
- [x] CI mobile-preview-ota workflow completes the fingerprint step
- [x] CI eas update bundler succeeds (preview branch shows new update group)
- [ ] Verify mobile-release.yml run on next `mobile-vX.Y.Z` tag
- [ ] Verify mobile-promote.yml run for `track=beta` once Open testing track is set up

## Changes Made

- `.github/workflows/mobile-release.yml`, `mobile-preview-ota.yml`, `mobile-promote.yml`: drop invalid `--json` flag, add `--platform android`, surface stderr
- `.npmrc` (new): hoist `*babel*`, `babel-preset-expo`, `nativewind` to root `node_modules`
- `apps/mobile/package.json`: simplify `build-apk` script — temp `.npmrc` workaround no longer needed

## Checklist

- [ ] I have added/updated tests for my changes
- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have tested these changes locally
- [x] My changes generate no new warnings
- [x] I have reviewed my own code

## Screenshots/Recordings

EAS dashboard after green run:
- Update branches: `preview` shows latest update group with both Android + iOS runtimes
- Update groups: commit `b22bfc5` published to `preview`

## Additional Notes

Follow-up (not in this PR):
- Older Play Store builds (≤ v1.21.0) were created before `eas.json` had `channel`/`fingerprint` config — they cannot receive OTAs. First fresh `internal`-profile build via `release.yml` will start the OTA-eligible chain.
- Play Console "Open testing" track still needs to be set up before `mobile-promote.yml track=beta` will succeed at submit.