### PR TITLE
revert: mobile macro wrapper contract (4be4d77)

### DIFF
--- a/apps/mobile/src/components/measurement-result/measurement-result.tsx
+++ b/apps/mobile/src/components/measurement-result/measurement-result.tsx
@@ -41,13 +41,10 @@ export function MeasurementResult({
     return await applyMacro(rawMeasurement, macro);
   }, [rawMeasurement, macro]);
 
-  const messageGroups: MacroMessageGroup[] = processedMeasurement?.messages
-    ? [processedMeasurement.messages]
-    : [];
-
-  const processedKeys = processedMeasurement
-    ? Object.keys(processedMeasurement).filter((key) => key !== "messages")
-    : [];
+  const messageGroups: MacroMessageGroup[] =
+    processedMeasurement
+      ?.map((output) => output.messages)
+      .filter((msg): msg is MacroMessageGroup => msg !== undefined) ?? [];
 
   const renderRawContent = () => (
     <Text className={clsx("font-mono text-sm leading-5", classes.text)}>
@@ -70,7 +67,7 @@ export function MeasurementResult({
       return <ActivityIndicator size="large" color={colors.primary.dark} />;
     }
 
-    if (!processedMeasurement || processedKeys.length === 0) {
+    if (!processedMeasurement?.length) {
       return (
         <View className="items-center justify-center p-6">
           <Text className={clsx("text-center text-lg", classes.textSecondary)}>
@@ -82,15 +79,23 @@ export function MeasurementResult({
 
     return (
       <View>
-        {processedKeys.map((key) => {
-          const value = processedMeasurement[key];
-          if (typeof value === "string" || typeof value === "number") {
-            return <KeyValue key={key} value={value} name={key} />;
-          }
-          if (Array.isArray(value) && typeof value[0] === "number") {
-            return <Chart key={key} name={key} values={value} />;
-          }
-          return null;
+        {processedMeasurement.map((output, outputIndex) => {
+          return (
+            <View key={outputIndex}>
+              {Object.keys(output)
+                .filter((key) => key !== "messages")
+                .map((key) => {
+                  const value = output[key];
+                  if (typeof value === "string" || typeof value === "number") {
+                    return <KeyValue key={key} value={value} name={key} />;
+                  }
+                  if (Array.isArray(value) && typeof value[0] === "number") {
+                    return <Chart key={key} name={key} values={value} />;
+                  }
+                  return null;
+                })}
+            </View>
+          );
         })}
       </View>
     );

--- a/apps/mobile/src/utils/process-scan/process-scan.test.ts
+++ b/apps/mobile/src/utils/process-scan/process-scan.test.ts
@@ -34,51 +34,95 @@ vi.mock("expo-file-system", () => ({
 
 const encode = (code: string) => Buffer.from(code, "utf8").toString("base64");
 
-describe("applyMacro — wrapper contract", () => {
+describe("applyMacro — input isolation (OJD-1463)", () => {
   describe("JavaScript macros", () => {
-    it("passes the full wrapper to the macro (json.sample is the array)", async () => {
-      const result = {
-        device_id: "dev-1",
-        sample: [{ set: [{ par: 1234 }] }],
-      };
+    it("does not mutate top-level scalar properties on the original sample", async () => {
+      const sample = { meta: "original", phi2: 0.5 };
+      const result = { sample };
 
       const code = encode(`
-        return {
-          device_id: json.device_id,
-          par: json.sample[0].set[0].par,
-          n_samples: json.sample.length,
-        };
+        json.meta = "mutated";
+        json.phi2 = -1;
+        return { ok: true };
       `);
 
-      const out = await applyMacro(result, { code, language: "javascript" });
+      const [out] = await applyMacro(result, { code, language: "javascript" });
 
-      expect(out).toEqual({ device_id: "dev-1", par: 1234, n_samples: 1 });
+      // Macro saw its own copy and was free to mutate it.
+      expect(out).toEqual({ ok: true });
+      // Original is untouched.
+      expect(sample).toEqual({ meta: "original", phi2: 0.5 });
     });
 
-    it("does not mutate the caller's wrapper", async () => {
-      const result = {
-        sample: [{ data_raw: [1, 2, 3, 4, 5] }],
-      };
+    it("does not mutate array elements on the original sample", async () => {
+      const sample = { data_raw: [1, 2, 3, 4, 5] };
+      const result = { sample };
 
       const code = encode(`
-        json.sample[0].data_raw[0] = 999;
-        json.sample.push({ injected: true });
+        for (var i = 0; i < json.data_raw.length; i++) {
+          json.data_raw[i] = -json.data_raw[i];
+        }
+        json.data_raw.push(999);
         return { ok: true };
       `);
 
       await applyMacro(result, { code, language: "javascript" });
 
-      expect(result.sample.length).toBe(1);
-      expect(result.sample[0].data_raw).toEqual([1, 2, 3, 4, 5]);
+      expect(sample.data_raw).toEqual([1, 2, 3, 4, 5]);
     });
 
-    it("rejects unknown languages instead of silently running them as JS", async () => {
-      const result = { sample: [{}] };
-      const code = encode("return { ok: true };");
+    it("does not mutate nested objects on the original sample", async () => {
+      const sample = {
+        nested: { phi2: 0.5, deep: { value: 42 } },
+      };
+      const result = { sample };
 
-      await expect(applyMacro(result, { code, language: "r" })).rejects.toThrow(
-        /Unsupported macro language: r/,
-      );
+      const code = encode(`
+        json.nested.phi2 = -1;
+        json.nested.deep.value = 0;
+        delete json.nested.deep;
+        return { ok: true };
+      `);
+
+      await applyMacro(result, { code, language: "javascript" });
+
+      expect(sample.nested.phi2).toBe(0.5);
+      expect(sample.nested.deep).toEqual({ value: 42 });
+    });
+
+    it("isolates mutations between sibling samples in a batch", async () => {
+      const sample1 = { data_raw: [1, 2, 3] };
+      const sample2 = { data_raw: [4, 5, 6] };
+      const result = { sample: [sample1, sample2] };
+
+      const code = encode(`
+        json.data_raw[0] = 999;
+        return { first: json.data_raw[0] };
+      `);
+
+      const outputs = await applyMacro(result, { code, language: "javascript" });
+
+      expect(outputs).toEqual([{ first: 999 }, { first: 999 }]);
+      expect(sample1.data_raw).toEqual([1, 2, 3]);
+      expect(sample2.data_raw).toEqual([4, 5, 6]);
+    });
+
+    it("gives the macro a different object reference than the original sample", async () => {
+      const sample = { marker: { tag: "original" } };
+      const result = { sample };
+
+      // Smuggle the `json` reference out of the macro so we can assert on it.
+      let macroSawReference: unknown = null;
+      const code = encode(`
+        json.__capturedBy = "macro";
+        return { capturedRef: json };
+      `);
+
+      const [out] = await applyMacro(result, { code, language: "javascript" });
+      macroSawReference = (out as { capturedRef: unknown }).capturedRef;
+
+      expect(macroSawReference).not.toBe(sample);
+      expect(sample).toEqual({ marker: { tag: "original" } });
     });
   });
 
@@ -87,38 +131,36 @@ describe("applyMacro — wrapper contract", () => {
       registerPythonMacroRunner(null);
     });
 
-    it("passes the full wrapper to the Python runner", async () => {
-      const result = {
-        device_id: "dev-1",
-        sample: [{ set: [{ par: 1234 }] }],
-      };
+    it("does not mutate the original sample even if the Python runner mutates its arg", async () => {
+      const sample = { meta: "original", data_raw: [1, 2, 3] };
+      const result = { sample };
 
-      let receivedJson: unknown = null;
+      let receivedRef: unknown = null;
       registerPythonMacroRunner((_code, json) => {
-        receivedJson = json;
+        receivedRef = json;
+        (json as { meta: string }).meta = "mutated-by-python";
+        (json as { data_raw: number[] }).data_raw[0] = 999;
         return Promise.resolve({ ok: true });
       });
 
       await applyMacro(result, {
-        code: encode("# runner is mocked"),
+        code: encode("# python body irrelevant — runner is mocked"),
         language: "python",
       });
 
-      expect(receivedJson).toEqual({
-        device_id: "dev-1",
-        sample: [{ set: [{ par: 1234 }] }],
-      });
+      // The runner must have received a clone, not the caller's reference.
+      expect(receivedRef).not.toBe(sample);
+      // Original must still be intact.
+      expect(sample).toEqual({ meta: "original", data_raw: [1, 2, 3] });
     });
 
-    it("does not mutate the caller's wrapper even if the runner mutates its arg", async () => {
-      const result = {
-        device_id: "dev-1",
-        sample: [{ data_raw: [1, 2, 3] }],
-      };
+    it("isolates mutations between sibling Python samples in a batch", async () => {
+      const sample1 = { data_raw: [1, 2, 3] };
+      const sample2 = { data_raw: [4, 5, 6] };
+      const result = { sample: [sample1, sample2] };
 
       registerPythonMacroRunner((_code, json) => {
-        (json as { device_id: string }).device_id = "tampered";
-        (json as { sample: { data_raw: number[] }[] }).sample[0].data_raw[0] = 999;
+        (json as { data_raw: number[] }).data_raw[0] = 999;
         return Promise.resolve({ ok: true });
       });
 
@@ -127,8 +169,8 @@ describe("applyMacro — wrapper contract", () => {
         language: "python",
       });
 
-      expect(result.device_id).toBe("dev-1");
-      expect(result.sample[0].data_raw).toEqual([1, 2, 3]);
+      expect(sample1.data_raw).toEqual([1, 2, 3]);
+      expect(sample2.data_raw).toEqual([4, 5, 6]);
     });
   });
 });

--- a/apps/mobile/src/utils/process-scan/process-scan.ts
+++ b/apps/mobile/src/utils/process-scan/process-scan.ts
@@ -50,12 +50,21 @@ export interface MacroInput {
   language?: string;
 }
 
-// Macros receive the full measurement wrapper and loop over json["sample"]
-// themselves, matching the Databricks and macro-sandbox executors.
-export async function applyMacro(result: object, macro: MacroInput | string): Promise<MacroOutput> {
+export async function applyMacro(
+  result: object,
+  macro: MacroInput | string,
+): Promise<MacroOutput[]> {
   if (!("sample" in result)) {
     throw new Error("Result does not contain sample data");
   }
+
+  const { sample } = result;
+
+  if (!sample) {
+    throw new Error("Sample data is missing");
+  }
+
+  const samples = Array.isArray(sample) ? sample : [sample];
 
   const macroInput: MacroInput =
     typeof macro === "string" ? { code: macro, language: "javascript" } : macro;
@@ -64,24 +73,38 @@ export async function applyMacro(result: object, macro: MacroInput | string): Pr
 
   const codePreview = code.length > 500 ? code.slice(0, 500) + "..." : code;
   console.log("[macro] code preview:", codePreview);
-  console.log("[macro] language:", language);
+  console.log("[macro] language:", language, "samples:", samples.length);
 
   if (language === "python") {
     const runPython = getPythonMacroRunner();
     if (!runPython) {
       throw new Error("Python macro runner not ready. Ensure PythonMacroProvider is mounted.");
     }
+    const outputs: MacroOutput[] = [];
+    for (let i = 0; i < samples.length; i++) {
+      const sample = samples[i];
+      console.log("[macro] (Python) input sample", i, JSON.stringify(sample));
+      try {
+        const out = await runPython(code, structuredClone(sample));
+        console.log("[macro] (Python) output sample", i, JSON.stringify(out));
+        outputs.push(out);
+      } catch (err) {
+        console.error("[macro] (Python) error sample", i, err);
+        throw err;
+      }
+    }
+    return outputs;
+  }
+
+  const outputs: MacroOutput[] = [];
+  for (let i = 0; i < samples.length; i++) {
     try {
-      return await runPython(code, structuredClone(result));
+      const out = await executeMacro(code, samples[i]);
+      outputs.push(out);
     } catch (err) {
-      console.error("[macro] (Python) error:", err);
+      console.error("[macro] (JS) error sample", i, err);
       throw err;
     }
   }
-
-  if (language !== "javascript") {
-    throw new Error(`Unsupported macro language: ${language}`);
-  }
-
-  return executeMacro(code, structuredClone(result));
+  return outputs;
 }


### PR DESCRIPTION
Reverts #4be4d77 (`fix(mobile): align macro contract with Databricks/sandbox by passing full wrapper to runner`).

The commit broke macro processing in mobile 1.20: legacy macros that call `GetProtocolByLabel` / read `json.set` (i.e. effectively all of them, via `math.lib.js.txt`) blow up with `Cannot read property 'filter' of undefined` because `json` is now the wrapper `{sample: [...], device_id, ...}` and has no `.set`.

The commit's premise — that Databricks/sandbox pass the wrapper to the macro — doesn't hold. On the online path:

- `apps/data/src/pipelines/centrum_pipeline.py:558` does `parse_json(sample)`, so the `data` column the UDF sends is the **sample array**, not the wrapper.
- `apps/macro-sandbox/lib/wrappers/wrapper.js`'s `unwrapMeasurement` then unwraps that array to `[0]`.
- Net result: `json` is a single sample with `.set` directly on it.

So the real contract — same in both runtimes — is `json = single sample`. Mobile's pre-`4be4d77` code already matched this (per-sample loop, `MacroOutput[]`). The revert restores that.

Reported in Slack: phone fails to process measurements during student induction; openJII processes the same measurement fine.

## Test plan


- [ ] Verify Tom's failing measurement (14:54 in experiment d2b9c92a-4695-4017-bc3d-78924886e0a2) processes on the phone
- [ ] Spot-check a couple of other macros that use `GetProtocolByLabel`