### PR TITLE
fix(iam): add ListInstanceProfilesForRole permission to GitHub Actions deploy role

### DIFF
--- a/infrastructure/modules/iam-oidc/main.tf
+++ b/infrastructure/modules/iam-oidc/main.tf
@@ -290,6 +290,7 @@ locals {
         "iam:DeleteRole",
         "iam:GetRole",
         "iam:ListRoles",
+        "iam:ListInstanceProfilesForRole",
         "iam:UpdateAssumeRolePolicy",
         "iam:PassRole",
         "iam:TagRole",


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description
OpenTofu requires `iam:ListInstanceProfilesForRole` when deleting an IAM role.
This was missing from the GithubActionsDeployAccess policy, causing apply to fail when removing the Timestream IAM role as part of the IoT S3 archive cleanup.

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #
- Related to #