### PR TITLE
refactor(cicd/mobile): extract shared composite actions

### DIFF
--- a/.github/actions/mobile-fingerprint-decide/action.yml
+++ b/.github/actions/mobile-fingerprint-decide/action.yml
@@ -1,0 +1,79 @@
+name: "Compute and compare mobile fingerprint"
+description: "Computes the current Expo fingerprint and compares against the last finished build for a profile. Emits both build/ota mode and drift true/false/unknown so callers can pick either semantic."
+inputs:
+  profile:
+    description: "EAS build profile to compare against (preview | internal | beta | production)"
+    required: true
+  platform:
+    description: "Platform to compute fingerprint for"
+    required: false
+    default: "android"
+  working-directory:
+    description: "Directory containing app.json / eas.json"
+    required: false
+    default: "apps/mobile"
+outputs:
+  current:
+    description: "Current fingerprint hash"
+    value: ${{ steps.fp.outputs.hash }}
+  last:
+    description: "Fingerprint hash of last finished build for the profile (empty if none)"
+    value: ${{ steps.last_fp.outputs.hash }}
+  mode:
+    description: "build | ota — build when fingerprint changed or no prior build"
+    value: ${{ steps.decide.outputs.mode }}
+  drift:
+    description: "true | false | unknown — unknown when no prior build exists"
+    value: ${{ steps.decide.outputs.drift }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Compute current fingerprint
+      id: fp
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        HASH=$(pnpm exec expo-updates fingerprint:generate --platform ${{ inputs.platform }} | jq -r .hash)
+        if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
+          echo "::error::Failed to compute fingerprint"
+          exit 1
+        fi
+        echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+        echo "Current fingerprint: $HASH"
+
+    - name: Get last build fingerprint for profile
+      id: last_fp
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        LAST=$(eas build:list \
+          --profile ${{ inputs.profile }} \
+          --status finished \
+          --platform ${{ inputs.platform }} \
+          --limit 1 \
+          --non-interactive \
+          --json | jq -r '.[0].fingerprintHash // .[0].runtimeVersion // empty')
+        echo "hash=$LAST" >> "$GITHUB_OUTPUT"
+        echo "Last ${{ inputs.profile }} fingerprint: ${LAST:-<none>}"
+
+    - name: Decide build vs OTA
+      id: decide
+      shell: bash
+      env:
+        CURRENT: ${{ steps.fp.outputs.hash }}
+        LAST: ${{ steps.last_fp.outputs.hash }}
+      run: |
+        if [ -z "$LAST" ]; then
+          echo "mode=build" >> "$GITHUB_OUTPUT"
+          echo "drift=unknown" >> "$GITHUB_OUTPUT"
+          echo "No prior ${{ inputs.profile }} build — defaulting to build"
+        elif [ "$CURRENT" = "$LAST" ]; then
+          echo "mode=ota" >> "$GITHUB_OUTPUT"
+          echo "drift=false" >> "$GITHUB_OUTPUT"
+          echo "Fingerprint matches latest ${{ inputs.profile }} build — OTA path"
+        else
+          echo "mode=build" >> "$GITHUB_OUTPUT"
+          echo "drift=true" >> "$GITHUB_OUTPUT"
+          echo "Fingerprint changed since last ${{ inputs.profile }} build — full rebuild"
+        fi

--- a/.github/actions/mobile-fingerprint-decide/action.yml
+++ b/.github/actions/mobile-fingerprint-decide/action.yml
@@ -51,14 +51,15 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: |
         set -o pipefail
-        if ! JSON=$(eas build:list \
-          --profile ${{ inputs.profile }} \
+        JSON=$(eas build:list \
+          --profile "${{ inputs.profile }}" \
           --status finished \
-          --platform ${{ inputs.platform }} \
+          --platform "${{ inputs.platform }}" \
           --limit 1 \
           --non-interactive \
-          --json); then
-          EXIT=$?
+          --json)
+        EXIT=$?
+        if [ "$EXIT" -ne 0 ]; then
           echo "::error::eas build:list failed (exit $EXIT) — refusing to default to full rebuild"
           exit "$EXIT"
         fi

--- a/.github/actions/mobile-fingerprint-decide/action.yml
+++ b/.github/actions/mobile-fingerprint-decide/action.yml
@@ -33,8 +33,11 @@ runs:
       id: fp
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        PLATFORM: ${{ inputs.platform }}
       run: |
-        HASH=$(pnpm exec expo-updates fingerprint:generate --platform ${{ inputs.platform }} | jq -r .hash)
+        set -euo pipefail
+        HASH=$(pnpm exec expo-updates fingerprint:generate --platform "$PLATFORM" | jq -r .hash)
         if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
           echo "::error::Failed to compute fingerprint"
           exit 1
@@ -47,13 +50,19 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        LAST=$(eas build:list \
+        set -o pipefail
+        if ! JSON=$(eas build:list \
           --profile ${{ inputs.profile }} \
           --status finished \
           --platform ${{ inputs.platform }} \
           --limit 1 \
           --non-interactive \
-          --json | jq -r '.[0].fingerprintHash // .[0].runtimeVersion // empty')
+          --json); then
+          EXIT=$?
+          echo "::error::eas build:list failed (exit $EXIT) — refusing to default to full rebuild"
+          exit "$EXIT"
+        fi
+        LAST=$(printf '%s' "$JSON" | jq -r '.[0].fingerprintHash // .[0].runtimeVersion // empty')
         echo "hash=$LAST" >> "$GITHUB_OUTPUT"
         echo "Last ${{ inputs.profile }} fingerprint: ${LAST:-<none>}"
 

--- a/.github/actions/set-app-version/action.yml
+++ b/.github/actions/set-app-version/action.yml
@@ -1,0 +1,27 @@
+name: "Set Expo app version"
+description: "Writes inputs.version into app.json's expo.version field."
+inputs:
+  version:
+    description: "Semver version string"
+    required: true
+  working-directory:
+    description: "Directory containing app.json"
+    required: false
+    default: "apps/mobile"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set app version
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        APP_VERSION: ${{ inputs.version }}
+      run: |
+        node -e "
+          const fs = require('fs');
+          const app = JSON.parse(fs.readFileSync('app.json', 'utf8'));
+          app.expo.version = process.env.APP_VERSION;
+          fs.writeFileSync('app.json', JSON.stringify(app, null, 2) + '\n');
+        "
+        echo "Set app version to $APP_VERSION"

--- a/.github/actions/setup-mobile-ci/action.yml
+++ b/.github/actions/setup-mobile-ci/action.yml
@@ -1,0 +1,25 @@
+name: "Setup mobile CI environment"
+description: "Sets up Node.js, pnpm, and Expo/EAS CLI. Call after actions/checkout."
+inputs:
+  node-version:
+    description: "Node.js version"
+    required: false
+    default: "22"
+  expo-token:
+    description: "Expo access token (typically secrets.EXPO_TOKEN)"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Node.js and pnpm
+      uses: ./.github/actions/setup-nodejs-pnpm
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Setup Expo CLI
+      uses: expo/expo-github-action@v8
+      with:
+        expo-version: latest
+        eas-version: latest
+        token: ${{ inputs.expo-token }}

--- a/.github/workflows/mobile-preview-ota.yml
+++ b/.github/workflows/mobile-preview-ota.yml
@@ -37,67 +37,28 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js and pnpm
-        uses: ./.github/actions/setup-nodejs-pnpm
+      - name: Setup mobile CI environment
+        uses: ./.github/actions/setup-mobile-ci
         with:
-          node-version: "22"
+          expo-token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: Setup Expo CLI
-        uses: expo/expo-github-action@v8
-        with:
-          expo-version: latest
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Compute current fingerprint
-        id: fp
-        working-directory: apps/mobile
-        run: |
-          HASH=$(pnpm exec expo-updates fingerprint:generate --platform android | jq -r .hash)
-          if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
-            echo "::error::Failed to compute fingerprint"
-            exit 1
-          fi
-          echo "hash=$HASH" >> $GITHUB_OUTPUT
-          echo "Current fingerprint: $HASH"
-
-      - name: Get last preview build fingerprint
-        id: last_fp
-        working-directory: apps/mobile
-        run: |
-          LAST=$(eas build:list \
-            --profile preview \
-            --status finished \
-            --platform android \
-            --limit 1 \
-            --non-interactive \
-            --json 2>/dev/null | jq -r '.[0].fingerprintHash // .[0].runtimeVersion // empty')
-          echo "hash=$LAST" >> $GITHUB_OUTPUT
-          echo "Last preview fingerprint: ${LAST:-<none>}"
-
-      - name: Check fingerprint drift
+      - name: Compute fingerprint and check drift
         id: drift
-        run: |
-          CURRENT="${{ steps.fp.outputs.hash }}"
-          LAST="${{ steps.last_fp.outputs.hash }}"
-          FORCE="${{ inputs.force || 'false' }}"
-          if [ -z "$LAST" ]; then
-            echo "drift=unknown" >> $GITHUB_OUTPUT
-            echo "::warning::No prior preview build found. OTA proceeding but may not reach any device."
-          elif [ "$CURRENT" != "$LAST" ]; then
-            echo "drift=true" >> $GITHUB_OUTPUT
-            if [ "$FORCE" != "true" ]; then
-              echo "::warning::Fingerprint drift detected. Preview testers need a new APK. OTA will not reach them. Skipping publish. Run \`eas build --profile preview --platform android\` to ship a new APK, or re-run this workflow with \`force=true\` to publish anyway."
-            else
-              echo "::warning::Fingerprint drift detected but force=true — publishing anyway."
-            fi
-          else
-            echo "drift=false" >> $GITHUB_OUTPUT
-            echo "Fingerprint matches latest preview build"
-          fi
+        uses: ./.github/actions/mobile-fingerprint-decide
+        with:
+          profile: preview
+
+      - name: Warn on drift
+        if: steps.drift.outputs.drift == 'true' && inputs.force != true
+        run: echo "::warning::Fingerprint drift detected. Preview testers need a new APK. OTA will not reach them. Skipping publish. Run \`eas build --profile preview --platform android\` to ship a new APK, or re-run this workflow with \`force=true\` to publish anyway."
+
+      - name: Warn on forced drift
+        if: steps.drift.outputs.drift == 'true' && inputs.force == true
+        run: echo "::warning::Fingerprint drift detected but force=true — publishing anyway."
+
+      - name: Warn on unknown baseline
+        if: steps.drift.outputs.drift == 'unknown'
+        run: echo "::warning::No prior preview build found. OTA proceeding but may not reach any device."
 
       - name: Resolve commit subject
         id: msg
@@ -130,8 +91,8 @@ jobs:
           echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|---|---|" >> $GITHUB_STEP_SUMMARY
           echo "| Branch | \`${{ inputs.branch || 'preview' }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Current fingerprint | \`${{ steps.fp.outputs.hash }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Last preview fingerprint | \`${{ steps.last_fp.outputs.hash || '<none>' }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Current fingerprint | \`${{ steps.drift.outputs.current }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Last preview fingerprint | \`${{ steps.drift.outputs.last || '<none>' }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Drift | ${{ steps.drift.outputs.drift }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Forced | ${{ inputs.force || false }} |" >> $GITHUB_STEP_SUMMARY
           PUBLISHED="${{ (steps.drift.outputs.drift != 'true' || inputs.force == true) && 'yes' || 'skipped' }}"

--- a/.github/workflows/mobile-promote.yml
+++ b/.github/workflows/mobile-promote.yml
@@ -52,69 +52,21 @@ jobs:
           printf 'version=%s\n' "$VERSION" >> $GITHUB_OUTPUT
           echo "Promoting version: $VERSION to track: ${{ inputs.track }}"
 
-      - name: Setup Node.js and pnpm
-        uses: ./.github/actions/setup-nodejs-pnpm
+      - name: Setup mobile CI environment
+        uses: ./.github/actions/setup-mobile-ci
         with:
-          node-version: "22"
-
-      - name: Setup Expo CLI
-        uses: expo/expo-github-action@v8
-        with:
-          expo-version: latest
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: Install dependencies
-        run: pnpm install
+          expo-token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Set app version
-        working-directory: apps/mobile
-        env:
-          APP_VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          node -e "
-            const fs = require('fs');
-            const app = JSON.parse(fs.readFileSync('app.json', 'utf8'));
-            app.expo.version = process.env.APP_VERSION;
-            fs.writeFileSync('app.json', JSON.stringify(app, null, 2) + '\n');
-          "
+        uses: ./.github/actions/set-app-version
+        with:
+          version: ${{ steps.version.outputs.version }}
 
-      - name: Compute current fingerprint
-        id: fp
-        working-directory: apps/mobile
-        run: |
-          HASH=$(pnpm exec expo-updates fingerprint:generate --platform android | jq -r .hash)
-          if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
-            echo "::error::Failed to compute fingerprint"
-            exit 1
-          fi
-          echo "hash=$HASH" >> $GITHUB_OUTPUT
-
-      - name: Get last build fingerprint for target track
-        id: last_fp
-        working-directory: apps/mobile
-        run: |
-          LAST=$(eas build:list \
-            --profile ${{ inputs.track }} \
-            --status finished \
-            --platform android \
-            --limit 1 \
-            --non-interactive \
-            --json 2>/dev/null | jq -r '.[0].fingerprintHash // .[0].runtimeVersion // empty')
-          echo "hash=$LAST" >> $GITHUB_OUTPUT
-
-      - name: Decide build vs OTA
+      - name: Compute fingerprint and decide build vs OTA
         id: decide
-        run: |
-          CURRENT="${{ steps.fp.outputs.hash }}"
-          LAST="${{ steps.last_fp.outputs.hash }}"
-          if [ -n "$LAST" ] && [ "$CURRENT" = "$LAST" ]; then
-            echo "mode=ota" >> $GITHUB_OUTPUT
-            echo "Fingerprint unchanged for track ${{ inputs.track }} — OTA-only"
-          else
-            echo "mode=build" >> $GITHUB_OUTPUT
-            echo "Fingerprint changed (or no prior build) — full AAB rebuild"
-          fi
+        uses: ./.github/actions/mobile-fingerprint-decide
+        with:
+          profile: ${{ inputs.track }}
 
       - name: Build and submit AAB
         if: steps.decide.outputs.mode == 'build'
@@ -146,8 +98,8 @@ jobs:
           echo "| Version | \`${{ steps.version.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Track | \`${{ inputs.track }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Mode | \`${{ steps.decide.outputs.mode }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Current fingerprint | \`${{ steps.fp.outputs.hash }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Last fingerprint (${{ inputs.track }}) | \`${{ steps.last_fp.outputs.hash || '<none>' }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Current fingerprint | \`${{ steps.decide.outputs.current }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Last fingerprint (${{ inputs.track }}) | \`${{ steps.decide.outputs.last || '<none>' }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| AAB built | ${{ steps.decide.outputs.mode == 'build' && 'yes' || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| OTA channel | ${{ inputs.track }} |" >> $GITHUB_STEP_SUMMARY
           if [ "${{ inputs.track }}" = "production" ]; then

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -64,33 +64,15 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Releasing version: $VERSION"
 
-      - name: Setup Node.js and pnpm
-        uses: ./.github/actions/setup-nodejs-pnpm
+      - name: Setup mobile CI environment
+        uses: ./.github/actions/setup-mobile-ci
         with:
-          node-version: "22"
-
-      - name: Setup Expo CLI
-        uses: expo/expo-github-action@v8
-        with:
-          expo-version: latest
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: Install dependencies
-        run: pnpm install
+          expo-token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Set app version from release
-        working-directory: apps/mobile
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          node -e "
-            const fs = require('fs');
-            const app = JSON.parse(fs.readFileSync('app.json', 'utf8'));
-            app.expo.version = process.env.VERSION;
-            fs.writeFileSync('app.json', JSON.stringify(app, null, 2) + '\n');
-          "
-          echo "Set app version to $VERSION"
+        uses: ./.github/actions/set-app-version
+        with:
+          version: ${{ steps.version.outputs.version }}
 
       - name: Generate release notes
         id: release-notes
@@ -124,44 +106,11 @@ jobs:
             echo "Release notes not available"
           fi
 
-      - name: Compute current fingerprint
-        id: fp
-        working-directory: apps/mobile
-        run: |
-          HASH=$(pnpm exec expo-updates fingerprint:generate --platform android | jq -r .hash)
-          if [ -z "$HASH" ] || [ "$HASH" = "null" ]; then
-            echo "::error::Failed to compute fingerprint"
-            exit 1
-          fi
-          echo "hash=$HASH" >> $GITHUB_OUTPUT
-          echo "Current fingerprint: $HASH"
-
-      - name: Get last internal build fingerprint
-        id: last_fp
-        working-directory: apps/mobile
-        run: |
-          LAST=$(eas build:list \
-            --profile internal \
-            --status finished \
-            --platform android \
-            --limit 1 \
-            --non-interactive \
-            --json 2>/dev/null | jq -r '.[0].fingerprintHash // .[0].runtimeVersion // empty')
-          echo "hash=$LAST" >> $GITHUB_OUTPUT
-          echo "Last internal fingerprint: ${LAST:-<none>}"
-
-      - name: Decide build vs OTA
+      - name: Compute fingerprint and decide build vs OTA
         id: decide
-        run: |
-          CURRENT="${{ steps.fp.outputs.hash }}"
-          LAST="${{ steps.last_fp.outputs.hash }}"
-          if [ -n "$LAST" ] && [ "$CURRENT" = "$LAST" ]; then
-            echo "mode=ota" >> $GITHUB_OUTPUT
-            echo "Fingerprint unchanged — OTA-only path"
-          else
-            echo "mode=build" >> $GITHUB_OUTPUT
-            echo "Fingerprint changed (or no prior build) — full AAB rebuild"
-          fi
+        uses: ./.github/actions/mobile-fingerprint-decide
+        with:
+          profile: internal
 
       - name: Build and submit AAB to Play internal track
         if: steps.decide.outputs.mode == 'build'
@@ -187,8 +136,8 @@ jobs:
           echo "|---|---|" >> $GITHUB_STEP_SUMMARY
           echo "| Version | \`${{ steps.version.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| Mode | \`${{ steps.decide.outputs.mode }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Current fingerprint | \`${{ steps.fp.outputs.hash }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| Last build fingerprint | \`${{ steps.last_fp.outputs.hash || '<none>' }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Current fingerprint | \`${{ steps.decide.outputs.current }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Last build fingerprint | \`${{ steps.decide.outputs.last || '<none>' }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| AAB built | ${{ steps.decide.outputs.mode == 'build' && 'yes' || 'skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Play track | internal |" >> $GITHUB_STEP_SUMMARY
           echo "| OTA channel | internal |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Refs: OJD-1501

## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description

The three mobile pipeline workflows (\`mobile-release\`, \`mobile-promote\`, \`mobile-preview-ota\`) had ~120 lines of duplicated logic between them: setup steps, fingerprint computation, last-build lookup, and the build-vs-OTA decision. Extracted into three composite actions so a bug fix or behavior tweak only needs to land once.

While extracting, also dropped a redundant \`pnpm install\` step from each workflow — \`setup-nodejs-pnpm\` already runs \`pnpm install --frozen-lockfile\` internally, so the workflows were installing twice.

## Related Issues

- Closes #
- Related to #1372, #1404, #1405

## Testing Instructions

- [ ] mobile-preview-ota: trigger via \`gh workflow run mobile-preview-ota.yml\` (or natural push to main, depending on whether #1405 has merged); verify drift detection still warns / skips correctly
- [ ] mobile-release: dry-run via \`gh workflow run mobile-release.yml -f version=1.21.0\`; verify mode=ota path emits an update (or expected build path)
- [ ] mobile-promote: \`gh workflow run mobile-promote.yml -f track=beta -f version=1.21.0\` once \`beta\` track exists in Play Console; verify build vs OTA decision identical to pre-refactor
- [ ] Job summary tables still populated (fingerprint + last + mode columns now sourced from composite outputs)

## Changes Made

New composite actions under \`.github/actions/\`:

- \`setup-mobile-ci/\` — Node.js + pnpm + Expo/EAS CLI setup in one step. Inputs: \`node-version\` (default \`22\`), \`expo-token\`. Replaces 3 sequential steps in each workflow.
- \`mobile-fingerprint-decide/\` — Computes current fingerprint via \`expo-updates fingerprint:generate\`, looks up the last finished build for a given profile, emits four outputs: \`current\`, \`last\`, \`mode\` (\`build\`/\`ota\`), \`drift\` (\`true\`/\`false\`/\`unknown\`). Replaces 3 steps in each workflow with 1; callers pick \`mode\` (release, promote) or \`drift\` (preview-ota) depending on which semantic they need.
- \`set-app-version/\` — Writes \`inputs.version\` into \`app.json\`'s \`expo.version\` field. Replaces a duplicated 6-line node script.

Workflow updates:

- \`mobile-release.yml\` — uses all three composites; redundant \`pnpm install\` removed
- \`mobile-promote.yml\` — uses all three composites; redundant \`pnpm install\` removed
- \`mobile-preview-ota.yml\` — uses setup-mobile-ci + mobile-fingerprint-decide; the inline drift-warning / force logic is now three short \`if:\`-gated \`echo\` steps reading the composite's \`drift\` output

Net diff: workflows shrink by ~140 lines combined; composites add ~131 lines; gate logic exists once instead of three times.

## Checklist

- [ ] I have added/updated tests for my changes
- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have tested these changes locally (YAML lint, manual diff review)
- [x] My changes generate no new warnings
- [x] I have reviewed my own code

## Screenshots/Recordings

n/a — pipeline-only refactor, no behavior change intended.

## Additional Notes

**Stacking with #1405 (\`chore(mobile/cicd): gate preview OTA on mobile changes via release orchestrator\`):**
This PR only touches the \`publish\` job in \`mobile-preview-ota.yml\`. #1405 removes the \`detect\` job and the \`push\` trigger from the same file but does not modify the \`publish\` job. Whichever lands first, the other should rebase cleanly with no manual conflict resolution.

**Stacking with #1404 (\`fix(mobile/ci): unblock OTA fingerprint + bundler resolution\`):**
The \`--platform android\` argument and the dropped \`2>/dev/null\` from #1404 are preserved inside the new \`mobile-fingerprint-decide\` action.
