### PR TITLE
chore(mobile/cicd): gate preview OTA on mobile changes via release orchestrator

### DIFF
--- a/.github/workflows/mobile-preview-ota.yml
+++ b/.github/workflows/mobile-preview-ota.yml
@@ -1,8 +1,6 @@
 name: Mobile Preview OTA
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
     inputs:
       branch:
@@ -30,48 +28,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  detect:
-    name: Detect mobile changes
-    runs-on: ubuntu-latest
-    outputs:
-      affected: ${{ steps.check.outputs.affected }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js and pnpm
-        uses: ./.github/actions/setup-nodejs-pnpm
-        with:
-          node-version: "22"
-
-      - name: Detect affected packages
-        id: detect_pkgs
-        if: github.event_name == 'push'
-        uses: ./.github/actions/detect-affected-packages
-
-      - name: Check if mobile is affected
-        id: check
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "affected=true" >> $GITHUB_OUTPUT
-            echo "Manual dispatch — proceeding"
-            exit 0
-          fi
-          AFFECTED='${{ steps.detect_pkgs.outputs.affected_apps }}'
-          if echo "$AFFECTED" | jq -e 'index("mobile")' >/dev/null; then
-            echo "affected=true" >> $GITHUB_OUTPUT
-            echo "Mobile is in affected packages"
-          else
-            echo "affected=false" >> $GITHUB_OUTPUT
-            echo "Mobile not affected — skipping"
-          fi
-
   publish:
     name: Publish OTA
-    needs: detect
-    if: needs.detect.outputs.affected == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,3 +149,11 @@ jobs:
             --field version=${{ steps.extract_mobile.outputs.mobile_version }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger Mobile Preview OTA
+        if: contains(fromJson(needs.detect.outputs.affected_apps), 'mobile')
+        run: |
+          gh workflow run mobile-preview-ota.yml \
+            --ref ${{ github.ref_name }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description
`mobile-preview-ota` was firing on every merge to main regardless of whether mobile was affected, wasting runners on the detect job. Removed the `push` trigger and its internal detect job — `release.yml` already detects affected packages, so it now conditionally triggers `mobile-preview-ota` when mobile is in the affected apps, consistent with how `mobile-release` is handled.

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #
- Related to #

