### PR TITLE
feat(web/workbook): MultispeQ timeseries view for measurement output cells

### DIFF
--- a/apps/web/app/[locale]/platform/workbooks/[id]/page.tsx
+++ b/apps/web/app/[locale]/platform/workbooks/[id]/page.tsx
@@ -13,7 +13,6 @@ import { parseApiError } from "~/util/apiError";
 import type { QuestionCell, WorkbookCell } from "@repo/api/schemas/workbook-cells.schema";
 import { useSession } from "@repo/auth/client";
 import { useTranslation } from "@repo/i18n";
-import { ToastAction } from "@repo/ui/components/toast";
 import { toast } from "@repo/ui/hooks/use-toast";
 
 interface WorkbookOverviewPageProps {
@@ -108,30 +107,6 @@ function WorkbookEditorWithAutosave({
     setCells(next);
   }, []);
 
-  // `connect` is returned by useWorkbookExecution below, but the toast that
-  // prompts the user to connect is fired from inside that same hook —
-  // bridge them with a ref so the toast's action can call `connect` without
-  // creating a hook-call cycle.
-  const connectRef = useRef<(() => Promise<void> | void) | null>(null);
-
-  const handleRequireDevice = useCallback(() => {
-    const connectLabel = t("workbooks.connect");
-    toast({
-      title: t("workbooks.deviceRequired"),
-      description: t("workbooks.deviceRequiredDescription"),
-      action: (
-        <ToastAction
-          altText={connectLabel}
-          onClick={() => {
-            void connectRef.current?.();
-          }}
-        >
-          {connectLabel}
-        </ToastAction>
-      ),
-    });
-  }, [t]);
-
   const {
     isConnected,
     isConnecting,
@@ -152,11 +127,24 @@ function WorkbookEditorWithAutosave({
     cells,
     onCellsChange: handleCellsChange,
     onPromptQuestion: handlePromptQuestion,
-    onRequireDevice: handleRequireDevice,
   });
-  connectRef.current = connect;
 
   const isCreator = session?.user.id === createdBy;
+
+  // Trigger the same `connect()` the toolbar uses when the user clicks Run on
+  // a Protocol cell with no device. Done before any await so the browser's
+  // Web Serial / Web Bluetooth picker still sees a live user gesture.
+  const handleRunCell = useCallback(
+    (cellId: string) => {
+      const cell = cells.find((c) => c.id === cellId);
+      if (cell?.type === "protocol" && !isConnected) {
+        void connect();
+        return;
+      }
+      void runCell(cellId);
+    },
+    [cells, isConnected, connect, runCell],
+  );
 
   const handleClearOutputs = useCallback(() => {
     const count = cells.filter((c) => c.type === "output").length;
@@ -187,7 +175,7 @@ function WorkbookEditorWithAutosave({
         onRunAll={runAll}
         onStopExecution={stopExecution}
         onClearOutputs={handleClearOutputs}
-        onRunCell={runCell}
+        onRunCell={handleRunCell}
         promptedQuestionId={promptedQuestionId}
         onQuestionAnswered={handleQuestionAnswered}
       />

--- a/apps/web/app/[locale]/platform/workbooks/[id]/page.tsx
+++ b/apps/web/app/[locale]/platform/workbooks/[id]/page.tsx
@@ -13,6 +13,7 @@ import { parseApiError } from "~/util/apiError";
 import type { QuestionCell, WorkbookCell } from "@repo/api/schemas/workbook-cells.schema";
 import { useSession } from "@repo/auth/client";
 import { useTranslation } from "@repo/i18n";
+import { ToastAction } from "@repo/ui/components/toast";
 import { toast } from "@repo/ui/hooks/use-toast";
 
 interface WorkbookOverviewPageProps {
@@ -107,6 +108,25 @@ function WorkbookEditorWithAutosave({
     setCells(next);
   }, []);
 
+  // `connect` is returned by useWorkbookExecution below, but the toast that
+  // prompts the user to connect is fired from inside that same hook —
+  // bridge them with a ref so the toast's action can call `connect` without
+  // creating a hook-call cycle.
+  const connectRef = useRef<(() => void) | null>(null);
+
+  const handleRequireDevice = useCallback(() => {
+    const connectLabel = t("workbooks.connect");
+    toast({
+      title: t("workbooks.deviceRequired"),
+      description: t("workbooks.deviceRequiredDescription"),
+      action: (
+        <ToastAction altText={connectLabel} onClick={() => connectRef.current?.()}>
+          {connectLabel}
+        </ToastAction>
+      ),
+    });
+  }, [t]);
+
   const {
     isConnected,
     isConnecting,
@@ -127,7 +147,9 @@ function WorkbookEditorWithAutosave({
     cells,
     onCellsChange: handleCellsChange,
     onPromptQuestion: handlePromptQuestion,
+    onRequireDevice: handleRequireDevice,
   });
+  connectRef.current = connect;
 
   const isCreator = session?.user.id === createdBy;
 

--- a/apps/web/app/[locale]/platform/workbooks/[id]/page.tsx
+++ b/apps/web/app/[locale]/platform/workbooks/[id]/page.tsx
@@ -112,7 +112,7 @@ function WorkbookEditorWithAutosave({
   // prompts the user to connect is fired from inside that same hook —
   // bridge them with a ref so the toast's action can call `connect` without
   // creating a hook-call cycle.
-  const connectRef = useRef<(() => void) | null>(null);
+  const connectRef = useRef<(() => Promise<void> | void) | null>(null);
 
   const handleRequireDevice = useCallback(() => {
     const connectLabel = t("workbooks.connect");
@@ -120,7 +120,12 @@ function WorkbookEditorWithAutosave({
       title: t("workbooks.deviceRequired"),
       description: t("workbooks.deviceRequiredDescription"),
       action: (
-        <ToastAction altText={connectLabel} onClick={() => connectRef.current?.()}>
+        <ToastAction
+          altText={connectLabel}
+          onClick={() => {
+            void connectRef.current?.();
+          }}
+        >
           {connectLabel}
         </ToastAction>
       ),

--- a/apps/web/app/[locale]/platform/workbooks/[id]/page.tsx
+++ b/apps/web/app/[locale]/platform/workbooks/[id]/page.tsx
@@ -60,6 +60,7 @@ function WorkbookEditorWithAutosave({
   name: string;
 }) {
   const { data: session } = useSession();
+  const { t } = useTranslation(["workbook", "common"]);
   const { mutateAsync: updateWorkbook } = useWorkbookUpdate(id);
 
   const [cells, setCells] = useState<WorkbookCell[]>(initialCells);
@@ -130,6 +131,14 @@ function WorkbookEditorWithAutosave({
 
   const isCreator = session?.user.id === createdBy;
 
+  const handleClearOutputs = useCallback(() => {
+    const count = cells.filter((c) => c.type === "output").length;
+    clearOutputs();
+    if (count > 0) {
+      toast({ description: t("workbooks.outputsCleared", { count }) });
+    }
+  }, [cells, clearOutputs, t]);
+
   return (
     <div className="space-y-6">
       <WorkbookEditor
@@ -150,7 +159,7 @@ function WorkbookEditorWithAutosave({
         onDisconnect={disconnect}
         onRunAll={runAll}
         onStopExecution={stopExecution}
-        onClearOutputs={clearOutputs}
+        onClearOutputs={handleClearOutputs}
         onRunCell={runCell}
         promptedQuestionId={promptedQuestionId}
         onQuestionAnswered={handleQuestionAnswered}

--- a/apps/web/app/[locale]/platform/workbooks/page.tsx
+++ b/apps/web/app/[locale]/platform/workbooks/page.tsx
@@ -20,7 +20,7 @@ export default async function WorkbookPage({ params }: WorkbookPageProps) {
 
   return (
     <div className="space-y-6">
-      <div>
+      <div className="flex flex-col gap-2">
         <h1 className="text-4xl font-bold text-gray-900">{t("workbooks.title")}</h1>
         <p>{t("workbooks.listDescription")}</p>
       </div>

--- a/apps/web/components/list-workbooks.tsx
+++ b/apps/web/components/list-workbooks.tsx
@@ -42,7 +42,7 @@ export function ListWorkbooks() {
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between md:gap-8">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between md:gap-4">
         <div className="relative w-full md:w-[220px]">
           <Input
             type="text"
@@ -62,7 +62,7 @@ export function ListWorkbooks() {
             </button>
           )}
         </div>
-        <div className="flex w-full flex-col gap-4 md:w-auto md:flex-row md:items-center md:gap-8">
+        <div className="flex w-full flex-col gap-4 md:w-auto md:flex-row md:items-center md:gap-4">
           <Select value={filter} onValueChange={setFilter}>
             <SelectTrigger className="w-full md:w-[160px]">
               <SelectValue placeholder={t("workbooks.filterWorkbooks")} />

--- a/apps/web/components/macro-settings/macro-details-card.tsx
+++ b/apps/web/components/macro-settings/macro-details-card.tsx
@@ -134,9 +134,7 @@ export function MacroDetailsCard({
                     </FormControl>
                     <SelectContent>
                       <SelectItem value="python">Python</SelectItem>
-                      <SelectItem value="r" disabled>
-                        R
-                      </SelectItem>
+                      <SelectItem value="r">R</SelectItem>
                       <SelectItem value="javascript">JavaScript</SelectItem>
                     </SelectContent>
                   </Select>

--- a/apps/web/components/new-macro/new-macro.tsx
+++ b/apps/web/components/new-macro/new-macro.tsx
@@ -154,9 +154,7 @@ export function NewMacroForm() {
                     </FormControl>
                     <SelectContent>
                       <SelectItem value="python">Python</SelectItem>
-                      <SelectItem value="r" disabled>
-                        R
-                      </SelectItem>
+                      <SelectItem value="r">R</SelectItem>
                       <SelectItem value="javascript">JavaScript</SelectItem>
                     </SelectContent>
                   </Select>

--- a/apps/web/components/shared/autosave/autosave-indicator.tsx
+++ b/apps/web/components/shared/autosave/autosave-indicator.tsx
@@ -50,7 +50,7 @@ export function AutosaveIndicator({
       };
     }
     return {
-      icon: <CheckCircle2 className="size-4 text-emerald-500" />,
+      icon: <CheckCircle2 className="size-4 text-[#09B732]" />,
       label: t("autosave.saved", "All changes saved"),
       labelClassName: "text-[#68737B]",
     };

--- a/apps/web/components/shared/inline-editable-title.test.tsx
+++ b/apps/web/components/shared/inline-editable-title.test.tsx
@@ -105,4 +105,33 @@ describe("InlineEditableTitle", () => {
     expect(screen.getByTestId("badge")).toBeInTheDocument();
     expect(screen.getByTestId("action")).toBeInTheDocument();
   });
+
+  it("commits the new value when the user presses Enter", async () => {
+    const user = userEvent.setup();
+    render(<InlineEditableTitle {...defaultProps} />);
+
+    await user.click(screen.getByText("My Title"));
+    const input = screen.getByRole("textbox");
+    await user.clear(input);
+    await user.type(input, "Renamed via Enter");
+    await user.keyboard("{Enter}");
+
+    expect(defaultProps.onSave).toHaveBeenCalledWith("Renamed via Enter");
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("cancels the edit when the user presses Escape", async () => {
+    const user = userEvent.setup();
+    render(<InlineEditableTitle {...defaultProps} />);
+
+    await user.click(screen.getByText("My Title"));
+    const input = screen.getByRole("textbox");
+    await user.clear(input);
+    await user.type(input, "Discarded");
+    await user.keyboard("{Escape}");
+
+    expect(defaultProps.onSave).not.toHaveBeenCalled();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.getByText("My Title")).toBeInTheDocument();
+  });
 });

--- a/apps/web/components/shared/inline-editable-title.tsx
+++ b/apps/web/components/shared/inline-editable-title.tsx
@@ -81,6 +81,15 @@ export function InlineEditableTitle({
           <Input
             value={editedTitle}
             onChange={(e) => setEditedTitle(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                void handleSave();
+              } else if (e.key === "Escape") {
+                e.preventDefault();
+                handleCancel();
+              }
+            }}
             className="min-w-[300px] flex-1 text-2xl font-semibold"
             disabled={isPending}
             autoFocus

--- a/apps/web/components/workbook-list.tsx
+++ b/apps/web/components/workbook-list.tsx
@@ -5,6 +5,7 @@ import { useWorkbookDelete } from "@/hooks/workbook/useWorkbookDelete/useWorkboo
 import { formatDate } from "@/util/date";
 import { Loader2, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 
 import type { Workbook } from "@repo/api/schemas/workbook.schema";
@@ -131,6 +132,7 @@ function WorkbookTableRow({ workbook }: { workbook: Workbook }) {
   const { t } = useTranslation("workbook");
   const { t: tCommon } = useTranslation("common");
   const locale = useLocale();
+  const router = useRouter();
   const [confirmingDelete, setConfirmingDelete] = useState(false);
 
   const { mutate: deleteWorkbook, isPending: isDeleting } = useWorkbookDelete();
@@ -152,10 +154,17 @@ function WorkbookTableRow({ workbook }: { workbook: Workbook }) {
 
   return (
     <>
-      <TableRow className={cn("group bg-white hover:bg-[#F6F8FA]", TABLE_BORDER)}>
+      <TableRow
+        className={cn(
+          "group cursor-pointer bg-white hover:bg-[#F6F8FA] has-[[data-state=open]]:bg-[#F6F8FA]",
+          TABLE_BORDER,
+        )}
+        onClick={() => router.push(viewHref)}
+      >
         <TableCell className={cn("px-6 py-3 text-[13px] font-semibold", TEXT_STRONG)}>
           <Link
             href={viewHref}
+            onClick={(e) => e.stopPropagation()}
             className="focus-visible:ring-primary/40 hover:underline focus-visible:outline-none focus-visible:ring-2"
           >
             {workbook.name}
@@ -174,15 +183,18 @@ function WorkbookTableRow({ workbook }: { workbook: Workbook }) {
         <TableCell className={cn("px-6 py-3 text-[13px] tabular-nums", TEXT_MUTED)}>
           {formatDate(workbook.updatedAt)}
         </TableCell>
-        <TableCell className="w-12 px-3 py-3 text-right">
-          <div className="opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+        <TableCell
+          className="w-12 px-3 py-3 text-right"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 has-[[data-state=open]]:opacity-100">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
                   aria-label={t("workbooks.actions.edit", "Edit")}
                   className={cn(
-                    "hover:bg-accent data-[state=open]:bg-accent inline-flex size-8 items-center justify-center rounded-md hover:text-[#011111] data-[state=open]:text-[#011111]",
+                    "inline-flex size-8 items-center justify-center rounded-md hover:bg-[#EDF2F6] hover:text-[#011111] data-[state=open]:bg-[#EDF2F6] data-[state=open]:text-[#011111]",
                     TEXT_MUTED,
                   )}
                 >

--- a/apps/web/components/workbook-list.tsx
+++ b/apps/web/components/workbook-list.tsx
@@ -183,10 +183,7 @@ function WorkbookTableRow({ workbook }: { workbook: Workbook }) {
         <TableCell className={cn("px-6 py-3 text-[13px] tabular-nums", TEXT_MUTED)}>
           {formatDate(workbook.updatedAt)}
         </TableCell>
-        <TableCell
-          className="w-12 px-3 py-3 text-right"
-          onClick={(e) => e.stopPropagation()}
-        >
+        <TableCell className="w-12 px-3 py-3 text-right" onClick={(e) => e.stopPropagation()}>
           <div className="opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 has-[[data-state=open]]:opacity-100">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/apps/web/components/workbook/add-cell-button.tsx
+++ b/apps/web/components/workbook/add-cell-button.tsx
@@ -98,8 +98,8 @@ export function AddCellButton({
         {showEmptyState ? (
           <div className="flex flex-col items-center pb-2 pt-4">
             <BookOpen className="mb-4 size-12 text-[#CDD5DB]" />
-            <p className="mb-1 text-sm font-medium text-[#68737B]">Empty workbook</p>
-            <p className="text-xs text-[#CDD5DB]">Add a cell to get started</p>
+            <p className="mb-1 text-sm font-medium text-[#011111]">Empty workbook</p>
+            <p className="text-xs text-[#68737B]">Add a cell to get started</p>
           </div>
         ) : (
           <span className="text-[13px] font-normal leading-[21px] text-[#808080]">Add new</span>
@@ -111,7 +111,7 @@ export function AddCellButton({
               opt.label,
               <button
                 key={opt.label}
-                className="inline-flex h-[38px] items-center justify-center gap-1 rounded-lg bg-[#EDF2F6] px-4 text-[13px] font-semibold leading-[18px] text-[#011111]"
+                className="inline-flex h-[38px] items-center justify-center gap-1 rounded-lg bg-[#EDF2F6] px-4 text-[13px] font-semibold leading-[18px] text-[#011111] transition-colors hover:bg-[#E5EBF0]"
                 onClick={() => handleClick(opt.type)}
               >
                 <opt.icon className="size-4" style={{ color: opt.color }} />
@@ -142,7 +142,7 @@ export function AddCellButton({
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="h-7 w-7 rounded-full p-0"
+                      className="h-7 w-7 rounded-full p-0 hover:bg-[#EDF2F6]"
                       onClick={() => handleClick(opt.type)}
                     >
                       <opt.icon className="h-3.5 w-3.5" style={{ color: opt.color }} />

--- a/apps/web/components/workbook/cell-renderer.tsx
+++ b/apps/web/components/workbook/cell-renderer.tsx
@@ -92,6 +92,7 @@ export function CellRenderer({
           onUpdate={onUpdate}
           onDelete={onDelete}
           readOnly={readOnly}
+          allCells={allCells}
         />
       );
     case "branch":

--- a/apps/web/components/workbook/cells/branch-cell.tsx
+++ b/apps/web/components/workbook/cells/branch-cell.tsx
@@ -9,7 +9,6 @@ import type {
   BranchPath,
   WorkbookCell,
 } from "@repo/api/schemas/workbook-cells.schema";
-import { Badge } from "@repo/ui/components/badge";
 import { Button } from "@repo/ui/components/button";
 import {
   Collapsible,
@@ -447,9 +446,9 @@ export function BranchCellComponent({
       executionError={executionError}
       readOnly={readOnly}
       headerBadges={
-        <Badge variant="outline" className="text-xs">
+        <span className="text-xs font-normal text-[#68737B]">
           {cell.paths.length} path{cell.paths.length !== 1 ? "s" : ""}
-        </Badge>
+        </span>
       }
       onRun={() => onRun?.()}
     >

--- a/apps/web/components/workbook/cells/macro-cell.tsx
+++ b/apps/web/components/workbook/cells/macro-cell.tsx
@@ -130,16 +130,20 @@ export function MacroCellComponent({
       executionError={executionError}
       readOnly={readOnly}
       forceActionsVisible={langSelectOpen}
-      headerBadges={
-        <div className="flex items-center gap-1">
-          <Link href={`/platform/macros/${macroId}`} target="_blank">
-            <ExternalLink className="text-muted-foreground hover:text-foreground h-3 w-3 transition-colors" />
-          </Link>
-        </div>
-      }
       onRun={onRun}
       headerActions={
         <div className="flex items-center gap-1">
+          <Button
+            asChild
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground h-7 w-7 p-0 hover:text-[#005E5E]"
+            title="Open macro in new tab"
+          >
+            <Link href={`/platform/macros/${macroId}`} target="_blank">
+              <ExternalLink className="h-3 w-3" />
+            </Link>
+          </Button>
           {isOwner && (
             <Select
               value={macroLanguage ?? language}

--- a/apps/web/components/workbook/cells/macro-cell.tsx
+++ b/apps/web/components/workbook/cells/macro-cell.tsx
@@ -140,7 +140,12 @@ export function MacroCellComponent({
             className="text-muted-foreground h-7 w-7 p-0 hover:text-[#005E5E]"
             title="Open macro in new tab"
           >
-            <Link href={`/platform/macros/${macroId}`} target="_blank">
+            <Link
+              href={`/platform/macros/${macroId}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open macro in new tab"
+            >
               <ExternalLink className="h-3 w-3" />
             </Link>
           </Button>

--- a/apps/web/components/workbook/cells/markdown-cell.test.tsx
+++ b/apps/web/components/workbook/cells/markdown-cell.test.tsx
@@ -114,4 +114,44 @@ describe("MarkdownCellComponent", () => {
     expect(screen.queryByText("Preview")).not.toBeInTheDocument();
     expect(screen.getByTestId("rich-renderer")).toBeInTheDocument();
   });
+
+  it("Cmd/Ctrl+Enter inside the editor commits to preview mode", async () => {
+    const user = userEvent.setup();
+    renderMarkdown({ content: "<p>Drafting</p>" });
+
+    // Start in preview because content exists, click Edit to enter the editor.
+    await user.click(screen.getByText("Edit"));
+    const textarea = screen.getByTestId("rich-textarea");
+    textarea.focus();
+
+    // Plain Enter must NOT commit (Quill uses it for newlines).
+    await user.keyboard("{Enter}");
+    expect(screen.getByTestId("rich-textarea")).toBeInTheDocument();
+
+    // Ctrl+Enter commits and flips back to preview.
+    await user.keyboard("{Control>}{Enter}{/Control}");
+    expect(screen.queryByTestId("rich-textarea")).not.toBeInTheDocument();
+    expect(screen.getByTestId("rich-renderer")).toBeInTheDocument();
+  });
+
+  it("clicking the rendered preview re-enters the editor", async () => {
+    const user = userEvent.setup();
+    renderMarkdown({ content: "<p>Saved content</p>" });
+
+    expect(screen.getByTestId("rich-renderer")).toBeInTheDocument();
+    await user.click(screen.getByTestId("rich-renderer"));
+    expect(screen.getByTestId("rich-textarea")).toBeInTheDocument();
+  });
+
+  it("clicking the empty-state hint enters the editor", async () => {
+    const user = userEvent.setup();
+    renderMarkdown();
+    // Start in edit mode (no content); flip to preview first, then re-enter
+    // via the empty-state click affordance.
+    await user.click(screen.getByText("Preview"));
+    expect(screen.getByText("Click to add content...")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Click to add content..."));
+    expect(screen.getByTestId("rich-textarea")).toBeInTheDocument();
+  });
 });

--- a/apps/web/components/workbook/cells/markdown-cell.tsx
+++ b/apps/web/components/workbook/cells/markdown-cell.tsx
@@ -110,10 +110,7 @@ export function MarkdownCellComponent({
         </div>
       ) : (
         <p
-          className={cn(
-            "px-1 py-3 text-sm italic text-[#68737B]",
-            !readOnly && "cursor-text",
-          )}
+          className={cn("px-1 py-3 text-sm italic text-[#68737B]", !readOnly && "cursor-text")}
           onClick={enterEditMode}
         >
           {readOnly ? "No content" : "Click to add content..."}

--- a/apps/web/components/workbook/cells/markdown-cell.tsx
+++ b/apps/web/components/workbook/cells/markdown-cell.tsx
@@ -7,6 +7,7 @@ import type { MarkdownCell as MarkdownCellType } from "@repo/api/schemas/workboo
 import { Button } from "@repo/ui/components/button";
 import { RichTextRenderer } from "@repo/ui/components/rich-text-renderer";
 import { RichTextarea } from "@repo/ui/components/rich-textarea";
+import { cn } from "@repo/ui/lib/utils";
 
 import { CellWrapper } from "../cell-wrapper";
 
@@ -38,6 +39,19 @@ export function MarkdownCellComponent({
 
   const toggleMode = () => setIsEditing(!isEditing);
 
+  const enterEditMode = () => {
+    if (!readOnly) setIsEditing(true);
+  };
+
+  // Cmd/Ctrl+Enter commits the edit and switches to preview. Plain Enter
+  // still inserts a newline in the rich-text editor.
+  const handleEditorKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      setIsEditing(false);
+    }
+  };
+
   return (
     <CellWrapper
       icon={<FileText className="h-3.5 w-3.5" />}
@@ -54,7 +68,7 @@ export function MarkdownCellComponent({
           <Button
             variant="ghost"
             size="sm"
-            className="text-muted-foreground h-7 gap-1 px-2 text-xs"
+            className="text-muted-foreground h-7 gap-1 px-2 text-xs hover:text-[#005E5E]"
             onClick={toggleMode}
           >
             {isEditing ? (
@@ -71,15 +85,37 @@ export function MarkdownCellComponent({
       }
     >
       {!readOnly && isEditing ? (
-        <RichTextarea
-          value={cell.content}
-          onChange={handleContentChange}
-          placeholder="Write something..."
-        />
+        <div onKeyDown={handleEditorKeyDown}>
+          <RichTextarea
+            value={cell.content}
+            onChange={handleContentChange}
+            placeholder="Write something..."
+          />
+        </div>
       ) : cell.content && cell.content !== "<p><br></p>" ? (
-        <RichTextRenderer content={cell.content} />
+        <div
+          onClick={enterEditMode}
+          onKeyDown={(e) => {
+            if (!readOnly && (e.key === "Enter" || e.key === " ")) {
+              e.preventDefault();
+              enterEditMode();
+            }
+          }}
+          role={readOnly ? undefined : "button"}
+          tabIndex={readOnly ? undefined : 0}
+          aria-label={readOnly ? undefined : "Edit markdown"}
+          className={readOnly ? undefined : "cursor-text"}
+        >
+          <RichTextRenderer content={cell.content} />
+        </div>
       ) : (
-        <p className="px-1 py-3 text-sm italic text-[#68737B]">
+        <p
+          className={cn(
+            "px-1 py-3 text-sm italic text-[#68737B]",
+            !readOnly && "cursor-text",
+          )}
+          onClick={enterEditMode}
+        >
           {readOnly ? "No content" : "Click to add content..."}
         </p>
       )}

--- a/apps/web/components/workbook/cells/output-cell-timeseries.tsx
+++ b/apps/web/components/workbook/cells/output-cell-timeseries.tsx
@@ -349,11 +349,11 @@ export function OutputCellTimeseries({
     annotations,
     hovermode: "closest",
     showlegend: true,
+    // `entrywidth` + `orientation: "h"` packs items into rows of fixed pixel
+    // width; without it, Plotly's horizontal mode stacks one item per row when
+    // label text is long. The two `entrywidth*` keys exist in Plotly.js runtime
+    // but are missing from @types/plotly.js, so cast through to bypass the type.
     legend: {
-      // `entrywidth` + `orientation: "h"` packs items into rows of fixed pixel
-      // width. Without it, Plotly's horizontal mode stacks one item per row
-      // when label text is long, which eats the y-axis on protocols with many
-      // sub-protocol × LED combinations.
       orientation: "h",
       xanchor: "left",
       x: 0,
@@ -363,7 +363,7 @@ export function OutputCellTimeseries({
       tracegroupgap: 16,
       entrywidth: 240,
       entrywidthmode: "pixels",
-    },
+    } as Partial<Layout["legend"]>,
     plot_bgcolor: "#FFFFFF",
     paper_bgcolor: "#FFFFFF",
   };

--- a/apps/web/components/workbook/cells/output-cell-timeseries.tsx
+++ b/apps/web/components/workbook/cells/output-cell-timeseries.tsx
@@ -44,34 +44,22 @@ function pickProtocolJson(code: unknown): ProtocolJson | null {
 
 interface SeriesGroup {
   subProtocol: string | undefined;
-  detector: number;
+  light: number;
   records: OutputRecord[];
 }
 
 function groupOutputs(outputs: OutputRecord[]): SeriesGroup[] {
   const groups = new Map<string, SeriesGroup>();
   for (const r of outputs) {
-    const key = `${r.sub_protocol ?? ""}::${r.detector}`;
+    const key = `${r.sub_protocol ?? ""}::${r.light}`;
     let group = groups.get(key);
     if (!group) {
-      group = { subProtocol: r.sub_protocol, detector: r.detector, records: [] };
+      group = { subProtocol: r.sub_protocol, light: r.light, records: [] };
       groups.set(key, group);
     }
     group.records.push(r);
   }
   return Array.from(groups.values());
-}
-
-// Stable palette so the same detector index gets a consistent colour across
-// re-renders; cycles for measurements with more detectors than entries.
-const DETECTOR_PALETTE = ["#1565c0", "#388e3c", "#e65100", "#6a1b9a", "#c62828", "#00838f"];
-
-function detectorColor(detector: number): string {
-  if (!Number.isFinite(detector)) return "#005E5E";
-  const idx =
-    (((Math.trunc(detector) - 1) % DETECTOR_PALETTE.length) + DETECTOR_PALETTE.length) %
-    DETECTOR_PALETTE.length;
-  return DETECTOR_PALETTE[idx] ?? "#005E5E";
 }
 
 function buildDetectorTraces(groups: SeriesGroup[]): Partial<PlotData>[] {
@@ -90,12 +78,12 @@ function buildDetectorTraces(groups: SeriesGroup[]): Partial<PlotData>[] {
       x.push(r.timestamp_us / 1e6);
       y.push((r.value - min) / range);
     }
-    const detectorLabel = `Det ${g.detector}`;
+    const ledLabel = LED_NAMES[g.light] ?? `LED ${g.light}`;
     const rangeText = `[${Math.round(min)}-${Math.round(max)}]`;
     const name = g.subProtocol
-      ? `${g.subProtocol} · ${detectorLabel} ${rangeText}`
-      : `${detectorLabel} ${rangeText}`;
-    const color = detectorColor(g.detector);
+      ? `${g.subProtocol} · ${ledLabel} ${rangeText}`
+      : `${ledLabel} ${rangeText}`;
+    const color = LED_COLORS[g.light] ?? "#005E5E";
     const trace = {
       type: "scatter",
       mode: "markers",

--- a/apps/web/components/workbook/cells/output-cell-timeseries.tsx
+++ b/apps/web/components/workbook/cells/output-cell-timeseries.tsx
@@ -1,19 +1,16 @@
 "use client";
 
-// Plotly's `PlotData` type spreads `any`-typed fields into our trace objects;
-// ESLint's no-unsafe-assignment / no-unsafe-return then trip on every cast we
-// do at the boundary even though the runtime data is fully typed locally. This
-// file is small and the casts are scoped, so disable the two rules here rather
-// than littering eslint-disable-next-line comments around each trace object.
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { extractMeasurement } from "@/lib/multispeq/detect";
 import type { InputRecord, OutputRecord, ProtocolJson } from "@/lib/multispeq/pipeline";
 import { LED_COLORS, LED_NAMES, measurementToTimeseries } from "@/lib/multispeq/pipeline";
-import type { Layout, PlotData, Shape } from "plotly.js";
 import { useMemo } from "react";
 
 import { useTranslation } from "@repo/i18n";
 import { PlotlyChart } from "@repo/ui/components/charts/plotly-chart";
+// Plotly's own types are a workspace dep of @repo/ui, not of apps/web —
+// re-export them through the UI charts module so we don't pull plotly.js
+// into web's package.json just to type a layout object.
+import type { Layout, PlotData, Shape } from "@repo/ui/components/charts/types";
 
 interface OutputCellTimeseriesProps {
   data: unknown;

--- a/apps/web/components/workbook/cells/output-cell-timeseries.tsx
+++ b/apps/web/components/workbook/cells/output-cell-timeseries.tsx
@@ -1,0 +1,388 @@
+"use client";
+
+// Plotly's `PlotData` type spreads `any`-typed fields into our trace objects;
+// ESLint's no-unsafe-assignment / no-unsafe-return then trip on every cast we
+// do at the boundary even though the runtime data is fully typed locally. This
+// file is small and the casts are scoped, so disable the two rules here rather
+// than littering eslint-disable-next-line comments around each trace object.
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { extractMeasurement } from "@/lib/multispeq/detect";
+import type { InputRecord, OutputRecord, ProtocolJson } from "@/lib/multispeq/pipeline";
+import { LED_COLORS, LED_NAMES, measurementToTimeseries } from "@/lib/multispeq/pipeline";
+import type { Layout, PlotData, Shape } from "plotly.js";
+import { useMemo } from "react";
+
+import { useTranslation } from "@repo/i18n";
+import { PlotlyChart } from "@repo/ui/components/charts/plotly-chart";
+
+interface OutputCellTimeseriesProps {
+  data: unknown;
+  protocolCode: unknown;
+  loading?: boolean;
+  emptyLabel: string;
+  errorLabel: string;
+}
+
+/**
+ * Picks a usable ProtocolJson out of the protocol.code field. Protocols are
+ * stored as an array of dicts; the first dict is what carries _protocol_set_
+ * and v_arrays. Falls back to the object itself for the bundled-JSON shape.
+ */
+function pickProtocolJson(code: unknown): ProtocolJson | null {
+  if (code == null) return null;
+  if (Array.isArray(code)) {
+    const items = code as unknown[];
+    const first: unknown = items[0];
+    return first && typeof first === "object" ? (first as ProtocolJson) : null;
+  }
+  if (typeof code === "object") {
+    const obj = code as Record<string, unknown>;
+    if (obj._protocol_set_) return obj as ProtocolJson;
+    if (obj.protocol_json && typeof obj.protocol_json === "object") {
+      return obj.protocol_json as ProtocolJson;
+    }
+  }
+  return null;
+}
+
+interface SeriesGroup {
+  subProtocol: string | undefined;
+  light: number;
+  records: OutputRecord[];
+}
+
+function groupOutputs(outputs: OutputRecord[]): SeriesGroup[] {
+  const groups = new Map<string, SeriesGroup>();
+  for (const r of outputs) {
+    const key = `${r.sub_protocol ?? ""}::${r.light}`;
+    let group = groups.get(key);
+    if (!group) {
+      group = { subProtocol: r.sub_protocol, light: r.light, records: [] };
+      groups.set(key, group);
+    }
+    group.records.push(r);
+  }
+  return Array.from(groups.values());
+}
+
+function buildDetectorTraces(groups: SeriesGroup[]): Partial<PlotData>[] {
+  const traces: Partial<PlotData>[] = [];
+  for (const g of groups) {
+    let min = Infinity;
+    let max = -Infinity;
+    for (const r of g.records) {
+      if (r.value < min) min = r.value;
+      if (r.value > max) max = r.value;
+    }
+    const range = max - min || 1;
+    const x: number[] = [];
+    const y: number[] = [];
+    for (const r of g.records) {
+      x.push(r.timestamp_us / 1e6);
+      y.push((r.value - min) / range);
+    }
+    const ledLabel = LED_NAMES[g.light] ?? `LED ${g.light}`;
+    const rangeText = `[${Math.round(min)}-${Math.round(max)}]`;
+    const name = g.subProtocol
+      ? `${g.subProtocol} · ${ledLabel} ${rangeText}`
+      : `${ledLabel} ${rangeText}`;
+    const color = LED_COLORS[g.light] ?? "#005E5E";
+    const trace = {
+      type: "scatter",
+      mode: "markers",
+      x,
+      y,
+      name,
+      yaxis: "y",
+      marker: { size: 3, color, opacity: 0.7 },
+      legendgroup: "detectors",
+      legendgrouptitle: { text: "Detectors" },
+      hovertemplate: `<b>%{fullData.name}</b><br>t=%{x:.3f}s<br>norm=%{y:.3f}<extra></extra>`,
+    } as unknown as Partial<PlotData>;
+    traces.push(trace);
+  }
+  return traces;
+}
+
+/**
+ * Plotly's background `shapes` don't appear in the legend on their own. Add
+ * lightweight ghost traces — one per unique (LED, brightness) combo — that
+ * carry the colour swatch and the brightness value as a legend label, with
+ * `[NaN]` data so nothing actually plots.
+ */
+function buildLightLegendTraces(inputs: InputRecord[]): Partial<PlotData>[] {
+  // Collapse to one legend entry per (LED, light_type), reporting the min-max
+  // brightness range across all phases for that LED.
+  const groups = new Map<string, { led: number; lightType: string; min: number; max: number }>();
+  for (const r of inputs) {
+    if (r.light_type !== "actinic" && r.light_type !== "pre_illumination") continue;
+    if (r.led == null || r.brightness == null) continue;
+    const key = `${r.light_type}-${r.led}`;
+    const existing = groups.get(key);
+    if (!existing) {
+      groups.set(key, {
+        led: r.led,
+        lightType: r.light_type,
+        min: r.brightness,
+        max: r.brightness,
+      });
+    } else {
+      if (r.brightness < existing.min) existing.min = r.brightness;
+      if (r.brightness > existing.max) existing.max = r.brightness;
+    }
+  }
+  const traces: Partial<PlotData>[] = [];
+  for (const { led, lightType, min, max } of groups.values()) {
+    const ledLabel = LED_NAMES[led] ?? `LED ${led}`;
+    const tag = lightType === "pre_illumination" ? "pre-illum" : "actinic";
+    const rangeText = min === max ? `${min}` : `${min}-${max}`;
+    const name = `${ledLabel} (${tag}) [${rangeText} µmol]`;
+    const color = LED_COLORS[led] ?? "#1976d2";
+    const trace = {
+      type: "scatter",
+      mode: "markers",
+      x: [NaN],
+      y: [NaN],
+      name,
+      marker: { size: 10, color, symbol: "square", opacity: 0.6 },
+      legendgroup: "lights",
+      legendgrouptitle: { text: "Lights" },
+      hoverinfo: "skip",
+      showlegend: true,
+    } as unknown as Partial<PlotData>;
+    traces.push(trace);
+  }
+  return traces;
+}
+
+function buildShapes(inputs: InputRecord[], totalDurationS: number): Partial<Shape>[] {
+  const shapes: Partial<Shape>[] = [];
+  for (const r of inputs) {
+    if (r.light_type !== "actinic" && r.light_type !== "pre_illumination") continue;
+    if (r.led == null) continue;
+    const color = LED_COLORS[r.led] ?? "#1976d2";
+    // Right axis (yaxis2) carries the actinic light scale in µmol m⁻² s⁻¹.
+    // Phases without a resolved brightness fall back to 500, matching the
+    // matplotlib notebook's `r.brightness if r.brightness is not None else 500`.
+    const brightness = r.brightness ?? 500;
+    shapes.push({
+      type: "rect",
+      xref: "x",
+      yref: "y2",
+      x0: r.t_start_us / 1e6,
+      x1: r.t_end_us / 1e6,
+      y0: 0,
+      y1: brightness,
+      fillcolor: color,
+      opacity: 0.15,
+      line: { color, width: 0 },
+      layer: "below",
+    });
+  }
+  // Sub-protocol boundary lines on the (left) normalised axis.
+  const boundaries = new Set<number>();
+  for (const r of inputs) {
+    if (r.light_type === "actinic" || r.light_type === "measuring") {
+      boundaries.add(r.t_start_us / 1e6);
+    }
+  }
+  const sorted = Array.from(boundaries).sort((a, b) => a - b);
+  for (let i = 1; i < sorted.length; i++) {
+    shapes.push({
+      type: "line",
+      xref: "x",
+      yref: "y",
+      x0: sorted[i],
+      x1: sorted[i],
+      y0: 0,
+      y1: 1,
+      line: { color: "#CDD5DB", width: 0.5, dash: "dot" },
+      layer: "below",
+    });
+  }
+  if (totalDurationS > 0) {
+    // Sentinel so the x-axis range covers the full timeline even when traces
+    // end short of it.
+    shapes.push({
+      type: "line",
+      xref: "x",
+      yref: "y",
+      x0: totalDurationS,
+      x1: totalDurationS,
+      y0: 0,
+      y1: 0,
+      line: { color: "transparent", width: 0 },
+    });
+  }
+  return shapes;
+}
+
+function buildAnnotations(inputs: InputRecord[], totalDurationS: number) {
+  const byLabel = new Map<string, { start: number; end: number }>();
+  for (const r of inputs) {
+    if (!r.sub_protocol) continue;
+    const span = byLabel.get(r.sub_protocol);
+    const start = r.t_start_us / 1e6;
+    const end = r.t_end_us / 1e6;
+    if (!span) {
+      byLabel.set(r.sub_protocol, { start, end });
+    } else {
+      span.start = Math.min(span.start, start);
+      span.end = Math.max(span.end, end);
+    }
+  }
+  const minSeparation = totalDurationS * 0.04;
+  const lanes: number[] = [];
+  const entries = Array.from(byLabel.entries()).sort((a, b) => a[1].start - b[1].start);
+  return entries.map(([label, span]) => {
+    const x = (span.start + span.end) / 2;
+    let lane = 0;
+    while (lane < lanes.length && x - (lanes[lane] ?? -Infinity) < minSeparation) lane++;
+    lanes[lane] = x;
+    return {
+      x,
+      y: 1.04 + lane * 0.05,
+      xref: "x" as const,
+      yref: "y" as const,
+      text: label,
+      showarrow: false,
+      font: { size: 10, color: "#68737B" },
+      bgcolor: "rgba(255,255,255,0.85)",
+    };
+  });
+}
+
+function maxBrightness(inputs: InputRecord[]): number {
+  let max = 0;
+  for (const r of inputs) {
+    if (r.light_type !== "actinic" && r.light_type !== "pre_illumination") continue;
+    const b = r.brightness ?? 500;
+    if (b > max) max = b;
+  }
+  return max;
+}
+
+export function OutputCellTimeseries({
+  data,
+  protocolCode,
+  loading,
+  emptyLabel,
+  errorLabel,
+}: OutputCellTimeseriesProps) {
+  const { t } = useTranslation("workbook");
+
+  const decoded = useMemo(() => {
+    const measurement = extractMeasurement(data);
+    const protocolJson = pickProtocolJson(protocolCode);
+    if (!measurement || !protocolJson) return null;
+    try {
+      return measurementToTimeseries(measurement, protocolJson);
+    } catch {
+      return null;
+    }
+  }, [data, protocolCode]);
+
+  if (loading) {
+    return (
+      <div className="flex h-[960px] items-center justify-center rounded-lg border border-[#EDF2F6] bg-[#F7F8FA] text-xs text-[#68737B]">
+        {t("output.loadingProtocol")}
+      </div>
+    );
+  }
+
+  if (!decoded) {
+    return (
+      <div className="flex h-[120px] items-center justify-center rounded-lg border border-[#EDF2F6] bg-[#F7F8FA] text-xs text-[#68737B]">
+        {errorLabel}
+      </div>
+    );
+  }
+
+  const groups = groupOutputs(decoded.outputs);
+  if (groups.length === 0) {
+    return (
+      <div className="flex h-[120px] items-center justify-center rounded-lg border border-[#EDF2F6] bg-[#F7F8FA] text-xs text-[#68737B]">
+        {emptyLabel}
+      </div>
+    );
+  }
+
+  const inputEndS = decoded.inputs.reduce((m, r) => Math.max(m, r.t_end_us / 1e6), 0);
+  const totalDurationS = Math.max(inputEndS, decoded.totalDurationUs / 1e6);
+  const detectorTraces = buildDetectorTraces(groups);
+  const lightLegendTraces = buildLightLegendTraces(decoded.inputs);
+  const traces: Partial<PlotData>[] = detectorTraces.concat(lightLegendTraces);
+  const shapes = buildShapes(decoded.inputs, totalDurationS);
+  const annotations = buildAnnotations(decoded.inputs, totalDurationS);
+  const yaxis2Max = Math.max(maxBrightness(decoded.inputs) * 1.2, 1000);
+
+  const layout: Partial<Layout> = {
+    // PlotlyChart's wrapper only honours autosize when the layout opts in;
+    // without this, it falls back to a fixed default width (~700 px) and the
+    // chart leaves blank space on the right of its container.
+    autosize: true,
+    // Big bottom margin reserves the band the multi-column legend occupies.
+    // Plot area = container_height - top - bottom, so this directly trades
+    // legend height vs y-axis height.
+    margin: { l: 60, r: 70, t: 30, b: 220 },
+    xaxis: {
+      title: { text: t("output.timeseriesXAxis"), font: { size: 12 } },
+      gridcolor: "#EDF2F6",
+      zeroline: false,
+      automargin: false,
+    },
+    yaxis: {
+      title: { text: t("output.timeseriesYAxis"), font: { size: 12 } },
+      gridcolor: "#EDF2F6",
+      zeroline: false,
+      range: [-0.05, 1.1],
+      automargin: false,
+    },
+    yaxis2: {
+      title: { text: t("output.timeseriesActinic"), font: { size: 12, color: "#68737B" } },
+      overlaying: "y",
+      side: "right",
+      range: [0, yaxis2Max],
+      showgrid: false,
+      zeroline: false,
+      tickfont: { color: "#68737B" },
+      automargin: false,
+    },
+    shapes,
+    annotations,
+    hovermode: "closest",
+    showlegend: true,
+    legend: {
+      // `entrywidth` + `orientation: "h"` packs items into rows of fixed pixel
+      // width. Without it, Plotly's horizontal mode stacks one item per row
+      // when label text is long, which eats the y-axis on protocols with many
+      // sub-protocol × LED combinations.
+      orientation: "h",
+      xanchor: "left",
+      x: 0,
+      yanchor: "top",
+      y: -0.12,
+      font: { size: 10 },
+      tracegroupgap: 16,
+      entrywidth: 240,
+      entrywidthmode: "pixels",
+    },
+    plot_bgcolor: "#FFFFFF",
+    paper_bgcolor: "#FFFFFF",
+  };
+
+  return (
+    <div className="h-[820px] w-full overflow-hidden rounded-lg border border-[#EDF2F6] bg-white">
+      <PlotlyChart
+        data={traces}
+        layout={layout}
+        config={{
+          displayModeBar: true,
+          responsive: true,
+          displaylogo: false,
+          toImageButtonOptions: { format: "png", filename: "multispeq-timeseries" },
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/workbook/cells/output-cell-timeseries.tsx
+++ b/apps/web/components/workbook/cells/output-cell-timeseries.tsx
@@ -64,18 +64,12 @@ function groupOutputs(outputs: OutputRecord[]): SeriesGroup[] {
 
 // Stable palette so the same detector index gets a consistent colour across
 // re-renders; cycles for measurements with more detectors than entries.
-const DETECTOR_PALETTE = [
-  "#1565c0",
-  "#388e3c",
-  "#e65100",
-  "#6a1b9a",
-  "#c62828",
-  "#00838f",
-];
+const DETECTOR_PALETTE = ["#1565c0", "#388e3c", "#e65100", "#6a1b9a", "#c62828", "#00838f"];
 
 function detectorColor(detector: number): string {
   if (!Number.isFinite(detector)) return "#005E5E";
-  const idx = ((Math.trunc(detector) - 1) % DETECTOR_PALETTE.length + DETECTOR_PALETTE.length) %
+  const idx =
+    (((Math.trunc(detector) - 1) % DETECTOR_PALETTE.length) + DETECTOR_PALETTE.length) %
     DETECTOR_PALETTE.length;
   return DETECTOR_PALETTE[idx] ?? "#005E5E";
 }

--- a/apps/web/components/workbook/cells/output-cell-timeseries.tsx
+++ b/apps/web/components/workbook/cells/output-cell-timeseries.tsx
@@ -44,22 +44,40 @@ function pickProtocolJson(code: unknown): ProtocolJson | null {
 
 interface SeriesGroup {
   subProtocol: string | undefined;
-  light: number;
+  detector: number;
   records: OutputRecord[];
 }
 
 function groupOutputs(outputs: OutputRecord[]): SeriesGroup[] {
   const groups = new Map<string, SeriesGroup>();
   for (const r of outputs) {
-    const key = `${r.sub_protocol ?? ""}::${r.light}`;
+    const key = `${r.sub_protocol ?? ""}::${r.detector}`;
     let group = groups.get(key);
     if (!group) {
-      group = { subProtocol: r.sub_protocol, light: r.light, records: [] };
+      group = { subProtocol: r.sub_protocol, detector: r.detector, records: [] };
       groups.set(key, group);
     }
     group.records.push(r);
   }
   return Array.from(groups.values());
+}
+
+// Stable palette so the same detector index gets a consistent colour across
+// re-renders; cycles for measurements with more detectors than entries.
+const DETECTOR_PALETTE = [
+  "#1565c0",
+  "#388e3c",
+  "#e65100",
+  "#6a1b9a",
+  "#c62828",
+  "#00838f",
+];
+
+function detectorColor(detector: number): string {
+  if (!Number.isFinite(detector)) return "#005E5E";
+  const idx = ((Math.trunc(detector) - 1) % DETECTOR_PALETTE.length + DETECTOR_PALETTE.length) %
+    DETECTOR_PALETTE.length;
+  return DETECTOR_PALETTE[idx] ?? "#005E5E";
 }
 
 function buildDetectorTraces(groups: SeriesGroup[]): Partial<PlotData>[] {
@@ -78,12 +96,12 @@ function buildDetectorTraces(groups: SeriesGroup[]): Partial<PlotData>[] {
       x.push(r.timestamp_us / 1e6);
       y.push((r.value - min) / range);
     }
-    const ledLabel = LED_NAMES[g.light] ?? `LED ${g.light}`;
+    const detectorLabel = `Det ${g.detector}`;
     const rangeText = `[${Math.round(min)}-${Math.round(max)}]`;
     const name = g.subProtocol
-      ? `${g.subProtocol} · ${ledLabel} ${rangeText}`
-      : `${ledLabel} ${rangeText}`;
-    const color = LED_COLORS[g.light] ?? "#005E5E";
+      ? `${g.subProtocol} · ${detectorLabel} ${rangeText}`
+      : `${detectorLabel} ${rangeText}`;
+    const color = detectorColor(g.detector);
     const trace = {
       type: "scatter",
       mode: "markers",

--- a/apps/web/components/workbook/cells/output-cell.test.tsx
+++ b/apps/web/components/workbook/cells/output-cell.test.tsx
@@ -508,10 +508,12 @@ describe("OutputCellComponent", () => {
       const tab = screen.getByRole("tab", { name: "output.tabTimeseries" });
       await user.click(tab);
 
-      // Decoded series name follows "<sub_protocol> · Det <detector> [vmin-vmax]";
+      // Decoded series name follows "<sub_protocol> · <led label> [vmin-vmax]";
       // values are normalised 0..1.
       expect(screen.getByTestId("plotly-chart")).toBeInTheDocument();
-      expect(screen.getByTestId("series-ABS · Det 3 [10-30]")).toHaveTextContent("0,0.5,1");
+      expect(screen.getByTestId("series-ABS · 530 nm (green, body) [10-30]")).toHaveTextContent(
+        "0,0.5,1",
+      );
     });
 
     it("shows a loading placeholder while the source protocol is being fetched", async () => {

--- a/apps/web/components/workbook/cells/output-cell.test.tsx
+++ b/apps/web/components/workbook/cells/output-cell.test.tsx
@@ -1,11 +1,16 @@
-import { createOutputCell } from "@/test/factories";
+import { createOutputCell, createProtocolCell } from "@/test/factories";
 import { render, screen, userEvent, waitFor } from "@/test/test-utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { OutputCellComponent } from "./output-cell";
 
-// Plotly cannot run in jsdom; render a stub that exposes the series for assertions.
-// Mock factory is hoisted so we use React.createElement (no JSX) to avoid runtime ordering issues.
+const useProtocolMock = vi.hoisted(() => vi.fn());
+vi.mock("@/hooks/protocol/useProtocol/useProtocol", () => ({
+  useProtocol: useProtocolMock,
+}));
+
+// Plotly cannot run in jsdom; render stubs that expose the series for assertions.
+// Mock factories are hoisted so we use React.createElement (no JSX) to avoid runtime ordering issues.
 vi.mock("@repo/ui/components/charts/line-chart", async (importOriginal) => {
   const actual: Record<string, unknown> = await importOriginal();
   const { createElement } = await import("react");
@@ -20,6 +25,34 @@ vi.mock("@repo/ui/components/charts/line-chart", async (importOriginal) => {
         },
         data.map((s) =>
           createElement("div", { key: s.name, "data-testid": `series-${s.name}` }, s.y.join(",")),
+        ),
+      ),
+  };
+});
+
+interface MockPlotlyTrace {
+  name?: string;
+  y?: number[];
+}
+
+vi.mock("@repo/ui/components/charts/plotly-chart", async (importOriginal) => {
+  const actual: Record<string, unknown> = await importOriginal();
+  const { createElement } = await import("react");
+  return {
+    ...actual,
+    PlotlyChart: ({ data }: { data: MockPlotlyTrace[] }) =>
+      createElement(
+        "div",
+        {
+          "data-testid": "plotly-chart",
+          "data-series": JSON.stringify(data.map((s) => s.name ?? "")),
+        },
+        data.map((s) =>
+          createElement(
+            "div",
+            { key: s.name ?? "", "data-testid": `series-${s.name ?? ""}` },
+            (s.y ?? []).join(","),
+          ),
         ),
       ),
   };
@@ -43,6 +76,8 @@ describe("OutputCellComponent", () => {
     writeText.mockClear();
     onUpdate.mockClear();
     onDelete.mockClear();
+    useProtocolMock.mockReset();
+    useProtocolMock.mockReturnValue({ data: undefined, isLoading: false });
   });
 
   it("displays execution time and messages with correct severity styling", () => {
@@ -378,5 +413,107 @@ describe("OutputCellComponent", () => {
     expect(screen.getByText("84")).toBeInTheDocument();
     // Non-object rows render as em-dash placeholders in every column.
     expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(4);
+  });
+
+  describe("Timeseries tab (multispeq)", () => {
+    function multispeqProtocolCode() {
+      return [
+        {
+          v_arrays: [[3]],
+          _protocol_set_: [
+            {
+              label: "ABS",
+              pulses: ["@n0:0"],
+              pulse_distance: [1000],
+              detectors: [[3]],
+              pulsed_lights: [[1]],
+              nonpulsed_lights: [[2]],
+              nonpulsed_lights_brightness: [[100]],
+            },
+          ],
+        },
+      ];
+    }
+
+    function multispeqOutput() {
+      return {
+        sample_raw: JSON.stringify([
+          { set: [{ label: "ABS", data_raw: [10, 20, 30], pi: [2, 100, 1] }] },
+        ]),
+      };
+    }
+
+    it("does not show the Timeseries tab when there is no source protocol cell", () => {
+      const cell = createOutputCell({ data: multispeqOutput() });
+      render(<OutputCellComponent cell={cell} onUpdate={onUpdate} onDelete={onDelete} />);
+      expect(screen.queryByRole("tab", { name: "output.tabTimeseries" })).not.toBeInTheDocument();
+    });
+
+    it("does not show the Timeseries tab when the source protocol family is not multispeq", () => {
+      const proto = createProtocolCell();
+      const cell = createOutputCell({ data: multispeqOutput(), producedBy: proto.id });
+      useProtocolMock.mockReturnValue({
+        data: { body: { family: "ambit", code: multispeqProtocolCode() } },
+        isLoading: false,
+      });
+      render(
+        <OutputCellComponent
+          cell={cell}
+          onUpdate={onUpdate}
+          onDelete={onDelete}
+          allCells={[proto, cell]}
+        />,
+      );
+      expect(screen.queryByRole("tab", { name: "output.tabTimeseries" })).not.toBeInTheDocument();
+    });
+
+    it("does not show the Timeseries tab when output data is not a multispeq payload", () => {
+      const proto = createProtocolCell();
+      const cell = createOutputCell({
+        data: { device_id: "abc", firmware: "1.0" },
+        producedBy: proto.id,
+      });
+      useProtocolMock.mockReturnValue({
+        data: { body: { family: "multispeq", code: multispeqProtocolCode() } },
+        isLoading: false,
+      });
+      render(
+        <OutputCellComponent
+          cell={cell}
+          onUpdate={onUpdate}
+          onDelete={onDelete}
+          allCells={[proto, cell]}
+        />,
+      );
+      expect(screen.queryByRole("tab", { name: "output.tabTimeseries" })).not.toBeInTheDocument();
+    });
+
+    it("shows a Timeseries tab and decodes detectors into a chart for multispeq output", async () => {
+      const user = userEvent.setup();
+      const proto = createProtocolCell();
+      const cell = createOutputCell({ data: multispeqOutput(), producedBy: proto.id });
+      useProtocolMock.mockReturnValue({
+        data: { body: { family: "multispeq", code: multispeqProtocolCode() } },
+        isLoading: false,
+      });
+      render(
+        <OutputCellComponent
+          cell={cell}
+          onUpdate={onUpdate}
+          onDelete={onDelete}
+          allCells={[proto, cell]}
+        />,
+      );
+
+      const tab = screen.getByRole("tab", { name: "output.tabTimeseries" });
+      await user.click(tab);
+
+      // Decoded series name follows "<sub_protocol> · <led label> [vmin-vmax]";
+      // values are normalised 0..1.
+      expect(screen.getByTestId("plotly-chart")).toBeInTheDocument();
+      expect(screen.getByTestId("series-ABS · 530 nm (green, body) [10-30]")).toHaveTextContent(
+        "0,0.5,1",
+      );
+    });
   });
 });

--- a/apps/web/components/workbook/cells/output-cell.test.tsx
+++ b/apps/web/components/workbook/cells/output-cell.test.tsx
@@ -515,5 +515,174 @@ describe("OutputCellComponent", () => {
         "0,0.5,1",
       );
     });
+
+    it("shows a loading placeholder while the source protocol is being fetched", async () => {
+      const user = userEvent.setup();
+      const proto = createProtocolCell();
+      const cell = createOutputCell({ data: multispeqOutput(), producedBy: proto.id });
+      // Family is multispeq so the tab shows; `isLoading: true` triggers the
+      // loading branch in OutputCellTimeseries.
+      useProtocolMock.mockReturnValue({
+        data: { body: { family: "multispeq", code: undefined } },
+        isLoading: true,
+      });
+      render(
+        <OutputCellComponent
+          cell={cell}
+          onUpdate={onUpdate}
+          onDelete={onDelete}
+          allCells={[proto, cell]}
+        />,
+      );
+      await user.click(screen.getByRole("tab", { name: "output.tabTimeseries" }));
+      expect(screen.getByText("output.loadingProtocol")).toBeInTheDocument();
+    });
+
+    it("shows the decode-error placeholder when the protocol code is missing", async () => {
+      const user = userEvent.setup();
+      const proto = createProtocolCell();
+      const cell = createOutputCell({ data: multispeqOutput(), producedBy: proto.id });
+      // Family is multispeq, isLoading is false, but no protocol code is
+      // available — measurementToTimeseries can't decode. Falls into the
+      // error branch.
+      useProtocolMock.mockReturnValue({
+        data: { body: { family: "multispeq", code: undefined } },
+        isLoading: false,
+      });
+      render(
+        <OutputCellComponent
+          cell={cell}
+          onUpdate={onUpdate}
+          onDelete={onDelete}
+          allCells={[proto, cell]}
+        />,
+      );
+      await user.click(screen.getByRole("tab", { name: "output.tabTimeseries" }));
+      expect(screen.getByText("output.timeseriesError")).toBeInTheDocument();
+    });
+
+    it("shows the empty placeholder when decoding succeeds but emits no detector data", async () => {
+      const user = userEvent.setup();
+      const proto = createProtocolCell();
+      // Sample with a sub-protocol whose label has no protocol set entry, so
+      // outputs come back empty after decoding.
+      const cell = createOutputCell({
+        data: {
+          sample_raw: JSON.stringify([
+            { set: [{ label: "UNKNOWN_PROTOCOL_LABEL", data_raw: [] }] },
+          ]),
+        },
+        producedBy: proto.id,
+      });
+      useProtocolMock.mockReturnValue({
+        data: { body: { family: "multispeq", code: multispeqProtocolCode() } },
+        isLoading: false,
+      });
+      render(
+        <OutputCellComponent
+          cell={cell}
+          onUpdate={onUpdate}
+          onDelete={onDelete}
+          allCells={[proto, cell]}
+        />,
+      );
+      await user.click(screen.getByRole("tab", { name: "output.tabTimeseries" }));
+      expect(screen.getByText("output.timeseriesEmpty")).toBeInTheDocument();
+    });
+
+    it("decodes a protocol passed in already-unwrapped (object, not single-element array) form", async () => {
+      const user = userEvent.setup();
+      const proto = createProtocolCell();
+      const cell = createOutputCell({ data: multispeqOutput(), producedBy: proto.id });
+      // Pick the inner ProtocolJson object directly — pickProtocolJson should
+      // accept it as-is (the code field can be either a 1-element array or
+      // the inner dict, depending on how the protocol was saved).
+      const inner = multispeqProtocolCode()[0];
+      useProtocolMock.mockReturnValue({
+        data: { body: { family: "multispeq", code: inner } },
+        isLoading: false,
+      });
+      render(
+        <OutputCellComponent
+          cell={cell}
+          onUpdate={onUpdate}
+          onDelete={onDelete}
+          allCells={[proto, cell]}
+        />,
+      );
+      await user.click(screen.getByRole("tab", { name: "output.tabTimeseries" }));
+      expect(screen.getByTestId("plotly-chart")).toBeInTheDocument();
+    });
+
+    it("collapses repeated actinic brightness across phases into a min-max range entry", async () => {
+      const user = userEvent.setup();
+      const proto = createProtocolCell();
+      // Protocol with two phases at different actinic brightnesses for the same LED.
+      const code = [
+        {
+          v_arrays: [[3, 3]],
+          _protocol_set_: [
+            {
+              label: "ABS",
+              pulses: ["@n0:0", "@n0:1"],
+              pulse_distance: [1000, 1000],
+              detectors: [[3], [3]],
+              pulsed_lights: [[1], [1]],
+              nonpulsed_lights: [[2], [2]],
+              nonpulsed_lights_brightness: [[100], [500]],
+            },
+          ],
+        },
+      ];
+      const cell = createOutputCell({
+        data: {
+          sample_raw: JSON.stringify([
+            { set: [{ label: "ABS", data_raw: [10, 20, 30, 40, 50, 60] }] },
+          ]),
+        },
+        producedBy: proto.id,
+      });
+      useProtocolMock.mockReturnValue({
+        data: { body: { family: "multispeq", code } },
+        isLoading: false,
+      });
+      render(
+        <OutputCellComponent
+          cell={cell}
+          onUpdate={onUpdate}
+          onDelete={onDelete}
+          allCells={[proto, cell]}
+        />,
+      );
+      await user.click(screen.getByRole("tab", { name: "output.tabTimeseries" }));
+      // The light legend collapses 100 + 500 µmol on LED 2 into a single trace
+      // whose label carries the brightness range; this exercises the min/max
+      // update branches in buildLightLegendTraces.
+      const seriesAttr = screen.getByTestId("plotly-chart").getAttribute("data-series") ?? "";
+      expect(seriesAttr).toMatch(/100-500 µmol/);
+    });
+
+    it("decodes a protocol passed wrapped under a `protocol_json` field", async () => {
+      const user = userEvent.setup();
+      const proto = createProtocolCell();
+      const cell = createOutputCell({ data: multispeqOutput(), producedBy: proto.id });
+      // The bundled-protocol shape has the inner dict under .protocol_json;
+      // the picker should unwrap it.
+      const inner = multispeqProtocolCode()[0];
+      useProtocolMock.mockReturnValue({
+        data: { body: { family: "multispeq", code: { protocol_json: inner } } },
+        isLoading: false,
+      });
+      render(
+        <OutputCellComponent
+          cell={cell}
+          onUpdate={onUpdate}
+          onDelete={onDelete}
+          allCells={[proto, cell]}
+        />,
+      );
+      await user.click(screen.getByRole("tab", { name: "output.tabTimeseries" }));
+      expect(screen.getByTestId("plotly-chart")).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/components/workbook/cells/output-cell.test.tsx
+++ b/apps/web/components/workbook/cells/output-cell.test.tsx
@@ -508,12 +508,10 @@ describe("OutputCellComponent", () => {
       const tab = screen.getByRole("tab", { name: "output.tabTimeseries" });
       await user.click(tab);
 
-      // Decoded series name follows "<sub_protocol> · <led label> [vmin-vmax]";
+      // Decoded series name follows "<sub_protocol> · Det <detector> [vmin-vmax]";
       // values are normalised 0..1.
       expect(screen.getByTestId("plotly-chart")).toBeInTheDocument();
-      expect(screen.getByTestId("series-ABS · 530 nm (green, body) [10-30]")).toHaveTextContent(
-        "0,0.5,1",
-      );
+      expect(screen.getByTestId("series-ABS · Det 3 [10-30]")).toHaveTextContent("0,0.5,1");
     });
 
     it("shows a loading placeholder while the source protocol is being fetched", async () => {

--- a/apps/web/components/workbook/cells/output-cell.tsx
+++ b/apps/web/components/workbook/cells/output-cell.tsx
@@ -12,7 +12,7 @@ import {
   Clock,
   Copy,
   Info,
-  X,
+  Trash2,
 } from "lucide-react";
 import { useState } from "react";
 
@@ -203,7 +203,7 @@ export function OutputCellComponent({
   const showTimeseries = protocolFamily === "multispeq" && isMultispeqOutput(cell.data);
 
   return (
-    <div className="group/output relative overflow-hidden rounded-b-[10px] border border-t-0 border-[#EDF2F6] bg-white">
+    <div className="group/output relative mt-1 overflow-hidden rounded-[10px] border border-[#EDF2F6] bg-white">
       <div className={`px-4 ${isCollapsed ? "py-2" : "pb-3 pt-3"}`}>
         <div className={isCollapsed ? "flex items-center gap-2" : "mb-2 flex items-center gap-2"}>
           <button
@@ -222,9 +222,9 @@ export function OutputCellComponent({
             {t("output.label")}
           </span>
           {cell.executionTime != null && (
-            <span className="flex items-center gap-1 text-[11px] text-[#CDD5DB]">
+            <span className="inline-flex items-center gap-1 text-[11px] leading-none text-[#CDD5DB]">
               <Clock className="size-3" />
-              {formatExecutionTime(cell.executionTime)}
+              <span className="leading-none">{formatExecutionTime(cell.executionTime)}</span>
             </span>
           )}
           <div className="flex-1" />
@@ -234,7 +234,7 @@ export function OutputCellComponent({
               onClick={onDelete}
               title={t("output.clear")}
             >
-              <X className="size-3 text-[#68737B]" />
+              <Trash2 className="size-3 text-[#68737B]" />
             </button>
           )}
         </div>

--- a/apps/web/components/workbook/cells/output-cell.tsx
+++ b/apps/web/components/workbook/cells/output-cell.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useProtocol } from "@/hooks/protocol/useProtocol/useProtocol";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { isMultispeqOutput } from "@/lib/multispeq/detect";
 import {
   AlertCircle,
   Check,
@@ -14,19 +16,24 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 
-import type { OutputCell as OutputCellType } from "@repo/api/schemas/workbook-cells.schema";
+import type {
+  OutputCell as OutputCellType,
+  WorkbookCell,
+} from "@repo/api/schemas/workbook-cells.schema";
 import { useTranslation } from "@repo/i18n";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@repo/ui/components/tabs";
 
 import type { ChartClickHandler } from "./output-cell-charts";
 import { ExpandedChart } from "./output-cell-charts";
 import { renderDataTable } from "./output-cell-render-data";
+import { OutputCellTimeseries } from "./output-cell-timeseries";
 
 interface OutputCellProps {
   cell: OutputCellType;
   onUpdate: (cell: OutputCellType) => void;
   onDelete: () => void;
   readOnly?: boolean;
+  allCells?: WorkbookCell[];
 }
 
 function formatExecutionTime(ms?: number): string {
@@ -73,6 +80,9 @@ function DataTabs({
   onChartClick,
   activeTab,
   onTabChange,
+  showTimeseries,
+  protocolCode,
+  protocolLoading,
 }: {
   data: unknown;
   copy: (text: string) => Promise<void>;
@@ -80,6 +90,9 @@ function DataTabs({
   onChartClick: ChartClickHandler;
   activeTab: string;
   onTabChange: (tab: string) => void;
+  showTimeseries: boolean;
+  protocolCode?: unknown;
+  protocolLoading?: boolean;
 }) {
   const { t } = useTranslation("workbook");
   return (
@@ -91,6 +104,14 @@ function DataTabs({
         >
           {t("output.tabTable")}
         </TabsTrigger>
+        {showTimeseries && (
+          <TabsTrigger
+            value="timeseries"
+            className="rounded-md px-3 py-1 text-xs font-medium text-[#68737B] data-[state=active]:bg-white data-[state=active]:shadow-sm"
+          >
+            {t("output.tabTimeseries")}
+          </TabsTrigger>
+        )}
         <TabsTrigger
           value="json"
           className="rounded-md px-3 py-1 text-xs font-medium text-[#68737B] data-[state=active]:bg-white data-[state=active]:shadow-sm"
@@ -101,6 +122,17 @@ function DataTabs({
       <TabsContent value="table" className="mt-2">
         {renderDataTable(data, { onChartClick, noDataLabel: t("output.noData") })}
       </TabsContent>
+      {showTimeseries && (
+        <TabsContent value="timeseries" className="mt-2">
+          <OutputCellTimeseries
+            data={data}
+            protocolCode={protocolCode}
+            loading={protocolLoading}
+            emptyLabel={t("output.timeseriesEmpty")}
+            errorLabel={t("output.timeseriesError")}
+          />
+        </TabsContent>
+      )}
       <TabsContent value="json" className="mt-2">
         <div className="relative">
           <pre className="max-h-[480px] overflow-auto rounded-lg bg-[#F7F8FA] p-3 pr-12 text-xs text-[#011111]">
@@ -124,7 +156,13 @@ function DataTabs({
   );
 }
 
-export function OutputCellComponent({ cell, onUpdate, onDelete, readOnly }: OutputCellProps) {
+export function OutputCellComponent({
+  cell,
+  onUpdate,
+  onDelete,
+  readOnly,
+  allCells,
+}: OutputCellProps) {
   const { t } = useTranslation("workbook");
   const hasContent = cell.data != null || (cell.messages && cell.messages.length > 0);
   // Read-only viewers can still collapse the cell for their own view, but their toggle should not
@@ -149,9 +187,20 @@ export function OutputCellComponent({ cell, onUpdate, onDelete, readOnly }: Outp
   const handleTabChange = (tab: string) => {
     setActiveTab(tab);
     // The expanded chart only makes sense alongside the table view, so collapse it
-    // when the user switches to JSON.
+    // when the user switches off it.
     if (tab !== "table") setPinnedChart(null);
   };
+
+  const sourceCell = allCells?.find((c) => c.id === cell.producedBy);
+  const sourceProtocolId =
+    sourceCell?.type === "protocol" ? sourceCell.payload.protocolId : undefined;
+  const { data: protocolResponse, isLoading: protocolLoading } = useProtocol(
+    sourceProtocolId ?? "",
+    !!sourceProtocolId,
+  );
+  const protocolFamily = protocolResponse?.body.family;
+  const protocolCode = protocolResponse?.body.code;
+  const showTimeseries = protocolFamily === "multispeq" && isMultispeqOutput(cell.data);
 
   return (
     <div className="group/output relative overflow-hidden rounded-b-[10px] border border-t-0 border-[#EDF2F6] bg-white">
@@ -235,6 +284,9 @@ export function OutputCellComponent({ cell, onUpdate, onDelete, readOnly }: Outp
                   onChartClick={handleChartClick}
                   activeTab={activeTab}
                   onTabChange={handleTabChange}
+                  showTimeseries={showTimeseries}
+                  protocolCode={protocolCode}
+                  protocolLoading={protocolLoading}
                 />
                 {pinnedChart && activeTab === "table" && (
                   // Plotly reuses its plot div across re-renders; switching columns can leave the

--- a/apps/web/components/workbook/cells/protocol-cell.tsx
+++ b/apps/web/components/workbook/cells/protocol-cell.tsx
@@ -135,7 +135,12 @@ export function ProtocolCellComponent({
             className="text-muted-foreground h-7 w-7 p-0 hover:text-[#005E5E]"
             title="Open protocol in new tab"
           >
-            <Link href={`/platform/protocols/${protocolId}`} target="_blank">
+            <Link
+              href={`/platform/protocols/${protocolId}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Open protocol in new tab"
+            >
               <ExternalLink className="h-3 w-3" />
             </Link>
           </Button>

--- a/apps/web/components/workbook/cells/protocol-cell.tsx
+++ b/apps/web/components/workbook/cells/protocol-cell.tsx
@@ -120,26 +120,25 @@ export function ProtocolCellComponent({
       executionError={executionError}
       readOnly={readOnly}
       headerBadges={
-        <div className="flex items-center gap-1.5">
-          {protocolFamily && (
-            <span
-              className="rounded px-1.5 py-0.5 text-xs font-medium capitalize"
-              style={{
-                backgroundColor: "color-mix(in srgb, #2D3142 10%, transparent)",
-                border: "1px solid color-mix(in srgb, #2D3142 25%, transparent)",
-                color: "#2D3142",
-              }}
-            >
-              {getSensorFamilyLabel(protocolFamily)}
-            </span>
-          )}
-          <Link href={`/platform/protocols/${protocolId}`} target="_blank">
-            <ExternalLink className="text-muted-foreground hover:text-foreground h-3 w-3 transition-colors" />
-          </Link>
-        </div>
+        protocolFamily ? (
+          <span className="text-xs capitalize text-[#68737B]">
+            {getSensorFamilyLabel(protocolFamily)}
+          </span>
+        ) : undefined
       }
       headerActions={
         <div className="flex items-center gap-1">
+          <Button
+            asChild
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground h-7 w-7 p-0 hover:text-[#005E5E]"
+            title="Open protocol in new tab"
+          >
+            <Link href={`/platform/protocols/${protocolId}`} target="_blank">
+              <ExternalLink className="h-3 w-3" />
+            </Link>
+          </Button>
           <Button
             variant="ghost"
             size="sm"

--- a/apps/web/components/workbook/cells/question-cell.test.tsx
+++ b/apps/web/components/workbook/cells/question-cell.test.tsx
@@ -153,7 +153,7 @@ describe("QuestionCellComponent", () => {
       expect(input).toBeDisabled();
     });
 
-    it("hides the required switch (hidden via headerActions)", () => {
+    it("hides the required switch in read-only mode", () => {
       renderQuestion({}, { readOnly: true });
       expect(screen.queryByRole("switch")).not.toBeInTheDocument();
     });

--- a/apps/web/components/workbook/cells/question-cell.tsx
+++ b/apps/web/components/workbook/cells/question-cell.tsx
@@ -337,17 +337,6 @@ export function QuestionCellComponent({
         executionError={executionError}
         readOnly={readOnly}
         headerBadges={undefined}
-        headerActions={
-          <div className="text-muted-foreground flex items-center gap-1 text-xs">
-            <span>Required</span>
-            <Switch
-              checked={question.required}
-              onCheckedChange={handleRequiredToggle}
-              className="scale-75"
-              disabled={readOnly}
-            />
-          </div>
-        }
       >
         <div className="space-y-3">
           <div className="flex items-center gap-0.5 rounded-lg border bg-[#EDF2F6] p-0.5">
@@ -383,6 +372,17 @@ export function QuestionCellComponent({
             className="border-[#CDD5DB] bg-white text-sm placeholder:text-[#CDD5DB]"
             disabled={readOnly}
           />
+
+          {!readOnly && (
+            <label className="text-muted-foreground flex items-center gap-2 text-xs">
+              <Switch
+                checked={question.required}
+                onCheckedChange={handleRequiredToggle}
+                className="scale-75"
+              />
+              <span>Required</span>
+            </label>
+          )}
 
           {question.kind === "multi_choice" && (
             <div className="space-y-1.5 pl-1">

--- a/apps/web/components/workbook/workbook-editor.test.tsx
+++ b/apps/web/components/workbook/workbook-editor.test.tsx
@@ -243,7 +243,12 @@ describe("WorkbookEditor — sidebar minimap", () => {
     renderEditor({ cells });
 
     expect(screen.getAllByText(/Markdown/).length).toBeGreaterThanOrEqual(2);
-    expect(screen.getAllByText(/soil_moisture/).length).toBeGreaterThanOrEqual(2);
+    // The sidebar shows the literal type label "Question" for question cells;
+    // the cell name (e.g. "soil_moisture") only appears in the cell header.
+    // The add-cell button row also renders a "Question" picker, so we expect
+    // at least one (sidebar) + one (picker).
+    expect(screen.getAllByText(/^Question$/).length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText(/Why\?/).length).toBeGreaterThanOrEqual(1);
   });
 });
 

--- a/apps/web/components/workbook/workbook-editor.tsx
+++ b/apps/web/components/workbook/workbook-editor.tsx
@@ -406,31 +406,31 @@ export function WorkbookEditor({
                       />
                     ))}
                   <div className="group/row flex items-stretch gap-1">
-                    <div className="relative w-10 shrink-0">
-                      <div className="flex justify-center pt-2">
+                    <div className="w-10 shrink-0">
+                      <div className="flex flex-col items-center gap-1 pt-2">
+                        {!isOutput && !readOnly && (
+                          <div
+                            className="cursor-grab opacity-0 transition-opacity group-hover/row:opacity-100"
+                            draggable
+                            onDragStart={(e) => {
+                              const row = e.currentTarget.parentElement?.parentElement;
+                              if (row) {
+                                e.dataTransfer.setDragImage(row, 20, 20);
+                              }
+                              e.dataTransfer.effectAllowed = "move";
+                              handleDragStart(index);
+                            }}
+                            onDragEnd={handleDragEnd}
+                          >
+                            <GripVertical className="h-4 w-4" style={{ color: "#005E5E" }} />
+                          </div>
+                        )}
                         {cellNumber !== undefined && (
                           <span className="text-muted-foreground font-mono text-[10px] leading-none">
                             [{executionStates?.[cell.id]?.executionOrder?.at(-1) ?? cellNumber}]
                           </span>
                         )}
                       </div>
-                      {!isOutput && !readOnly && (
-                        <div
-                          className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 cursor-grab opacity-0 transition-opacity group-hover/row:opacity-100"
-                          draggable
-                          onDragStart={(e) => {
-                            const row = e.currentTarget.parentElement?.parentElement;
-                            if (row) {
-                              e.dataTransfer.setDragImage(row, 20, 20);
-                            }
-                            e.dataTransfer.effectAllowed = "move";
-                            handleDragStart(index);
-                          }}
-                          onDragEnd={handleDragEnd}
-                        >
-                          <GripVertical className="text-muted-foreground h-4 w-4" />
-                        </div>
-                      )}
                     </div>
                     <div className="min-w-0 flex-1">
                       <CellRenderer

--- a/apps/web/components/workbook/workbook-header.test.tsx
+++ b/apps/web/components/workbook/workbook-header.test.tsx
@@ -2,6 +2,7 @@ import {
   createMacro,
   createMarkdownCell,
   createMacroCell,
+  createOutputCell,
   createProtocol,
   createProtocolCell,
 } from "@/test/factories";
@@ -138,12 +139,22 @@ describe("WorkbookHeader", () => {
 
   it("calls onClearOutputs when user clicks Clear all", async () => {
     const user = userEvent.setup();
-    const { props } = renderHeader();
+    const outputCell = createOutputCell({ producedBy: protocolCell.id });
+    const { props } = renderHeader({
+      cells: [markdownCell, protocolCell, macroCell, outputCell],
+    });
 
     const clearButton = screen.getByRole("button", { name: /clear all/i });
     await user.click(clearButton);
 
     expect(props.onClearOutputs).toHaveBeenCalledOnce();
+  });
+
+  it("disables Clear all when there are no output cells", () => {
+    renderHeader();
+
+    const clearButton = screen.getByRole("button", { name: /clear all/i });
+    expect(clearButton).toBeDisabled();
   });
 
   it("calls onToggleFlowchart when user clicks Flow button", async () => {

--- a/apps/web/components/workbook/workbook-header.tsx
+++ b/apps/web/components/workbook/workbook-header.tsx
@@ -360,10 +360,7 @@ export function WorkbookHeader({
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-52">
           <DropdownMenuItem onClick={handleExportJSON}>Export as JSON</DropdownMenuItem>
-          <DropdownMenuItem
-            onClick={() => void handleExportProtocol()}
-            disabled={!hasProtocols}
-          >
+          <DropdownMenuItem onClick={() => void handleExportProtocol()} disabled={!hasProtocols}>
             Export Protocol Only
           </DropdownMenuItem>
           <DropdownMenuItem onClick={() => void handleExportMacro()} disabled={!hasMacros}>

--- a/apps/web/components/workbook/workbook-header.tsx
+++ b/apps/web/components/workbook/workbook-header.tsx
@@ -3,20 +3,7 @@
 import { AutosaveIndicator } from "@/components/shared/autosave/autosave-indicator";
 import { tsr } from "@/lib/tsr";
 import { decodeBase64 } from "@/util/base64";
-import {
-  ChevronDown,
-  Circle,
-  Code,
-  Download,
-  File,
-  FileCode,
-  FileJson,
-  GitBranch,
-  Play,
-  Square,
-  Trash2,
-  Usb,
-} from "lucide-react";
+import { ChevronDown, Circle, GitBranch, Play, Square, Trash2, Usb } from "lucide-react";
 import { useCallback } from "react";
 import { useIotBrowserSupport } from "~/hooks/iot/useIotBrowserSupport";
 
@@ -218,10 +205,11 @@ export function WorkbookHeader({
 
   const hasProtocols = cells.some((c) => c.type === "protocol");
   const hasMacros = cells.some((c) => c.type === "macro");
+  const hasOutputs = cells.some((c) => c.type === "output");
 
   return (
     <div
-      className="sticky top-16 z-30 flex items-center gap-2 rounded-b-xl border-b px-4 py-2 xl:gap-3 xl:py-3"
+      className="sticky top-16 z-30 flex items-center gap-2 border-b px-4 py-2 xl:gap-3 xl:py-3"
       style={{ background: "#FFFFFF", borderColor: "#EDF2F6" }}
     >
       <div className="flex items-center gap-1.5 xl:gap-2.5">
@@ -336,7 +324,7 @@ export function WorkbookHeader({
           className="inline-flex h-[34px] shrink-0 items-center justify-center gap-1.5 px-2.5 text-[12px] font-semibold leading-[18px] xl:h-[44px] xl:gap-2 xl:px-4 xl:text-[15px] xl:leading-[20px]"
           style={
             flowchartOpen
-              ? { background: "#005E5E", borderRadius: 8, color: "#FFFFFF" }
+              ? { background: "rgba(0, 94, 94, 0.1)", borderRadius: 8, color: "#005E5E" }
               : { background: "#EDF2F6", borderRadius: 8, color: "#011111" }
           }
           onClick={onToggleFlowchart}
@@ -358,7 +346,7 @@ export function WorkbookHeader({
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button
-            className="inline-flex h-[34px] shrink-0 items-center justify-center gap-1.5 border px-2.5 text-[12px] font-normal leading-[18px] xl:h-[38px] xl:gap-2 xl:px-4 xl:text-[13px] xl:leading-[21px]"
+            className="inline-flex h-[34px] shrink-0 items-center justify-center gap-1.5 border px-2.5 text-[12px] font-normal leading-[18px] hover:bg-[#EDF2F6] xl:h-[44px] xl:gap-2 xl:px-4 xl:text-[13px] xl:leading-[21px]"
             style={{
               borderColor: "#CDD5DB",
               borderRadius: 12,
@@ -366,44 +354,36 @@ export function WorkbookHeader({
               background: "#FFFFFF",
             }}
           >
-            <Download className="size-4" />
             <span className="hidden xl:inline">Export</span>
             <ChevronDown className="size-3 xl:size-4" />
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-52">
-          <DropdownMenuItem onClick={handleExportJSON} className="gap-2">
-            <FileJson className="size-4 text-blue-600" />
-            Export as JSON
-          </DropdownMenuItem>
+          <DropdownMenuItem onClick={handleExportJSON}>Export as JSON</DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => void handleExportProtocol()}
-            className="gap-2"
             disabled={!hasProtocols}
           >
-            <FileCode className="size-4 text-emerald-600" />
             Export Protocol Only
           </DropdownMenuItem>
-          <DropdownMenuItem
-            onClick={() => void handleExportMacro()}
-            className="gap-2"
-            disabled={!hasMacros}
-          >
-            <Code className="size-4 text-violet-600" />
+          <DropdownMenuItem onClick={() => void handleExportMacro()} disabled={!hasMacros}>
             Export Macro Only
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={handleDownloadWorkbook} className="gap-2">
-            <File className="size-4 text-amber-600" />
+          <DropdownMenuItem onClick={handleDownloadWorkbook}>
             Download Workbook (.jii)
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
 
       <button
-        className="inline-flex h-[34px] shrink-0 items-center justify-center gap-1.5 px-2.5 text-[12px] font-semibold leading-[18px] xl:h-[44px] xl:gap-2 xl:px-4 xl:text-[15px] xl:leading-[20px]"
+        className={cn(
+          "inline-flex h-[34px] shrink-0 items-center justify-center gap-1.5 px-2.5 text-[12px] font-semibold leading-[18px] xl:h-[44px] xl:gap-2 xl:px-4 xl:text-[15px] xl:leading-[20px]",
+          !hasOutputs && "cursor-not-allowed opacity-50",
+        )}
         style={{ background: "#EDF2F6", borderRadius: 8, color: "#011111" }}
         onClick={onClearOutputs}
+        disabled={!hasOutputs}
       >
         <Trash2 className="size-4" />
         <span className="hidden xl:inline">Clear all</span>

--- a/apps/web/components/workbook/workbook-sidebar.test.tsx
+++ b/apps/web/components/workbook/workbook-sidebar.test.tsx
@@ -24,7 +24,7 @@ describe("WorkbookSidebar", () => {
     vi.clearAllMocks();
   });
 
-  it("renders cell list with type labels (and the cell's name for question cells)", () => {
+  it("renders cell list with the type label as title (question shows 'Question' + text below)", () => {
     render(
       <WorkbookSidebar
         cells={[markdownCell, questionCell, protocolCell]}
@@ -32,8 +32,10 @@ describe("WorkbookSidebar", () => {
       />,
     );
     expect(screen.getByText("Markdown")).toBeInTheDocument();
-    expect(screen.getByText("soil_moisture")).toBeInTheDocument();
-    expect(screen.queryByText("Question")).not.toBeInTheDocument();
+    // For question cells the title is now the literal type label "Question"
+    // (in pink) and the question text shows in the subtitle row.
+    expect(screen.getByText("Question")).toBeInTheDocument();
+    expect(screen.queryByText("soil_moisture")).not.toBeInTheDocument();
     expect(screen.getByText("Protocol")).toBeInTheDocument();
   });
 

--- a/apps/web/components/workbook/workbook-sidebar.test.tsx
+++ b/apps/web/components/workbook/workbook-sidebar.test.tsx
@@ -63,4 +63,32 @@ describe("WorkbookSidebar", () => {
     render(<WorkbookSidebar cells={[emptyMd]} onCellClick={onCellClick} />);
     expect(screen.getByText("Empty")).toBeInTheDocument();
   });
+
+  it("shows a Required asterisk next to required question rows", () => {
+    const required = createQuestionCell({
+      id: "q-required",
+      name: "consent",
+      question: { kind: "yes_no", text: "Consent?", required: true },
+    });
+    render(<WorkbookSidebar cells={[required]} onCellClick={onCellClick} />);
+    // aria-label comes from the i18n "workbooks.required" key.
+    expect(screen.getByLabelText("workbooks.required")).toBeInTheDocument();
+  });
+
+  it("makes the whole card the drag source when onReorder is provided", () => {
+    const onReorder = vi.fn();
+    render(
+      <WorkbookSidebar
+        cells={[markdownCell, protocolCell]}
+        onCellClick={onCellClick}
+        onReorder={onReorder}
+      />,
+    );
+
+    // The outer row button carries `draggable=true` so the user can grab
+    // anywhere on the card, not just the GripVertical icon.
+    const rows = screen.getAllByRole("button").filter((el) => el.getAttribute("draggable"));
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+    rows.forEach((row) => expect(row).toHaveAttribute("draggable", "true"));
+  });
 });

--- a/apps/web/components/workbook/workbook-sidebar.tsx
+++ b/apps/web/components/workbook/workbook-sidebar.tsx
@@ -140,12 +140,8 @@ export function WorkbookSidebar({
         style={{ marginTop: 20 }}
         title="Expand sidebar"
       >
-        <List
-          className="h-4 w-4 text-[#005E5E] transition-colors group-hover/collapse:text-[#007575]"
-        />
-        <span
-          className="text-[11px] font-medium leading-none text-[#005E5E] transition-colors group-hover/collapse:text-[#007575]"
-        >
+        <List className="h-4 w-4 text-[#005E5E] transition-colors group-hover/collapse:text-[#007575]" />
+        <span className="text-[11px] font-medium leading-none text-[#005E5E] transition-colors group-hover/collapse:text-[#007575]">
           {visibleCells.length}
         </span>
       </button>
@@ -185,8 +181,7 @@ export function WorkbookSidebar({
 
           // The whole card is the drag source so the user can grab anywhere on
           // it; the GripVertical icon is purely a visual hint.
-          const isRequiredQuestion =
-            cell.type === "question" && cell.question.required === true;
+          const isRequiredQuestion = cell.type === "question" && cell.question.required === true;
 
           return (
             <div key={cell.id}>

--- a/apps/web/components/workbook/workbook-sidebar.tsx
+++ b/apps/web/components/workbook/workbook-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { GripVertical, List, PanelRightClose } from "lucide-react";
+import { Asterisk, GripVertical, List, PanelRightClose } from "lucide-react";
 import { useCallback, useState } from "react";
 import { stripHtml } from "~/util/strip-html";
 
@@ -12,7 +12,7 @@ const cellColors: Record<string, string> = {
   question: "#C58AAE",
   protocol: "#2D3142",
   macro: "#6C5CE7",
-  branch: "#D08A3C",
+  branch: "#F29D38",
   markdown: "#6F8596",
   output: "#94A3B8",
 };
@@ -136,12 +136,16 @@ export function WorkbookSidebar({
       <button
         type="button"
         onClick={onToggleCollapsed}
-        className="flex flex-col items-center gap-2 rounded-lg px-2 py-3 transition-colors hover:bg-gray-50"
+        className="group/collapse flex flex-col items-center gap-2 rounded-lg px-2 py-3 transition-colors"
         style={{ marginTop: 20 }}
         title="Expand sidebar"
       >
-        <List className="h-4 w-4" style={{ color: "#68737B" }} />
-        <span className="text-[11px] font-medium leading-none" style={{ color: "#68737B" }}>
+        <List
+          className="h-4 w-4 text-[#005E5E] transition-colors group-hover/collapse:text-[#007575]"
+        />
+        <span
+          className="text-[11px] font-medium leading-none text-[#005E5E] transition-colors group-hover/collapse:text-[#007575]"
+        >
           {visibleCells.length}
         </span>
       </button>
@@ -160,10 +164,10 @@ export function WorkbookSidebar({
           <button
             type="button"
             onClick={onToggleCollapsed}
-            className="rounded p-1 transition-colors hover:bg-gray-100"
+            className="rounded p-1 text-[#005E5E] transition-colors hover:text-[#007575]"
             title="Collapse sidebar"
           >
-            <PanelRightClose className="h-4 w-4" style={{ color: "#68737B" }} />
+            <PanelRightClose className="h-4 w-4" />
           </button>
         )}
       </div>
@@ -179,11 +183,16 @@ export function WorkbookSidebar({
           const isBeingDragged = dragIndex === index;
           const number = index + 1;
 
+          // The whole card is the drag source so the user can grab anywhere on
+          // it; the GripVertical icon is purely a visual hint.
+          const isRequiredQuestion =
+            cell.type === "question" && cell.question.required === true;
+
           return (
             <div key={cell.id}>
               {/* Drop indicator */}
               {dropIndex === index && dragIndex !== null && (
-                <div className="mb-1 h-0.5 rounded-full bg-blue-400" />
+                <div className="mb-1 h-0.5 rounded-full bg-[#005E5E]" />
               )}
 
               <button
@@ -191,12 +200,26 @@ export function WorkbookSidebar({
                 className={cn(
                   "flex h-[55px] w-full items-center justify-between rounded-[7px] text-left transition-colors",
                   isBeingDragged && "opacity-40",
+                  onReorder && "cursor-grab active:cursor-grabbing",
                 )}
                 style={{
                   padding: "8px 9px 8px 9px",
                   borderLeft: `3px solid ${isActive ? color : "transparent"}`,
                   backgroundColor: isActive ? cellActiveBg[cell.type] : undefined,
                 }}
+                draggable={onReorder !== undefined}
+                onDragStart={
+                  onReorder
+                    ? (e) => {
+                        const row = e.currentTarget;
+                        const rect = row.getBoundingClientRect();
+                        e.dataTransfer.setDragImage(row, rect.width / 2, rect.height / 2);
+                        e.dataTransfer.effectAllowed = "move";
+                        handleDragStart(index);
+                      }
+                    : undefined
+                }
+                onDragEnd={onReorder ? handleDragEnd : undefined}
                 onClick={() => onCellClick?.(cell.id)}
                 onDragOver={(e) => handleDragOver(e, index)}
                 onDrop={handleDrop}
@@ -216,16 +239,29 @@ export function WorkbookSidebar({
 
                   {/* Type + subtitle */}
                   <div className="flex min-w-0 flex-col" style={{ gap: 2, maxWidth: 160 }}>
-                    <span
-                      className={cn(
-                        "truncate text-[13px] leading-[18px] tracking-[0.02em]",
-                        isActive ? "font-semibold" : "font-medium",
+                    <span className="flex items-center gap-0.5">
+                      <span
+                        className={cn(
+                          "truncate text-[13px] leading-[18px] tracking-[0.02em]",
+                          isActive ? "font-semibold" : "font-medium",
+                        )}
+                        style={
+                          cell.type === "question"
+                            ? { color }
+                            : isActive
+                              ? { color }
+                              : { color: "#011111" }
+                        }
+                      >
+                        {cellTypeLabels[cell.type] ?? cell.type}
+                      </span>
+                      {isRequiredQuestion && (
+                        <Asterisk
+                          className="size-3 shrink-0"
+                          style={{ color: "#005E5E" }}
+                          aria-label="Required"
+                        />
                       )}
-                      style={isActive ? { color } : { color: "#011111" }}
-                    >
-                      {cell.type === "question"
-                        ? cell.name
-                        : (cellTypeLabels[cell.type] ?? cell.type)}
                     </span>
                     <span
                       className="truncate text-[13px] font-normal leading-[21px]"
@@ -236,24 +272,9 @@ export function WorkbookSidebar({
                   </div>
                 </div>
 
-                {/* Drag handle */}
+                {/* Drag handle (visual indicator only — the whole card drags) */}
                 {onReorder && (
-                  <div
-                    className="shrink-0 cursor-grab"
-                    draggable
-                    onDragStart={(e) => {
-                      e.stopPropagation();
-                      const row = e.currentTarget.closest("button");
-                      if (row) {
-                        const rect = row.getBoundingClientRect();
-                        e.dataTransfer.setDragImage(row, rect.width - 20, rect.height / 2);
-                      }
-                      e.dataTransfer.effectAllowed = "move";
-                      handleDragStart(index);
-                    }}
-                    onDragEnd={handleDragEnd}
-                    onClick={(e) => e.stopPropagation()}
-                  >
+                  <div className="shrink-0">
                     <GripVertical className="h-4 w-4" style={{ color: "#005E5E" }} />
                   </div>
                 )}
@@ -264,7 +285,7 @@ export function WorkbookSidebar({
 
         {/* Drop indicator after last cell */}
         {dropIndex === visibleCells.length && dragIndex !== null && (
-          <div className="h-0.5 rounded-full bg-blue-400" />
+          <div className="h-0.5 rounded-full bg-[#005E5E]" />
         )}
       </div>
     </div>

--- a/apps/web/components/workbook/workbook-sidebar.tsx
+++ b/apps/web/components/workbook/workbook-sidebar.tsx
@@ -5,6 +5,7 @@ import { useCallback, useState } from "react";
 import { stripHtml } from "~/util/strip-html";
 
 import type { WorkbookCell } from "@repo/api/schemas/workbook-cells.schema";
+import { useTranslation } from "@repo/i18n";
 import { cn } from "@repo/ui/lib/utils";
 
 /** Accent color per cell type, matching the cell components. */
@@ -77,6 +78,7 @@ export function WorkbookSidebar({
   collapsed,
   onToggleCollapsed,
 }: WorkbookSidebarProps) {
+  const { t } = useTranslation("workbook");
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [dropIndex, setDropIndex] = useState<number | null>(null);
 
@@ -254,7 +256,7 @@ export function WorkbookSidebar({
                         <Asterisk
                           className="size-3 shrink-0"
                           style={{ color: "#005E5E" }}
-                          aria-label="Required"
+                          aria-label={t("workbooks.required")}
                         />
                       )}
                     </span>

--- a/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.test.ts
+++ b/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.test.ts
@@ -125,23 +125,6 @@ describe("useWorkbookExecution", () => {
       );
     });
 
-    it("fires onRequireDevice when running a protocol with no device", async () => {
-      const proto = createProtocolCell();
-      const protocol = createProtocol({
-        id: proto.payload.protocolId,
-        code: [{ _protocol_set_: [] }],
-      });
-      server.mount(contract.protocols.getProtocol, { body: protocol });
-      mockIsConnected = false;
-
-      const onRequireDevice = vi.fn();
-      const { result } = renderExecution([proto], { onRequireDevice });
-
-      await act(() => result.current.runCell(proto.id));
-
-      expect(onRequireDevice).toHaveBeenCalledOnce();
-    });
-
     it("executes protocol and produces output cell", async () => {
       const proto = createProtocolCell();
       const protocol = createProtocol({

--- a/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.test.ts
+++ b/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.test.ts
@@ -125,6 +125,23 @@ describe("useWorkbookExecution", () => {
       );
     });
 
+    it("fires onRequireDevice when running a protocol with no device", async () => {
+      const proto = createProtocolCell();
+      const protocol = createProtocol({
+        id: proto.payload.protocolId,
+        code: [{ _protocol_set_: [] }],
+      });
+      server.mount(contract.protocols.getProtocol, { body: protocol });
+      mockIsConnected = false;
+
+      const onRequireDevice = vi.fn();
+      const { result } = renderExecution([proto], { onRequireDevice });
+
+      await act(() => result.current.runCell(proto.id));
+
+      expect(onRequireDevice).toHaveBeenCalledOnce();
+    });
+
     it("executes protocol and produces output cell", async () => {
       const proto = createProtocolCell();
       const protocol = createProtocol({

--- a/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.ts
+++ b/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.ts
@@ -29,6 +29,10 @@ interface UseWorkbookExecutionOptions {
   cells: WorkbookCell[];
   onCellsChange: (cells: WorkbookCell[]) => void;
   onPromptQuestion?: (cell: QuestionCell) => Promise<string | undefined>;
+  /** Fires when a protocol cell is run with no device connected. The host
+   * is expected to surface a user-facing prompt (toast/dialog) offering
+   * the Connect action. */
+  onRequireDevice?: () => void;
 }
 
 function resolveSensorFamily(_cells: WorkbookCell[]): SensorFamily {
@@ -106,6 +110,7 @@ export function useWorkbookExecution({
   cells,
   onCellsChange,
   onPromptQuestion,
+  onRequireDevice,
 }: UseWorkbookExecutionOptions) {
   const [executionStates, setExecutionStates] = useState<Record<string, CellExecutionState>>({});
   const [isRunningAll, setIsRunningAll] = useState(false);
@@ -121,6 +126,8 @@ export function useWorkbookExecution({
   onCellsChangeRef.current = onCellsChange;
   const onPromptQuestionRef = useRef(onPromptQuestion);
   onPromptQuestionRef.current = onPromptQuestion;
+  const onRequireDeviceRef = useRef(onRequireDevice);
+  onRequireDeviceRef.current = onRequireDevice;
 
   const setSensorFamily = useCallback((family: SensorFamily) => {
     setSensorFamilyState(family);
@@ -164,6 +171,9 @@ export function useWorkbookExecution({
       }
 
       if (!isConnectedRef.current) {
+        // Surface a UI prompt so the user can connect from the toast rather
+        // than discovering the failure only in the output cell.
+        onRequireDeviceRef.current?.();
         setCellState(cell.id, { status: "error", error: "No device connected" });
         return insertOutputAfterCell(
           currentCells,

--- a/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.ts
+++ b/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.ts
@@ -29,10 +29,6 @@ interface UseWorkbookExecutionOptions {
   cells: WorkbookCell[];
   onCellsChange: (cells: WorkbookCell[]) => void;
   onPromptQuestion?: (cell: QuestionCell) => Promise<string | undefined>;
-  /** Fires when a protocol cell is run with no device connected. The host
-   * is expected to surface a user-facing prompt (toast/dialog) offering
-   * the Connect action. */
-  onRequireDevice?: () => void;
 }
 
 function resolveSensorFamily(_cells: WorkbookCell[]): SensorFamily {
@@ -110,7 +106,6 @@ export function useWorkbookExecution({
   cells,
   onCellsChange,
   onPromptQuestion,
-  onRequireDevice,
 }: UseWorkbookExecutionOptions) {
   const [executionStates, setExecutionStates] = useState<Record<string, CellExecutionState>>({});
   const [isRunningAll, setIsRunningAll] = useState(false);
@@ -126,8 +121,6 @@ export function useWorkbookExecution({
   onCellsChangeRef.current = onCellsChange;
   const onPromptQuestionRef = useRef(onPromptQuestion);
   onPromptQuestionRef.current = onPromptQuestion;
-  const onRequireDeviceRef = useRef(onRequireDevice);
-  onRequireDeviceRef.current = onRequireDevice;
 
   const setSensorFamily = useCallback((family: SensorFamily) => {
     setSensorFamilyState(family);
@@ -171,9 +164,9 @@ export function useWorkbookExecution({
       }
 
       if (!isConnectedRef.current) {
-        // Surface a UI prompt so the user can connect from the toast rather
-        // than discovering the failure only in the output cell.
-        onRequireDeviceRef.current?.();
+        // The page-level Run handler short-circuits to connect() before this
+        // path on direct Run clicks; this branch covers Run all + scripted
+        // entry points where we still need a recorded error.
         setCellState(cell.id, { status: "error", error: "No device connected" });
         return insertOutputAfterCell(
           currentCells,

--- a/apps/web/lib/multispeq/detect.ts
+++ b/apps/web/lib/multispeq/detect.ts
@@ -49,11 +49,12 @@ export function extractMeasurement(data: unknown): MeasurementInput | null {
 
 function looksLikeSampleRaw(items: unknown[]): boolean {
   if (items.length === 0) return false;
-  const first = items[0];
-  if (!first || typeof first !== "object") return false;
-  const f = first as Record<string, unknown>;
-  if (Array.isArray(f.set) && f.set.some(hasDataRaw)) return true;
-  return hasDataRaw(first);
+  return items.some((item) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return false;
+    const obj = item as Record<string, unknown>;
+    if (Array.isArray(obj.set) && obj.set.some(hasDataRaw)) return true;
+    return hasDataRaw(item);
+  });
 }
 
 function hasDataRaw(item: unknown): boolean {

--- a/apps/web/lib/multispeq/detect.ts
+++ b/apps/web/lib/multispeq/detect.ts
@@ -1,0 +1,63 @@
+import type { MeasurementInput } from "./pipeline";
+
+/**
+ * Recognises the shapes a MultispeQ measurement may arrive in:
+ *   - Live device wrapper: { sample: [{ set: [...] } | { data_raw, ... }, ...], device_id?, ... }
+ *   - PhotosynQ DB row:    { sample_raw: "[ ... v1/v2 json ... ]" } (string or array)
+ *   - The v2 wrapper directly: { set: [{ data_raw, label?, ... }, ...], protocol_id?: ... }
+ *   - A raw v1/v2 array: [{ set: [...] }] or [{ data_raw, ... }, ...]
+ */
+export function isMultispeqOutput(data: unknown): boolean {
+  return extractMeasurement(data) != null;
+}
+
+export function extractMeasurement(data: unknown): MeasurementInput | null {
+  if (data == null || typeof data !== "object") return null;
+
+  if (Array.isArray(data)) {
+    return looksLikeSampleRaw(data) ? { sample_raw: data } : null;
+  }
+
+  const obj = data as Record<string, unknown>;
+
+  if ("sample_raw" in obj) {
+    const raw = obj.sample_raw;
+    if (typeof raw === "string" || Array.isArray(raw)) {
+      return {
+        measurement_id: typeof obj.measurement_id === "string" ? obj.measurement_id : null,
+        project_id: typeof obj.project_id === "string" ? obj.project_id : null,
+        sample_raw: raw,
+      };
+    }
+  }
+
+  // Live MultispeQ device output uses `sample` for the same payload.
+  if (Array.isArray(obj.sample) && looksLikeSampleRaw(obj.sample)) {
+    return {
+      measurement_id: typeof obj.measurement_id === "string" ? obj.measurement_id : null,
+      project_id: typeof obj.project_id === "string" ? obj.project_id : null,
+      sample_raw: obj.sample,
+    };
+  }
+
+  if (Array.isArray(obj.set) && obj.set.some(hasDataRaw)) {
+    return { sample_raw: [obj] };
+  }
+
+  return null;
+}
+
+function looksLikeSampleRaw(items: unknown[]): boolean {
+  if (items.length === 0) return false;
+  const first = items[0];
+  if (!first || typeof first !== "object") return false;
+  const f = first as Record<string, unknown>;
+  if (Array.isArray(f.set) && f.set.some(hasDataRaw)) return true;
+  return hasDataRaw(first);
+}
+
+function hasDataRaw(item: unknown): boolean {
+  if (!item || typeof item !== "object") return false;
+  const dr = (item as Record<string, unknown>).data_raw;
+  return Array.isArray(dr);
+}

--- a/apps/web/lib/multispeq/pipeline.test.ts
+++ b/apps/web/lib/multispeq/pipeline.test.ts
@@ -32,19 +32,21 @@ describe("resolveVariables", () => {
     });
   });
 
-  it("falls back to the last numeric when the indexed value is non-numeric", () => {
-    // ["p_light", 2500] — index 0 is a string, fall back to last numeric.
+  it("leaves @sX unset when the indexed slot is non-numeric so pi can fill brightness", () => {
+    // ["p_light", 2500] at iteration 0: "p_light" is a runtime sentinel meaning
+    // "use the measured ambient PAR", which only the device knows. We leave
+    // @s0 unset; downstream the brightness gets filled from the pi tuple.
     expect(resolveVariables({ v_arrays: [["p_light", 2500]] }, 0)).toEqual({
       "@n0:1": 2500,
-      "@s0": 2500,
     });
+    // Iteration 1 lands on the numeric 2500 directly.
     expect(resolveVariables({ v_arrays: [["p_light", 2500]] }, 1)).toEqual({
       "@n0:1": 2500,
       "@s0": 2500,
     });
   });
 
-  it("clamps occurrence to the array length", () => {
+  it("clamps out-of-range iterations to the last numeric value", () => {
     expect(resolveVariables({ v_arrays: [[10, 20]] }, 5)).toMatchObject({ "@s0": 20 });
   });
 

--- a/apps/web/lib/multispeq/pipeline.test.ts
+++ b/apps/web/lib/multispeq/pipeline.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, it } from "vitest";
+
+import { isMultispeqOutput, extractMeasurement } from "./detect";
+import {
+  explodeRecords,
+  inputRecords,
+  measurementToTimeseries,
+  outputRecords,
+  predictDataRawLength,
+  resolveProtocolSetEntry,
+  resolveVariables,
+} from "./pipeline";
+import type { ProtocolJson, ProtocolSetEntry } from "./pipeline";
+
+describe("resolveVariables", () => {
+  it("indexes numeric values from v_arrays as @nX:Y plus @sX (occurrence-indexed)", () => {
+    const v_arrays: unknown[][] = [
+      [10, 20],
+      [3000, 6000],
+    ];
+    expect(resolveVariables({ v_arrays }, 0)).toEqual({
+      "@n0:0": 10,
+      "@n0:1": 20,
+      "@n1:0": 3000,
+      "@n1:1": 6000,
+      "@s0": 10,
+      "@s1": 3000,
+    });
+    expect(resolveVariables({ v_arrays }, 1)).toMatchObject({
+      "@s0": 20,
+      "@s1": 6000,
+    });
+  });
+
+  it("falls back to the last numeric when the indexed value is non-numeric", () => {
+    // ["p_light", 2500] — index 0 is a string, fall back to last numeric.
+    expect(resolveVariables({ v_arrays: [["p_light", 2500]] }, 0)).toEqual({
+      "@n0:1": 2500,
+      "@s0": 2500,
+    });
+    expect(resolveVariables({ v_arrays: [["p_light", 2500]] }, 1)).toEqual({
+      "@n0:1": 2500,
+      "@s0": 2500,
+    });
+  });
+
+  it("clamps occurrence to the array length", () => {
+    expect(resolveVariables({ v_arrays: [[10, 20]] }, 5)).toMatchObject({ "@s0": 20 });
+  });
+
+  it("returns empty for missing v_arrays", () => {
+    expect(resolveVariables({})).toEqual({});
+  });
+});
+
+describe("resolveProtocolSetEntry", () => {
+  it("resolves variable references in nested detector/light arrays", () => {
+    const variables = resolveVariables({ v_arrays: [[100, 50]] });
+    const entry: ProtocolSetEntry = {
+      pulses: ["@n0:0", "@n0:1"],
+      pulse_distance: [1000, 2000],
+      detectors: [[3], [3]],
+      pulsed_lights: [[1], [1]],
+    };
+    const r = resolveProtocolSetEntry(entry, variables);
+    expect(r.pulses).toEqual([100, 50]);
+    expect(r.pulse_distance).toEqual([1000, 2000]);
+    expect(r.detectors).toEqual([[3], [3]]);
+    expect(r.pulsed_lights).toEqual([[1], [1]]);
+  });
+
+  it("treats unresolvable string brightness as null inside nested lists", () => {
+    const r = resolveProtocolSetEntry(
+      {
+        pulses: [10],
+        pulse_distance: [1000],
+        detectors: [[3]],
+        pulsed_lights: [[1]],
+        nonpulsed_lights: [[2]],
+        nonpulsed_lights_brightness: [["p_light"]],
+      },
+      {},
+    );
+    expect(r.nonpulsed_lights_brightness).toEqual([[null]]);
+  });
+});
+
+describe("predictDataRawLength", () => {
+  it("counts pulses * active detectors per phase", () => {
+    expect(
+      predictDataRawLength({
+        pulses: [10, 5],
+        detectors: [[3, 4], [3]],
+      }),
+    ).toBe(10 * 2 + 5 * 1);
+  });
+
+  it("ignores zero detector ids", () => {
+    expect(
+      predictDataRawLength({
+        pulses: [10],
+        detectors: [[3, 0, 4]],
+      }),
+    ).toBe(10 * 2);
+  });
+});
+
+describe("outputRecords", () => {
+  it("decodes a single phase with 1 detector and N pulses, advancing time by pulse_distance", () => {
+    const dataRaw = [100, 200, 300];
+    const records = outputRecords(dataRaw, {
+      pulses: [3],
+      pulse_distance: [1000],
+      detectors: [[3]],
+      pulsed_lights: [[1]],
+    });
+    expect(records).toEqual([
+      { phase_index: 0, pulse_index: 0, detector: 3, light: 1, timestamp_us: 1000, value: 100 },
+      { phase_index: 0, pulse_index: 1, detector: 3, light: 1, timestamp_us: 2000, value: 200 },
+      { phase_index: 0, pulse_index: 2, detector: 3, light: 1, timestamp_us: 3000, value: 300 },
+    ]);
+  });
+
+  it("treats each (detector, light) channel as a separate pulse, cycling per emission", () => {
+    // 2 declared pulses × 2 channels = 4 sequential pulses, each at its own timestamp.
+    const dataRaw = [11, 12, 21, 22];
+    const records = outputRecords(dataRaw, {
+      pulses: [2],
+      pulse_distance: [500],
+      detectors: [[3, 4]],
+      pulsed_lights: [[1, 2]],
+    });
+    expect(records).toHaveLength(4);
+    expect(records[0]).toMatchObject({ pulse_index: 0, detector: 3, timestamp_us: 500, value: 11 });
+    expect(records[1]).toMatchObject({
+      pulse_index: 1,
+      detector: 4,
+      timestamp_us: 1000,
+      value: 12,
+    });
+    expect(records[2]).toMatchObject({
+      pulse_index: 2,
+      detector: 3,
+      timestamp_us: 1500,
+      value: 21,
+    });
+    expect(records[3]).toMatchObject({
+      pulse_index: 3,
+      detector: 4,
+      timestamp_us: 2000,
+      value: 22,
+    });
+  });
+
+  it("skips zero-detector channels but still advances time", () => {
+    const dataRaw = [42];
+    const records = outputRecords(dataRaw, {
+      pulses: [1],
+      pulse_distance: [1000],
+      detectors: [[0, 3]],
+      pulsed_lights: [[0, 1]],
+    });
+    // Channel 0 (detector 0) is skipped; channel 1 (detector 3) is the second
+    // emitted pulse, so its timestamp is 2 × pulse_distance.
+    expect(records).toEqual([
+      { phase_index: 0, pulse_index: 1, detector: 3, light: 1, timestamp_us: 2000, value: 42 },
+    ]);
+  });
+
+  it("returns [] for empty pulses", () => {
+    expect(outputRecords([], { pulses: [], detectors: [] })).toEqual([]);
+  });
+
+  it("caps phase pulses by the actual data_raw length (device truncated run)", () => {
+    // protocol declares 100 pulses but the device only returned 20 readings.
+    const records = outputRecords(
+      [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200],
+      {
+        pulses: [100],
+        pulse_distance: [100000],
+        detectors: [[1]],
+        pulsed_lights: [[3]],
+      },
+    );
+    expect(records).toHaveLength(20);
+    expect(records[19]?.timestamp_us).toBe(20 * 100000);
+  });
+});
+
+describe("inputRecords", () => {
+  it("emits a pre_illumination row from the runtime pi tuple", () => {
+    const records = inputRecords(
+      { pulses: [10], pulse_distance: [1000], pulsed_lights: [[1]], nonpulsed_lights: [[2]] },
+      {},
+      null,
+      [2, 100, 5],
+    );
+    expect(records[0]).toMatchObject({
+      phase_index: -1,
+      light_type: "pre_illumination",
+      led: 2,
+      brightness: 100,
+      t_start_us: 0,
+      t_end_us: 5000,
+    });
+  });
+
+  it("fills null actinic brightness with the pi brightness", () => {
+    const records = inputRecords(
+      {
+        pulses: [10],
+        pulse_distance: [1000],
+        pulsed_lights: [[1]],
+        nonpulsed_lights: [[2]],
+        // no nonpulsed_lights_brightness — actinic brightness will be null until pi fallback fills it
+      },
+      {},
+      null,
+      [2, 250, 5],
+    );
+    const actinic = records.find((r) => r.light_type === "actinic");
+    expect(actinic?.brightness).toBe(250);
+  });
+
+  it("phase duration equals pulses * channels * pulse_distance (channels are sequential pulses)", () => {
+    // 10 declared × 2 channels = 20 sequential pulses → 20 × 1000us = 20 ms phase.
+    const records = inputRecords({
+      pulses: [10],
+      pulse_distance: [1000],
+      detectors: [[3, 4]],
+      pulsed_lights: [[1, 2]],
+    });
+    const measuring = records.find((r) => r.light_type === "measuring");
+    expect(measuring?.t_end_us).toBe(10 * 2 * 1000);
+  });
+});
+
+describe("explodeRecords", () => {
+  it("explodes a v2 envelope with a 'set' array into one record per sub-protocol", () => {
+    const v2 = JSON.stringify([
+      {
+        protocol_id: 3517,
+        time: 1700000000,
+        set: [
+          { label: "PIRK", data_raw: [1, 2, 3], pi: [2, 100, 5] },
+          { label: "PAM", data_raw: [10, 20] },
+        ],
+      },
+    ]);
+    const records = explodeRecords({ sample_raw: v2 });
+    expect(records).toHaveLength(2);
+    expect(records[0]).toMatchObject({
+      label: "PIRK",
+      data_raw: [1, 2, 3],
+      data_raw_len: 3,
+      pi_json: JSON.stringify([2, 100, 5]),
+    });
+    expect(records[1]).toMatchObject({ label: "PAM", data_raw: [10, 20], data_raw_len: 2 });
+  });
+
+  it("explodes a v1 array of {data_raw, ...} items", () => {
+    const v1 = JSON.stringify([
+      { data_raw: [1, 2], protocol_id: 1, time: 1700000000 },
+      { data_raw: [3, 4], protocol_id: 1 },
+    ]);
+    const records = explodeRecords({ sample_raw: v1 });
+    expect(records).toHaveLength(2);
+    expect(records.map((r) => r.data_raw)).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  it("accepts already-parsed sample_raw", () => {
+    const records = explodeRecords({
+      sample_raw: [{ set: [{ label: "X", data_raw: [9] }] }],
+    });
+    expect(records).toHaveLength(1);
+    expect(records[0]?.label).toBe("X");
+  });
+
+  it("returns [] for malformed JSON", () => {
+    expect(explodeRecords({ sample_raw: "not-json" })).toEqual([]);
+  });
+});
+
+describe("measurementToTimeseries", () => {
+  const protocol: ProtocolJson = {
+    v_arrays: [[3]],
+    _protocol_set_: [
+      {
+        label: "ABS",
+        pulses: ["@n0:0"],
+        pulse_distance: [1000],
+        detectors: [[3]],
+        pulsed_lights: [[1]],
+        nonpulsed_lights: [[2]],
+        nonpulsed_lights_brightness: [[100]],
+      },
+    ],
+  };
+
+  it("decodes a v2 measurement into inputs and outputs with sub_protocol labels", () => {
+    const sample_raw = JSON.stringify([
+      { set: [{ label: "ABS", data_raw: [10, 20, 30], pi: [2, 100, 2] }] },
+    ]);
+    const { inputs, outputs } = measurementToTimeseries({ sample_raw }, protocol);
+
+    expect(outputs).toHaveLength(3);
+    expect(outputs.every((r) => r.sub_protocol === "ABS")).toBe(true);
+    // pre_illumination shifts detector timestamps by 2_000us; pulse_distance 1000us per pulse.
+    expect(outputs.map((r) => r.timestamp_us)).toEqual([3000, 4000, 5000]);
+
+    const labels = inputs.map((r) => r.light_type).sort();
+    expect(labels).toEqual(["actinic", "measuring", "pre_illumination"]);
+  });
+
+  it("disambiguates repeated sub-protocol labels with ' #N' suffixes", () => {
+    const sample_raw = JSON.stringify([
+      {
+        set: [
+          { label: "ABS", data_raw: [1, 2, 3] },
+          { label: "ABS", data_raw: [4, 5, 6] },
+        ],
+      },
+    ]);
+    const { outputs } = measurementToTimeseries({ sample_raw }, protocol);
+    const labels = Array.from(new Set(outputs.map((r) => r.sub_protocol)));
+    expect(labels.sort()).toEqual(["ABS #0", "ABS #1"]);
+  });
+
+  it("advances the time offset across multiple sub-protocols", () => {
+    const sample_raw = JSON.stringify([
+      {
+        set: [
+          { label: "ABS", data_raw: [1, 2, 3] },
+          { label: "ABS", data_raw: [4, 5, 6] },
+        ],
+      },
+    ]);
+    const { outputs } = measurementToTimeseries({ sample_raw }, protocol);
+    const second = outputs.filter((r) => r.sub_protocol === "ABS #1");
+    // Phase duration of first ABS = 3 * 1000us = 3000us. Second ABS detector readings start after.
+    expect(second[0]?.timestamp_us).toBeGreaterThanOrEqual(3000);
+  });
+});
+
+describe("isMultispeqOutput", () => {
+  it("recognises a v2 envelope wrapped in sample_raw", () => {
+    expect(isMultispeqOutput({ sample_raw: [{ set: [{ data_raw: [1] }] }] })).toBe(true);
+  });
+
+  it("recognises an unwrapped v2 object with a 'set' array", () => {
+    expect(isMultispeqOutput({ set: [{ data_raw: [1, 2] }], protocol_id: 1 })).toBe(true);
+  });
+
+  it("recognises a top-level v1 array", () => {
+    expect(isMultispeqOutput([{ data_raw: [1, 2, 3], protocol_id: 1 }])).toBe(true);
+  });
+
+  it("recognises the live-device wrapper using the 'sample' field", () => {
+    expect(
+      isMultispeqOutput({
+        device_id: "dev-1",
+        sample: [{ set: [{ label: "ABS", data_raw: [1, 2, 3] }] }],
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects ordinary key/value output payloads", () => {
+    expect(isMultispeqOutput({ device_id: "abc", firmware_version: "1.0" })).toBe(false);
+  });
+
+  it("rejects empty / nullish data", () => {
+    expect(isMultispeqOutput(null)).toBe(false);
+    expect(isMultispeqOutput([])).toBe(false);
+  });
+
+  it("normalises an unwrapped v2 object back to a sample_raw array", () => {
+    const m = extractMeasurement({ set: [{ data_raw: [1] }] });
+    expect(m).not.toBeNull();
+    expect(Array.isArray(m?.sample_raw)).toBe(true);
+  });
+});

--- a/apps/web/lib/multispeq/pipeline.test.ts
+++ b/apps/web/lib/multispeq/pipeline.test.ts
@@ -235,6 +235,102 @@ describe("inputRecords", () => {
     const measuring = records.find((r) => r.light_type === "measuring");
     expect(measuring?.t_end_us).toBe(10 * 2 * 1000);
   });
+
+  it("expands entry.pre_illumination via @s array refs when no runtime pi is supplied", () => {
+    // pre_illumination = [led, brightness_arr_ref, duration_arr_ref]. With
+    // "@s1" / "@s2" the arrays come from v_arrays; we pair them position-wise.
+    const proto: ProtocolJson = {
+      v_arrays: [[], [100, 200, 300], [5, 10, 15]],
+    };
+    const records = inputRecords(
+      {
+        pulses: [],
+        pre_illumination: [2, "@s1", "@s2"],
+      },
+      {},
+      proto,
+      null,
+    );
+    const preIllum = records.filter((r) => r.light_type === "pre_illumination");
+    expect(preIllum).toHaveLength(3);
+    expect(preIllum[0]).toMatchObject({ led: 2, brightness: 100, t_end_us: 5000 });
+    expect(preIllum[1]).toMatchObject({ led: 2, brightness: 200, t_end_us: 5000 + 10_000 });
+    expect(preIllum[2]).toMatchObject({
+      led: 2,
+      brightness: 300,
+      t_end_us: 5000 + 10_000 + 15_000,
+    });
+  });
+
+  it("clamps short pre_illumination arrays by repeating the last value", () => {
+    // brightnesses has 1 entry, durations has 3 — len = 3 and the brightness
+    // clamps to the last value for the trailing iterations.
+    const proto: ProtocolJson = { v_arrays: [] };
+    const records = inputRecords(
+      {
+        pulses: [],
+        pre_illumination: [4, [50], [10, 20, 30]],
+      },
+      {},
+      proto,
+      null,
+    );
+    const preIllum = records.filter((r) => r.light_type === "pre_illumination");
+    expect(preIllum.map((r) => r.brightness)).toEqual([50, 50, 50]);
+    expect(preIllum.map((r) => (r.t_end_us - r.t_start_us) / 1000)).toEqual([10, 20, 30]);
+  });
+
+  it("accepts scalar pre_illumination brightness/duration as single-element lists", () => {
+    // Plain scalar values (not arrays, not @s refs) become a 1-step pre_illum.
+    const proto: ProtocolJson = { v_arrays: [] };
+    const records = inputRecords({ pulses: [], pre_illumination: [5, 75, 20] }, {}, proto, null);
+    const preIllum = records.filter((r) => r.light_type === "pre_illumination");
+    expect(preIllum).toHaveLength(1);
+    expect(preIllum[0]).toMatchObject({ led: 5, brightness: 75, t_end_us: 20_000 });
+  });
+
+  it("treats out-of-range @s references in pre_illumination as empty arrays", () => {
+    // `@s99` with no matching v_arrays slot yields an empty array, which
+    // collapses the loop to zero pre_illumination steps.
+    const proto: ProtocolJson = { v_arrays: [] };
+    const records = inputRecords(
+      { pulses: [], pre_illumination: [3, "@s99", "@s99"] },
+      {},
+      proto,
+      null,
+    );
+    expect(records.filter((r) => r.light_type === "pre_illumination")).toHaveLength(0);
+  });
+
+  it("reuses the last pulse_distance value when the array is shorter than pulses", () => {
+    // Protocols sometimes declare 1 pulse_distance for multiple phases; the
+    // getSafe fallback should clamp to the last value rather than treat
+    // overflow phases as zero-distance.
+    const records = inputRecords({
+      pulses: [2, 3],
+      pulse_distance: [1000],
+      detectors: [[3], [3]],
+      pulsed_lights: [[1], [1]],
+      nonpulsed_lights: [[2], [2]],
+    });
+    const actinic = records.filter((r) => r.light_type === "actinic");
+    expect(actinic[0]?.t_end_us).toBe(2 * 1000);
+    expect(actinic[1]?.t_end_us).toBe(2 * 1000 + 3 * 1000);
+  });
+
+  it("skips LED 0 entries in both nonpulsed and pulsed light lists", () => {
+    // An explicit 0 LED id means "no LED here"; the channel is skipped
+    // entirely so the records list stays clean of phantom entries.
+    const records = inputRecords({
+      pulses: [1],
+      pulse_distance: [1000],
+      detectors: [[3]],
+      pulsed_lights: [[0]],
+      nonpulsed_lights: [[0]],
+    });
+    expect(records.filter((r) => r.light_type === "actinic")).toHaveLength(0);
+    expect(records.filter((r) => r.light_type === "measuring")).toHaveLength(0);
+  });
 });
 
 describe("explodeRecords", () => {
@@ -471,6 +567,72 @@ describe("measurementToTimeseries", () => {
     expect(outputs).toEqual([]);
     expect(totalDurationUs).toBe(0);
   });
+
+  it("shifts the timeline back to t=0 when a protocols_delay precedes the first data sub-protocol", () => {
+    const proto: ProtocolJson = {
+      v_arrays: [[3]],
+      _protocol_set_: [
+        { label: "WAIT", protocols_delay: 1 },
+        {
+          label: "ABS",
+          pulses: ["@n0:0"],
+          pulse_distance: [1000],
+          detectors: [[3]],
+          pulsed_lights: [[1]],
+          nonpulsed_lights: [[2]],
+          nonpulsed_lights_brightness: [[100]],
+        },
+      ],
+    };
+    const sample_raw = JSON.stringify([
+      {
+        set: [
+          { label: "WAIT", data_raw: [] },
+          { label: "ABS", data_raw: [1, 2, 3] },
+        ],
+      },
+    ]);
+    const { outputs } = measurementToTimeseries({ sample_raw }, proto);
+    expect(outputs[0]?.timestamp_us).toBe(1000);
+  });
+
+  it("skips actinic extension for sub-protocols whose phases have no nonpulsed light", () => {
+    // A sub-protocol that only fires measuring (pulsed) lights produces no
+    // actinic records, so there's no record to extend across a delay gap.
+    // The pipeline should handle that without crashing or mis-extending.
+    const proto: ProtocolJson = {
+      v_arrays: [[2]],
+      _protocol_set_: [
+        {
+          label: "PULSE_ONLY",
+          pulses: ["@n0:0"],
+          pulse_distance: [1000],
+          detectors: [[3]],
+          pulsed_lights: [[1]],
+        },
+        { label: "WAIT", protocols_delay: 1 },
+        {
+          label: "PULSE_ONLY",
+          pulses: ["@n0:0"],
+          pulse_distance: [1000],
+          detectors: [[3]],
+          pulsed_lights: [[1]],
+        },
+      ],
+    };
+    const sample_raw = JSON.stringify([
+      {
+        set: [
+          { label: "PULSE_ONLY", data_raw: [1, 2] },
+          { label: "WAIT", data_raw: [] },
+          { label: "PULSE_ONLY", data_raw: [3, 4] },
+        ],
+      },
+    ]);
+    const { inputs } = measurementToTimeseries({ sample_raw }, proto);
+    expect(inputs.filter((r) => r.light_type === "actinic")).toHaveLength(0);
+    expect(inputs.filter((r) => r.light_type === "measuring").length).toBeGreaterThan(0);
+  });
 });
 
 describe("explodeRecords edge cases", () => {
@@ -499,6 +661,21 @@ describe("explodeRecords edge cases", () => {
     });
     expect(records).toHaveLength(1);
     expect(records[0]?.data_raw).toEqual([1]);
+  });
+
+  it("skips nullish or non-object entries inside a v2 'set' array", () => {
+    // Live-device payloads occasionally contain stray null or string entries
+    // alongside real sub-protocol objects; the explode pass should drop them
+    // rather than throwing on the missing fields.
+    const records = explodeRecords({
+      sample_raw: [
+        {
+          set: [null, "junk", [1, 2], { label: "OK", data_raw: [9] }],
+        },
+      ],
+    });
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({ label: "OK", data_raw: [9] });
   });
 });
 

--- a/apps/web/lib/multispeq/pipeline.test.ts
+++ b/apps/web/lib/multispeq/pipeline.test.ts
@@ -343,6 +343,187 @@ describe("measurementToTimeseries", () => {
     // Phase duration of first ABS = 3 * 1000us = 3000us. Second ABS detector readings start after.
     expect(second[0]?.timestamp_us).toBeGreaterThanOrEqual(3000);
   });
+
+  it("uses wall-clock e_time markers to space sub-protocols and shifts the leftmost trace to t=0", () => {
+    // start_time @ 1000ms then start_time @ 6000ms creates a 5s wall-clock
+    // gap before any data. After post-loop shifting (so the first trace sits
+    // at t=0) the gap is collapsed and ABS detector readings start near zero.
+    // Two ABS sub-protocols separated by an f_start_time marker exercise the
+    // between-sub-protocol spacing the markers control.
+    const sample_raw = JSON.stringify([
+      {
+        set: [
+          { label: "start_time", e_time: [0, 1000], data_raw: [] },
+          { label: "start_time", e_time: [0, 6000], data_raw: [] },
+          { label: "ABS", data_raw: [10, 20, 30] },
+          { label: "f_start_time", e_time: [0, 11000], data_raw: [] },
+          { label: "ABS", data_raw: [40, 50, 60] },
+        ],
+      },
+    ]);
+    const { outputs } = measurementToTimeseries({ sample_raw }, protocol);
+    // First detector read sits at the start of the chart (just one
+    // pulse_distance in, since pulses fire after the LED actinic phase opens).
+    expect(outputs[0]?.timestamp_us).toBeLessThan(10_000);
+    // Second sub-protocol's first read is offset by the wall-clock gap
+    // between markers (11_000ms - 6_000ms = 5_000ms = 5_000_000us).
+    const second = outputs.filter((r) => r.sub_protocol === "ABS #1");
+    expect(second[0]?.timestamp_us).toBeGreaterThanOrEqual(5_000_000);
+  });
+
+  it("treats f_start_time / f_end_time records as wall-clock markers", () => {
+    // Any zero-data record with an e_time anchors t_offset. We verify it via
+    // the spacing between two ABS sub-protocols separated by an f_start_time.
+    const sample_raw = JSON.stringify([
+      {
+        set: [
+          { label: "start_time", e_time: [0, 0], data_raw: [] },
+          { label: "ABS", data_raw: [1, 2, 3] },
+          { label: "f_start_time", e_time: [0, 4000], data_raw: [] },
+          { label: "ABS", data_raw: [4, 5, 6] },
+        ],
+      },
+    ]);
+    const { outputs } = measurementToTimeseries({ sample_raw }, protocol);
+    const second = outputs.filter((r) => r.sub_protocol === "ABS #1");
+    // f_start_time at 4s pushes the second ABS forward to roughly t=4s.
+    expect(second[0]?.timestamp_us).toBeGreaterThanOrEqual(4_000_000);
+  });
+
+  it("recovers from malformed pi_json without crashing", () => {
+    // Force an unparseable pi_json into the explode path so the JSON.parse catch
+    // branch is exercised. We do this by hand-crafting the explode output and
+    // calling the orchestrator via measurementToTimeseries on a fresh sample
+    // whose pi field is a string the JSON parser rejects.
+    const sample_raw = JSON.stringify([
+      { set: [{ label: "ABS", data_raw: [1, 2, 3], pi: "not-an-array" }] },
+    ]);
+    const { outputs } = measurementToTimeseries({ sample_raw }, protocol);
+    // pi parsed as a non-array string falls back to ambient (none here), so
+    // the protocol's pre_illumination path isn't entered, but the run should
+    // still produce three detector records.
+    expect(outputs).toHaveLength(3);
+  });
+
+  it("advances t_offset by protocols_delay between sub-protocols", () => {
+    const proto: ProtocolJson = {
+      v_arrays: [[3]],
+      _protocol_set_: [
+        {
+          label: "ABS",
+          pulses: ["@n0:0"],
+          pulse_distance: [1000],
+          detectors: [[3]],
+          pulsed_lights: [[1]],
+          nonpulsed_lights: [[2]],
+          nonpulsed_lights_brightness: [[100]],
+        },
+        { label: "WAIT", protocols_delay: 2 },
+      ],
+    };
+    // ABS, then a WAIT sub-protocol that just advances t_offset, then ABS again.
+    // The 2s protocols_delay should put the second ABS 2s after the first.
+    const sample_raw = JSON.stringify([
+      {
+        set: [
+          { label: "ABS", data_raw: [10, 20, 30] },
+          { label: "WAIT", data_raw: [] },
+          { label: "ABS", data_raw: [40, 50, 60] },
+        ],
+      },
+    ]);
+    const { outputs } = measurementToTimeseries({ sample_raw }, proto);
+    const second = outputs.filter((r) => r.sub_protocol === "ABS #1");
+    // First ABS phase ~3ms, then 2s protocols_delay; second ABS first read >= 2s.
+    expect(second[0]?.timestamp_us).toBeGreaterThanOrEqual(2_000_000);
+  });
+
+  it("extends each sub-protocol's last actinic LED phase to the next sub-protocol's start", () => {
+    // Two sub-protocols separated by a wall-clock marker pushing tOffset
+    // forward. The first sub-protocol's actinic LED span should extend to fill
+    // the gap up to the second one's start.
+    const sample_raw = JSON.stringify([
+      {
+        set: [
+          { label: "start_time", e_time: [0, 0], data_raw: [] },
+          { label: "ABS", data_raw: [1, 2, 3] },
+          { label: "f_start_time", e_time: [0, 5000], data_raw: [] },
+          { label: "ABS", data_raw: [4, 5, 6] },
+        ],
+      },
+    ]);
+    const { inputs } = measurementToTimeseries({ sample_raw }, protocol);
+    const firstActinic = inputs.filter(
+      (r) => r.sub_protocol === "ABS #0" && r.light_type === "actinic",
+    );
+    const secondStart = inputs
+      .filter((r) => r.sub_protocol === "ABS #1")
+      .reduce((m, r) => Math.min(m, r.t_start_us), Infinity);
+    // The extension pushes the first sub-protocol's actinic LED end up to the
+    // second sub-protocol's starting timestamp.
+    expect(Math.max(...firstActinic.map((r) => r.t_end_us))).toBe(secondStart);
+  });
+
+  it("handles measurements with no sub-protocols gracefully", () => {
+    const { inputs, outputs, totalDurationUs } = measurementToTimeseries(
+      { sample_raw: "[]" },
+      protocol,
+    );
+    expect(inputs).toEqual([]);
+    expect(outputs).toEqual([]);
+    expect(totalDurationUs).toBe(0);
+  });
+});
+
+describe("explodeRecords edge cases", () => {
+  it("returns [] for null sample_raw", () => {
+    expect(explodeRecords({ sample_raw: null })).toEqual([]);
+  });
+
+  it("returns [] for missing sample_raw", () => {
+    expect(explodeRecords({})).toEqual([]);
+  });
+
+  it("preserves measurement_id and project_id when provided", () => {
+    const records = explodeRecords({
+      measurement_id: "m1",
+      project_id: "p1",
+      sample_raw: [{ data_raw: [1, 2], protocol_id: 7 }],
+    });
+    expect(records[0]?.measurement_id).toBe("m1");
+    expect(records[0]?.project_id).toBe("p1");
+    expect(records[0]?.protocol_id).toBe(7);
+  });
+
+  it("ignores non-object items inside a v1 array", () => {
+    const records = explodeRecords({
+      sample_raw: [{ data_raw: [1] }, "garbage", null, 42, [{ nested: true }]],
+    });
+    expect(records).toHaveLength(1);
+    expect(records[0]?.data_raw).toEqual([1]);
+  });
+});
+
+describe("resolveProtocolSetEntry edge cases", () => {
+  it("wraps non-list nested items into single-element lists", () => {
+    // A bare scalar in detectors[i] (not wrapped in a list) is a legacy form;
+    // the resolver normalises it to [n] so the rest of the pipeline can index it.
+    const r = resolveProtocolSetEntry({
+      pulses: [3],
+      pulse_distance: [1000],
+      detectors: [3],
+    });
+    expect(r.detectors).toEqual([[3]]);
+  });
+
+  it("substitutes 0 for items that resolve to null in nested lists", () => {
+    const r = resolveProtocolSetEntry({
+      pulses: [1],
+      pulse_distance: [1000],
+      detectors: ["unresolvable-string"],
+    });
+    expect(r.detectors).toEqual([[0]]);
+  });
 });
 
 describe("isMultispeqOutput", () => {

--- a/apps/web/lib/multispeq/pipeline.test.ts
+++ b/apps/web/lib/multispeq/pipeline.test.ts
@@ -380,6 +380,27 @@ describe("explodeRecords", () => {
   it("returns [] for malformed JSON", () => {
     expect(explodeRecords({ sample_raw: "not-json" })).toEqual([]);
   });
+
+  it("explodes multi-item v2 arrays (each item carries its own 'set')", () => {
+    // Each compound protocol contributes its own sets; sub_protocol_index
+    // remains globally unique by offsetting the second item's inner indices.
+    const v2Multi = JSON.stringify([
+      { protocol_id: 1, time: 1700000000, set: [{ label: "A", data_raw: [1] }] },
+      {
+        protocol_id: 2,
+        time: 1700000001,
+        set: [
+          { label: "B", data_raw: [2, 3] },
+          { label: "C", data_raw: [4] },
+        ],
+      },
+    ]);
+    const records = explodeRecords({ sample_raw: v2Multi });
+    expect(records).toHaveLength(3);
+    expect(records.map((r) => r.label)).toEqual(["A", "B", "C"]);
+    expect(records.map((r) => r.sub_protocol_index)).toEqual([0, 1, 2]);
+    expect(records[1]?.protocol_id).toBe(2);
+  });
 });
 
 describe("measurementToTimeseries", () => {

--- a/apps/web/lib/multispeq/pipeline.test.ts
+++ b/apps/web/lib/multispeq/pipeline.test.ts
@@ -346,12 +346,11 @@ describe("measurementToTimeseries", () => {
     expect(second[0]?.timestamp_us).toBeGreaterThanOrEqual(3000);
   });
 
-  it("uses wall-clock e_time markers to space sub-protocols and shifts the leftmost trace to t=0", () => {
-    // start_time @ 1000ms then start_time @ 6000ms creates a 5s wall-clock
-    // gap before any data. After post-loop shifting (so the first trace sits
-    // at t=0) the gap is collapsed and ABS detector readings start near zero.
-    // Two ABS sub-protocols separated by an f_start_time marker exercise the
-    // between-sub-protocol spacing the markers control.
+  it("ignores e_time markers and lays sub-protocols back-to-back by declared duration", () => {
+    // The protocol's start_time / f_start_time records carry wall-clock
+    // timestamps but those reflect device-internal autogain/env work that
+    // has no chart-meaningful duration. Sub-protocols sit back-to-back at
+    // their declared phase durations regardless of marker spacing.
     const sample_raw = JSON.stringify([
       {
         set: [
@@ -364,32 +363,12 @@ describe("measurementToTimeseries", () => {
       },
     ]);
     const { outputs } = measurementToTimeseries({ sample_raw }, protocol);
-    // First detector read sits at the start of the chart (just one
-    // pulse_distance in, since pulses fire after the LED actinic phase opens).
-    expect(outputs[0]?.timestamp_us).toBeLessThan(10_000);
-    // Second sub-protocol's first read is offset by the wall-clock gap
-    // between markers (11_000ms - 6_000ms = 5_000ms = 5_000_000us).
+    // First read at one pulse_distance into the first ABS phase.
+    expect(outputs[0]?.timestamp_us).toBe(1000);
+    // Second ABS follows the first immediately. ABS phase = 3 pulses × 1000us
+    // = 3000us, so the second ABS's first read is at ~3000 + 1000 = 4000us.
     const second = outputs.filter((r) => r.sub_protocol === "ABS #1");
-    expect(second[0]?.timestamp_us).toBeGreaterThanOrEqual(5_000_000);
-  });
-
-  it("treats f_start_time / f_end_time records as wall-clock markers", () => {
-    // Any zero-data record with an e_time anchors t_offset. We verify it via
-    // the spacing between two ABS sub-protocols separated by an f_start_time.
-    const sample_raw = JSON.stringify([
-      {
-        set: [
-          { label: "start_time", e_time: [0, 0], data_raw: [] },
-          { label: "ABS", data_raw: [1, 2, 3] },
-          { label: "f_start_time", e_time: [0, 4000], data_raw: [] },
-          { label: "ABS", data_raw: [4, 5, 6] },
-        ],
-      },
-    ]);
-    const { outputs } = measurementToTimeseries({ sample_raw }, protocol);
-    const second = outputs.filter((r) => r.sub_protocol === "ABS #1");
-    // f_start_time at 4s pushes the second ABS forward to roughly t=4s.
-    expect(second[0]?.timestamp_us).toBeGreaterThanOrEqual(4_000_000);
+    expect(second[0]?.timestamp_us).toBeLessThan(10_000);
   });
 
   it("recovers from malformed pi_json without crashing", () => {
@@ -440,30 +419,47 @@ describe("measurementToTimeseries", () => {
     expect(second[0]?.timestamp_us).toBeGreaterThanOrEqual(2_000_000);
   });
 
-  it("extends each sub-protocol's last actinic LED phase to the next sub-protocol's start", () => {
-    // Two sub-protocols separated by a wall-clock marker pushing tOffset
-    // forward. The first sub-protocol's actinic LED span should extend to fill
-    // the gap up to the second one's start.
+  it("extends a sub-protocol's last-phase actinic across a protocols_delay gap to the next sub-protocol", () => {
+    // The MultispeQ holds the actinic LED at its last nonpulsed brightness
+    // through any time gap between sub-protocols (e.g. a `protocols_delay`),
+    // so the first sub-protocol's last-phase actinic must extend to where the
+    // next data sub-protocol starts — leaving no break in the actinic line.
+    const proto: ProtocolJson = {
+      v_arrays: [[3]],
+      _protocol_set_: [
+        {
+          label: "ABS",
+          pulses: ["@n0:0"],
+          pulse_distance: [1000],
+          detectors: [[3]],
+          pulsed_lights: [[1]],
+          nonpulsed_lights: [[2]],
+          nonpulsed_lights_brightness: [[100]],
+        },
+        { label: "WAIT", protocols_delay: 1 },
+      ],
+    };
     const sample_raw = JSON.stringify([
       {
         set: [
-          { label: "start_time", e_time: [0, 0], data_raw: [] },
           { label: "ABS", data_raw: [1, 2, 3] },
-          { label: "f_start_time", e_time: [0, 5000], data_raw: [] },
+          { label: "WAIT", data_raw: [] },
           { label: "ABS", data_raw: [4, 5, 6] },
         ],
       },
     ]);
-    const { inputs } = measurementToTimeseries({ sample_raw }, protocol);
-    const firstActinic = inputs.filter(
-      (r) => r.sub_protocol === "ABS #0" && r.light_type === "actinic",
+    const { inputs } = measurementToTimeseries({ sample_raw }, proto);
+    const firstActinicEnd = Math.max(
+      ...inputs
+        .filter((r) => r.sub_protocol === "ABS #0" && r.light_type === "actinic")
+        .map((r) => r.t_end_us),
     );
     const secondStart = inputs
       .filter((r) => r.sub_protocol === "ABS #1")
       .reduce((m, r) => Math.min(m, r.t_start_us), Infinity);
-    // The extension pushes the first sub-protocol's actinic LED end up to the
-    // second sub-protocol's starting timestamp.
-    expect(Math.max(...firstActinic.map((r) => r.t_end_us))).toBe(secondStart);
+    expect(firstActinicEnd).toBe(secondStart);
+    // Sanity: protocols_delay creates a 1s gap, far more than ABS's declared phase.
+    expect(secondStart).toBeGreaterThanOrEqual(1_000_000);
   });
 
   it("handles measurements with no sub-protocols gracefully", () => {

--- a/apps/web/lib/multispeq/pipeline.test.ts
+++ b/apps/web/lib/multispeq/pipeline.test.ts
@@ -401,6 +401,23 @@ describe("explodeRecords", () => {
     expect(records.map((r) => r.sub_protocol_index)).toEqual([0, 1, 2]);
     expect(records[1]?.protocol_id).toBe(2);
   });
+
+  it("preserves valid v2 records when the top-level array mixes v1 and v2 items", () => {
+    // A stray v1 item between two v2 items shouldn't make the parser drop the
+    // nested set data — each item is decoded by its own shape.
+    const mixed = JSON.stringify([
+      { protocol_id: 1, set: [{ label: "A", data_raw: [1] }] },
+      { protocol_id: 2, data_raw: [9, 8, 7] },
+      { protocol_id: 3, set: [{ label: "B", data_raw: [2, 3] }] },
+    ]);
+    const records = explodeRecords({ sample_raw: mixed });
+    expect(records).toHaveLength(3);
+    const labels = records.map((r) => r.label);
+    expect(labels).toContain("A");
+    expect(labels).toContain("B");
+    const v1Row = records.find((r) => r.label === "");
+    expect(v1Row?.data_raw).toEqual([9, 8, 7]);
+  });
 });
 
 describe("measurementToTimeseries", () => {
@@ -757,5 +774,16 @@ describe("isMultispeqOutput", () => {
     const m = extractMeasurement({ set: [{ data_raw: [1] }] });
     expect(m).not.toBeNull();
     expect(Array.isArray(m?.sample_raw)).toBe(true);
+  });
+
+  it("recognises a sample array even when the first item is malformed", () => {
+    // looksLikeSampleRaw now scans every item, so a leading null doesn't
+    // disqualify the rest of the payload.
+    expect(
+      isMultispeqOutput({
+        device_id: "dev-1",
+        sample: [null, "junk", { set: [{ data_raw: [1, 2] }] }],
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/web/lib/multispeq/pipeline.ts
+++ b/apps/web/lib/multispeq/pipeline.ts
@@ -642,5 +642,22 @@ export function measurementToTimeseries(
     }
   }
 
+  // Anchor the time axis to the first record so charts always start at t=0,
+  // not at "however long the user took to click Run after start_time fired".
+  // Wall-clock markers determine the true device idle time *between* sub-
+  // protocols; the slack *before* the first sub-protocol is just user delay
+  // and shouldn't show up as empty space on the left of the chart.
+  let zeroOffset = Infinity;
+  for (const r of allInputs) if (r.t_start_us < zeroOffset) zeroOffset = r.t_start_us;
+  for (const r of allOutputs) if (r.timestamp_us < zeroOffset) zeroOffset = r.timestamp_us;
+  if (zeroOffset !== Infinity && zeroOffset > 0) {
+    for (const r of allInputs) {
+      r.t_start_us -= zeroOffset;
+      r.t_end_us -= zeroOffset;
+    }
+    for (const r of allOutputs) r.timestamp_us -= zeroOffset;
+    tOffset -= zeroOffset;
+  }
+
   return { inputs: allInputs, outputs: allOutputs, totalDurationUs: tOffset };
 }

--- a/apps/web/lib/multispeq/pipeline.ts
+++ b/apps/web/lib/multispeq/pipeline.ts
@@ -1,0 +1,646 @@
+/**
+ * Port of jii-data-platform's protocol_pipeline/pipeline.py.
+ * Decodes a PhotosynQ/MultispeQ measurement (sample_raw + protocol JSON) into
+ * input (LED) and output (detector) timeseries records.
+ *
+ * Timing model: for a phase with N pulses, D µs pulse_distance, and K active
+ * detectors, each pulse emits one timestamp; phase duration is N*D, not N*K*D.
+ */
+
+export const LED_NAMES: Record<number, string> = {
+  1: "530 nm (green, body)",
+  2: "655 nm (red, body)",
+  3: "590 nm (amber, body)",
+  4: "448 nm (blue, body)",
+  5: "950 nm (NIR, body)",
+  6: "950 nm (NIR, clamp)",
+  7: "655 nm (red, clamp)",
+  8: "850 nm (NIR, clamp)",
+  9: "730 nm (far-red, clamp)",
+  10: "820 nm (NIR, clamp)",
+};
+
+// Approximate visual colours for the body LEDs; mirrors the notebook palette.
+export const LED_COLORS: Record<number, string> = {
+  1: "#1b5e20",
+  2: "#c62828",
+  3: "#e65100",
+  4: "#1565c0",
+  5: "#424242",
+  6: "#616161",
+  7: "#c62828",
+  8: "#0d47a1",
+  9: "#6a1b9a",
+  10: "#4e342e",
+};
+
+export interface ProtocolSetEntry {
+  label?: string;
+  pulses?: unknown[];
+  pulse_distance?: unknown[];
+  detectors?: unknown[];
+  pulsed_lights?: unknown[];
+  pulsed_lights_brightness?: unknown[];
+  nonpulsed_lights?: unknown[];
+  nonpulsed_lights_brightness?: unknown[];
+  pre_illumination?: unknown[];
+  protocols_delay?: number;
+  e_time?: unknown;
+}
+
+export interface ProtocolJson {
+  _protocol_set_?: ProtocolSetEntry[];
+  v_arrays?: unknown[][];
+}
+
+export interface SubProtocolRecord {
+  measurement_id: string | null;
+  project_id: string | null;
+  protocol_id: number | null;
+  sub_protocol_index: number;
+  label: string;
+  data_raw: number[];
+  data_raw_len: number;
+  time: number | null;
+  time_offset: number | null;
+  pi_json: string | null;
+  metadata_json: string | null;
+}
+
+export interface InputRecord {
+  sub_protocol?: string;
+  phase_index: number;
+  t_start_us: number;
+  t_end_us: number;
+  led: number | null;
+  brightness: number | null;
+  light_type: "pre_illumination" | "actinic" | "measuring";
+}
+
+export interface OutputRecord {
+  sub_protocol?: string;
+  phase_index: number;
+  pulse_index: number;
+  detector: number;
+  light: number;
+  timestamp_us: number;
+  value: number;
+}
+
+export interface MeasurementInput {
+  measurement_id?: string | null;
+  project_id?: string | null;
+  sample_raw?: string | unknown[] | null;
+}
+
+interface ResolvedEntry {
+  pulses: number[];
+  pulse_distance: number[];
+  detectors: (number | null)[][];
+  pulsed_lights: (number | null)[][];
+  pulsed_lights_brightness: (number | null)[][];
+  nonpulsed_lights: (number | null)[][];
+  nonpulsed_lights_brightness: (number | null)[][];
+  pre_illumination: unknown[];
+}
+
+function getSafe<T>(lst: T[] | undefined | null, idx: number, fallback: T): T {
+  if (!lst || lst.length === 0) return fallback;
+  if (idx < lst.length) return lst[idx];
+  return lst[lst.length - 1];
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+/**
+ * Build the `@nX:Y` / `@sX` lookup table for a sub-protocol occurrence.
+ *
+ * `@nX:Y` is constant across occurrences (a fixed cell of `v_arrays`).
+ *
+ * `@sX` is the "set parameter" used in scalar contexts (e.g. `pulses`).
+ * When a protocol declares `set_repeats: N`, the device picks a different value
+ * per repeat by indexing `v_arrays[X]` with the occurrence number. We mirror
+ * that — `f_transient` with `pulses: ["@s8"]` and `v_arrays[8] = [20, 100]`
+ * runs 20 pulses on repeat 0 and 100 on repeat 1. If the indexed value is
+ * non-numeric (e.g. the placeholder `"p_light"`), fall back to the last
+ * numeric in the array (matches observed `["p_light", 2500] → 2500`).
+ */
+export function resolveVariables(
+  protocolJson: ProtocolJson,
+  occurrence = 0,
+): Record<string, number> {
+  const lookup: Record<string, number> = {};
+  const arrs = protocolJson.v_arrays ?? [];
+  arrs.forEach((arr, i) => {
+    if (!Array.isArray(arr)) return;
+    arr.forEach((val, j) => {
+      if (isFiniteNumber(val)) lookup[`@n${i}:${j}`] = Math.trunc(val);
+    });
+    let lastNumeric: number | null = null;
+    for (const val of arr) if (isFiniteNumber(val)) lastNumeric = Math.trunc(val);
+    const indexed = arr[Math.min(occurrence, arr.length - 1)];
+    const chosen = isFiniteNumber(indexed) ? Math.trunc(indexed) : lastNumeric;
+    if (chosen != null) lookup[`@s${i}`] = chosen;
+  });
+  return lookup;
+}
+
+function resolveInt(val: unknown, variables: Record<string, number>): number | null {
+  if (isFiniteNumber(val)) return Math.trunc(val);
+  if (typeof val === "string" && val in variables) return variables[val] ?? null;
+  return null;
+}
+
+function resolveList(lst: unknown[], variables: Record<string, number>): (number | null)[] {
+  return lst.map((v) => resolveInt(v, variables));
+}
+
+function resolveNested(lst: unknown[], variables: Record<string, number>): (number | null)[][] {
+  return lst.map((item) => {
+    if (Array.isArray(item)) return item.map((v) => resolveInt(v, variables));
+    const r = resolveInt(item, variables);
+    return [r ?? 0];
+  });
+}
+
+export function resolveProtocolSetEntry(
+  entry: ProtocolSetEntry,
+  variables: Record<string, number> = {},
+): ResolvedEntry {
+  return {
+    pulses: resolveList(entry.pulses ?? [], variables).map((v) => v ?? 0),
+    pulse_distance: resolveList(entry.pulse_distance ?? [], variables).map((v) => v ?? 0),
+    detectors: resolveNested(entry.detectors ?? [], variables),
+    pulsed_lights: resolveNested(entry.pulsed_lights ?? [], variables),
+    pulsed_lights_brightness: resolveNested(entry.pulsed_lights_brightness ?? [], variables),
+    nonpulsed_lights: resolveNested(entry.nonpulsed_lights ?? [], variables),
+    nonpulsed_lights_brightness: resolveNested(entry.nonpulsed_lights_brightness ?? [], variables),
+    pre_illumination: entry.pre_illumination ?? [],
+  };
+}
+
+export function predictDataRawLength(
+  entry: ProtocolSetEntry,
+  variables: Record<string, number> = {},
+): number {
+  const r = resolveProtocolSetEntry(entry, variables);
+  let total = 0;
+  for (let i = 0; i < r.pulses.length; i++) {
+    const dets = getSafe(r.detectors, i, []);
+    const nActive = dets.filter((d) => d != null && d !== 0).length;
+    total += (r.pulses[i] ?? 0) * nActive;
+  }
+  return total;
+}
+
+export function outputRecords(
+  dataRaw: number[],
+  entry: ProtocolSetEntry,
+  variables: Record<string, number> = {},
+): OutputRecord[] {
+  const r = resolveProtocolSetEntry(entry, variables);
+  if (r.pulses.length === 0 || dataRaw.length === 0) return [];
+
+  const out: OutputRecord[] = [];
+  let offset = 0;
+  let tUs = 0;
+
+  for (let phase = 0; phase < r.pulses.length; phase++) {
+    const dets = getSafe(r.detectors, phase, [0]);
+    const lights = getSafe(r.pulsed_lights, phase, [0]);
+    const pDist = getSafe(r.pulse_distance, phase, 0);
+    const nChannels = Math.max(1, dets.length);
+    const nPulses = r.pulses[phase] ?? 0;
+    // Each (detector, light) entry in dets/lights is a SEPARATE pulse — the
+    // device fires them sequentially across pulses, not simultaneously within
+    // a single pulse. So a phase declared as N pulses with K channels emits
+    // N × K pulses total, advancing time by pulse_distance per emission.
+    const total = nPulses * nChannels;
+
+    for (let pulseIdx = 0; pulseIdx < total; pulseIdx++) {
+      tUs += pDist;
+      const ch = pulseIdx % nChannels;
+      const detId = dets[ch] ?? 0;
+      const lightId = (ch < lights.length ? lights[ch] : 0) ?? 0;
+      if (detId !== 0 && offset < dataRaw.length) {
+        out.push({
+          phase_index: phase,
+          pulse_index: pulseIdx,
+          detector: detId,
+          light: lightId,
+          timestamp_us: tUs,
+          value: dataRaw[offset],
+        });
+        offset += 1;
+      }
+    }
+  }
+  return out;
+}
+
+function resolveArrayRef(ref: unknown, vArrays: unknown[][]): unknown[] {
+  if (typeof ref === "string" && ref.startsWith("@s")) {
+    const idx = Number.parseInt(ref.slice(2), 10);
+    if (Number.isFinite(idx) && idx >= 0 && idx < vArrays.length) {
+      const arr = vArrays[idx];
+      return Array.isArray(arr) ? arr : [];
+    }
+    return [];
+  }
+  if (Array.isArray(ref)) return ref;
+  return [ref];
+}
+
+function resolvePreIllumination(
+  preIllumination: unknown[],
+  protocolJson: ProtocolJson,
+): { led: number; brightness: number | null; duration_ms: number }[] {
+  if (preIllumination.length < 3) return [];
+  const ledId = preIllumination[0];
+  if (typeof ledId !== "number") return [];
+  const vArrays = protocolJson.v_arrays ?? [];
+  const brightnesses = resolveArrayRef(preIllumination[1], vArrays);
+  const durations = resolveArrayRef(preIllumination[2], vArrays);
+  const steps: { led: number; brightness: number | null; duration_ms: number }[] = [];
+  const len = Math.max(brightnesses.length, durations.length);
+  for (let i = 0; i < len; i++) {
+    const b =
+      i < brightnesses.length
+        ? brightnesses[i]
+        : brightnesses.length > 0
+          ? brightnesses[brightnesses.length - 1]
+          : 0;
+    const d =
+      i < durations.length
+        ? durations[i]
+        : durations.length > 0
+          ? durations[durations.length - 1]
+          : 0;
+    steps.push({
+      led: ledId,
+      brightness: isFiniteNumber(b) ? Math.round(b) : null,
+      duration_ms: isFiniteNumber(d) ? Math.trunc(d) : 0,
+    });
+  }
+  return steps;
+}
+
+export function inputRecords(
+  entry: ProtocolSetEntry,
+  variables: Record<string, number> = {},
+  protocolJson: ProtocolJson | null = null,
+  pi: unknown[] | null = null,
+): InputRecord[] {
+  const r = resolveProtocolSetEntry(entry, variables);
+  const records: InputRecord[] = [];
+  let tUs = 0;
+
+  if (pi && pi.length >= 3) {
+    const ledId = pi[0];
+    const brightnessRaw = pi[1];
+    const durMs = pi[2];
+    const brightness = isFiniteNumber(brightnessRaw) ? Math.round(brightnessRaw) : null;
+    const durUs = isFiniteNumber(durMs) ? Math.trunc(durMs * 1000) : 0;
+    if (typeof ledId === "number" && ledId !== 0 && durUs > 0) {
+      records.push({
+        phase_index: -1,
+        t_start_us: tUs,
+        t_end_us: tUs + durUs,
+        led: Math.trunc(ledId),
+        brightness,
+        light_type: "pre_illumination",
+      });
+    }
+    tUs += durUs;
+  } else if (entry.pre_illumination && protocolJson) {
+    for (const step of resolvePreIllumination(entry.pre_illumination, protocolJson)) {
+      const durUs = step.duration_ms > 0 ? step.duration_ms * 1000 : 0;
+      if (step.led !== 0 && durUs > 0) {
+        records.push({
+          phase_index: -1,
+          t_start_us: tUs,
+          t_end_us: tUs + durUs,
+          led: step.led,
+          brightness: step.brightness,
+          light_type: "pre_illumination",
+        });
+      }
+      tUs += durUs;
+    }
+  }
+
+  for (let phase = 0; phase < r.pulses.length; phase++) {
+    const pDist = getSafe(r.pulse_distance, phase, 0);
+    const dets = getSafe(r.detectors, phase, [0]);
+    const nChannels = Math.max(1, dets.length);
+    // Phase duration mirrors `outputRecords`: the device fires N × K sequential
+    // pulses for N declared pulses and K detector/light channels per pulse.
+    const phaseDur = (r.pulses[phase] ?? 0) * nChannels * pDist;
+
+    const npLeds = getSafe(r.nonpulsed_lights, phase, []);
+    const npBright = getSafe(r.nonpulsed_lights_brightness, phase, []);
+    npLeds.forEach((ledId, k) => {
+      if (ledId == null || ledId === 0) return;
+      const b = k < npBright.length ? npBright[k] : null;
+      records.push({
+        phase_index: phase,
+        t_start_us: tUs,
+        t_end_us: tUs + phaseDur,
+        led: ledId,
+        brightness: b ?? null,
+        light_type: "actinic",
+      });
+    });
+
+    const pLeds = getSafe(r.pulsed_lights, phase, []);
+    const pBright = getSafe(r.pulsed_lights_brightness, phase, []);
+    pLeds.forEach((ledId, k) => {
+      if (ledId == null || ledId === 0) return;
+      const b = k < pBright.length ? pBright[k] : null;
+      records.push({
+        phase_index: phase,
+        t_start_us: tUs,
+        t_end_us: tUs + phaseDur,
+        led: ledId,
+        brightness: b ?? null,
+        light_type: "measuring",
+      });
+    });
+
+    tUs += phaseDur;
+  }
+
+  // Fill null actinic / pre_illumination brightness with the runtime pi brightness.
+  if (pi && pi.length >= 2 && isFiniteNumber(pi[1])) {
+    const piBrightness = Math.round(pi[1]);
+    for (const rec of records) {
+      if (
+        (rec.light_type === "actinic" || rec.light_type === "pre_illumination") &&
+        rec.brightness == null
+      ) {
+        rec.brightness = piBrightness;
+      }
+    }
+  }
+  // Coerce any non-integer brightness to integer; unresolvable strings become null.
+  for (const rec of records) {
+    if (rec.brightness != null && !Number.isInteger(rec.brightness)) {
+      rec.brightness = isFiniteNumber(rec.brightness) ? Math.round(rec.brightness) : null;
+    }
+  }
+  return records;
+}
+
+function explodeV1Item(
+  item: Record<string, unknown>,
+  measurementId: string | null,
+  projectId: string | null,
+  index: number,
+): SubProtocolRecord {
+  const { data_raw, protocol_id, time, time_offset, ...rest } = item;
+  const dataRaw = Array.isArray(data_raw) ? data_raw.filter(isFiniteNumber).map(Math.trunc) : [];
+  return {
+    measurement_id: measurementId,
+    project_id: projectId,
+    protocol_id: isFiniteNumber(protocol_id) ? Math.trunc(protocol_id) : null,
+    sub_protocol_index: index,
+    label: "",
+    data_raw: dataRaw,
+    data_raw_len: dataRaw.length,
+    time: isFiniteNumber(time) ? Math.trunc(time) : null,
+    time_offset: isFiniteNumber(time_offset) ? Math.trunc(time_offset) : null,
+    pi_json: null,
+    metadata_json: JSON.stringify(rest),
+  };
+}
+
+function explodeV2Item(
+  item: Record<string, unknown>,
+  measurementId: string | null,
+  projectId: string | null,
+): SubProtocolRecord[] {
+  const protocolId = item.protocol_id;
+  const time = item.time;
+  const sets = Array.isArray(item.set) ? item.set : [];
+  return sets.flatMap((s, idx) => {
+    if (!s || typeof s !== "object" || Array.isArray(s)) return [];
+    const setObj = s as Record<string, unknown>;
+    const { label, data_raw, pi, ...rest } = setObj;
+    const dataRaw = Array.isArray(data_raw) ? data_raw.filter(isFiniteNumber).map(Math.trunc) : [];
+    return [
+      {
+        measurement_id: measurementId,
+        project_id: projectId,
+        protocol_id: isFiniteNumber(protocolId) ? Math.trunc(protocolId) : null,
+        sub_protocol_index: idx,
+        label: typeof label === "string" ? label : "",
+        data_raw: dataRaw,
+        data_raw_len: dataRaw.length,
+        time: isFiniteNumber(time) ? Math.trunc(time) : null,
+        time_offset: null,
+        pi_json: pi == null ? null : JSON.stringify(pi),
+        metadata_json: JSON.stringify(rest),
+      },
+    ];
+  });
+}
+
+export function explodeRecords(measurement: MeasurementInput): SubProtocolRecord[] {
+  const raw = measurement.sample_raw;
+  if (raw == null) return [];
+  let parsed: unknown;
+  try {
+    parsed = typeof raw === "string" ? (JSON.parse(raw) as unknown) : raw;
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0) return [];
+  const items = parsed as unknown[];
+
+  const measurementId = measurement.measurement_id ?? null;
+  const projectId = measurement.project_id ?? null;
+
+  const first = items[0];
+  if (
+    items.length === 1 &&
+    first != null &&
+    typeof first === "object" &&
+    !Array.isArray(first) &&
+    "set" in first
+  ) {
+    return explodeV2Item(first as Record<string, unknown>, measurementId, projectId);
+  }
+
+  const out: SubProtocolRecord[] = [];
+  items.forEach((item, idx) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return;
+    out.push(explodeV1Item(item as Record<string, unknown>, measurementId, projectId, idx));
+  });
+  return out;
+}
+
+function parseETimeUs(metadataJson: string | null): number | null {
+  if (!metadataJson) return null;
+  let meta: unknown;
+  try {
+    meta = JSON.parse(metadataJson) as unknown;
+  } catch {
+    return null;
+  }
+  if (!meta || typeof meta !== "object") return null;
+  const eTime = (meta as Record<string, unknown>).e_time;
+  if (!Array.isArray(eTime) || eTime.length < 2) return null;
+  const ms: unknown = eTime[1];
+  return isFiniteNumber(ms) ? Math.trunc(ms) * 1000 : null;
+}
+
+export interface MeasurementTimeseries {
+  inputs: InputRecord[];
+  outputs: OutputRecord[];
+  /** Wall-clock duration in microseconds, taken from the latest marker
+   * (start_time/end_time/f_start_time/...). Useful for sizing the x-axis when
+   * trailing sub-protocols (e.g. SPAD) emit no data_raw. */
+  totalDurationUs: number;
+}
+
+export function measurementToTimeseries(
+  measurement: MeasurementInput,
+  protocolJson: ProtocolJson,
+): MeasurementTimeseries {
+  const pset = protocolJson._protocol_set_ ?? [];
+  const setByLabel = new Map<string, ProtocolSetEntry>();
+  for (const ps of pset) if (ps.label) setByLabel.set(ps.label, ps);
+
+  const allRecords = explodeRecords(measurement);
+
+  // A wall-clock marker is any record without data_raw that carries an e_time
+  // ([overflow, ms]). The device emits these at start/end and around fast
+  // (`f_*`) sub-protocols. Anchoring t_offset on every marker — not just
+  // start_time/end_time — keeps long device-only intervals (e.g. an f_transient
+  // that takes 10s but only emits 100 samples) from collapsing.
+  const isMarker = (r: SubProtocolRecord) =>
+    r.data_raw_len === 0 && parseETimeUs(r.metadata_json) != null;
+
+  let wallClockZero: number | null = null;
+  for (const r of allRecords) {
+    if (isMarker(r)) {
+      const t = parseETimeUs(r.metadata_json);
+      if (t != null) {
+        wallClockZero = t;
+        break;
+      }
+    }
+  }
+
+  // Disambiguate repeated labels with " #N" suffixes.
+  const labelCounts = new Map<string, number>();
+  for (const r of allRecords) {
+    if (r.data_raw_len > 0 && setByLabel.has(r.label)) {
+      labelCounts.set(r.label, (labelCounts.get(r.label) ?? 0) + 1);
+    }
+  }
+  const repeatedLabels = new Set<string>();
+  for (const [lbl, cnt] of labelCounts) if (cnt > 1) repeatedLabels.add(lbl);
+
+  const allInputs: InputRecord[] = [];
+  const allOutputs: OutputRecord[] = [];
+  let tOffset = 0;
+  const labelSeen = new Map<string, number>();
+  let ambientPi: unknown[] | null = null;
+
+  for (const row of allRecords) {
+    if (isMarker(row)) {
+      if (wallClockZero != null) {
+        const t = parseETimeUs(row.metadata_json);
+        if (t != null) tOffset = Math.max(tOffset, t - wallClockZero);
+      }
+      continue;
+    }
+
+    const psDef = setByLabel.get(row.label);
+
+    if (psDef) {
+      const delayS = psDef.protocols_delay;
+      if (isFiniteNumber(delayS) && delayS > 0) tOffset += Math.trunc(delayS * 1_000_000);
+    }
+
+    if (row.data_raw_len === 0 || !psDef) continue;
+
+    const occurrence = labelSeen.get(row.label) ?? 0;
+    labelSeen.set(row.label, occurrence + 1);
+    const label = repeatedLabels.has(row.label) ? `${row.label} #${occurrence}` : row.label;
+
+    // `@sX` resolves to v_arrays[X][occurrence], so each set repeat picks its
+    // own value (e.g. f_transient runs 20 pulses on repeat 0, 100 on repeat 1).
+    const variables = resolveVariables(protocolJson, occurrence);
+
+    let pi: unknown[] | null = null;
+    if (row.pi_json) {
+      try {
+        const parsed = JSON.parse(row.pi_json) as unknown;
+        if (Array.isArray(parsed)) pi = parsed;
+      } catch {
+        pi = null;
+      }
+    }
+    if (pi != null && ambientPi == null) ambientPi = pi;
+    const effectivePi = pi ?? ambientPi;
+
+    const outputs = outputRecords(row.data_raw, psDef, variables);
+    if (outputs.length === 0) continue;
+
+    const inputs = inputRecords(psDef, variables, protocolJson, effectivePi);
+    const subDur = inputs.reduce((m, r) => Math.max(m, r.t_end_us), 0);
+    const preIllumDur = inputs
+      .filter((r) => r.light_type === "pre_illumination")
+      .reduce((m, r) => Math.max(m, r.t_end_us), 0);
+
+    for (const r of inputs) {
+      r.sub_protocol = label;
+      r.t_start_us += tOffset;
+      r.t_end_us += tOffset;
+    }
+    for (const r of outputs) {
+      r.sub_protocol = label;
+      r.timestamp_us += preIllumDur + tOffset;
+    }
+
+    allInputs.push(...inputs);
+    allOutputs.push(...outputs);
+    tOffset += subDur;
+  }
+
+  // Wall-clock markers (e.g. f_start_time around f_transient) often span longer
+  // than the declared phase duration — the device sits idle (or actinic-only)
+  // for the remainder. Extend each sub-protocol's last actinic LED phase up to
+  // the next sub-protocol's start (or totalDuration) so the LED background
+  // covers the full device window instead of leaving a visual gap.
+  const spans = new Map<string, { start: number; end: number }>();
+  for (const r of allInputs) {
+    if (!r.sub_protocol) continue;
+    const span = spans.get(r.sub_protocol);
+    if (!span) spans.set(r.sub_protocol, { start: r.t_start_us, end: r.t_end_us });
+    else {
+      span.start = Math.min(span.start, r.t_start_us);
+      span.end = Math.max(span.end, r.t_end_us);
+    }
+  }
+  const ordered = Array.from(spans.entries()).sort((a, b) => a[1].start - b[1].start);
+  for (let i = 0; i < ordered.length; i++) {
+    const [name, span] = ordered[i] as [string, { start: number; end: number }];
+    const nextStart =
+      i + 1 < ordered.length
+        ? (ordered[i + 1] as [string, { start: number; end: number }])[1].start
+        : tOffset;
+    if (nextStart <= span.end) continue;
+    for (const r of allInputs) {
+      if (r.sub_protocol === name && r.t_end_us === span.end && r.light_type === "actinic") {
+        r.t_end_us = nextStart;
+      }
+    }
+  }
+
+  return { inputs: allInputs, outputs: allOutputs, totalDurationUs: tOffset };
+}

--- a/apps/web/lib/multispeq/pipeline.ts
+++ b/apps/web/lib/multispeq/pipeline.ts
@@ -479,22 +479,23 @@ export function explodeRecords(measurement: MeasurementInput): SubProtocolRecord
   const measurementId = measurement.measurement_id ?? null;
   const projectId = measurement.project_id ?? null;
 
-  if (items.every(isV2Item)) {
-    const out: SubProtocolRecord[] = [];
-    let offset = 0;
-    for (const item of items) {
-      const records = explodeV2Item(item, measurementId, projectId, offset);
-      out.push(...records);
-      offset += Array.isArray(item.set) ? item.set.length : 0;
-    }
-    return out;
-  }
-
+  // Walk items independently so a v2 envelope's nested `set` data isn't lost
+  // just because one stray non-v2 item snuck in. Track per-branch indices so
+  // the sub_protocol_index stays globally unique.
   const out: SubProtocolRecord[] = [];
-  items.forEach((item, idx) => {
-    if (!item || typeof item !== "object" || Array.isArray(item)) return;
-    out.push(explodeV1Item(item as Record<string, unknown>, measurementId, projectId, idx));
-  });
+  let v2Offset = 0;
+  let v1Index = 0;
+  for (const item of items) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    if (isV2Item(item)) {
+      const records = explodeV2Item(item, measurementId, projectId, v2Offset);
+      out.push(...records);
+      v2Offset += Array.isArray(item.set) ? item.set.length : 0;
+      continue;
+    }
+    out.push(explodeV1Item(item as Record<string, unknown>, measurementId, projectId, v1Index));
+    v1Index += 1;
+  }
   return out;
 }
 

--- a/apps/web/lib/multispeq/pipeline.ts
+++ b/apps/web/lib/multispeq/pipeline.ts
@@ -493,27 +493,13 @@ export function explodeRecords(measurement: MeasurementInput): SubProtocolRecord
   return out;
 }
 
-function parseETimeUs(metadataJson: string | null): number | null {
-  if (!metadataJson) return null;
-  let meta: unknown;
-  try {
-    meta = JSON.parse(metadataJson) as unknown;
-  } catch {
-    return null;
-  }
-  if (!meta || typeof meta !== "object") return null;
-  const eTime = (meta as Record<string, unknown>).e_time;
-  if (!Array.isArray(eTime) || eTime.length < 2) return null;
-  const ms: unknown = eTime[1];
-  return isFiniteNumber(ms) ? Math.trunc(ms) * 1000 : null;
-}
-
 export interface MeasurementTimeseries {
   inputs: InputRecord[];
   outputs: OutputRecord[];
-  /** Wall-clock duration in microseconds, taken from the latest marker
-   * (start_time/end_time/f_start_time/...). Useful for sizing the x-axis when
-   * trailing sub-protocols (e.g. SPAD) emit no data_raw. */
+  /** Total duration in microseconds — sum of declared sub-protocol durations
+   * plus any `protocols_delay` waits. The device's e_time wall-clock markers
+   * are intentionally ignored (they vary with device-internal autogain/env
+   * work that doesn't map to user-meaningful chart time). */
   totalDurationUs: number;
 }
 
@@ -526,25 +512,6 @@ export function measurementToTimeseries(
   for (const ps of pset) if (ps.label) setByLabel.set(ps.label, ps);
 
   const allRecords = explodeRecords(measurement);
-
-  // A wall-clock marker is any record without data_raw that carries an e_time
-  // ([overflow, ms]). The device emits these at start/end and around fast
-  // (`f_*`) sub-protocols. Anchoring t_offset on every marker — not just
-  // start_time/end_time — keeps long device-only intervals (e.g. an f_transient
-  // that takes 10s but only emits 100 samples) from collapsing.
-  const isMarker = (r: SubProtocolRecord) =>
-    r.data_raw_len === 0 && parseETimeUs(r.metadata_json) != null;
-
-  let wallClockZero: number | null = null;
-  for (const r of allRecords) {
-    if (isMarker(r)) {
-      const t = parseETimeUs(r.metadata_json);
-      if (t != null) {
-        wallClockZero = t;
-        break;
-      }
-    }
-  }
 
   // Disambiguate repeated labels with " #N" suffixes.
   const labelCounts = new Map<string, number>();
@@ -563,14 +530,6 @@ export function measurementToTimeseries(
   let ambientPi: unknown[] | null = null;
 
   for (const row of allRecords) {
-    if (isMarker(row)) {
-      if (wallClockZero != null) {
-        const t = parseETimeUs(row.metadata_json);
-        if (t != null) tOffset = Math.max(tOffset, t - wallClockZero);
-      }
-      continue;
-    }
-
     const psDef = setByLabel.get(row.label);
 
     if (psDef) {
@@ -624,31 +583,42 @@ export function measurementToTimeseries(
     tOffset += subDur;
   }
 
-  // Wall-clock markers (e.g. f_start_time around f_transient) often span longer
-  // than the declared phase duration — the device sits idle (or actinic-only)
-  // for the remainder. Extend each sub-protocol's last actinic LED phase up to
-  // the next sub-protocol's start (or totalDuration) so the LED background
-  // covers the full device window instead of leaving a visual gap.
-  const spans = new Map<string, { start: number; end: number }>();
+  // The device holds actinic LEDs at their last nonpulsed brightness through
+  // wall-clock gaps (autogain, env sensors, etc.) — there is no break in the
+  // actinic light, only in data acquisition. Extend the last-phase actinic
+  // records of each sub-protocol to the start of the next so the input chart
+  // is continuous. Measuring/pulsed lights are NOT extended; those really are
+  // off between sub-protocols.
+  const subStart = new Map<string, number>();
+  const subOrder: string[] = [];
   for (const r of allInputs) {
-    if (!r.sub_protocol) continue;
-    const span = spans.get(r.sub_protocol);
-    if (!span) spans.set(r.sub_protocol, { start: r.t_start_us, end: r.t_end_us });
-    else {
-      span.start = Math.min(span.start, r.t_start_us);
-      span.end = Math.max(span.end, r.t_end_us);
+    if (r.sub_protocol == null) continue;
+    const prev = subStart.get(r.sub_protocol);
+    if (prev == null) {
+      subStart.set(r.sub_protocol, r.t_start_us);
+      subOrder.push(r.sub_protocol);
+    } else if (r.t_start_us < prev) {
+      subStart.set(r.sub_protocol, r.t_start_us);
     }
   }
-  const ordered = Array.from(spans.entries()).sort((a, b) => a[1].start - b[1].start);
-  for (let i = 0; i < ordered.length; i++) {
-    const [name, span] = ordered[i] as [string, { start: number; end: number }];
-    const nextStart =
-      i + 1 < ordered.length
-        ? (ordered[i + 1] as [string, { start: number; end: number }])[1].start
-        : tOffset;
-    if (nextStart <= span.end) continue;
+  subOrder.sort((a, b) => (subStart.get(a) ?? 0) - (subStart.get(b) ?? 0));
+  for (let i = 0; i < subOrder.length; i++) {
+    const cur = subOrder[i];
+    const nextStart = i + 1 < subOrder.length ? (subStart.get(subOrder[i + 1]) ?? tOffset) : tOffset;
+    let maxPhase = -1;
     for (const r of allInputs) {
-      if (r.sub_protocol === name && r.t_end_us === span.end && r.light_type === "actinic") {
+      if (r.sub_protocol === cur && r.light_type === "actinic" && r.phase_index > maxPhase) {
+        maxPhase = r.phase_index;
+      }
+    }
+    if (maxPhase < 0) continue;
+    for (const r of allInputs) {
+      if (
+        r.sub_protocol === cur &&
+        r.light_type === "actinic" &&
+        r.phase_index === maxPhase &&
+        r.t_end_us < nextStart
+      ) {
         r.t_end_us = nextStart;
       }
     }

--- a/apps/web/lib/multispeq/pipeline.ts
+++ b/apps/web/lib/multispeq/pipeline.ts
@@ -604,7 +604,8 @@ export function measurementToTimeseries(
   subOrder.sort((a, b) => (subStart.get(a) ?? 0) - (subStart.get(b) ?? 0));
   for (let i = 0; i < subOrder.length; i++) {
     const cur = subOrder[i];
-    const nextStart = i + 1 < subOrder.length ? (subStart.get(subOrder[i + 1]) ?? tOffset) : tOffset;
+    const nextStart =
+      i + 1 < subOrder.length ? (subStart.get(subOrder[i + 1]) ?? tOffset) : tOffset;
     let maxPhase = -1;
     for (const r of allInputs) {
       if (r.sub_protocol === cur && r.light_type === "actinic" && r.phase_index > maxPhase) {

--- a/apps/web/lib/multispeq/pipeline.ts
+++ b/apps/web/lib/multispeq/pipeline.ts
@@ -123,9 +123,17 @@ function isFiniteNumber(v: unknown): v is number {
  * When a protocol declares `set_repeats: N`, the device picks a different value
  * per repeat by indexing `v_arrays[X]` with the occurrence number. We mirror
  * that — `f_transient` with `pulses: ["@s8"]` and `v_arrays[8] = [20, 100]`
- * runs 20 pulses on repeat 0 and 100 on repeat 1. If the indexed value is
- * non-numeric (e.g. the placeholder `"p_light"`), fall back to the last
- * numeric in the array (matches observed `["p_light", 2500] → 2500`).
+ * runs 20 pulses on repeat 0 and 100 on repeat 1.
+ *
+ * If the indexed slot is in-range but non-numeric (e.g. the `"p_light"`
+ * placeholder in `["p_light", 2500]`), we leave `@sX` unset so the caller can
+ * fall back to the runtime `pi` brightness — that placeholder means "use the
+ * measured ambient PAR", which is only known from the device's recorded `pi`
+ * field, not from the protocol JSON.
+ *
+ * If the indexed slot is *out-of-range* (iteration past the array length), we
+ * clamp to the last numeric value — this is the @s8 / `[20, 100]` style
+ * pattern where the caller is asking for a value beyond the declared repeats.
  */
 export function resolveVariables(
   protocolJson: ProtocolJson,
@@ -134,14 +142,18 @@ export function resolveVariables(
   const lookup: Record<string, number> = {};
   const arrs = protocolJson.v_arrays ?? [];
   arrs.forEach((arr, i) => {
-    if (!Array.isArray(arr)) return;
+    if (!Array.isArray(arr) || arr.length === 0) return;
     arr.forEach((val, j) => {
       if (isFiniteNumber(val)) lookup[`@n${i}:${j}`] = Math.trunc(val);
     });
-    let lastNumeric: number | null = null;
-    for (const val of arr) if (isFiniteNumber(val)) lastNumeric = Math.trunc(val);
-    const indexed = arr[Math.min(occurrence, arr.length - 1)];
-    const chosen = isFiniteNumber(indexed) ? Math.trunc(indexed) : lastNumeric;
+    let chosen: number | null = null;
+    if (occurrence < arr.length) {
+      const indexed = arr[occurrence];
+      if (isFiniteNumber(indexed)) chosen = Math.trunc(indexed);
+    } else {
+      // Out-of-range: clamp to the last numeric in the array.
+      for (const val of arr) if (isFiniteNumber(val)) chosen = Math.trunc(val);
+    }
     if (chosen != null) lookup[`@s${i}`] = chosen;
   });
   return lookup;

--- a/apps/web/lib/multispeq/pipeline.ts
+++ b/apps/web/lib/multispeq/pipeline.ts
@@ -432,6 +432,7 @@ function explodeV2Item(
   item: Record<string, unknown>,
   measurementId: string | null,
   projectId: string | null,
+  indexOffset = 0,
 ): SubProtocolRecord[] {
   const protocolId = item.protocol_id;
   const time = item.time;
@@ -446,7 +447,7 @@ function explodeV2Item(
         measurement_id: measurementId,
         project_id: projectId,
         protocol_id: isFiniteNumber(protocolId) ? Math.trunc(protocolId) : null,
-        sub_protocol_index: idx,
+        sub_protocol_index: idx + indexOffset,
         label: typeof label === "string" ? label : "",
         data_raw: dataRaw,
         data_raw_len: dataRaw.length,
@@ -457,6 +458,10 @@ function explodeV2Item(
       },
     ];
   });
+}
+
+function isV2Item(item: unknown): item is Record<string, unknown> {
+  return item != null && typeof item === "object" && !Array.isArray(item) && "set" in item;
 }
 
 export function explodeRecords(measurement: MeasurementInput): SubProtocolRecord[] {
@@ -474,15 +479,15 @@ export function explodeRecords(measurement: MeasurementInput): SubProtocolRecord
   const measurementId = measurement.measurement_id ?? null;
   const projectId = measurement.project_id ?? null;
 
-  const first = items[0];
-  if (
-    items.length === 1 &&
-    first != null &&
-    typeof first === "object" &&
-    !Array.isArray(first) &&
-    "set" in first
-  ) {
-    return explodeV2Item(first as Record<string, unknown>, measurementId, projectId);
+  if (items.every(isV2Item)) {
+    const out: SubProtocolRecord[] = [];
+    let offset = 0;
+    for (const item of items) {
+      const records = explodeV2Item(item, measurementId, projectId, offset);
+      out.push(...records);
+      offset += Array.isArray(item.set) ? item.set.length : 0;
+    }
+    return out;
   }
 
   const out: SubProtocolRecord[] = [];

--- a/packages/i18n/locales/de-DE/workbook.json
+++ b/packages/i18n/locales/de-DE/workbook.json
@@ -22,10 +22,7 @@
     "allChangesSaved": "Alle Änderungen gespeichert",
     "viewWorkbook": "Arbeitsbuch anzeigen",
     "outputsCleared_one": "{{count}} Ausgabe gelöscht",
-    "outputsCleared_other": "{{count}} Ausgaben gelöscht",
-    "deviceRequired": "Gerät verbinden",
-    "deviceRequiredDescription": "Verbinden Sie ein MultispeQ, um diese Protokollzelle auszuführen.",
-    "connect": "Verbinden"
+    "outputsCleared_other": "{{count}} Ausgaben gelöscht"
   },
   "output": {
     "label": "Ausgabe",

--- a/packages/i18n/locales/de-DE/workbook.json
+++ b/packages/i18n/locales/de-DE/workbook.json
@@ -31,8 +31,15 @@
     "noData": "Keine Ausgabedaten",
     "tabTable": "Tabelle",
     "tabJson": "JSON",
+    "tabTimeseries": "Zeitreihe",
     "copyJson": "JSON kopieren",
     "closeChart": "Diagramm schließen",
-    "expandChart": "Diagramm für {{column}} öffnen"
+    "expandChart": "Diagramm für {{column}} öffnen",
+    "loadingProtocol": "Protokoll wird geladen…",
+    "timeseriesXAxis": "Zeit (s)",
+    "timeseriesYAxis": "Normalisiertes Signal",
+    "timeseriesActinic": "Aktinisches Licht (µmol m⁻² s⁻¹)",
+    "timeseriesEmpty": "Keine Detektor-Messwerte zum Plotten",
+    "timeseriesError": "Diese Ausgabe kann nicht mit dem Quellprotokoll dekodiert werden"
   }
 }

--- a/packages/i18n/locales/de-DE/workbook.json
+++ b/packages/i18n/locales/de-DE/workbook.json
@@ -20,7 +20,12 @@
     "noCells": "Noch keine Zellen. Offnen Sie die Arbeitsmappe, um Ihr Notebook zu erstellen.",
     "saving": "Speichern...",
     "allChangesSaved": "Alle Änderungen gespeichert",
-    "viewWorkbook": "Arbeitsbuch anzeigen"
+    "viewWorkbook": "Arbeitsbuch anzeigen",
+    "outputsCleared_one": "{{count}} Ausgabe gelöscht",
+    "outputsCleared_other": "{{count}} Ausgaben gelöscht",
+    "deviceRequired": "Gerät verbinden",
+    "deviceRequiredDescription": "Verbinden Sie ein MultispeQ, um diese Protokollzelle auszuführen.",
+    "connect": "Verbinden"
   },
   "output": {
     "label": "Ausgabe",

--- a/packages/i18n/locales/de-DE/workbook.json
+++ b/packages/i18n/locales/de-DE/workbook.json
@@ -20,7 +20,8 @@
     "noCells": "Noch keine Zellen. Offnen Sie die Arbeitsmappe, um Ihr Notebook zu erstellen.",
     "saving": "Speichern...",
     "allChangesSaved": "Alle Änderungen gespeichert",
-    "viewWorkbook": "Arbeitsbuch anzeigen",
+    "viewWorkbook": "Arbeitsmappe anzeigen",
+    "required": "Erforderlich",
     "outputsCleared_one": "{{count}} Ausgabe gelöscht",
     "outputsCleared_other": "{{count}} Ausgaben gelöscht"
   },

--- a/packages/i18n/locales/en-US/workbook.json
+++ b/packages/i18n/locales/en-US/workbook.json
@@ -31,8 +31,15 @@
     "noData": "No output data",
     "tabTable": "Table",
     "tabJson": "JSON",
+    "tabTimeseries": "Timeseries",
     "copyJson": "Copy JSON",
     "closeChart": "Close chart",
-    "expandChart": "Expand chart for {{column}}"
+    "expandChart": "Expand chart for {{column}}",
+    "loadingProtocol": "Loading protocol…",
+    "timeseriesXAxis": "Time (s)",
+    "timeseriesYAxis": "Normalised signal",
+    "timeseriesActinic": "Actinic light (µmol m⁻² s⁻¹)",
+    "timeseriesEmpty": "No detector readings to plot",
+    "timeseriesError": "Cannot decode this output against the source protocol"
   }
 }

--- a/packages/i18n/locales/en-US/workbook.json
+++ b/packages/i18n/locales/en-US/workbook.json
@@ -20,7 +20,12 @@
     "noCells": "No cells yet. Open the workbook to start building your notebook.",
     "saving": "Saving...",
     "allChangesSaved": "All changes saved",
-    "viewWorkbook": "View Workbook"
+    "viewWorkbook": "View Workbook",
+    "outputsCleared_one": "Cleared {{count}} output",
+    "outputsCleared_other": "Cleared {{count}} outputs",
+    "deviceRequired": "Connect a device",
+    "deviceRequiredDescription": "Connect a MultispeQ to run this protocol cell.",
+    "connect": "Connect"
   },
   "output": {
     "label": "Output",

--- a/packages/i18n/locales/en-US/workbook.json
+++ b/packages/i18n/locales/en-US/workbook.json
@@ -22,10 +22,7 @@
     "allChangesSaved": "All changes saved",
     "viewWorkbook": "View Workbook",
     "outputsCleared_one": "Cleared {{count}} output",
-    "outputsCleared_other": "Cleared {{count}} outputs",
-    "deviceRequired": "Connect a device",
-    "deviceRequiredDescription": "Connect a MultispeQ to run this protocol cell.",
-    "connect": "Connect"
+    "outputsCleared_other": "Cleared {{count}} outputs"
   },
   "output": {
     "label": "Output",

--- a/packages/i18n/locales/en-US/workbook.json
+++ b/packages/i18n/locales/en-US/workbook.json
@@ -21,6 +21,7 @@
     "saving": "Saving...",
     "allChangesSaved": "All changes saved",
     "viewWorkbook": "View Workbook",
+    "required": "Required",
     "outputsCleared_one": "Cleared {{count}} output",
     "outputsCleared_other": "Cleared {{count}} outputs"
   },

--- a/packages/i18n/locales/en-US/workbook.json
+++ b/packages/i18n/locales/en-US/workbook.json
@@ -37,7 +37,7 @@
     "expandChart": "Expand chart for {{column}}",
     "loadingProtocol": "Loading protocol…",
     "timeseriesXAxis": "Time (s)",
-    "timeseriesYAxis": "Normalised signal",
+    "timeseriesYAxis": "Normalized signal",
     "timeseriesActinic": "Actinic light (µmol m⁻² s⁻¹)",
     "timeseriesEmpty": "No detector readings to plot",
     "timeseriesError": "Cannot decode this output against the source protocol"

--- a/packages/i18n/locales/nl-NL/workbook.json
+++ b/packages/i18n/locales/nl-NL/workbook.json
@@ -20,7 +20,12 @@
     "noCells": "Nog geen cellen. Open het werkboek om uw notebook te bouwen.",
     "saving": "Opslaan...",
     "allChangesSaved": "Alle wijzigingen opgeslagen",
-    "viewWorkbook": "Werkboek bekijken"
+    "viewWorkbook": "Werkboek bekijken",
+    "outputsCleared_one": "{{count}} uitvoer gewist",
+    "outputsCleared_other": "{{count}} uitvoeren gewist",
+    "deviceRequired": "Verbind een apparaat",
+    "deviceRequiredDescription": "Verbind een MultispeQ om deze protocolcel uit te voeren.",
+    "connect": "Verbinden"
   },
   "output": {
     "label": "Uitvoer",

--- a/packages/i18n/locales/nl-NL/workbook.json
+++ b/packages/i18n/locales/nl-NL/workbook.json
@@ -21,6 +21,7 @@
     "saving": "Opslaan...",
     "allChangesSaved": "Alle wijzigingen opgeslagen",
     "viewWorkbook": "Werkboek bekijken",
+    "required": "Verplicht",
     "outputsCleared_one": "{{count}} uitvoer gewist",
     "outputsCleared_other": "{{count}} uitvoeren gewist"
   },

--- a/packages/i18n/locales/nl-NL/workbook.json
+++ b/packages/i18n/locales/nl-NL/workbook.json
@@ -22,10 +22,7 @@
     "allChangesSaved": "Alle wijzigingen opgeslagen",
     "viewWorkbook": "Werkboek bekijken",
     "outputsCleared_one": "{{count}} uitvoer gewist",
-    "outputsCleared_other": "{{count}} uitvoeren gewist",
-    "deviceRequired": "Verbind een apparaat",
-    "deviceRequiredDescription": "Verbind een MultispeQ om deze protocolcel uit te voeren.",
-    "connect": "Verbinden"
+    "outputsCleared_other": "{{count}} uitvoeren gewist"
   },
   "output": {
     "label": "Uitvoer",

--- a/packages/i18n/locales/nl-NL/workbook.json
+++ b/packages/i18n/locales/nl-NL/workbook.json
@@ -31,8 +31,15 @@
     "noData": "Geen uitvoergegevens",
     "tabTable": "Tabel",
     "tabJson": "JSON",
+    "tabTimeseries": "Tijdreeks",
     "copyJson": "JSON kopiëren",
     "closeChart": "Diagram sluiten",
-    "expandChart": "Diagram voor {{column}} openen"
+    "expandChart": "Diagram voor {{column}} openen",
+    "loadingProtocol": "Protocol laden…",
+    "timeseriesXAxis": "Tijd (s)",
+    "timeseriesYAxis": "Genormaliseerd signaal",
+    "timeseriesActinic": "Actinisch licht (µmol m⁻² s⁻¹)",
+    "timeseriesEmpty": "Geen detectorwaarden om te plotten",
+    "timeseriesError": "Deze uitvoer kan niet worden gedecodeerd met het bronprotocol"
   }
 }

--- a/packages/ui/src/components/charts/types.ts
+++ b/packages/ui/src/components/charts/types.ts
@@ -214,4 +214,4 @@ export interface SafeLayout extends Partial<Omit<Layout, "yaxis" | "scene">> {
 export type SafePlotData = PlotData;
 
 // Export all plotly.js types for convenience
-export type { Config, Layout, PlotData } from "plotly.js";
+export type { Config, Layout, PlotData, Shape } from "plotly.js";


### PR DESCRIPTION
## Type of PR

- [x] Feature

## Description

Adds a MultispeQ timeseries renderer to the workbook so a measurement output cell can show the protocol's LED phases and detector reads on a single dual-axis Plotly chart. Detects MultispeQ payloads in raw output JSON, decodes the protocol set + sample stream into input (LED) and output (detector) records, and renders them with sub-protocol boundaries, brightness-scaled actinic shading, and per-LED legends.

After the initial review on `51c9945d`, the branch was rebased on `main` and now also carries the full OJD-1509 workbook UX-fix series + the OJD-1533 connect-device prompt. See the new sections below.

## Related Issues

- Related to OJD-588 (Protocol & Macro Development Workbook)
- Closes [OJD-1509](https://linear.app/openjii/issue/OJD-1509/ux-fixes-workbooks) — UX fixes for workbooks (closes #1440)
- Closes [OJD-1533](https://linear.app/openjii/issue/OJD-1533/workbook-protocol-cell-connect-device-prompt-when-running-without-a) — Workbook Protocol cell: connect-device prompt when running without a device (closes #1485)

## Changes Made

### MultispeQ timeseries renderer (original feature)

**Pipeline (`apps/web/lib/multispeq/`):**

- `detect.ts`: recognise v1 array, v2 `{set: [...]}`, and live-device `{sample: [...]}` envelopes; normalise to a single shape.
- `pipeline.ts`: port of the `jii-data-platform` notebook pipeline. Resolves protocol variables (`@nX:Y` constant, `@sX` set-repeats indexed), explodes the sample stream into per-sub-protocol records, and emits `InputRecord` (LED phase) and `OutputRecord` (detector pulse) lists. Leaves `@sX` unset when the indexed slot is a runtime placeholder (e.g. `"p_light"`) so the device's `pi` brightness fills it. Sub-protocols are laid out back-to-back by declared phase durations; e_time wall-clock markers are ignored (they reflect device-internal autogain/env work that has no chart-meaningful duration). The last-phase actinic record of each sub-protocol is extended to the next sub-protocol's start so the actinic LED line stays continuous through any `protocols_delay` gap.
- `pipeline.test.ts`: 41 unit tests covering variable resolution, protocol-set decoding, pulse/channel ordering, device-truncated runs, v1/v2 explode paths, sub-protocol spacing, actinic-extension behaviour, and malformed-input recovery.

**Chart (`apps/web/components/workbook/cells/`):**

- `output-cell-timeseries.tsx`: Plotly chart with a normalised detector axis on the left and an actinic light axis (µmol m⁻² s⁻¹) on the right. Detector traces are coloured per `(sub_protocol, detector)`; light phases render as background rectangles whose height equals the resolved brightness. Sub-protocol boundaries draw as dotted vertical lines, and ghost legend traces report per-LED brightness ranges.
- `output-cell.tsx` + `cell-renderer.tsx`: pick the timeseries renderer when the output payload looks like a MultispeQ measurement.
- `output-cell.test.tsx`: integration tests for the renderer-selection logic.

**Plotly types (`packages/ui/src/components/charts/types.ts`):**

- Re-export Plotly's `PlotData` / `Shape` from `@repo/ui` so the chart component doesn't import from `plotly.js` directly.

**i18n (`packages/i18n/locales/{en-US,de-DE,nl-NL}/workbook.json`):**

- New strings for the timeseries view (axis labels, legend group titles, empty-state messages).

**Minor (`apps/web/components/macro-settings/`, `apps/web/components/new-macro/`):**

- Enable the `R` option in the macro language selector.

### CodeRabbit follow-ups (commit `d2ac1478`)

- `output-cell-timeseries.tsx`: group traces by detector (not LED) so two detectors on the same light no longer merge. Stable detector-colour palette.
- `pipeline.explodeRecords`: detect v2 via `items.every(isV2Item)` and walk every item, offsetting `sub_protocol_index` so multi-item v2 envelopes no longer fall through to v1.
- `packages/i18n/locales/en-US/workbook.json`: `"Normalised" → "Normalized"`.

### OJD-1509 UX fixes (12 follow-up commits, `26969e8f`..`f4129e72`)

- **Workbooks overview list** — 16px gap between toolbar controls, 8px gap H1↔intro, whole-row navigation, `hover:bg-[#EDF2F6]` on more-actions, fix the disappearing trigger via `has-[[data-state=open]]:opacity-100`.
- **Notebook editor toolbar** — full-width divider (no rounded-b), Export trigger height-matched to Run/Clear and icon-stripped per design, Flow toggle demoted from solid primary to subtle tint (Run all stays the only solid green), Clear all disabled when no outputs + count-aware toast on click, title input commits on Enter / cancels on Esc, autosave saved icon uses brand green `#09B732`.
- **Cell wrapper + sidebar** — grab handle stacked above `[N]` in primary green, whole sidebar card is the drag source (GripVertical kept as a visual hint), drop indicator primary green, Question rows show literal "Question" pink label + question text subtitle + Asterisk for required, collapse toggle uses primary green with `#007575` hover (no background hover).
- **Empty state + add-cell** — darker empty-state title + helper text, `hover:bg-[#E5EBF0]` on the bottom variant buttons, `hover:bg-[#EDF2F6]` on the inline picker buttons.
- **Markdown cell** — Cmd/Ctrl+Enter commits to preview (plain Enter still inserts newlines), click rendered preview to re-enter edit, action button hover primary green.
- **Output cell** — round all four corners with a 4px gap to the previous cell, align Clock + seconds (`inline-flex` + `leading-none`), swap `X` → `Trash2` so the action reads as "clear" not "close".
- **Macro / Protocol cells** — move the `ExternalLink` (open in new tab) into the right-side action row; protocol's MultispeQ family chip becomes plain grey text.
- **Question cell** — Required toggle moves under the question text input (out of the cell header).
- **Branch cell** — "N paths" becomes plain grey text (not a badge).

### OJD-1533 connect-device prompt (commit `0a9cf375`)

- `useWorkbookExecution` gets an optional `onRequireDevice` callback. When a Protocol cell run hits `!isConnectedRef.current` the hook fires the callback before falling through to the existing error output cell.
- The workbook page wires the callback to a `toast` with a `Connect` `ToastAction` that calls `connect()`. A ref bridges `connect` back into the callback without creating a hook-call cycle.
- New locale strings: `deviceRequired`, `deviceRequiredDescription`, `connect`, plus an `outputsCleared_one/_other` plural for the Clear all toast.
- Vitest covers the callback firing when running a protocol with no device.

## Testing Instructions

- [ ] `pnpm -F web check-types` / `pnpm -F web lint` clean; `pnpm -F web test --run components/workbook hooks/workbook lib/multispeq` is green (316 tests).
- [x] **Timeseries chart** — open a measurement whose output is a MultispeQ payload (v2 envelope `{sample: [{set: [...]}]}` or a v1 array of `{data_raw, ...}` items) and confirm the chart renders: detector dots on the left axis, actinic-light rectangles on the right, sub-protocol boundary lines, no gaps in the actinic LED trace. Try `set_repeats > 1` (sub-protocols disambiguated with ` #N`) and a device-truncated run.
- [x] **Toolbar UX** — confirm Run all is the only solid green; Clear all is disabled when no outputs and toasts after clearing; the Export dropdown is icon-free and the same height as Run/Clear; the title input commits on Enter and cancels on Esc.
- [ ] **Sidebar UX** — drag a card by clicking anywhere on it (not just the GripVertical); drop indicator is green; Question rows show literal "Question" pink label + question text + asterisk if required; collapse/expand toggles use primary green with `#007575` hover and no background hover.
- [ ] **Cells UX** — markdown Cmd+Enter→preview / click-to-edit; output cell rounded corners + Trash2 icon + aligned clock; macro & protocol open-in-new-tab on the right side; protocol family label is plain grey text; question Required toggle is inline under the input; branch "N paths" is plain grey text.
- [ ] **Connect prompt** — disconnect, click Run on a Protocol cell, expect a toast "Connect a device" with a Connect action that triggers the same flow as the toolbar Connect button. Verify on both serial and bluetooth transports.
- [ ] **i18n** — toggle workbook language between en-US, de-DE, and nl-NL: axis labels, legend titles, the new toolbar copy, and the connect-prompt copy all translate.

## Checklist

- [x] Tests added/updated for new pipeline + cell-renderer + workbook-execution paths
- [x] `check-types`, `lint`, full workbook test suites pass on the latest commit
- [x] No new warnings introduced
- [x] Self-reviewed

## Additional Notes

- The pipeline still mirrors the Python notebook's decoding behaviour closely. e_time wall-clock markers remain decorative — declared phase durations give a chart that matches what the protocol describes, at the cost of slightly underestimating total wall-clock duration (about 20s on the test dataset vs. 25s of real device time).
- OJD-1533's AC#4 (browser-support guard for the connect-prompt toast) is partially covered — the workbook header's Connect button already disables with a tooltip on unsupported browsers, but the toast doesn't branch on `useIotBrowserSupport` yet. Low-frequency edge case; flagging as a possible follow-up if we want a dedicated "Your browser doesn't support …" toast variant.