### PR TITLE
feat(mobile): allow all orientations

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -6,7 +6,7 @@
     "name": "openJII",
     "slug": "openjii",
     "version": "1.1.0",
-    "orientation": "portrait",
+    "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
     "newArchEnabled": true,


### PR DESCRIPTION
## Summary
- Switches Expo `orientation` from `portrait` to `default` in `apps/mobile/app.json` so the app can rotate freely on phones and tablets.
- Requested for tablet-based scoring in the field, where landscape is preferred.

Closes [OJD-1503](https://linear.app/openjii/issue/OJD-1503/support-landscape-mode-on-tablets-for-scoring) / refs #1425.

## Test plan
- [ ] Build a dev/preview client (native config change — OTA cannot deliver this).
- [ ] On an iPad in landscape, verify the scoring/measurement flow renders and is usable.
- [ ] On a phone, rotate through portrait → landscape → portrait and confirm core flows (login, list, measurement, BLE scan) still render without clipping/overflow.
- [ ] Confirm the splash screen still displays correctly on first launch.