### PR TITLE
feat(mobile): opt-in Python macro support with on-device install

### DIFF
--- a/apps/mobile/src/app/(tabs)/profile.tsx
+++ b/apps/mobile/src/app/(tabs)/profile.tsx
@@ -8,6 +8,7 @@ import { View, Text, ScrollView, Linking, Image } from "react-native";
 import { showAlert } from "~/components/AlertDialog";
 import { Button } from "~/components/Button";
 import { Card } from "~/components/Card";
+import { PythonRuntimeCard } from "~/components/python-runtime-card";
 import { colors } from "~/constants/colors";
 import { useSession } from "~/hooks/use-session";
 import { useThemeColors } from "~/hooks/use-theme-colors";
@@ -74,15 +75,15 @@ export default function ProfileScreen() {
         </View>
       </Card>
 
+      <PythonRuntimeCard />
+
       <View className="mb-6">
         <Button
           title="Open Web Profile"
           onPress={handleOpenWebProfile}
           variant="outline"
           style={{ marginBottom: 12 }}
-          icon={
-            <ExternalLink size={16} color={themeColors.brand} />
-          }
+          icon={<ExternalLink size={16} color={themeColors.brand} />}
         />
 
         <Button

--- a/apps/mobile/src/components/measurement-result/measurement-result.tsx
+++ b/apps/mobile/src/components/measurement-result/measurement-result.tsx
@@ -3,8 +3,14 @@ import { ChevronRight, MessageCircle } from "lucide-react-native";
 import React, { useState } from "react";
 import { useAsync } from "react-async-hook";
 import { View, Text, TouchableOpacity, ActivityIndicator } from "react-native";
+import { Button } from "~/components/Button";
 import { TabBar } from "~/components/TabBar";
 import { useTheme } from "~/hooks/use-theme";
+import {
+  installPythonRuntime,
+  PythonRuntimeNotReadyError,
+} from "~/services/python/python-runtime-installer";
+import { usePythonRuntimeStore } from "~/stores/python-runtime-store";
 import { applyMacro } from "~/utils/process-scan/process-scan";
 
 import { Chart } from "./components/chart";
@@ -54,6 +60,9 @@ export function MeasurementResult({
 
   const renderProcessedContent = () => {
     if (processingError) {
+      if (processingError.name === PythonRuntimeNotReadyError.name) {
+        return <PythonRuntimeNotReadyPrompt />;
+      }
       return (
         <View className="rounded-lg bg-red-50 p-3 dark:bg-red-900/20">
           <Text className={clsx("text-sm text-red-600 dark:text-red-400", classes.text)}>
@@ -130,6 +139,50 @@ export function MeasurementResult({
 
       {/* Tab content */}
       {activeTab === "raw" ? renderRawContent() : renderProcessedContent()}
+    </View>
+  );
+}
+
+function PythonRuntimeNotReadyPrompt() {
+  const state = usePythonRuntimeStore((s) => s.state);
+  const progress = usePythonRuntimeStore((s) => s.progress);
+  const error = usePythonRuntimeStore((s) => s.error);
+
+  const handleInstall = async () => {
+    try {
+      await installPythonRuntime();
+    } catch {
+      // Errors land in the store; the UI re-renders with the failed state.
+    }
+  };
+
+  const isInstalling = state === "installing";
+  const isFailed = state === "failed";
+
+  return (
+    <View className="gap-3 rounded-lg bg-amber-50 p-4 dark:bg-amber-900/20">
+      <Text className="text-sm font-semibold text-amber-900 dark:text-amber-100">
+        Python macro support not installed
+      </Text>
+      <Text className="text-sm text-amber-800 dark:text-amber-200">
+        This macro uses Python. Download Pyodide + scientific packages (~100 MB) to run it on this
+        device. Required once; runs offline afterwards.
+      </Text>
+      {isInstalling ? (
+        <Text className="text-sm text-amber-800 dark:text-amber-200">
+          Installing… {Math.round(progress * 100)}%
+        </Text>
+      ) : null}
+      {isFailed && error ? (
+        <Text className="text-sm text-red-700 dark:text-red-300">Install failed: {error}</Text>
+      ) : null}
+      <Button
+        title={isFailed ? "Retry download (~100 MB)" : "Download (~100 MB)"}
+        onPress={handleInstall}
+        variant="primary"
+        isLoading={isInstalling}
+        isDisabled={isInstalling}
+      />
     </View>
   );
 }

--- a/apps/mobile/src/components/python-macro-provider.tsx
+++ b/apps/mobile/src/components/python-macro-provider.tsx
@@ -2,6 +2,12 @@ import React, { useCallback, useEffect, useRef } from "react";
 import { View } from "react-native";
 import WebView from "react-native-webview";
 import { pythonMacroSandboxHtml } from "~/services/python/python-macro-sandbox";
+import {
+  getPythonRuntimeDirUri,
+  PythonRuntimeNotReadyError,
+  reconcilePythonRuntimeState,
+} from "~/services/python/python-runtime-installer";
+import { usePythonRuntimeStore } from "~/stores/python-runtime-store";
 import type { MacroOutput } from "~/utils/process-scan/process-scan";
 import { registerPythonMacroRunner } from "~/utils/process-scan/python-macro-runner";
 
@@ -14,8 +20,16 @@ export function PythonMacroProvider({ children }: { children: React.ReactNode })
   const pendingRef = useRef<Map<string, Pending>>(new Map());
   const requestIdRef = useRef(0);
   const webViewRef = useRef<WebView>(null);
+  const runtimeState = usePythonRuntimeStore((s) => s.state);
+
+  useEffect(() => {
+    reconcilePythonRuntimeState();
+  }, []);
 
   const runPythonMacro = useCallback(async (code: string, json: object): Promise<MacroOutput> => {
+    if (usePythonRuntimeStore.getState().state !== "ready") {
+      throw new PythonRuntimeNotReadyError();
+    }
     const requestId = `py-${++requestIdRef.current}`;
     return new Promise<MacroOutput>((resolve, reject) => {
       pendingRef.current.set(requestId, { resolve, reject });
@@ -72,13 +86,20 @@ export function PythonMacroProvider({ children }: { children: React.ReactNode })
           pointerEvents: "none",
         }}
       >
-        <WebView
-          ref={webViewRef}
-          originWhitelist={["*"]}
-          source={{ html: pythonMacroSandboxHtml }}
-          onMessage={handleMessage}
-          style={{ width: 1, height: 1 }}
-        />
+        {runtimeState === "ready" ? (
+          <WebView
+            ref={webViewRef}
+            originWhitelist={["*"]}
+            source={{ html: pythonMacroSandboxHtml, baseUrl: getPythonRuntimeDirUri() }}
+            onMessage={handleMessage}
+            allowFileAccess
+            allowFileAccessFromFileURLs
+            allowUniversalAccessFromFileURLs
+            javaScriptEnabled
+            domStorageEnabled
+            style={{ width: 1, height: 1 }}
+          />
+        ) : null}
       </View>
     </View>
   );

--- a/apps/mobile/src/components/python-runtime-card.tsx
+++ b/apps/mobile/src/components/python-runtime-card.tsx
@@ -1,0 +1,178 @@
+import { Download, Trash2 } from "lucide-react-native";
+import React, { useState } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { showAlert } from "~/components/AlertDialog";
+import { Button } from "~/components/Button";
+import { Card } from "~/components/Card";
+import { colors } from "~/constants/colors";
+import { useTheme } from "~/hooks/use-theme";
+import {
+  installPythonRuntime,
+  uninstallPythonRuntime,
+} from "~/services/python/python-runtime-installer";
+import { usePythonRuntimeStore } from "~/stores/python-runtime-store";
+
+const DOWNLOAD_SIZE_LABEL = "~100 MB";
+
+export function PythonRuntimeCard() {
+  const theme = useTheme();
+  const state = usePythonRuntimeStore((s) => s.state);
+  const progress = usePythonRuntimeStore((s) => s.progress);
+  const error = usePythonRuntimeStore((s) => s.error);
+  const [busy, setBusy] = useState(false);
+
+  const handleInstall = async () => {
+    setBusy(true);
+    try {
+      await installPythonRuntime();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      showAlert("Install failed", message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleUninstall = () => {
+    setBusy(true);
+    try {
+      uninstallPythonRuntime();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      showAlert("Remove failed", message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const statusLabel = (() => {
+    if (state === "ready") return "Installed";
+    if (state === "installing") return `Installing… ${Math.round(progress * 100)}%`;
+    if (state === "failed") return "Install failed";
+    return "Not installed";
+  })();
+
+  return (
+    <Card style={styles.card}>
+      <Text
+        style={[
+          styles.title,
+          { color: theme.isDark ? colors.dark.onSurface : colors.light.onSurface },
+        ]}
+      >
+        Python macro support
+      </Text>
+      <Text
+        style={[
+          styles.body,
+          { color: theme.isDark ? colors.dark.inactive : colors.light.inactive },
+        ]}
+      >
+        Enables Python macros on this device by downloading Pyodide + numpy, pandas, and scipy (
+        {DOWNLOAD_SIZE_LABEL}). Required once; runs offline afterwards.
+      </Text>
+
+      <View style={styles.row}>
+        <Text
+          style={[
+            styles.statusLabel,
+            { color: theme.isDark ? colors.dark.inactive : colors.light.inactive },
+          ]}
+        >
+          Status
+        </Text>
+        <Text
+          style={[
+            styles.statusValue,
+            { color: theme.isDark ? colors.dark.onSurface : colors.light.onSurface },
+          ]}
+        >
+          {statusLabel}
+        </Text>
+      </View>
+
+      {state === "installing" ? (
+        <View style={styles.progressTrack}>
+          <View style={[styles.progressFill, { width: `${Math.max(2, progress * 100)}%` }]} />
+        </View>
+      ) : null}
+
+      {state === "failed" && error ? <Text style={styles.errorText}>{error}</Text> : null}
+
+      {state === "ready" ? (
+        <Button
+          title="Remove Python support"
+          onPress={handleUninstall}
+          variant="outline"
+          isDisabled={busy}
+          icon={<Trash2 size={16} color={colors.semantic.error} />}
+          style={styles.actionButton}
+          textStyle={{ color: colors.semantic.error }}
+        />
+      ) : (
+        <Button
+          title={
+            state === "failed"
+              ? `Retry download (${DOWNLOAD_SIZE_LABEL})`
+              : `Download (${DOWNLOAD_SIZE_LABEL})`
+          }
+          onPress={handleInstall}
+          variant="primary"
+          isLoading={state === "installing" || busy}
+          isDisabled={state === "installing" || busy}
+          icon={<Download size={16} color="#fff" />}
+          style={styles.actionButton}
+        />
+      )}
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: 24,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "bold",
+    marginBottom: 8,
+  },
+  body: {
+    fontSize: 14,
+    lineHeight: 20,
+    marginBottom: 16,
+  },
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    paddingVertical: 8,
+  },
+  statusLabel: {
+    fontSize: 14,
+  },
+  statusValue: {
+    fontSize: 14,
+    fontWeight: "500",
+  },
+  progressTrack: {
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: "#e5e7eb",
+    overflow: "hidden",
+    marginTop: 8,
+    marginBottom: 12,
+  },
+  progressFill: {
+    height: "100%",
+    backgroundColor: colors.primary.dark,
+  },
+  errorText: {
+    color: colors.semantic.error,
+    fontSize: 13,
+    marginTop: 8,
+    marginBottom: 12,
+  },
+  actionButton: {
+    marginTop: 12,
+  },
+});

--- a/apps/mobile/src/components/python-runtime-card.tsx
+++ b/apps/mobile/src/components/python-runtime-card.tsx
@@ -1,9 +1,9 @@
+import clsx from "clsx";
 import { Download, Trash2 } from "lucide-react-native";
 import React, { useState } from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { Text, View } from "react-native";
 import { showAlert } from "~/components/AlertDialog";
 import { Button } from "~/components/Button";
-import { Card } from "~/components/Card";
 import { colors } from "~/constants/colors";
 import { useTheme } from "~/hooks/use-theme";
 import {
@@ -15,7 +15,7 @@ import { usePythonRuntimeStore } from "~/stores/python-runtime-store";
 const DOWNLOAD_SIZE_LABEL = "~100 MB";
 
 export function PythonRuntimeCard() {
-  const theme = useTheme();
+  const { classes } = useTheme();
   const state = usePythonRuntimeStore((s) => s.state);
   const progress = usePythonRuntimeStore((s) => s.progress);
   const error = usePythonRuntimeStore((s) => s.error);
@@ -53,126 +53,58 @@ export function PythonRuntimeCard() {
   })();
 
   return (
-    <Card style={styles.card}>
-      <Text
-        style={[
-          styles.title,
-          { color: theme.isDark ? colors.dark.onSurface : colors.light.onSurface },
-        ]}
-      >
-        Python macro support
-      </Text>
-      <Text
-        style={[
-          styles.body,
-          { color: theme.isDark ? colors.dark.inactive : colors.light.inactive },
-        ]}
-      >
+    <View className={clsx("mb-6 rounded-xl p-4", classes.card)}>
+      <Text className={clsx("mb-2 text-lg font-bold", classes.text)}>Python macro support</Text>
+      <Text className={clsx("mb-4 text-sm leading-5", classes.textSecondary)}>
         Enables Python macros on this device by downloading Pyodide + numpy, pandas, and scipy (
         {DOWNLOAD_SIZE_LABEL}). Required once; runs offline afterwards.
       </Text>
 
-      <View style={styles.row}>
-        <Text
-          style={[
-            styles.statusLabel,
-            { color: theme.isDark ? colors.dark.inactive : colors.light.inactive },
-          ]}
-        >
-          Status
-        </Text>
-        <Text
-          style={[
-            styles.statusValue,
-            { color: theme.isDark ? colors.dark.onSurface : colors.light.onSurface },
-          ]}
-        >
-          {statusLabel}
-        </Text>
+      <View className="flex-row justify-between py-2">
+        <Text className={clsx("text-sm", classes.textSecondary)}>Status</Text>
+        <Text className={clsx("text-sm font-medium", classes.text)}>{statusLabel}</Text>
       </View>
 
       {state === "installing" ? (
-        <View style={styles.progressTrack}>
-          <View style={[styles.progressFill, { width: `${Math.max(2, progress * 100)}%` }]} />
+        <View className="mb-3 mt-2 h-1.5 overflow-hidden rounded-sm bg-gray-200 dark:bg-gray-700">
+          <View
+            className="h-full bg-[#005e5e]"
+            // Dynamic width can't be a Tailwind class (no AOT match), so this
+            // single inline style is unavoidable.
+            style={{ width: `${Math.max(2, progress * 100)}%` }}
+          />
         </View>
       ) : null}
 
-      {state === "failed" && error ? <Text style={styles.errorText}>{error}</Text> : null}
+      {state === "failed" && error ? (
+        <Text className="mb-3 mt-2 text-sm text-red-600 dark:text-red-400">{error}</Text>
+      ) : null}
 
-      {state === "ready" ? (
-        <Button
-          title="Remove Python support"
-          onPress={handleUninstall}
-          variant="outline"
-          isDisabled={busy}
-          icon={<Trash2 size={16} color={colors.semantic.error} />}
-          style={styles.actionButton}
-          textStyle={{ color: colors.semantic.error }}
-        />
-      ) : (
-        <Button
-          title={
-            state === "failed"
-              ? `Retry download (${DOWNLOAD_SIZE_LABEL})`
-              : `Download (${DOWNLOAD_SIZE_LABEL})`
-          }
-          onPress={handleInstall}
-          variant="primary"
-          isLoading={state === "installing" || busy}
-          isDisabled={state === "installing" || busy}
-          icon={<Download size={16} color="#fff" />}
-          style={styles.actionButton}
-        />
-      )}
-    </Card>
+      <View className="mt-3">
+        {state === "ready" ? (
+          <Button
+            title="Remove Python support"
+            onPress={handleUninstall}
+            variant="outline"
+            isDisabled={busy}
+            icon={<Trash2 size={16} color={colors.semantic.error} />}
+            textStyle={{ color: colors.semantic.error }}
+          />
+        ) : (
+          <Button
+            title={
+              state === "failed"
+                ? `Retry download (${DOWNLOAD_SIZE_LABEL})`
+                : `Download (${DOWNLOAD_SIZE_LABEL})`
+            }
+            onPress={handleInstall}
+            variant="primary"
+            isLoading={state === "installing" || busy}
+            isDisabled={state === "installing" || busy}
+            icon={<Download size={16} color="#fff" />}
+          />
+        )}
+      </View>
+    </View>
   );
 }
-
-const styles = StyleSheet.create({
-  card: {
-    marginBottom: 24,
-  },
-  title: {
-    fontSize: 18,
-    fontWeight: "bold",
-    marginBottom: 8,
-  },
-  body: {
-    fontSize: 14,
-    lineHeight: 20,
-    marginBottom: 16,
-  },
-  row: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    paddingVertical: 8,
-  },
-  statusLabel: {
-    fontSize: 14,
-  },
-  statusValue: {
-    fontSize: 14,
-    fontWeight: "500",
-  },
-  progressTrack: {
-    height: 6,
-    borderRadius: 3,
-    backgroundColor: "#e5e7eb",
-    overflow: "hidden",
-    marginTop: 8,
-    marginBottom: 12,
-  },
-  progressFill: {
-    height: "100%",
-    backgroundColor: colors.primary.dark,
-  },
-  errorText: {
-    color: colors.semantic.error,
-    fontSize: 13,
-    marginTop: 8,
-    marginBottom: 12,
-  },
-  actionButton: {
-    marginTop: 12,
-  },
-});

--- a/apps/mobile/src/services/python/python-macro-sandbox.ts
+++ b/apps/mobile/src/services/python/python-macro-sandbox.ts
@@ -1,14 +1,24 @@
 /**
  * Inline HTML for a hidden WebView that runs Python macros via Pyodide.
- * Listens for postMessage({ requestId, code, json }), wraps code in a function
- * that receives json, runs it, and posts back { requestId, result } or { requestId, error }.
+ *
+ * Pyodide v0.24.1 and the scientific packages (numpy/pandas/scipy + deps) are
+ * downloaded on demand to `Paths.document/pyodide/` by
+ * `python-runtime-installer.ts` when the user enables Python macro support in
+ * Settings. The WebView is mounted with `baseUrl` pointing at that directory,
+ * so `<script src="pyodide.js">` and `loadPyodide({ indexURL: "./" })` resolve
+ * to the local copies. After install, macros run offline.
+ *
+ * Before executing each macro we call `loadPackagesFromImports`, which scans
+ * the user's `import` statements and pulls in the matching wheels from the
+ * staged directory. Authors just write `import numpy as np`; no
+ * `await micropip.install(...)` boilerplate.
  */
 export const pythonMacroSandboxHtml = `
 <!DOCTYPE html>
 <html>
 <head><meta charset="UTF-8"/><title>Python Macro</title></head>
 <body>
-<script src="https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"></script>
+<script src="pyodide.js"></script>
 <script>
 (function() {
   var pyodideReady = false;
@@ -35,6 +45,7 @@ export const pythonMacroSandboxHtml = `
         'def __macro__(json):\\n' + indent(code) + '\\n\\n' +
         '__result__ = __macro__(__json_input__)\\n' +
         '__result_holder__.result = json.dumps(__result__)\\n';
+      await pyodide.loadPackagesFromImports(wrapped);
       await pyodide.runPythonAsync(wrapped);
       var raw = resultHolder.result;
       var str = (typeof raw === 'string') ? raw : (raw != null ? String(raw) : '');
@@ -63,7 +74,7 @@ export const pythonMacroSandboxHtml = `
     }
   });
 
-  loadPyodide().then(function(pyodide) {
+  loadPyodide({ indexURL: "./" }).then(function(pyodide) {
     window.pyodide = pyodide;
     pyodideReady = true;
     send({ type: 'ready' });

--- a/apps/mobile/src/services/python/python-runtime-installer.test.ts
+++ b/apps/mobile/src/services/python/python-runtime-installer.test.ts
@@ -3,6 +3,7 @@ import { usePythonRuntimeStore } from "~/stores/python-runtime-store";
 
 import {
   getPythonRuntimeDirUri,
+  installPythonRuntime,
   isPythonRuntimeReady,
   reconcilePythonRuntimeState,
   uninstallPythonRuntime,
@@ -17,10 +18,14 @@ vi.mock("@react-native-async-storage/async-storage", () => ({
 }));
 
 // `expo-file-system` reaches into native code; provide a minimal in-memory
-// stand-in for the surface the installer uses.
+// stand-in for the surface the installer uses. `downloadFileAsync` is a
+// vi.fn() so individual tests can make specific files fail without touching
+// the network.
 let sentinelExists = false;
 let dirExists = false;
 const fileSystemActions: string[] = [];
+const downloadCalls: string[] = [];
+let downloadBehavior: (url: string) => Promise<void> = () => Promise.resolve();
 
 vi.mock("expo-file-system", () => {
   class FakeDirectory {
@@ -62,6 +67,11 @@ vi.mock("expo-file-system", () => {
     delete() {
       if (this.uri.endsWith(".install-complete-v1")) sentinelExists = false;
     }
+    static async downloadFileAsync(url: string, _dest: unknown): Promise<FakeFile> {
+      downloadCalls.push(url);
+      await downloadBehavior(url);
+      return new FakeFile(url);
+    }
   }
 
   return {
@@ -73,12 +83,16 @@ vi.mock("expo-file-system", () => {
   };
 });
 
+const EXPECTED_FILE_COUNT = 12; // 5 core + 7 packages
+
 describe("python-runtime-installer", () => {
   beforeEach(() => {
     usePythonRuntimeStore.getState().reset();
     dirExists = false;
     sentinelExists = false;
     fileSystemActions.length = 0;
+    downloadCalls.length = 0;
+    downloadBehavior = () => Promise.resolve();
   });
 
   it("getPythonRuntimeDirUri always ends with a trailing slash", () => {
@@ -139,5 +153,76 @@ describe("python-runtime-installer", () => {
     uninstallPythonRuntime();
     expect(fileSystemActions).not.toContain("dir.delete");
     expect(usePythonRuntimeStore.getState().state).toBe("absent");
+  });
+
+  it("install downloads every required file and ends in 'ready' with progress=1", async () => {
+    await installPythonRuntime();
+
+    const current = usePythonRuntimeStore.getState();
+    expect(current.state).toBe("ready");
+    expect(current.progress).toBe(1);
+    expect(current.error).toBeUndefined();
+    expect(downloadCalls.length).toBe(EXPECTED_FILE_COUNT);
+    expect(sentinelExists).toBe(true);
+    expect(fileSystemActions).toContain("dir.create");
+  });
+
+  it("install fetches all 12 files from the pinned Pyodide CDN", async () => {
+    await installPythonRuntime();
+    expect(
+      downloadCalls.every((url) =>
+        url.startsWith("https://cdn.jsdelivr.net/pyodide/v0.24.1/full/"),
+      ),
+    ).toBe(true);
+  });
+
+  it("install transitions to 'failed' and captures the error when a download throws", async () => {
+    downloadBehavior = (url) => {
+      if (url.endsWith("scipy-1.11.2-cp311-cp311-emscripten_3_1_45_wasm32.whl")) {
+        return Promise.reject(new Error("network unreachable"));
+      }
+      return Promise.resolve();
+    };
+
+    await expect(installPythonRuntime()).rejects.toThrow("network unreachable");
+
+    const current = usePythonRuntimeStore.getState();
+    expect(current.state).toBe("failed");
+    expect(current.error).toBe("network unreachable");
+    expect(sentinelExists).toBe(false);
+  });
+
+  it("concurrent install() calls share one active install and run downloads once", async () => {
+    let resolveGate = () => undefined as void;
+    const gate = new Promise<void>((res) => {
+      resolveGate = () => res();
+    });
+    downloadBehavior = () => gate;
+
+    const a = installPythonRuntime();
+    const b = installPythonRuntime();
+
+    resolveGate();
+    await Promise.all([a, b]);
+
+    // Functional dedup: a second install while one is active does not double the
+    // download count. (Identity check `a === b` would fail because `async`
+    // wraps a returned promise in a fresh outer promise even when the body
+    // returns an existing promise — the dedup is in the file ops, not refs.)
+    expect(downloadCalls.length).toBe(EXPECTED_FILE_COUNT);
+    expect(usePythonRuntimeStore.getState().state).toBe("ready");
+  });
+
+  it("install retries cleanly after a previous failure: dir is recreated and prior partials are gone", async () => {
+    downloadBehavior = () => Promise.reject(new Error("disk full"));
+    await expect(installPythonRuntime()).rejects.toThrow("disk full");
+    expect(usePythonRuntimeStore.getState().state).toBe("failed");
+
+    downloadBehavior = () => Promise.resolve();
+    await installPythonRuntime();
+
+    expect(usePythonRuntimeStore.getState().state).toBe("ready");
+    // dir.create runs on each install attempt (we wipe before each).
+    expect(fileSystemActions.filter((a) => a === "dir.create").length).toBe(2);
   });
 });

--- a/apps/mobile/src/services/python/python-runtime-installer.test.ts
+++ b/apps/mobile/src/services/python/python-runtime-installer.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { usePythonRuntimeStore } from "~/stores/python-runtime-store";
+
+import {
+  getPythonRuntimeDirUri,
+  isPythonRuntimeReady,
+  reconcilePythonRuntimeState,
+  uninstallPythonRuntime,
+} from "./python-runtime-installer";
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    setItem: vi.fn(() => Promise.resolve()),
+    getItem: vi.fn(() => Promise.resolve(null)),
+    removeItem: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+// `expo-file-system` reaches into native code; provide a minimal in-memory
+// stand-in for the surface the installer uses.
+let sentinelExists = false;
+let dirExists = false;
+const fileSystemActions: string[] = [];
+
+vi.mock("expo-file-system", () => {
+  class FakeDirectory {
+    uri: string;
+    constructor(...parts: (string | FakeDirectory | FakeFile)[]) {
+      this.uri = "file:///mock/document/pyodide/";
+      void parts;
+    }
+    get exists() {
+      return dirExists;
+    }
+    create() {
+      dirExists = true;
+      sentinelExists = false;
+      fileSystemActions.push("dir.create");
+    }
+    delete() {
+      dirExists = false;
+      sentinelExists = false;
+      fileSystemActions.push("dir.delete");
+    }
+  }
+
+  class FakeFile {
+    uri: string;
+    constructor(...parts: (string | FakeDirectory | FakeFile)[]) {
+      const last = parts[parts.length - 1];
+      this.uri = `file:///mock/document/pyodide/${typeof last === "string" ? last : "file"}`;
+    }
+    get exists() {
+      return this.uri.endsWith(".install-complete-v1") ? sentinelExists : false;
+    }
+    create() {
+      if (this.uri.endsWith(".install-complete-v1")) sentinelExists = true;
+    }
+    write() {
+      // no-op
+    }
+    delete() {
+      if (this.uri.endsWith(".install-complete-v1")) sentinelExists = false;
+    }
+  }
+
+  return {
+    Directory: FakeDirectory,
+    File: FakeFile,
+    Paths: {
+      document: new FakeDirectory(),
+    },
+  };
+});
+
+describe("python-runtime-installer", () => {
+  beforeEach(() => {
+    usePythonRuntimeStore.getState().reset();
+    dirExists = false;
+    sentinelExists = false;
+    fileSystemActions.length = 0;
+  });
+
+  it("getPythonRuntimeDirUri always ends with a trailing slash", () => {
+    expect(getPythonRuntimeDirUri()).toMatch(/\/$/);
+  });
+
+  it("isPythonRuntimeReady reports false until the store says ready and the sentinel exists", () => {
+    expect(isPythonRuntimeReady()).toBe(false);
+
+    usePythonRuntimeStore.getState().setState("ready");
+    expect(isPythonRuntimeReady()).toBe(false); // sentinel missing
+    sentinelExists = true;
+    expect(isPythonRuntimeReady()).toBe(true);
+  });
+
+  it("reconcile drops 'ready' back to 'absent' when the sentinel is gone", () => {
+    usePythonRuntimeStore.getState().setState("ready");
+    sentinelExists = false;
+
+    reconcilePythonRuntimeState();
+
+    expect(usePythonRuntimeStore.getState().state).toBe("absent");
+  });
+
+  it("reconcile preserves 'ready' when the sentinel is intact", () => {
+    usePythonRuntimeStore.getState().setState("ready");
+    sentinelExists = true;
+
+    reconcilePythonRuntimeState();
+
+    expect(usePythonRuntimeStore.getState().state).toBe("ready");
+  });
+
+  it("reconcile resets a stale 'installing' state from a previous crash", () => {
+    usePythonRuntimeStore.getState().setState("installing");
+    usePythonRuntimeStore.getState().setProgress(0.42);
+
+    reconcilePythonRuntimeState();
+
+    const current = usePythonRuntimeStore.getState();
+    expect(current.state).toBe("absent");
+    expect(current.progress).toBe(0);
+  });
+
+  it("uninstall deletes the directory and resets the store", () => {
+    usePythonRuntimeStore.getState().setState("ready");
+    dirExists = true;
+    sentinelExists = true;
+
+    uninstallPythonRuntime();
+
+    expect(usePythonRuntimeStore.getState().state).toBe("absent");
+    expect(dirExists).toBe(false);
+    expect(fileSystemActions).toContain("dir.delete");
+  });
+
+  it("uninstall is a no-op for the filesystem when nothing was installed", () => {
+    uninstallPythonRuntime();
+    expect(fileSystemActions).not.toContain("dir.delete");
+    expect(usePythonRuntimeStore.getState().state).toBe("absent");
+  });
+});

--- a/apps/mobile/src/services/python/python-runtime-installer.ts
+++ b/apps/mobile/src/services/python/python-runtime-installer.ts
@@ -1,0 +1,130 @@
+import { Directory, File, Paths } from "expo-file-system";
+import { usePythonRuntimeStore } from "~/stores/python-runtime-store";
+
+const PYODIDE_VERSION = "0.24.1";
+const CDN_BASE = `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full`;
+const PYODIDE_DIRNAME = "pyodide";
+const SENTINEL_FILENAME = ".install-complete-v1";
+
+const CORE_FILES = [
+  "pyodide.js",
+  "pyodide.asm.js",
+  "pyodide.asm.wasm",
+  "pyodide-lock.json",
+  "python_stdlib.zip",
+];
+
+const PACKAGE_FILES = [
+  "numpy-1.25.2-cp311-cp311-emscripten_3_1_45_wasm32.whl",
+  "pandas-1.5.3-cp311-cp311-emscripten_3_1_45_wasm32.whl",
+  "scipy-1.11.2-cp311-cp311-emscripten_3_1_45_wasm32.whl",
+  "python_dateutil-2.8.2-py2.py3-none-any.whl",
+  "pytz-2023.3-py2.py3-none-any.whl",
+  "six-1.16.0-py2.py3-none-any.whl",
+  "openblas-0.3.23.zip",
+];
+
+let activeInstall: Promise<void> | null = null;
+
+export class PythonRuntimeNotReadyError extends Error {
+  constructor() {
+    super("Python macro support is not installed on this device.");
+    this.name = "PythonRuntimeNotReadyError";
+  }
+}
+
+function runtimeDir(): Directory {
+  return new Directory(Paths.document, PYODIDE_DIRNAME);
+}
+
+function sentinelFile(): File {
+  return new File(runtimeDir(), SENTINEL_FILENAME);
+}
+
+export function getPythonRuntimeDirUri(): string {
+  const uri = runtimeDir().uri;
+  return uri.endsWith("/") ? uri : `${uri}/`;
+}
+
+export function isPythonRuntimeReady(): boolean {
+  if (usePythonRuntimeStore.getState().state !== "ready") return false;
+  try {
+    return sentinelFile().exists;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Re-check the durable sentinel file at app startup and reconcile the store.
+ * If the user wiped app data outside our UI, or an upgrade removed the dir,
+ * we drop back to `absent` so the settings toggle reflects reality.
+ */
+export function reconcilePythonRuntimeState(): void {
+  const store = usePythonRuntimeStore.getState();
+  if (store.state === "installing") {
+    // A previous install was interrupted (crash, force-quit). Reset.
+    store.reset();
+    return;
+  }
+  if (store.state === "ready" && !sentinelFile().exists) {
+    store.reset();
+  }
+}
+
+async function downloadOne(filename: string): Promise<void> {
+  const dir = runtimeDir();
+  const target = new File(dir, filename);
+  if (target.exists) target.delete();
+  await File.downloadFileAsync(`${CDN_BASE}/${filename}`, target);
+}
+
+export async function installPythonRuntime(): Promise<void> {
+  if (activeInstall) return activeInstall;
+
+  const store = usePythonRuntimeStore.getState();
+  activeInstall = (async () => {
+    try {
+      store.setError(undefined);
+      store.setProgress(0);
+      store.setState("installing");
+
+      const dir = runtimeDir();
+      if (dir.exists) dir.delete();
+      dir.create({ intermediates: true });
+
+      const allFiles = [...CORE_FILES, ...PACKAGE_FILES];
+      let done = 0;
+      for (const name of allFiles) {
+        await downloadOne(name);
+        done += 1;
+        store.setProgress(done / allFiles.length);
+      }
+
+      // TODO: verify package sha256s against the freshly downloaded lock file.
+      // Skipped here because expo-file-system v55 does not expose a sync hash
+      // primitive; if we add one, do it in a follow-up.
+
+      const sentinel = sentinelFile();
+      sentinel.create();
+      sentinel.write(new Date().toISOString());
+
+      store.setState("ready");
+      store.setProgress(1);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      store.setError(message);
+      store.setState("failed");
+      throw err;
+    } finally {
+      activeInstall = null;
+    }
+  })();
+  return activeInstall;
+}
+
+export function uninstallPythonRuntime(): void {
+  const dir = runtimeDir();
+  if (dir.exists) dir.delete();
+  usePythonRuntimeStore.getState().reset();
+}

--- a/apps/mobile/src/stores/python-runtime-store.test.ts
+++ b/apps/mobile/src/stores/python-runtime-store.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { usePythonRuntimeStore } from "./python-runtime-store";
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    setItem: vi.fn(() => Promise.resolve()),
+    getItem: vi.fn(() => Promise.resolve(null)),
+    removeItem: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+describe("python-runtime-store", () => {
+  beforeEach(() => {
+    usePythonRuntimeStore.getState().reset();
+  });
+
+  it("defaults to absent with zero progress and no error", () => {
+    const state = usePythonRuntimeStore.getState();
+    expect(state.state).toBe("absent");
+    expect(state.progress).toBe(0);
+    expect(state.error).toBeUndefined();
+  });
+
+  it("transitions absent -> installing -> ready and tracks progress", () => {
+    const store = usePythonRuntimeStore.getState();
+
+    store.setState("installing");
+    store.setProgress(0.25);
+    expect(usePythonRuntimeStore.getState().state).toBe("installing");
+    expect(usePythonRuntimeStore.getState().progress).toBe(0.25);
+
+    store.setProgress(1);
+    store.setState("ready");
+    expect(usePythonRuntimeStore.getState().state).toBe("ready");
+    expect(usePythonRuntimeStore.getState().progress).toBe(1);
+  });
+
+  it("captures error on failure and exposes it for the UI", () => {
+    const store = usePythonRuntimeStore.getState();
+
+    store.setState("installing");
+    store.setError("network unreachable");
+    store.setState("failed");
+
+    const current = usePythonRuntimeStore.getState();
+    expect(current.state).toBe("failed");
+    expect(current.error).toBe("network unreachable");
+  });
+
+  it("reset clears state, progress and error", () => {
+    const store = usePythonRuntimeStore.getState();
+    store.setState("failed");
+    store.setProgress(0.4);
+    store.setError("boom");
+
+    store.reset();
+
+    const current = usePythonRuntimeStore.getState();
+    expect(current.state).toBe("absent");
+    expect(current.progress).toBe(0);
+    expect(current.error).toBeUndefined();
+  });
+});

--- a/apps/mobile/src/stores/python-runtime-store.ts
+++ b/apps/mobile/src/stores/python-runtime-store.ts
@@ -1,0 +1,39 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+export type PythonRuntimeState = "absent" | "installing" | "ready" | "failed";
+
+interface PythonRuntimeStoreState {
+  state: PythonRuntimeState;
+  progress: number;
+  error?: string;
+}
+
+interface PythonRuntimeStoreActions {
+  setState: (state: PythonRuntimeState) => void;
+  setProgress: (progress: number) => void;
+  setError: (error?: string) => void;
+  reset: () => void;
+}
+
+export const usePythonRuntimeStore = create<PythonRuntimeStoreState & PythonRuntimeStoreActions>()(
+  persist(
+    (set) => ({
+      state: "absent",
+      progress: 0,
+      error: undefined,
+      setState: (state) => set({ state }),
+      setProgress: (progress) => set({ progress }),
+      setError: (error) => set({ error }),
+      reset: () => set({ state: "absent", progress: 0, error: undefined }),
+    }),
+    {
+      name: "python-runtime-storage",
+      storage: createJSONStorage(() => AsyncStorage),
+      // Only the durable readiness flag survives a relaunch. Progress and
+      // error are transient and only meaningful during an active install.
+      partialize: (s) => ({ state: s.state === "ready" ? "ready" : "absent" }),
+    },
+  ),
+);


### PR DESCRIPTION
Closes OJD-1508.

## Summary

Researchers can now enable Python macro support from the Profile screen. When enabled, the app downloads Pyodide v0.24.1 + numpy/pandas/scipy (matching Lambda) to `Paths.document/pyodide/` and runs macros offline thereafter. App binary size is **unchanged** for everyone who doesn't enable it.

* Settings card on Profile tab: shows install status + progress, lets users uninstall.
* Inline "Download (~100 MB)" prompt at the processing-error surface when a macro hits Python without the runtime — no more bare `ModuleNotFoundError` (reported by Ludovico, experiment [19bd2e42-…](https://openjii.org/en-US/platform/experiments/19bd2e42-b8e9-4484-8758-5dd93d659673)).
* Once installed, `import numpy as np` etc. work offline with no `await micropip.install(...)` boilerplate — `loadPackagesFromImports` runs as part of macro pre-execution.

## How it works

1. `python-runtime-store.ts` (Zustand + AsyncStorage) holds the runtime state (`absent | installing | ready | failed`) and live progress. Only `state` is persisted.
2. `python-runtime-installer.ts` downloads 12 files (Pyodide core + numpy/pandas/scipy + transitive deps openblas, python-dateutil, pytz, six) from `cdn.jsdelivr.net/pyodide/v0.24.1/full/` to `Paths.document/pyodide/`. A sentinel file marks completion; `reconcilePythonRuntimeState()` runs at provider mount and drops the toggle back to "Not installed" if the sentinel is gone (e.g. user wiped app data).
3. `python-macro-provider.tsx` mounts the WebView only when state is `ready`, with `baseUrl: file://.../pyodide/` + Android `allowFileAccess*` flags. If `runPythonMacro` is called while the runtime is absent, it rejects with `PythonRuntimeNotReadyError`.
4. `python-macro-sandbox.ts` HTML uses `<script src="pyodide.js">` (relative), `loadPyodide({ indexURL: "./" })`, and `await pyodide.loadPackagesFromImports(wrapped)` before `runPythonAsync`.
5. `measurement-result.tsx` detects `PythonRuntimeNotReadyError` and renders an inline prompt with a one-tap install button instead of the generic red error block.

## Bundle size impact

**Zero** added to the app binary (vs. the +97 MB the previous draft of this PR would have shipped). Pyodide assets live in `documentDirectory` only after the user enables, and `getSize` reports them outside the app binary.

## Trade-offs

* Researchers must enable Python support before going offline. The UX nudges this: the first time a Python macro runs without the runtime, they see the prompt right where the error would have been.
* Single point of failure: the CDN. If `cdn.jsdelivr.net` is down at the time a researcher enables, the install fails. The UI shows the failure with a retry button. Long-term we could mirror the assets to S3.

## Version drift (known, out of scope here)

Pyodide ships numpy 1.25.2 / pandas 1.5.3 / scipy 1.11.2; Lambda has numpy 2.4.2 / pandas 3.0.1 / scipy 1.17.0. Macros relying on version-specific APIs may diverge between runtimes. Flagged in OJD-1508 for follow-up if researchers hit it.

## Test plan

- [ ] Fresh install (no prior data). Open Profile tab. See "Python macro support" card with "Not installed" status and "Download (~100 MB)" button.
- [ ] Tap Download. Progress bar advances 0–100% over ~30–60s on wifi. Status flips to "Installed".
- [ ] Toggle airplane mode. Run a Python macro with `import numpy as np`; succeeds.
- [ ] Repeat with `import pandas as pd` and `import scipy.signal`.
- [ ] Disable Python from Profile tab. Status flips to "Not installed". `documentDirectory/pyodide/` is gone.
- [ ] Run a Python macro now. Result tab shows "Python macro support not installed" prompt with a Download button. Tap; install proceeds; macro re-runs successfully.
- [ ] Force-quit the app mid-install. Relaunch. Status should be "Not installed" (the reconciler resets the interrupted "installing" state).
- [ ] Inspect logs / proxy: after install, no requests to `cdn.jsdelivr.net` during macro execution.