### PR TITLE
feat(web/workbook): inline sparkline cells with click-to-expand chart

### DIFF
--- a/apps/web/components/workbook/cells/output-cell.test.tsx
+++ b/apps/web/components/workbook/cells/output-cell.test.tsx
@@ -5,19 +5,27 @@ import { describe, it, expect, vi } from "vitest";
 import { OutputCellComponent } from "./output-cell";
 
 // Plotly cannot run in jsdom; render a stub that exposes the series for assertions.
+// Mock factory is hoisted so we use React.createElement (no JSX) to avoid runtime ordering issues.
 vi.mock("@repo/ui/components/charts/line-chart", async (importOriginal) => {
   const actual: Record<string, unknown> = await importOriginal();
+  const { createElement } = await import("react");
   return {
     ...actual,
-    LineChart: ({ data }: { data: { name: string; y: number[] }[] }) => (
-      <div data-testid="line-chart" data-series={JSON.stringify(data.map((s) => s.name))}>
-        {data.map((s) => (
-          <div key={s.name} data-testid={`series-${s.name}`}>
-            {s.y.join(",")}
-          </div>
-        ))}
-      </div>
-    ),
+    LineChart: ({ data }: { data: { name: string; y: number[] }[] }) =>
+      createElement(
+        "div",
+        {
+          "data-testid": "line-chart",
+          "data-series": JSON.stringify(data.map((s) => s.name)),
+        },
+        data.map((s) =>
+          createElement(
+            "div",
+            { key: s.name, "data-testid": `series-${s.name}` },
+            s.y.join(","),
+          ),
+        ),
+      ),
   };
 });
 
@@ -184,6 +192,35 @@ describe("OutputCellComponent", () => {
     expect(screen.getByTestId("line-chart")).toBeInTheDocument();
 
     await user.click(trigger);
+    expect(screen.queryByTestId("line-chart")).not.toBeInTheDocument();
+  });
+
+  it("switches the expanded chart to a different column on a single click", async () => {
+    const user = userEvent.setup();
+    const cell = createOutputCell({ data: { spectrum: [10, 20, 30], baseline: [1, 2, 3] } });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    await user.click(screen.getByRole("button", { name: "Expand chart for spectrum" }));
+    expect(screen.getByTestId("series-spectrum")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Expand chart for baseline" }));
+    expect(screen.queryByTestId("series-spectrum")).not.toBeInTheDocument();
+    expect(screen.getByTestId("series-baseline")).toHaveTextContent("1,2,3");
+  });
+
+  it("collapses the expanded chart when the user switches to the JSON tab", async () => {
+    const user = userEvent.setup();
+    const cell = createOutputCell({ data: { spectrum: [10, 20, 30] } });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    await user.click(screen.getByRole("button", { name: "Expand chart for spectrum" }));
+    expect(screen.getByTestId("line-chart")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "JSON" }));
+    expect(screen.queryByTestId("line-chart")).not.toBeInTheDocument();
+
+    // Switching back to Table doesn't auto-restore the chart; the user re-clicks the sparkline.
+    await user.click(screen.getByRole("tab", { name: "Table" }));
     expect(screen.queryByTestId("line-chart")).not.toBeInTheDocument();
   });
 

--- a/apps/web/components/workbook/cells/output-cell.test.tsx
+++ b/apps/web/components/workbook/cells/output-cell.test.tsx
@@ -157,6 +157,22 @@ describe("OutputCellComponent", () => {
     expect(screen.getByTestId("series-baseline")).toHaveTextContent("1,2,3");
   });
 
+  it("walks into nested set[] arrays of objects (MultispeQ-style payload)", () => {
+    const cell = createOutputCell({
+      data: {
+        set: [{ ENV: [1, 2, 3], SUN: [10, 20, 30], Fluo: [100, 200, 300] }],
+        protocol_id: NaN,
+      },
+    });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    const chart = screen.getByTestId("line-chart");
+    // Common "set[0]." prefix is stripped so the legend reads ENV/SUN/Fluo.
+    expect(chart).toHaveAttribute("data-series", JSON.stringify(["ENV", "SUN", "Fluo"]));
+    expect(screen.getByTestId("series-ENV")).toHaveTextContent("1,2,3");
+    expect(screen.getByTestId("series-SUN")).toHaveTextContent("10,20,30");
+  });
+
   it("hides the Chart tab and defaults to Table when no field is a numeric array", () => {
     const cell = createOutputCell({ data: { device_id: "abc-123", firmware_version: "1.2.3" } });
     render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);

--- a/apps/web/components/workbook/cells/output-cell.test.tsx
+++ b/apps/web/components/workbook/cells/output-cell.test.tsx
@@ -4,6 +4,23 @@ import { describe, it, expect, vi } from "vitest";
 
 import { OutputCellComponent } from "./output-cell";
 
+// Plotly cannot run in jsdom; render a stub that exposes the series for assertions.
+vi.mock("@repo/ui/components/charts/line-chart", async (importOriginal) => {
+  const actual: Record<string, unknown> = await importOriginal();
+  return {
+    ...actual,
+    LineChart: ({ data }: { data: { name: string; y: number[] }[] }) => (
+      <div data-testid="line-chart" data-series={JSON.stringify(data.map((s) => s.name))}>
+        {data.map((s) => (
+          <div key={s.name} data-testid={`series-${s.name}`}>
+            {s.y.join(",")}
+          </div>
+        ))}
+      </div>
+    ),
+  };
+});
+
 // jsdom does not implement navigator.clipboard — provide a minimal stub so
 // useCopyToClipboard resolves instead of throwing.
 Object.defineProperty(navigator, "clipboard", {
@@ -115,6 +132,38 @@ describe("OutputCellComponent", () => {
     );
     expect(screen.queryByText("time")).not.toBeInTheDocument();
     expect(screen.getByTitle("Expand output")).toBeInTheDocument();
+  });
+
+  it("renders a chart by default and exposes Table/JSON tabs when data is a numeric array", async () => {
+    const cell = createOutputCell({ data: [1, 2, 3, 4, 5] });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    expect(screen.getByTestId("line-chart")).toBeInTheDocument();
+    expect(screen.getByTestId("series-value")).toHaveTextContent("1,2,3,4,5");
+    expect(screen.getByRole("tab", { name: "Chart" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Table" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "JSON" })).toBeInTheDocument();
+  });
+
+  it("plots each numeric-array field of an object payload as a separate series", () => {
+    const cell = createOutputCell({
+      data: { device_id: "abc", spectrum: [10, 20, 30], baseline: [1, 2, 3] },
+    });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    const chart = screen.getByTestId("line-chart");
+    expect(chart).toHaveAttribute("data-series", JSON.stringify(["spectrum", "baseline"]));
+    expect(screen.getByTestId("series-spectrum")).toHaveTextContent("10,20,30");
+    expect(screen.getByTestId("series-baseline")).toHaveTextContent("1,2,3");
+  });
+
+  it("hides the Chart tab and defaults to Table when no field is a numeric array", () => {
+    const cell = createOutputCell({ data: { device_id: "abc-123", firmware_version: "1.2.3" } });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    expect(screen.queryByRole("tab", { name: "Chart" })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("line-chart")).not.toBeInTheDocument();
+    expect(screen.getByText("device_id")).toBeInTheDocument();
   });
 
   it("shows a copy button in the JSON view that swaps to a check icon when clicked", async () => {

--- a/apps/web/components/workbook/cells/output-cell.test.tsx
+++ b/apps/web/components/workbook/cells/output-cell.test.tsx
@@ -134,50 +134,64 @@ describe("OutputCellComponent", () => {
     expect(screen.getByTitle("Expand output")).toBeInTheDocument();
   });
 
-  it("renders a chart by default and exposes Table/JSON tabs when data is a numeric array", async () => {
-    const cell = createOutputCell({ data: [1, 2, 3, 4, 5] });
-    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
-
-    expect(screen.getByTestId("line-chart")).toBeInTheDocument();
-    expect(screen.getByTestId("series-value")).toHaveTextContent("1,2,3,4,5");
-    expect(screen.getByRole("tab", { name: "Chart" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Table" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "JSON" })).toBeInTheDocument();
-  });
-
-  it("plots each numeric-array field of an object payload as a separate series", () => {
+  it("renders inline sparklines for numeric-array fields in the table", () => {
     const cell = createOutputCell({
       data: { device_id: "abc", spectrum: [10, 20, 30], baseline: [1, 2, 3] },
     });
     render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
 
-    const chart = screen.getByTestId("line-chart");
-    expect(chart).toHaveAttribute("data-series", JSON.stringify(["spectrum", "baseline"]));
-    expect(screen.getByTestId("series-spectrum")).toHaveTextContent("10,20,30");
-    expect(screen.getByTestId("series-baseline")).toHaveTextContent("1,2,3");
+    expect(screen.getByRole("button", { name: "Expand chart for spectrum" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Expand chart for baseline" })).toBeInTheDocument();
+    // Plain string values still render as text, not as charts.
+    expect(screen.getByText("abc")).toBeInTheDocument();
+    expect(screen.queryByTestId("line-chart")).not.toBeInTheDocument();
   });
 
-  it("walks into nested set[] arrays of objects (MultispeQ-style payload)", () => {
+  it("renders sparklines inside nested rows (MultispeQ-style set[0] payload)", () => {
     const cell = createOutputCell({
-      data: {
-        set: [{ ENV: [1, 2, 3], SUN: [10, 20, 30], Fluo: [100, 200, 300] }],
-        protocol_id: NaN,
-      },
+      data: { set: [{ ENV: [1, 2, 3], SUN: [10, 20, 30] }], protocol_id: 12 },
     });
     render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
 
-    const chart = screen.getByTestId("line-chart");
-    // Common "set[0]." prefix is stripped so the legend reads ENV/SUN/Fluo.
-    expect(chart).toHaveAttribute("data-series", JSON.stringify(["ENV", "SUN", "Fluo"]));
-    expect(screen.getByTestId("series-ENV")).toHaveTextContent("1,2,3");
-    expect(screen.getByTestId("series-SUN")).toHaveTextContent("10,20,30");
+    expect(screen.getByRole("button", { name: "Expand chart for ENV" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Expand chart for SUN" })).toBeInTheDocument();
   });
 
-  it("hides the Chart tab and defaults to Table when no field is a numeric array", () => {
+  it("expands the full chart below the table when a sparkline is clicked, and closes it again", async () => {
+    const user = userEvent.setup();
+    const cell = createOutputCell({
+      data: { spectrum: [10, 20, 30], baseline: [1, 2, 3] },
+    });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    expect(screen.queryByTestId("line-chart")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Expand chart for spectrum" }));
+    expect(screen.getByTestId("line-chart")).toBeInTheDocument();
+    expect(screen.getByTestId("series-spectrum")).toHaveTextContent("10,20,30");
+
+    await user.click(screen.getByRole("button", { name: "Close chart" }));
+    expect(screen.queryByTestId("line-chart")).not.toBeInTheDocument();
+  });
+
+  it("clicking the same sparkline a second time toggles the expanded chart off", async () => {
+    const user = userEvent.setup();
+    const cell = createOutputCell({ data: { spectrum: [10, 20, 30] } });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    const trigger = screen.getByRole("button", { name: "Expand chart for spectrum" });
+    await user.click(trigger);
+    expect(screen.getByTestId("line-chart")).toBeInTheDocument();
+
+    await user.click(trigger);
+    expect(screen.queryByTestId("line-chart")).not.toBeInTheDocument();
+  });
+
+  it("does not render a sparkline when no field is a numeric array", () => {
     const cell = createOutputCell({ data: { device_id: "abc-123", firmware_version: "1.2.3" } });
     render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
 
-    expect(screen.queryByRole("tab", { name: "Chart" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Expand chart/ })).not.toBeInTheDocument();
     expect(screen.queryByTestId("line-chart")).not.toBeInTheDocument();
     expect(screen.getByText("device_id")).toBeInTheDocument();
   });

--- a/apps/web/components/workbook/cells/output-cell.test.tsx
+++ b/apps/web/components/workbook/cells/output-cell.test.tsx
@@ -19,11 +19,7 @@ vi.mock("@repo/ui/components/charts/line-chart", async (importOriginal) => {
           "data-series": JSON.stringify(data.map((s) => s.name)),
         },
         data.map((s) =>
-          createElement(
-            "div",
-            { key: s.name, "data-testid": `series-${s.name}` },
-            s.y.join(","),
-          ),
+          createElement("div", { key: s.name, "data-testid": `series-${s.name}` }, s.y.join(",")),
         ),
       ),
   };
@@ -231,6 +227,101 @@ describe("OutputCellComponent", () => {
     expect(screen.queryByRole("button", { name: /Expand chart/ })).not.toBeInTheDocument();
     expect(screen.queryByTestId("line-chart")).not.toBeInTheDocument();
     expect(screen.getByText("device_id")).toBeInTheDocument();
+  });
+
+  it("renders an array of non-numeric primitives as a comma-joined string in a cell", () => {
+    const cell = createOutputCell({
+      data: { device_id: "abc", tags: ["alpha", "beta", "gamma"] },
+    });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    expect(screen.getByText("alpha, beta, gamma")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Expand chart/ })).not.toBeInTheDocument();
+  });
+
+  it("renders a nested plain object inside a cell as a sub-table", () => {
+    const cell = createOutputCell({
+      data: { device: { id: "esp32-c3", firmware: "1.0.0" } },
+    });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    expect(screen.getByText("device")).toBeInTheDocument();
+    expect(screen.getByText("id")).toBeInTheDocument();
+    expect(screen.getByText("esp32-c3")).toBeInTheDocument();
+    expect(screen.getByText("firmware")).toBeInTheDocument();
+    expect(screen.getByText("1.0.0")).toBeInTheDocument();
+  });
+
+  it("renders a top-level primitive data value as plain text in the table tab", () => {
+    const cell = createOutputCell({ data: "raw measurement string" });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    expect(screen.getByText("raw measurement string")).toBeInTheDocument();
+  });
+
+  it("renders a top-level array of primitives via JSON in the table tab", () => {
+    const cell = createOutputCell({ data: [1, 2, 3] });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    expect(screen.getByText("[1,2,3]")).toBeInTheDocument();
+  });
+
+  it("renders nullish entries in a non-numeric array as empty strings", () => {
+    const cell = createOutputCell({ data: { tags: ["a", null, "b"] } });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    expect(screen.getByText("a, , b")).toBeInTheDocument();
+  });
+
+  it("falls back to the empty-state message when data is an empty object", () => {
+    const cell = createOutputCell({ data: {} });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    expect(screen.getByText("No output data")).toBeInTheDocument();
+  });
+
+  it("renders an em-dash placeholder for nullish cell values", () => {
+    const cell = createOutputCell({ data: { device_id: "abc", missing: null } });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    expect(screen.getByText("missing")).toBeInTheDocument();
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("renders an empty-array placeholder for empty-array cell values", () => {
+    const cell = createOutputCell({ data: { device_id: "abc", samples: [] } });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    expect(screen.getByText("samples")).toBeInTheDocument();
+    expect(screen.getByText("[]")).toBeInTheDocument();
+  });
+
+  it("renders a sparkline for a single-point numeric array (no division by zero)", () => {
+    const cell = createOutputCell({ data: { spectrum: [42] } });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    expect(screen.getByRole("button", { name: "Expand chart for spectrum" })).toBeInTheDocument();
+    expect(screen.getByText("n=1")).toBeInTheDocument();
+  });
+
+  it("renders a sparkline for a constant-value numeric array (no NaN range)", () => {
+    const cell = createOutputCell({ data: { spectrum: [5, 5, 5] } });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    expect(screen.getByRole("button", { name: "Expand chart for spectrum" })).toBeInTheDocument();
+  });
+
+  it("renders multi-row array-of-objects tables with row dividers", () => {
+    const cell = createOutputCell({
+      data: [
+        { time: 1, value: 42 },
+        { time: 2, value: 84 },
+      ],
+    });
+    render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("84")).toBeInTheDocument();
   });
 
   it("shows a copy button in the JSON view that swaps to a check icon when clicked", async () => {

--- a/apps/web/components/workbook/cells/output-cell.tsx
+++ b/apps/web/components/workbook/cells/output-cell.tsx
@@ -40,19 +40,57 @@ function isNumericArray(val: unknown): val is number[] {
   );
 }
 
-// Pull out the first chartable series in `data`: a top-level numeric array, or each numeric-array
-// field of a plain object (capped so a 200-key payload doesn't dump 200 lines onto the chart).
-function getChartableSeries(data: unknown): ChartSeries[] {
-  if (isNumericArray(data)) return [{ name: "value", values: data }];
-  if (data != null && typeof data === "object" && !Array.isArray(data)) {
-    const series: ChartSeries[] = [];
-    for (const [key, val] of Object.entries(data as Record<string, unknown>)) {
-      if (isNumericArray(val)) series.push({ name: key, values: val });
-      if (series.length >= CHART_SERIES_COLORS.length) break;
-    }
-    return series;
+// Walk the payload looking for numeric-array leaves so MultispeQ-style outputs
+// (e.g. `{ set: [{ ENV: [...], SUN: [...] }] }`) light up too. For arrays of objects we only
+// recurse into the first element so we don't dump every set onto a single chart.
+function collectChartableSeries(
+  data: unknown,
+  prefix: string,
+  out: ChartSeries[],
+  cap: number,
+): void {
+  if (out.length >= cap) return;
+  if (isNumericArray(data)) {
+    out.push({ name: prefix || "value", values: data });
+    return;
   }
-  return [];
+  if (Array.isArray(data)) {
+    if (data.length > 0 && typeof data[0] === "object" && data[0] !== null) {
+      collectChartableSeries(data[0], prefix ? `${prefix}[0]` : "[0]", out, cap);
+    }
+    return;
+  }
+  if (data != null && typeof data === "object") {
+    for (const [k, v] of Object.entries(data as Record<string, unknown>)) {
+      if (out.length >= cap) break;
+      collectChartableSeries(v, prefix ? `${prefix}.${k}` : k, out, cap);
+    }
+  }
+}
+
+// Strip the longest common dotted prefix from series names so the legend stays readable
+// when every series lives under the same wrapper (e.g. all under "set[0].").
+function stripCommonPrefix(series: ChartSeries[]): ChartSeries[] {
+  if (series.length < 2) return series;
+  const parts = series.map((s) => s.name.split(/[.[]/));
+  const minLen = Math.min(...parts.map((p) => p.length));
+  let common = 0;
+  for (let i = 0; i < minLen; i++) {
+    const candidate = parts[0][i];
+    if (parts.every((p) => p[i] === candidate)) common = i + 1;
+    else break;
+  }
+  if (common === 0) return series;
+  return series.map((s) => {
+    const trimmed = s.name.split(/[.[]/).slice(common).join(".");
+    return { ...s, name: trimmed || s.name };
+  });
+}
+
+function getChartableSeries(data: unknown): ChartSeries[] {
+  const out: ChartSeries[] = [];
+  collectChartableSeries(data, "", out, CHART_SERIES_COLORS.length);
+  return stripCommonPrefix(out);
 }
 
 interface OutputCellProps {
@@ -141,7 +179,10 @@ function renderDataTable(data: unknown): React.ReactNode {
     );
   }
 
-  return <p className="px-3 py-2 text-xs text-[#011111]">{String(data)}</p>;
+  if (typeof data === "string" || typeof data === "number" || typeof data === "boolean") {
+    return <p className="px-3 py-2 text-xs text-[#011111]">{String(data)}</p>;
+  }
+  return <p className="px-3 py-2 text-xs text-[#011111]">{JSON.stringify(data)}</p>;
 }
 
 function getMessageType(message: string): "error" | "warning" | "info" {

--- a/apps/web/components/workbook/cells/output-cell.tsx
+++ b/apps/web/components/workbook/cells/output-cell.tsx
@@ -241,7 +241,10 @@ function ExpandedChart({
           <X className="size-3" />
         </button>
       </div>
-      <div className="h-[280px] w-full p-2">
+      {/* Plotly's X-axis title + tick labels need ~60px of bottom margin. The container is sized
+          generously so the trace doesn't squeeze them out, and pb-2 gives the panel breathing room
+          inside the cell wrapper's overflow-hidden boundary. */}
+      <div className="h-[340px] w-full px-2 pb-2 pt-1">
         <LineChart
           data={plotData}
           config={{ xAxisTitle: "Index", yAxisTitle: columnName, useWebGL: false }}
@@ -256,14 +259,18 @@ function DataTabs({
   copy,
   copied,
   onChartClick,
+  activeTab,
+  onTabChange,
 }: {
   data: unknown;
   copy: (text: string) => Promise<void>;
   copied: boolean;
   onChartClick: ChartClickHandler;
+  activeTab: string;
+  onTabChange: (tab: string) => void;
 }) {
   return (
-    <Tabs defaultValue="table" className="w-full">
+    <Tabs value={activeTab} onValueChange={onTabChange} className="w-full">
       <TabsList className="h-8 rounded-lg border border-[#EDF2F6] bg-[#F7F8FA] p-0.5">
         <TabsTrigger
           value="table"
@@ -311,10 +318,15 @@ export function OutputCellComponent({ cell, onUpdate, onDelete, readOnly }: Outp
   const [pinnedChart, setPinnedChart] = useState<{ data: number[]; columnName: string } | null>(
     null,
   );
+  const [activeTab, setActiveTab] = useState("table");
   const handleChartClick: ChartClickHandler = (data, columnName) => {
-    setPinnedChart((prev) =>
-      prev?.columnName === columnName ? null : { data, columnName },
-    );
+    setPinnedChart((prev) => (prev?.columnName === columnName ? null : { data, columnName }));
+  };
+  const handleTabChange = (tab: string) => {
+    setActiveTab(tab);
+    // The expanded chart only makes sense alongside the table view, so collapse it
+    // when the user switches to JSON.
+    if (tab !== "table") setPinnedChart(null);
   };
 
   return (
@@ -399,9 +411,14 @@ export function OutputCellComponent({ cell, onUpdate, onDelete, readOnly }: Outp
                   copy={copy}
                   copied={copied}
                   onChartClick={handleChartClick}
+                  activeTab={activeTab}
+                  onTabChange={handleTabChange}
                 />
-                {pinnedChart && (
+                {pinnedChart && activeTab === "table" && (
+                  // Plotly reuses its plot div across re-renders; switching columns can leave the
+                  // previous trace on screen. Keying on columnName forces a fresh mount.
                   <ExpandedChart
+                    key={pinnedChart.columnName}
                     data={pinnedChart.data}
                     columnName={pinnedChart.columnName}
                     onClose={() => setPinnedChart(null)}

--- a/apps/web/components/workbook/cells/output-cell.tsx
+++ b/apps/web/components/workbook/cells/output-cell.tsx
@@ -12,25 +12,14 @@ import {
   Info,
   X,
 } from "lucide-react";
+import { useState } from "react";
 
 import type { OutputCell as OutputCellType } from "@repo/api/schemas/workbook-cells.schema";
 import type { LineSeriesData } from "@repo/ui/components/charts/line-chart";
 import { LineChart } from "@repo/ui/components/charts/line-chart";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@repo/ui/components/tabs";
 
-const CHART_SERIES_COLORS = [
-  "#005E5E",
-  "#D97706",
-  "#6C5CE7",
-  "#D14343",
-  "#2563EB",
-  "#10B981",
-];
-
-interface ChartSeries {
-  name: string;
-  values: number[];
-}
+type ChartClickHandler = (data: number[], columnName: string) => void;
 
 function isNumericArray(val: unknown): val is number[] {
   return (
@@ -40,57 +29,51 @@ function isNumericArray(val: unknown): val is number[] {
   );
 }
 
-// Walk the payload looking for numeric-array leaves so MultispeQ-style outputs
-// (e.g. `{ set: [{ ENV: [...], SUN: [...] }] }`) light up too. For arrays of objects we only
-// recurse into the first element so we don't dump every set onto a single chart.
-function collectChartableSeries(
-  data: unknown,
-  prefix: string,
-  out: ChartSeries[],
-  cap: number,
-): void {
-  if (out.length >= cap) return;
-  if (isNumericArray(data)) {
-    out.push({ name: prefix || "value", values: data });
-    return;
-  }
-  if (Array.isArray(data)) {
-    if (data.length > 0 && typeof data[0] === "object" && data[0] !== null) {
-      collectChartableSeries(data[0], prefix ? `${prefix}[0]` : "[0]", out, cap);
-    }
-    return;
-  }
-  if (data != null && typeof data === "object") {
-    for (const [k, v] of Object.entries(data as Record<string, unknown>)) {
-      if (out.length >= cap) break;
-      collectChartableSeries(v, prefix ? `${prefix}.${k}` : k, out, cap);
-    }
-  }
-}
-
-// Strip the longest common dotted prefix from series names so the legend stays readable
-// when every series lives under the same wrapper (e.g. all under "set[0].").
-function stripCommonPrefix(series: ChartSeries[]): ChartSeries[] {
-  if (series.length < 2) return series;
-  const parts = series.map((s) => s.name.split(/[.[]/));
-  const minLen = Math.min(...parts.map((p) => p.length));
-  let common = 0;
-  for (let i = 0; i < minLen; i++) {
-    const candidate = parts[0][i];
-    if (parts.every((p) => p[i] === candidate)) common = i + 1;
-    else break;
-  }
-  if (common === 0) return series;
-  return series.map((s) => {
-    const trimmed = s.name.split(/[.[]/).slice(common).join(".");
-    return { ...s, name: trimmed || s.name };
-  });
-}
-
-function getChartableSeries(data: unknown): ChartSeries[] {
-  const out: ChartSeries[] = [];
-  collectChartableSeries(data, "", out, CHART_SERIES_COLORS.length);
-  return stripCommonPrefix(out);
+function Sparkline({
+  data,
+  columnName,
+  onClick,
+}: {
+  data: number[];
+  columnName: string;
+  onClick?: ChartClickHandler;
+}) {
+  const width = 80;
+  const height = 24;
+  const padding = 2;
+  const minY = Math.min(...data);
+  const maxY = Math.max(...data);
+  const rangeY = maxY - minY || 1;
+  const points = data
+    .map((value, index) => {
+      const x = padding + (index / (data.length - 1 || 1)) * (width - 2 * padding);
+      const y = height - padding - ((value - minY) / rangeY) * (height - 2 * padding);
+      return `${x},${y}`;
+    })
+    .join(" L ");
+  const path = `M ${points}`;
+  const interactive = !!onClick;
+  return (
+    <button
+      type="button"
+      className={`flex items-center gap-2 rounded p-1 text-left transition-colors ${interactive ? "hover:bg-[#EDF2F6]" : "cursor-default"}`}
+      onClick={() => onClick?.(data, columnName)}
+      aria-label={interactive ? `Expand chart for ${columnName}` : undefined}
+      disabled={!interactive}
+    >
+      <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`} className="shrink-0">
+        <path
+          d={path}
+          fill="none"
+          stroke="#005E5E"
+          strokeWidth="1"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+      <span className="text-[10px] tabular-nums text-[#68737B]">n={data.length}</span>
+    </button>
+  );
 }
 
 interface OutputCellProps {
@@ -106,21 +89,28 @@ function formatExecutionTime(ms?: number): string {
   return `${(ms / 1000).toFixed(2)}s`;
 }
 
-function renderCellValue(val: unknown): React.ReactNode {
+function renderCellValue(
+  val: unknown,
+  columnName: string,
+  onChartClick?: ChartClickHandler,
+): React.ReactNode {
   if (val == null) return <span className="text-[#CDD5DB]">—</span>;
   if (typeof val === "string" || typeof val === "number" || typeof val === "boolean") {
     return String(val);
   }
   if (Array.isArray(val)) {
     if (val.length === 0) return <span className="text-[#CDD5DB]">[]</span>;
-    if (typeof val[0] === "object" && val[0] !== null) return renderDataTable(val);
+    if (isNumericArray(val)) {
+      return <Sparkline data={val} columnName={columnName} onClick={onChartClick} />;
+    }
+    if (typeof val[0] === "object" && val[0] !== null) return renderDataTable(val, onChartClick);
     return val.map((v) => (v == null ? "" : String(v))).join(", ");
   }
-  if (typeof val === "object") return renderDataTable(val);
+  if (typeof val === "object") return renderDataTable(val, onChartClick);
   return JSON.stringify(val);
 }
 
-function renderDataTable(data: unknown): React.ReactNode {
+function renderDataTable(data: unknown, onChartClick?: ChartClickHandler): React.ReactNode {
   if (data == null) return <p className="text-sm text-[#68737B]">No output data</p>;
 
   if (Array.isArray(data) && data.length > 0 && typeof data[0] === "object" && data[0] !== null) {
@@ -144,7 +134,7 @@ function renderDataTable(data: unknown): React.ReactNode {
               <tr key={i} className={i < data.length - 1 ? "border-b border-b-[#EDF2F6]" : ""}>
                 {keys.map((key) => (
                   <td key={key} className="px-3 py-2 align-top text-xs text-[#011111]">
-                    {renderCellValue((row as Record<string, unknown>)[key])}
+                    {renderCellValue((row as Record<string, unknown>)[key], key, onChartClick)}
                   </td>
                 ))}
               </tr>
@@ -170,7 +160,9 @@ function renderDataTable(data: unknown): React.ReactNode {
                 >
                   {k}
                 </th>
-                <td className="px-3 py-2 align-top text-xs text-[#011111]">{renderCellValue(v)}</td>
+                <td className="px-3 py-2 align-top text-xs text-[#011111]">
+                  {renderCellValue(v, k, onChartClick)}
+                </td>
               </tr>
             ))}
           </tbody>
@@ -216,26 +208,43 @@ function isQuestionAnswer(data: unknown): data is { answer: string } {
   );
 }
 
-function ChartView({ series }: { series: ChartSeries[] }) {
-  const plotData: LineSeriesData[] = series.map((s, i) => ({
-    name: s.name,
-    x: s.values.map((_, idx) => idx),
-    y: s.values,
-    mode: "lines",
-    line: { color: CHART_SERIES_COLORS[i % CHART_SERIES_COLORS.length], width: 2 },
-    showlegend: series.length > 1,
-  }));
-
+function ExpandedChart({
+  data,
+  columnName,
+  onClose,
+}: {
+  data: number[];
+  columnName: string;
+  onClose: () => void;
+}) {
+  const plotData: LineSeriesData[] = [
+    {
+      name: columnName,
+      x: data.map((_, idx) => idx),
+      y: data,
+      mode: "lines",
+      line: { color: "#005E5E", width: 2 },
+      showlegend: false,
+    },
+  ];
   return (
-    <div className="overflow-hidden rounded-lg border border-[#EDF2F6] bg-white">
-      <div className="h-[280px] w-full">
+    <div className="mt-3 overflow-hidden rounded-lg border border-[#EDF2F6] bg-white">
+      <div className="flex items-center justify-between border-b border-[#EDF2F6] bg-[#F7F8FA] px-3 py-1.5">
+        <span className="text-xs font-semibold text-[#011111]">{columnName}</span>
+        <button
+          type="button"
+          className="flex size-5 items-center justify-center rounded text-[#68737B] hover:bg-[#EDF2F6]"
+          onClick={onClose}
+          title="Close chart"
+          aria-label="Close chart"
+        >
+          <X className="size-3" />
+        </button>
+      </div>
+      <div className="h-[280px] w-full p-2">
         <LineChart
           data={plotData}
-          config={{
-            xAxisTitle: "Index",
-            yAxisTitle: series.length === 1 ? series[0].name : "Value",
-            useWebGL: false,
-          }}
+          config={{ xAxisTitle: "Index", yAxisTitle: columnName, useWebGL: false }}
         />
       </div>
     </div>
@@ -246,25 +255,16 @@ function DataTabs({
   data,
   copy,
   copied,
+  onChartClick,
 }: {
   data: unknown;
   copy: (text: string) => Promise<void>;
   copied: boolean;
+  onChartClick: ChartClickHandler;
 }) {
-  const chartSeries = getChartableSeries(data);
-  const showChart = chartSeries.length > 0;
-
   return (
-    <Tabs defaultValue={showChart ? "chart" : "table"} className="w-full">
+    <Tabs defaultValue="table" className="w-full">
       <TabsList className="h-8 rounded-lg border border-[#EDF2F6] bg-[#F7F8FA] p-0.5">
-        {showChart && (
-          <TabsTrigger
-            value="chart"
-            className="rounded-md px-3 py-1 text-xs font-medium text-[#68737B] data-[state=active]:bg-white data-[state=active]:shadow-sm"
-          >
-            Chart
-          </TabsTrigger>
-        )}
         <TabsTrigger
           value="table"
           className="rounded-md px-3 py-1 text-xs font-medium text-[#68737B] data-[state=active]:bg-white data-[state=active]:shadow-sm"
@@ -278,13 +278,8 @@ function DataTabs({
           JSON
         </TabsTrigger>
       </TabsList>
-      {showChart && (
-        <TabsContent value="chart" className="mt-2">
-          <ChartView series={chartSeries} />
-        </TabsContent>
-      )}
       <TabsContent value="table" className="mt-2">
-        {renderDataTable(data)}
+        {renderDataTable(data, onChartClick)}
       </TabsContent>
       <TabsContent value="json" className="mt-2">
         <div className="relative">
@@ -313,6 +308,14 @@ export function OutputCellComponent({ cell, onUpdate, onDelete, readOnly }: Outp
   const hasContent = cell.data != null || (cell.messages && cell.messages.length > 0);
   const toggleCollapsed = () => onUpdate({ ...cell, isCollapsed: !cell.isCollapsed });
   const { copy, copied } = useCopyToClipboard();
+  const [pinnedChart, setPinnedChart] = useState<{ data: number[]; columnName: string } | null>(
+    null,
+  );
+  const handleChartClick: ChartClickHandler = (data, columnName) => {
+    setPinnedChart((prev) =>
+      prev?.columnName === columnName ? null : { data, columnName },
+    );
+  };
 
   return (
     <div className="group/output relative overflow-hidden rounded-b-[10px] border border-t-0 border-[#EDF2F6] bg-white">
@@ -390,7 +393,21 @@ export function OutputCellComponent({ cell, onUpdate, onDelete, readOnly }: Outp
 
             {/* Measurement / generic data */}
             {cell.data != null && !isQuestionAnswer(cell.data) && (
-              <DataTabs data={cell.data} copy={copy} copied={copied} />
+              <>
+                <DataTabs
+                  data={cell.data}
+                  copy={copy}
+                  copied={copied}
+                  onChartClick={handleChartClick}
+                />
+                {pinnedChart && (
+                  <ExpandedChart
+                    data={pinnedChart.data}
+                    columnName={pinnedChart.columnName}
+                    onClose={() => setPinnedChart(null)}
+                  />
+                )}
+              </>
             )}
 
             {!hasContent && (

--- a/apps/web/components/workbook/cells/output-cell.tsx
+++ b/apps/web/components/workbook/cells/output-cell.tsx
@@ -106,13 +106,10 @@ function renderCellValue(
     if (typeof val[0] === "object" && val[0] !== null) return renderDataTable(val, onChartClick);
     return val.map((v) => (v == null ? "" : String(v))).join(", ");
   }
-  if (typeof val === "object") return renderDataTable(val, onChartClick);
-  return JSON.stringify(val);
+  return renderDataTable(val, onChartClick);
 }
 
 function renderDataTable(data: unknown, onChartClick?: ChartClickHandler): React.ReactNode {
-  if (data == null) return <p className="text-sm text-[#68737B]">No output data</p>;
-
   if (Array.isArray(data) && data.length > 0 && typeof data[0] === "object" && data[0] !== null) {
     const keys = Array.from(
       new Set(data.flatMap((row) => Object.keys(row as Record<string, unknown>))),
@@ -171,10 +168,11 @@ function renderDataTable(data: unknown, onChartClick?: ChartClickHandler): React
     );
   }
 
-  if (typeof data === "string" || typeof data === "number" || typeof data === "boolean") {
-    return <p className="px-3 py-2 text-xs text-[#011111]">{String(data)}</p>;
-  }
-  return <p className="px-3 py-2 text-xs text-[#011111]">{JSON.stringify(data)}</p>;
+  const text =
+    typeof data === "string" || typeof data === "number" || typeof data === "boolean"
+      ? String(data)
+      : JSON.stringify(data);
+  return <p className="px-3 py-2 text-xs text-[#011111]">{text}</p>;
 }
 
 function getMessageType(message: string): "error" | "warning" | "info" {

--- a/apps/web/components/workbook/cells/output-cell.tsx
+++ b/apps/web/components/workbook/cells/output-cell.tsx
@@ -241,10 +241,10 @@ function ExpandedChart({
           <X className="size-3" />
         </button>
       </div>
-      {/* Plotly's X-axis title + tick labels need ~60px of bottom margin. The container is sized
-          generously so the trace doesn't squeeze them out, and pb-2 gives the panel breathing room
-          inside the cell wrapper's overflow-hidden boundary. */}
-      <div className="h-[340px] w-full px-2 pb-2 pt-1">
+      {/* Plotly renders at ~450px when its container's height isn't propagated through the
+          plotly-container div (a quirk of the shared chart wrapper). Match the experiment-data
+          chart's 460px so the X-axis ticks and "Index" title aren't clipped. */}
+      <div className="h-[460px] w-full px-2 pb-2 pt-1">
         <LineChart
           data={plotData}
           config={{ xAxisTitle: "Index", yAxisTitle: columnName, useWebGL: false }}

--- a/apps/web/components/workbook/cells/output-cell.tsx
+++ b/apps/web/components/workbook/cells/output-cell.tsx
@@ -14,7 +14,46 @@ import {
 } from "lucide-react";
 
 import type { OutputCell as OutputCellType } from "@repo/api/schemas/workbook-cells.schema";
+import type { LineSeriesData } from "@repo/ui/components/charts/line-chart";
+import { LineChart } from "@repo/ui/components/charts/line-chart";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@repo/ui/components/tabs";
+
+const CHART_SERIES_COLORS = [
+  "#005E5E",
+  "#D97706",
+  "#6C5CE7",
+  "#D14343",
+  "#2563EB",
+  "#10B981",
+];
+
+interface ChartSeries {
+  name: string;
+  values: number[];
+}
+
+function isNumericArray(val: unknown): val is number[] {
+  return (
+    Array.isArray(val) &&
+    val.length > 0 &&
+    val.every((v) => typeof v === "number" && Number.isFinite(v))
+  );
+}
+
+// Pull out the first chartable series in `data`: a top-level numeric array, or each numeric-array
+// field of a plain object (capped so a 200-key payload doesn't dump 200 lines onto the chart).
+function getChartableSeries(data: unknown): ChartSeries[] {
+  if (isNumericArray(data)) return [{ name: "value", values: data }];
+  if (data != null && typeof data === "object" && !Array.isArray(data)) {
+    const series: ChartSeries[] = [];
+    for (const [key, val] of Object.entries(data as Record<string, unknown>)) {
+      if (isNumericArray(val)) series.push({ name: key, values: val });
+      if (series.length >= CHART_SERIES_COLORS.length) break;
+    }
+    return series;
+  }
+  return [];
+}
 
 interface OutputCellProps {
   cell: OutputCellType;
@@ -136,6 +175,99 @@ function isQuestionAnswer(data: unknown): data is { answer: string } {
   );
 }
 
+function ChartView({ series }: { series: ChartSeries[] }) {
+  const plotData: LineSeriesData[] = series.map((s, i) => ({
+    name: s.name,
+    x: s.values.map((_, idx) => idx),
+    y: s.values,
+    mode: "lines",
+    line: { color: CHART_SERIES_COLORS[i % CHART_SERIES_COLORS.length], width: 2 },
+    showlegend: series.length > 1,
+  }));
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-[#EDF2F6] bg-white">
+      <div className="h-[280px] w-full">
+        <LineChart
+          data={plotData}
+          config={{
+            xAxisTitle: "Index",
+            yAxisTitle: series.length === 1 ? series[0].name : "Value",
+            useWebGL: false,
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function DataTabs({
+  data,
+  copy,
+  copied,
+}: {
+  data: unknown;
+  copy: (text: string) => Promise<void>;
+  copied: boolean;
+}) {
+  const chartSeries = getChartableSeries(data);
+  const showChart = chartSeries.length > 0;
+
+  return (
+    <Tabs defaultValue={showChart ? "chart" : "table"} className="w-full">
+      <TabsList className="h-8 rounded-lg border border-[#EDF2F6] bg-[#F7F8FA] p-0.5">
+        {showChart && (
+          <TabsTrigger
+            value="chart"
+            className="rounded-md px-3 py-1 text-xs font-medium text-[#68737B] data-[state=active]:bg-white data-[state=active]:shadow-sm"
+          >
+            Chart
+          </TabsTrigger>
+        )}
+        <TabsTrigger
+          value="table"
+          className="rounded-md px-3 py-1 text-xs font-medium text-[#68737B] data-[state=active]:bg-white data-[state=active]:shadow-sm"
+        >
+          Table
+        </TabsTrigger>
+        <TabsTrigger
+          value="json"
+          className="rounded-md px-3 py-1 text-xs font-medium text-[#68737B] data-[state=active]:bg-white data-[state=active]:shadow-sm"
+        >
+          JSON
+        </TabsTrigger>
+      </TabsList>
+      {showChart && (
+        <TabsContent value="chart" className="mt-2">
+          <ChartView series={chartSeries} />
+        </TabsContent>
+      )}
+      <TabsContent value="table" className="mt-2">
+        {renderDataTable(data)}
+      </TabsContent>
+      <TabsContent value="json" className="mt-2">
+        <div className="relative">
+          <pre className="overflow-auto rounded-lg bg-[#F7F8FA] p-3 pr-12 text-xs text-[#011111]">
+            {JSON.stringify(data, null, 2)}
+          </pre>
+          <button
+            className="absolute right-2 top-2 z-10 flex size-7 items-center justify-center rounded-md border border-[#EDF2F6] bg-white text-[#68737B] shadow-sm transition-colors hover:bg-[#F7F8FA] hover:text-[#011111]"
+            onClick={() => void copy(JSON.stringify(data, null, 2))}
+            title="Copy JSON"
+            aria-label="Copy JSON"
+          >
+            {copied ? (
+              <Check className="size-3.5 text-emerald-500" />
+            ) : (
+              <Copy className="size-3.5" />
+            )}
+          </button>
+        </div>
+      </TabsContent>
+    </Tabs>
+  );
+}
+
 export function OutputCellComponent({ cell, onUpdate, onDelete, readOnly }: OutputCellProps) {
   const hasContent = cell.data != null || (cell.messages && cell.messages.length > 0);
   const toggleCollapsed = () => onUpdate({ ...cell, isCollapsed: !cell.isCollapsed });
@@ -217,44 +349,7 @@ export function OutputCellComponent({ cell, onUpdate, onDelete, readOnly }: Outp
 
             {/* Measurement / generic data */}
             {cell.data != null && !isQuestionAnswer(cell.data) && (
-              <Tabs defaultValue="table" className="w-full">
-                <TabsList className="h-8 rounded-lg border border-[#EDF2F6] bg-[#F7F8FA] p-0.5">
-                  <TabsTrigger
-                    value="table"
-                    className="rounded-md px-3 py-1 text-xs font-medium text-[#68737B] data-[state=active]:bg-white data-[state=active]:shadow-sm"
-                  >
-                    Table
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="json"
-                    className="rounded-md px-3 py-1 text-xs font-medium text-[#68737B] data-[state=active]:bg-white data-[state=active]:shadow-sm"
-                  >
-                    JSON
-                  </TabsTrigger>
-                </TabsList>
-                <TabsContent value="table" className="mt-2">
-                  {renderDataTable(cell.data)}
-                </TabsContent>
-                <TabsContent value="json" className="mt-2">
-                  <div className="relative">
-                    <pre className="overflow-auto rounded-lg bg-[#F7F8FA] p-3 pr-12 text-xs text-[#011111]">
-                      {JSON.stringify(cell.data, null, 2)}
-                    </pre>
-                    <button
-                      className="absolute right-2 top-2 z-10 flex size-7 items-center justify-center rounded-md border border-[#EDF2F6] bg-white text-[#68737B] shadow-sm transition-colors hover:bg-[#F7F8FA] hover:text-[#011111]"
-                      onClick={() => void copy(JSON.stringify(cell.data, null, 2))}
-                      title="Copy JSON"
-                      aria-label="Copy JSON"
-                    >
-                      {copied ? (
-                        <Check className="size-3.5 text-emerald-500" />
-                      ) : (
-                        <Copy className="size-3.5" />
-                      )}
-                    </button>
-                  </div>
-                </TabsContent>
-              </Tabs>
+              <DataTabs data={cell.data} copy={copy} copied={copied} />
             )}
 
             {!hasContent && (


### PR DESCRIPTION
## Summary

Stacked on top of #1407. Mirrors the experiment data tab's inline charting affordance: each numeric-array cell in the Output cell's Table view renders a small SVG sparkline, and clicking it pins a full chart below the table for that series. Reuses the shared `LineChart` from `@repo/ui/components/charts/line-chart` (same component the experiment data tab uses).

- Sparklines appear automatically wherever a `number[]` lives in the rendered table — top-level fields, fields of array-of-objects rows (e.g. MultispeQ-style `set[0].ENV`, `set[0].SUN`, `set[0].Fluo`), and nested objects.
- Clicking a sparkline pins a full chart panel below the Tabs with the column name as the title and Y-axis label. Clicking the same sparkline again, or the chart's close button, unpins it.
- Producer-agnostic: protocol outputs, macro outputs, and any future cell type that emits numeric arrays all light up — the gating is on data shape, not source.
- No new tab; the existing Table | JSON tabs are unchanged. Object payloads with no numeric arrays render exactly as before.

### Approach note

An earlier iteration (commits 53ab87f1, 11f136d3) added a separate Chart tab that flattened all numeric arrays into one multi-series plot. That mixed incompatible scales (e.g. one series in the thousands, another in the hundreds), and obscured which array came from which row in nested payloads. Refactored in e294de20 to the inline-sparkline-in-table approach per review feedback.

## Test plan

- [x] `pnpm vitest run components/workbook/cells/output-cell.test.tsx` — 15/15 pass, with new tests covering sparkline rendering for top-level and nested numeric arrays, click-to-expand, click-again-to-toggle-off, and the no-numeric-array fallback.
- [x] `pnpm vitest run components/workbook/` — 163/163 pass, no regressions.
- [ ] Manual: run a MultispeQ protocol (`{ set: [{ ENV: [...], SUN: [...], ... }], ... }`); verify each numeric column renders an inline sparkline, and clicking expands a full chart below the table.
- [ ] Manual: run a macro that emits `{ spectrum: [...], baseline: [...] }`; verify both rows show sparklines and the expanded chart targets the clicked one.
- [ ] Manual: verify object payloads without numeric arrays (e.g. `{ device_id, firmware_version }`) still render as a plain key/value table with no sparklines.

Linear: OJD-593