### PR TITLE
fix(mobile): offline measurements bug + Cognito burst fix + pending status

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -137,6 +137,19 @@ jobs:
         with:
           affected_apps: ${{ needs.detect.outputs.affected_apps }}
 
+      - name: Type Check Packages
+        shell: bash
+        run: |
+          echo "🔎 Type-checking affected packages"
+          AFFECTED_APPS='${{ needs.detect.outputs.affected_apps }}'
+          APPS=($(echo $AFFECTED_APPS | jq -r '.[]'))
+          CHECK_CMD="pnpm turbo run check-types"
+          for APP in "${APPS[@]}"; do
+            CHECK_CMD="$CHECK_CMD --filter=$APP"
+          done
+          echo "Running: $CHECK_CMD"
+          eval "$CHECK_CMD"
+
       - name: Test Packages
         uses: ./.github/actions/test-packages
         with:

--- a/apps/mobile/drizzle/0001_add_pending_status.sql
+++ b/apps/mobile/drizzle/0001_add_pending_status.sql
@@ -1,0 +1,33 @@
+-- Adds the "pending" measurement status and an enforcing CHECK constraint.
+--
+-- SQLite cannot add a CHECK constraint to an existing column in place, so we
+-- use the standard recreate-then-copy dance. Existing rows keep their current
+-- status values (failed / uploading / successful) which all remain valid.
+
+PRAGMA foreign_keys = OFF;
+--> statement-breakpoint
+
+CREATE TABLE `__new_measurements` (
+	`id` text PRIMARY KEY NOT NULL,
+	`status` text NOT NULL,
+	`topic` text NOT NULL,
+	`measurement_result` text NOT NULL,
+	`experiment_name` text NOT NULL,
+	`protocol_name` text NOT NULL,
+	`timestamp` text NOT NULL,
+	`created_at` integer NOT NULL,
+	CONSTRAINT `measurements_status_check` CHECK (`status` IN ('pending', 'uploading', 'failed', 'successful'))
+);
+--> statement-breakpoint
+
+INSERT INTO `__new_measurements` (`id`, `status`, `topic`, `measurement_result`, `experiment_name`, `protocol_name`, `timestamp`, `created_at`)
+SELECT `id`, `status`, `topic`, `measurement_result`, `experiment_name`, `protocol_name`, `timestamp`, `created_at` FROM `measurements`;
+--> statement-breakpoint
+
+DROP TABLE `measurements`;
+--> statement-breakpoint
+
+ALTER TABLE `__new_measurements` RENAME TO `measurements`;
+--> statement-breakpoint
+
+PRAGMA foreign_keys = ON;

--- a/apps/mobile/drizzle/meta/0001_snapshot.json
+++ b/apps/mobile/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,89 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b8e2a3d4-1f5a-4c7b-9d6e-2a3b4c5d6e7f",
+  "prevId": "0292bd0f-aa3c-475f-ab36-ff21aa433417",
+  "tables": {
+    "measurements": {
+      "name": "measurements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "measurement_result": {
+          "name": "measurement_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "experiment_name": {
+          "name": "experiment_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol_name": {
+          "name": "protocol_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "measurements_status_check": {
+          "name": "measurements_status_check",
+          "value": "\"measurements\".\"status\" IN ('pending', 'uploading', 'failed', 'successful')"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/mobile/drizzle/meta/_journal.json
+++ b/apps/mobile/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1774987880840,
       "tag": "0000_outgoing_firebird",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1778688000000,
+      "tag": "0001_add_pending_status",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/mobile/drizzle/migrations.ts
+++ b/apps/mobile/drizzle/migrations.ts
@@ -1,10 +1,12 @@
 // This file is required for Expo/React Native SQLite migrations - https://orm.drizzle.team/quick-sqlite/expo
 import m0000 from "./0000_outgoing_firebird.sql";
+import m0001 from "./0001_add_pending_status.sql";
 import journal from "./meta/_journal.json";
 
 export default {
   journal,
   migrations: {
     m0000,
+    m0001,
   },
 };

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -17,6 +17,7 @@
     "update:production": "eas update --branch production",
     "lint": "eslint 'src/**/*' --fix",
     "typecheck": "tsc --noEmit",
+    "check-types": "tsc --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",

--- a/apps/mobile/src/components/measurement-item.tsx
+++ b/apps/mobile/src/components/measurement-item.tsx
@@ -1,6 +1,6 @@
 import { cva } from "class-variance-authority";
 import { clsx } from "clsx";
-import { UploadCloud, Trash2, CloudCheck, CloudAlert } from "lucide-react-native";
+import { UploadCloud, Trash2, CloudCheck, CloudAlert, CloudUpload } from "lucide-react-native";
 import React, { memo } from "react";
 import { View, Text, TouchableOpacity, Pressable, ActivityIndicator } from "react-native";
 import type { MeasurementStatus } from "~/hooks/use-all-measurements";
@@ -42,8 +42,9 @@ export const MeasurementItem = memo(function MeasurementItem({
   hideActions = false,
 }: MeasurementItemProps) {
   const { colors, classes } = useTheme();
-  const isSynced = status === "synced";
-  const isSyncing = status === "syncing";
+  const isSynced = status === "successful";
+  const isSyncing = status === "uploading";
+  const isPending = status === "pending";
 
   const hasAnswers = questions && questions.length > 0;
   const answersText = hasAnswers ? questions.map((q) => q.question_answer).join(" | ") : null;
@@ -111,6 +112,8 @@ export const MeasurementItem = memo(function MeasurementItem({
             <ActivityIndicator size={16} color={colors.semantic.info} />
           ) : isSynced ? (
             <CloudCheck size={16} color={colors.semantic.success} />
+          ) : isPending ? (
+            <CloudUpload size={16} color={colors.semantic.info} />
           ) : (
             <CloudAlert size={16} color={colors.semantic.error} />
           )}

--- a/apps/mobile/src/components/recent-measurements-screen/measurement-questions-modal.tsx
+++ b/apps/mobile/src/components/recent-measurements-screen/measurement-questions-modal.tsx
@@ -59,7 +59,7 @@ export function MeasurementQuestionsModal({
   const experimentName = measurement.experimentName;
   const protocolName = measurement.data.metadata.protocolName;
   const timestamp = new Date(measurement.timestamp).toLocaleString();
-  const isUnsynced = measurement.status === "unsynced";
+  const isUnsynced = measurement.status === "pending" || measurement.status === "failed";
 
   const currentComment = getCommentFromMeasurementResult(measurementResult);
   const currentFlagType = getFlagTypeFromMeasurementResult(measurementResult);

--- a/apps/mobile/src/components/recent-measurements-screen/recent-measurements-screen.tsx
+++ b/apps/mobile/src/components/recent-measurements-screen/recent-measurements-screen.tsx
@@ -41,12 +41,14 @@ export function RecentMeasurementsScreen() {
       questions={item.questions}
       onPress={() => setModal({ kind: "questions", measurement: item })}
       onComment={
-        item.status === "unsynced"
+        item.status === "pending" || item.status === "failed"
           ? () => setModal({ kind: "comment", measurement: item })
           : undefined
       }
       onDelete={() => confirmDelete(item)}
-      onSync={item.status === "unsynced" ? () => confirmSync(item) : undefined}
+      onSync={
+        item.status === "pending" || item.status === "failed" ? () => confirmSync(item) : undefined
+      }
     />
   );
 

--- a/apps/mobile/src/components/recent-measurements-screen/swipeable-measurement-row.test.tsx
+++ b/apps/mobile/src/components/recent-measurements-screen/swipeable-measurement-row.test.tsx
@@ -25,7 +25,7 @@ const defaultProps = {
   id: "m1",
   timestamp: "2026-04-20T10:00:00.000Z",
   experimentName: "Photosynthesis",
-  status: "unsynced" as const,
+  status: "pending" as const,
 };
 
 describe("SwipeableMeasurementRow", () => {
@@ -39,28 +39,28 @@ describe("SwipeableMeasurementRow", () => {
   });
 
   it("shows the Upload button for unsynced rows when onSync is provided", () => {
-    render(<SwipeableMeasurementRow {...defaultProps} status="unsynced" onSync={vi.fn()} />);
+    render(<SwipeableMeasurementRow {...defaultProps} status="pending" onSync={vi.fn()} />);
     expect(screen.getByText("Upload")).toBeTruthy();
   });
 
   it("does not show the Upload button for synced rows", () => {
-    render(<SwipeableMeasurementRow {...defaultProps} status="synced" onSync={vi.fn()} />);
+    render(<SwipeableMeasurementRow {...defaultProps} status="successful" onSync={vi.fn()} />);
     expect(screen.queryByText("Upload")).toBeNull();
   });
 
   it("shows the Comment button for unsynced rows when onComment is provided", () => {
-    render(<SwipeableMeasurementRow {...defaultProps} status="unsynced" onComment={vi.fn()} />);
+    render(<SwipeableMeasurementRow {...defaultProps} status="pending" onComment={vi.fn()} />);
     expect(screen.getByText("Comment")).toBeTruthy();
   });
 
   it("does not show the Comment button for synced rows", () => {
-    render(<SwipeableMeasurementRow {...defaultProps} status="synced" onComment={vi.fn()} />);
+    render(<SwipeableMeasurementRow {...defaultProps} status="successful" onComment={vi.fn()} />);
     expect(screen.queryByText("Comment")).toBeNull();
   });
 
   it("calls onDelete with the row id when the delete button is pressed", () => {
     const onDelete = vi.fn();
-    render(<SwipeableMeasurementRow {...defaultProps} status="synced" onDelete={onDelete} />);
+    render(<SwipeableMeasurementRow {...defaultProps} status="successful" onDelete={onDelete} />);
     const touchables = screen.UNSAFE_getAllByType(TouchableOpacity);
     fireEvent.press(touchables[0]);
     expect(onDelete).toHaveBeenCalledWith("m1");

--- a/apps/mobile/src/components/recent-measurements-screen/swipeable-measurement-row.tsx
+++ b/apps/mobile/src/components/recent-measurements-screen/swipeable-measurement-row.tsx
@@ -44,8 +44,9 @@ export const SwipeableMeasurementRow = memo(function SwipeableMeasurementRow({
   const startX = useSharedValue(0);
   const actionWidthSV = useSharedValue(0);
 
-  const showComment = status === "unsynced" && !!onComment;
-  const showSync = status === "unsynced" && !!onSync;
+  const canFlag = status === "pending" || status === "failed";
+  const showComment = canFlag && !!onComment;
+  const showSync = canFlag && !!onSync;
   const showDelete = !!onDelete;
 
   const panGesture = Gesture.Pan()

--- a/apps/mobile/src/components/recent-measurements-screen/use-recent-measurements-actions.ts
+++ b/apps/mobile/src/components/recent-measurements-screen/use-recent-measurements-actions.ts
@@ -28,7 +28,7 @@ function confirmAndRun({ title, message, confirmText, variant, errorMessage, run
 }
 
 export function useRecentMeasurementsActions(filter: MeasurementFilter) {
-  const { measurements, allMeasurements, uploadingCount, invalidate } = useAllMeasurements(filter);
+  const { measurements, counts, uploadingCount, invalidate } = useAllMeasurements(filter);
   const {
     uploadAll,
     isUploading,
@@ -38,8 +38,10 @@ export function useRecentMeasurementsActions(filter: MeasurementFilter) {
     updateMeasurementComment,
   } = useMeasurements();
 
-  const unsyncedCount = allMeasurements.filter(({ status }) => status === "unsynced").length;
-  const syncedCount = allMeasurements.filter(({ status }) => status === "synced").length;
+  // Counts come from SQL — independent of the active filter.
+  const unsyncedCount = counts.pending + counts.failed;
+  const syncedCount = counts.successful;
+  const totalCount = counts.pending + counts.failed + counts.uploading + counts.successful;
 
   const confirmSync = (m: MeasurementItem) =>
     confirmAndRun({
@@ -58,7 +60,7 @@ export function useRecentMeasurementsActions(filter: MeasurementFilter) {
     });
 
   const confirmDelete = (m: MeasurementItem) => {
-    const isSynced = m.status === "synced";
+    const isSynced = m.status === "successful";
     confirmAndRun({
       title: isSynced ? "Delete Measurement" : "Remove Measurement",
       message: isSynced
@@ -114,7 +116,7 @@ export function useRecentMeasurementsActions(filter: MeasurementFilter) {
 
   return {
     measurements,
-    hasAnyMeasurements: allMeasurements.length > 0,
+    hasAnyMeasurements: totalCount > 0,
     syncedCount,
     unsyncedCount,
     uploadingCount,

--- a/apps/mobile/src/hooks/__tests__/use-all-measurements.test.ts
+++ b/apps/mobile/src/hooks/__tests__/use-all-measurements.test.ts
@@ -203,7 +203,7 @@ describe("useAllMeasurements", () => {
     it("re-queries SQL when the filter prop changes (no JS-side filtering)", async () => {
       const { rerender } = renderHook(
         ({ filter }: { filter: "all" | "synced" | "unsynced" }) => useAllMeasurements(filter),
-        { wrapper, initialProps: { filter: "all" as const } },
+        { wrapper, initialProps: { filter: "all" } },
       );
 
       await waitFor(() =>

--- a/apps/mobile/src/hooks/__tests__/use-all-measurements.test.ts
+++ b/apps/mobile/src/hooks/__tests__/use-all-measurements.test.ts
@@ -6,13 +6,19 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { useAllMeasurements } from "../use-all-measurements";
 
-const { mockGetMeasurements, mockParseQuestions } = vi.hoisted(() => ({
-  mockGetMeasurements: vi.fn().mockResolvedValue([]),
-  mockParseQuestions: vi.fn().mockReturnValue([]),
-}));
+const { mockGetMeasurements, mockCountMeasurementsByStatus, mockParseQuestions } = vi.hoisted(
+  () => ({
+    mockGetMeasurements: vi.fn().mockResolvedValue([]),
+    mockCountMeasurementsByStatus: vi
+      .fn()
+      .mockResolvedValue({ pending: 0, uploading: 0, failed: 0, successful: 0 }),
+    mockParseQuestions: vi.fn().mockReturnValue([]),
+  }),
+);
 
 vi.mock("~/services/measurements-storage", () => ({
   getMeasurements: mockGetMeasurements,
+  countMeasurementsByStatus: mockCountMeasurementsByStatus,
 }));
 
 vi.mock("~/utils/convert-cycle-answers-to-array", () => ({
@@ -25,21 +31,52 @@ function wrapper({ children }: { children: React.ReactNode }) {
   return React.createElement(QueryClientProvider, { client: queryClient }, children);
 }
 
-function entry(key: string, timestamp: string, experimentName: string) {
-  return [
-    key,
-    {
+type StorageStatus = "pending" | "failed" | "uploading" | "successful";
+
+interface StoredMeasurement {
+  id: string;
+  status: StorageStatus;
+  data: {
+    topic: string;
+    measurementResult: object;
+    metadata: { timestamp: string; experimentName: string; protocolName: string };
+  };
+}
+
+function row(
+  id: string,
+  status: StorageStatus,
+  timestamp: string,
+  experimentName: string,
+  measurementResult: object = { value: 1 },
+): StoredMeasurement {
+  return {
+    id,
+    status,
+    data: {
       topic: "test/topic",
-      measurementResult: { value: 1 },
+      measurementResult,
       metadata: { timestamp, experimentName, protocolName: "proto-1" },
     },
-  ];
+  };
+}
+
+// SQL-side filter: returns only the rows the storage call asked for.
+function rowsFor(rows: StoredMeasurement[], requested: StorageStatus | StorageStatus[]) {
+  const wanted = new Set(Array.isArray(requested) ? requested : [requested]);
+  return rows.filter((r) => wanted.has(r.status));
 }
 
 describe("useAllMeasurements", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetMeasurements.mockResolvedValue([]);
+    mockCountMeasurementsByStatus.mockResolvedValue({
+      pending: 0,
+      uploading: 0,
+      failed: 0,
+      successful: 0,
+    });
     mockParseQuestions.mockReturnValue([]);
     queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   });
@@ -49,60 +86,61 @@ describe("useAllMeasurements", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // fetching & mapping
+  // data fetching
   // ---------------------------------------------------------------------------
 
   describe("data fetching", () => {
-    it("fetches from failed, uploading, and successful buckets", async () => {
-      renderHook(() => useAllMeasurements(), { wrapper });
+    it("fetches all four statuses in a single SQL call when filter is 'all'", async () => {
+      renderHook(() => useAllMeasurements("all"), { wrapper });
 
-      await waitFor(() => expect(mockGetMeasurements).toHaveBeenCalledWith("failed"));
-      expect(mockGetMeasurements).toHaveBeenCalledWith("uploading");
-      expect(mockGetMeasurements).toHaveBeenCalledWith("successful");
-    });
-
-    it("maps failed entries to unsynced items", async () => {
-      mockGetMeasurements.mockImplementation((status: string) =>
-        Promise.resolve(status === "failed" ? [entry("k1", "2026-01-01T10:00:00Z", "Exp A")] : []),
+      await waitFor(() =>
+        expect(mockGetMeasurements).toHaveBeenCalledWith([
+          "pending",
+          "failed",
+          "uploading",
+          "successful",
+        ]),
       );
-
-      const { result } = renderHook(() => useAllMeasurements(), { wrapper });
-
-      await waitFor(() => expect(result.current.measurements).toHaveLength(1));
-      expect(result.current.measurements[0]).toMatchObject({
-        key: "k1",
-        status: "unsynced",
-        experimentName: "Exp A",
-      });
+      expect(mockGetMeasurements).toHaveBeenCalledTimes(1);
     });
 
-    it("maps successful entries to synced items", async () => {
-      mockGetMeasurements.mockImplementation((status: string) =>
-        Promise.resolve(
-          status === "successful" ? [entry("k2", "2026-01-01T09:00:00Z", "Exp B")] : [],
-        ),
+    it("queries only 'successful' when filter is 'synced'", async () => {
+      renderHook(() => useAllMeasurements("synced"), { wrapper });
+      await waitFor(() => expect(mockGetMeasurements).toHaveBeenCalledWith(["successful"]));
+    });
+
+    it("queries pending + failed + uploading when filter is 'unsynced'", async () => {
+      renderHook(() => useAllMeasurements("unsynced"), { wrapper });
+      await waitFor(() =>
+        expect(mockGetMeasurements).toHaveBeenCalledWith(["pending", "failed", "uploading"]),
       );
-
-      const { result } = renderHook(() => useAllMeasurements(), { wrapper });
-
-      await waitFor(() => expect(result.current.measurements).toHaveLength(1));
-      expect(result.current.measurements[0]).toMatchObject({
-        key: "k2",
-        status: "synced",
-        experimentName: "Exp B",
-      });
     });
 
-    it("sorts combined results newest-first by timestamp", async () => {
-      mockGetMeasurements.mockImplementation((status: string) => {
-        if (status === "failed")
-          return Promise.resolve([entry("old", "2026-01-01T08:00:00Z", "Old")]);
-        if (status === "successful")
-          return Promise.resolve([entry("new", "2026-01-01T12:00:00Z", "New")]);
-        return Promise.resolve([]);
-      });
+    it("hands the raw storage status through to MeasurementItem (no lossy mapping)", async () => {
+      mockGetMeasurements.mockResolvedValueOnce([
+        row("p1", "pending", "2026-01-01T11:00:00Z", "P"),
+        row("f1", "failed", "2026-01-01T10:00:00Z", "F"),
+        row("u1", "uploading", "2026-01-01T09:00:00Z", "U"),
+        row("s1", "successful", "2026-01-01T12:00:00Z", "S"),
+      ]);
 
-      const { result } = renderHook(() => useAllMeasurements(), { wrapper });
+      const { result } = renderHook(() => useAllMeasurements("all"), { wrapper });
+
+      await waitFor(() => expect(result.current.measurements).toHaveLength(4));
+      const byKey = new Map(result.current.measurements.map((m) => [m.key, m.status]));
+      expect(byKey.get("p1")).toBe("pending");
+      expect(byKey.get("f1")).toBe("failed");
+      expect(byKey.get("u1")).toBe("uploading");
+      expect(byKey.get("s1")).toBe("successful");
+    });
+
+    it("sorts results newest-first by timestamp", async () => {
+      mockGetMeasurements.mockResolvedValueOnce([
+        row("old", "failed", "2026-01-01T08:00:00Z", "Old"),
+        row("new", "successful", "2026-01-01T12:00:00Z", "New"),
+      ]);
+
+      const { result } = renderHook(() => useAllMeasurements("all"), { wrapper });
 
       await waitFor(() => expect(result.current.measurements).toHaveLength(2));
       expect(result.current.measurements[0].key).toBe("new");
@@ -111,184 +149,112 @@ describe("useAllMeasurements", () => {
 
     it("calls parseQuestions for each measurement result", async () => {
       const measurementResult = { value: 99 };
-      mockGetMeasurements.mockImplementation((status: string) =>
-        status === "failed"
-          ? Promise.resolve([
-              [
-                "k1",
-                {
-                  topic: "t",
-                  measurementResult,
-                  metadata: {
-                    timestamp: "2026-01-01T10:00:00Z",
-                    experimentName: "E",
-                    protocolName: "P",
-                  },
-                },
-              ],
-            ])
-          : Promise.resolve([]),
-      );
+      mockGetMeasurements.mockResolvedValueOnce([
+        row("k1", "failed", "2026-01-01T10:00:00Z", "E", measurementResult),
+      ]);
 
-      renderHook(() => useAllMeasurements(), { wrapper });
+      renderHook(() => useAllMeasurements("all"), { wrapper });
 
       await waitFor(() => expect(mockParseQuestions).toHaveBeenCalled());
       expect(mockParseQuestions).toHaveBeenCalledWith(measurementResult);
     });
 
-    it("maps uploading entries to syncing items", async () => {
-      mockGetMeasurements.mockImplementation((status: string) =>
-        Promise.resolve(
-          status === "uploading" ? [entry("k3", "2026-01-01T11:00:00Z", "Exp C")] : [],
-        ),
-      );
-
-      const { result } = renderHook(() => useAllMeasurements(), { wrapper });
-
-      await waitFor(() => expect(result.current.measurements).toHaveLength(1));
-      expect(result.current.measurements[0]).toMatchObject({
-        key: "k3",
-        status: "syncing",
-        experimentName: "Exp C",
-      });
-    });
-
-    it("returns empty array when no measurements exist", async () => {
-      const { result } = renderHook(() => useAllMeasurements(), { wrapper });
-
-      await waitFor(() => expect(result.current.allMeasurements).toEqual([]));
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // filter
-  // ---------------------------------------------------------------------------
-
-  describe("filter", () => {
-    beforeEach(() => {
-      mockGetMeasurements.mockImplementation((status: string) => {
-        if (status === "failed")
-          return Promise.resolve([entry("u1", "2026-01-01T10:00:00Z", "Unsynced")]);
-        if (status === "successful")
-          return Promise.resolve([
-            entry("s1", "2026-01-01T12:00:00Z", "Synced 1"),
-            entry("s2", "2026-01-01T08:00:00Z", "Synced 2"),
-          ]);
-        return Promise.resolve([]);
-      });
-    });
-
-    it("returns all measurements for filter 'all'", async () => {
+    it("returns an empty array when no measurements match the filter", async () => {
       const { result } = renderHook(() => useAllMeasurements("all"), { wrapper });
 
-      await waitFor(() => expect(result.current.measurements).toHaveLength(3));
+      await waitFor(() => expect(result.current.measurements).toEqual([]));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // filter applied at SQL level
+  // ---------------------------------------------------------------------------
+
+  describe("filter at SQL level", () => {
+    beforeEach(() => {
+      const fixture: StoredMeasurement[] = [
+        row("p1", "pending", "2026-01-01T11:00:00Z", "Pending"),
+        row("f1", "failed", "2026-01-01T10:00:00Z", "Failed"),
+        row("u1", "uploading", "2026-01-01T09:00:00Z", "Uploading"),
+        row("s1", "successful", "2026-01-01T12:00:00Z", "Synced 1"),
+        row("s2", "successful", "2026-01-01T08:00:00Z", "Synced 2"),
+      ];
+      mockGetMeasurements.mockImplementation((status) => Promise.resolve(rowsFor(fixture, status)));
     });
 
-    it("defaults to 'all' when no filter provided", async () => {
-      const { result } = renderHook(() => useAllMeasurements(), { wrapper });
-
-      await waitFor(() => expect(result.current.measurements).toHaveLength(3));
+    it("returns every row when filter is 'all'", async () => {
+      const { result } = renderHook(() => useAllMeasurements("all"), { wrapper });
+      await waitFor(() => expect(result.current.measurements).toHaveLength(5));
     });
 
-    it("returns only synced items for filter 'synced'", async () => {
+    it("returns only successful rows when filter is 'synced'", async () => {
       const { result } = renderHook(() => useAllMeasurements("synced"), { wrapper });
-
       await waitFor(() => expect(result.current.measurements).toHaveLength(2));
-      expect(result.current.measurements.every((m) => m.status === "synced")).toBe(true);
+      expect(result.current.measurements.every((m) => m.status === "successful")).toBe(true);
     });
 
-    it("returns only unsynced items for filter 'unsynced'", async () => {
+    it("returns pending/failed/uploading when filter is 'unsynced'", async () => {
       const { result } = renderHook(() => useAllMeasurements("unsynced"), { wrapper });
-
-      await waitFor(() => expect(result.current.measurements).toHaveLength(1));
-      expect(result.current.measurements[0].status).toBe("unsynced");
+      await waitFor(() => expect(result.current.measurements).toHaveLength(3));
+      const statuses = new Set(result.current.measurements.map((m) => m.status));
+      expect(statuses).toEqual(new Set(["pending", "failed", "uploading"]));
     });
 
-    it("includes syncing items in the 'unsynced' filter", async () => {
-      mockGetMeasurements.mockImplementation((status: string) => {
-        if (status === "failed")
-          return Promise.resolve([entry("u1", "2026-01-01T10:00:00Z", "Unsynced")]);
-        if (status === "uploading")
-          return Promise.resolve([entry("up1", "2026-01-01T09:00:00Z", "Uploading")]);
-        return Promise.resolve([entry("s1", "2026-01-01T12:00:00Z", "Synced")]);
-      });
-
-      const { result } = renderHook(() => useAllMeasurements("unsynced"), { wrapper });
-
-      await waitFor(() => expect(result.current.measurements).toHaveLength(2));
-      const statuses = result.current.measurements.map((m) => m.status);
-      expect(statuses).toContain("unsynced");
-      expect(statuses).toContain("syncing");
-    });
-
-    it("updates measurements reactively when filter changes", async () => {
-      const { result, rerender } = renderHook(
+    it("re-queries SQL when the filter prop changes (no JS-side filtering)", async () => {
+      const { rerender } = renderHook(
         ({ filter }: { filter: "all" | "synced" | "unsynced" }) => useAllMeasurements(filter),
-        {
-          wrapper,
-          initialProps: { filter: "all" as "all" | "synced" | "unsynced" },
-        },
+        { wrapper, initialProps: { filter: "all" as const } },
       );
 
-      await waitFor(() => expect(result.current.measurements).toHaveLength(3));
+      await waitFor(() =>
+        expect(mockGetMeasurements).toHaveBeenCalledWith([
+          "pending",
+          "failed",
+          "uploading",
+          "successful",
+        ]),
+      );
 
       rerender({ filter: "synced" });
-      expect(result.current.measurements).toHaveLength(2);
+      await waitFor(() => expect(mockGetMeasurements).toHaveBeenCalledWith(["successful"]));
     });
   });
 
   // ---------------------------------------------------------------------------
-  // allMeasurements vs measurements
+  // counts (SQL COUNT … GROUP BY)
   // ---------------------------------------------------------------------------
 
-  describe("allMeasurements", () => {
-    it("is unfiltered while measurements respects the active filter", async () => {
-      mockGetMeasurements.mockImplementation((status: string) => {
-        if (status === "failed") return Promise.resolve([entry("u1", "2026-01-01T10:00:00Z", "U")]);
-        if (status === "successful")
-          return Promise.resolve([entry("s1", "2026-01-01T12:00:00Z", "S")]);
-        return Promise.resolve([]);
+  describe("counts", () => {
+    it("exposes raw SQL counts unchanged by the active filter", async () => {
+      mockCountMeasurementsByStatus.mockResolvedValueOnce({
+        pending: 3,
+        uploading: 1,
+        failed: 2,
+        successful: 7,
       });
 
       const { result } = renderHook(() => useAllMeasurements("synced"), { wrapper });
 
-      await waitFor(() => expect(result.current.allMeasurements).toHaveLength(2));
-      expect(result.current.measurements).toHaveLength(1);
-      expect(result.current.measurements[0].status).toBe("synced");
+      await waitFor(() => expect(result.current.counts.successful).toBe(7));
+      expect(result.current.counts).toEqual({ pending: 3, uploading: 1, failed: 2, successful: 7 });
     });
-  });
 
-  // ---------------------------------------------------------------------------
-  // uploadingCount
-  // ---------------------------------------------------------------------------
-
-  describe("uploadingCount", () => {
-    it("counts items with syncing status", async () => {
-      mockGetMeasurements.mockImplementation((status: string) => {
-        if (status === "uploading")
-          return Promise.resolve([
-            entry("up1", "2026-01-01T10:00:00Z", "Up1"),
-            entry("up2", "2026-01-01T09:00:00Z", "Up2"),
-          ]);
-        return Promise.resolve([]);
+    it("uploadingCount mirrors counts.uploading", async () => {
+      mockCountMeasurementsByStatus.mockResolvedValueOnce({
+        pending: 0,
+        uploading: 4,
+        failed: 0,
+        successful: 0,
       });
 
-      const { result } = renderHook(() => useAllMeasurements(), { wrapper });
-
-      await waitFor(() => expect(result.current.uploadingCount).toBe(2));
+      const { result } = renderHook(() => useAllMeasurements("all"), { wrapper });
+      await waitFor(() => expect(result.current.uploadingCount).toBe(4));
     });
 
-    it("returns zero when no items are uploading", async () => {
-      mockGetMeasurements.mockImplementation((status: string) =>
-        status === "failed"
-          ? Promise.resolve([entry("u1", "2026-01-01T10:00:00Z", "U")])
-          : Promise.resolve([]),
-      );
-
-      const { result } = renderHook(() => useAllMeasurements(), { wrapper });
-
-      await waitFor(() => expect(result.current.measurements).toHaveLength(1));
-      expect(result.current.uploadingCount).toBe(0);
+    it("invokes countMeasurementsByStatus exactly once per render cycle", async () => {
+      renderHook(() => useAllMeasurements("all"), { wrapper });
+      await waitFor(() => expect(mockCountMeasurementsByStatus).toHaveBeenCalled());
+      expect(mockCountMeasurementsByStatus).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -297,10 +263,10 @@ describe("useAllMeasurements", () => {
   // ---------------------------------------------------------------------------
 
   describe("invalidate", () => {
-    it("invalidates the measurements query", async () => {
+    it("invalidates everything under the measurements query key", async () => {
       const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
-      const { result } = renderHook(() => useAllMeasurements(), { wrapper });
+      const { result } = renderHook(() => useAllMeasurements("all"), { wrapper });
       await waitFor(() => expect(result.current.measurements).toBeDefined());
 
       act(() => {

--- a/apps/mobile/src/hooks/__tests__/use-measurement-upload.test.ts
+++ b/apps/mobile/src/hooks/__tests__/use-measurement-upload.test.ts
@@ -10,6 +10,7 @@ const {
   mockExportSingle,
   mockToastSuccess,
   mockToastError,
+  mockToastInfo,
   mockShowAlert,
 } = vi.hoisted(() => ({
   mockSaveMeasurement: vi.fn(),
@@ -19,6 +20,7 @@ const {
   mockExportSingle: vi.fn(),
   mockToastSuccess: vi.fn(),
   mockToastError: vi.fn(),
+  mockToastInfo: vi.fn(),
   mockShowAlert: vi.fn(),
 }));
 
@@ -54,7 +56,7 @@ vi.mock("~/utils/measurement-annotations", () => ({
 }));
 
 vi.mock("sonner-native", () => ({
-  toast: { success: mockToastSuccess, error: mockToastError },
+  toast: { success: mockToastSuccess, error: mockToastError, info: mockToastInfo },
 }));
 
 vi.mock("~/components/AlertDialog", () => ({
@@ -209,6 +211,30 @@ describe("useMeasurementUpload", () => {
 
     expect(mockSendMqttEvent).not.toHaveBeenCalled();
     expect(mockSaveMeasurement).not.toHaveBeenCalled();
+  });
+
+  // Regression: a markUploaded failure that happens AFTER a successful MQTT
+  // publish must not flip the row back to "failed" — the data is on the
+  // cloud, only the local status write failed. The user sees an info toast,
+  // not the "upload not available" error toast.
+  it("does not mark the row failed when markUploaded errors after a successful publish", async () => {
+    mockSaveMeasurement.mockResolvedValueOnce("row-1");
+    mockSendMqttEvent.mockResolvedValueOnce(undefined);
+    mockMarkUploaded.mockRejectedValueOnce(new Error("disk full"));
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
+
+    await capturedCallback(baseArgs);
+
+    expect(mockMarkFailed).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(mockToastInfo).toHaveBeenCalledWith("Uploaded — local status will refresh on next sync");
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Local status update failed after successful publish:",
+      expect.any(Error),
+    );
+
+    consoleSpy.mockRestore();
   });
 
   it("logs the upload error", async () => {

--- a/apps/mobile/src/hooks/__tests__/use-measurement-upload.test.ts
+++ b/apps/mobile/src/hooks/__tests__/use-measurement-upload.test.ts
@@ -4,6 +4,8 @@ import { useMeasurementUpload } from "../use-measurement-upload";
 
 const {
   mockSaveMeasurement,
+  mockMarkUploaded,
+  mockMarkFailed,
   mockSendMqttEvent,
   mockExportSingle,
   mockToastSuccess,
@@ -11,6 +13,8 @@ const {
   mockShowAlert,
 } = vi.hoisted(() => ({
   mockSaveMeasurement: vi.fn(),
+  mockMarkUploaded: vi.fn(),
+  mockMarkFailed: vi.fn(),
   mockSendMqttEvent: vi.fn(),
   mockExportSingle: vi.fn(),
   mockToastSuccess: vi.fn(),
@@ -21,7 +25,11 @@ const {
 let capturedCallback: (...args: any[]) => Promise<any>;
 
 vi.mock("~/hooks/use-measurements", () => ({
-  useMeasurements: () => ({ saveMeasurement: mockSaveMeasurement }),
+  useMeasurements: () => ({
+    saveMeasurement: mockSaveMeasurement,
+    markUploaded: mockMarkUploaded,
+    markFailed: mockMarkFailed,
+  }),
 }));
 
 vi.mock("~/services/mqtt/send-mqtt-event", () => ({
@@ -78,38 +86,44 @@ describe("useMeasurementUpload", () => {
     useMeasurementUpload();
   });
 
-  it("uploads successfully and saves as successful", async () => {
+  it("persists the measurement as pending first, then marks it uploaded on MQTT success", async () => {
+    mockSaveMeasurement.mockResolvedValueOnce("row-1");
     mockSendMqttEvent.mockResolvedValueOnce(undefined);
-    mockSaveMeasurement.mockResolvedValueOnce(undefined);
+    mockMarkUploaded.mockResolvedValueOnce(undefined);
 
     await capturedCallback(baseArgs);
 
-    expect(mockSendMqttEvent).toHaveBeenCalled();
-    expect(mockToastSuccess).toHaveBeenCalledWith("Measurement uploaded!");
     expect(mockSaveMeasurement).toHaveBeenCalledWith(
       expect.objectContaining({ topic: "mock/topic" }),
-      "successful",
+      "pending",
     );
+    expect(mockSendMqttEvent).toHaveBeenCalled();
+    expect(mockMarkUploaded).toHaveBeenCalledWith("row-1");
+    expect(mockMarkFailed).not.toHaveBeenCalled();
+    expect(mockToastSuccess).toHaveBeenCalledWith("Measurement uploaded!");
+    expect(mockSaveMeasurement).toHaveBeenCalledTimes(1);
   });
 
-  it("saves as failed when MQTT upload fails", async () => {
+  it("transitions the pending row to failed when MQTT upload errors out", async () => {
+    mockSaveMeasurement.mockResolvedValueOnce("row-1");
     mockSendMqttEvent.mockRejectedValueOnce(new Error("offline"));
-    mockSaveMeasurement.mockResolvedValueOnce(undefined);
+    mockMarkFailed.mockResolvedValueOnce(undefined);
 
     await capturedCallback(baseArgs);
 
-    expect(mockToastError).toHaveBeenCalledWith(
-      "Upload not available, upload it later from Recent",
-    );
     expect(mockSaveMeasurement).toHaveBeenCalledWith(
       expect.objectContaining({ topic: "mock/topic" }),
-      "failed",
+      "pending",
+    );
+    expect(mockMarkUploaded).not.toHaveBeenCalled();
+    expect(mockMarkFailed).toHaveBeenCalledWith("row-1");
+    expect(mockToastError).toHaveBeenCalledWith(
+      "Upload not available, upload it later from Recent",
     );
     expect(mockShowAlert).not.toHaveBeenCalled();
   });
 
-  it("prompts file save when both upload and local storage fail", async () => {
-    mockSendMqttEvent.mockRejectedValueOnce(new Error("offline"));
+  it("prompts file save when local storage fails (upload is never attempted)", async () => {
     mockSaveMeasurement.mockRejectedValueOnce(new Error("storage full"));
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
@@ -133,7 +147,6 @@ describe("useMeasurementUpload", () => {
   });
 
   it("calls exportSingleMeasurementToFile when user taps Save to File", async () => {
-    mockSendMqttEvent.mockRejectedValueOnce(new Error("offline"));
     mockSaveMeasurement.mockRejectedValueOnce(new Error("storage full"));
     mockExportSingle.mockResolvedValueOnce(undefined);
 
@@ -158,7 +171,6 @@ describe("useMeasurementUpload", () => {
   });
 
   it("shows toast error when file export also fails", async () => {
-    mockSendMqttEvent.mockRejectedValueOnce(new Error("offline"));
     mockSaveMeasurement.mockRejectedValueOnce(new Error("storage full"));
     mockExportSingle.mockRejectedValueOnce(new Error("file system error"));
 
@@ -177,8 +189,9 @@ describe("useMeasurementUpload", () => {
   });
 
   it("forwards the UTC timestamp and timezone to the MQTT payload unchanged", async () => {
+    mockSaveMeasurement.mockResolvedValueOnce("row-1");
     mockSendMqttEvent.mockResolvedValueOnce(undefined);
-    mockSaveMeasurement.mockResolvedValueOnce(undefined);
+    mockMarkUploaded.mockResolvedValueOnce(undefined);
 
     const utcTimestamp = "2026-03-16T13:00:18.022Z";
     const timezone = "Europe/Amsterdam";
@@ -200,8 +213,8 @@ describe("useMeasurementUpload", () => {
 
   it("logs the upload error", async () => {
     const uploadError = new Error("network timeout");
+    mockSaveMeasurement.mockResolvedValueOnce("row-1");
     mockSendMqttEvent.mockRejectedValueOnce(uploadError);
-    mockSaveMeasurement.mockResolvedValueOnce(undefined);
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
 

--- a/apps/mobile/src/hooks/__tests__/use-measurement-upload.test.ts
+++ b/apps/mobile/src/hooks/__tests__/use-measurement-upload.test.ts
@@ -12,6 +12,7 @@ const {
   mockToastError,
   mockToastInfo,
   mockShowAlert,
+  mockUseNetworkState,
 } = vi.hoisted(() => ({
   mockSaveMeasurement: vi.fn(),
   mockMarkUploaded: vi.fn(),
@@ -22,6 +23,7 @@ const {
   mockToastError: vi.fn(),
   mockToastInfo: vi.fn(),
   mockShowAlert: vi.fn(),
+  mockUseNetworkState: vi.fn(),
 }));
 
 let capturedCallback: (...args: any[]) => Promise<any>;
@@ -70,6 +72,10 @@ vi.mock("react-async-hook", () => ({
   },
 }));
 
+vi.mock("expo-network", () => ({
+  useNetworkState: mockUseNetworkState,
+}));
+
 const baseArgs = {
   rawMeasurement: { data: 1 },
   timestamp: "2026-03-02T10:00:00.000Z",
@@ -85,6 +91,7 @@ const baseArgs = {
 describe("useMeasurementUpload", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseNetworkState.mockReturnValue({ isInternetReachable: true });
     useMeasurementUpload();
   });
 
@@ -104,6 +111,29 @@ describe("useMeasurementUpload", () => {
     expect(mockMarkFailed).not.toHaveBeenCalled();
     expect(mockToastSuccess).toHaveBeenCalledWith("Measurement uploaded!");
     expect(mockSaveMeasurement).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression: when the device is offline we must not attempt the MQTT
+  // publish (Cognito would throw) and must not flip the row to "failed".
+  // The row stays "pending" so useAutoUpload picks it up on reconnect.
+  it("leaves the row pending and skips MQTT when the device is offline", async () => {
+    mockSaveMeasurement.mockResolvedValueOnce("row-1");
+    mockUseNetworkState.mockReturnValue({ isInternetReachable: false });
+    useMeasurementUpload();
+
+    await capturedCallback(baseArgs);
+
+    expect(mockSaveMeasurement).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: "mock/topic" }),
+      "pending",
+    );
+    expect(mockSendMqttEvent).not.toHaveBeenCalled();
+    expect(mockMarkFailed).not.toHaveBeenCalled();
+    expect(mockMarkUploaded).not.toHaveBeenCalled();
+    expect(mockToastInfo).toHaveBeenCalledWith(
+      "Saved offline — will upload when you're back online",
+    );
+    expect(mockToastError).not.toHaveBeenCalled();
   });
 
   it("transitions the pending row to failed when MQTT upload errors out", async () => {

--- a/apps/mobile/src/hooks/__tests__/use-measurement-upload.test.ts
+++ b/apps/mobile/src/hooks/__tests__/use-measurement-upload.test.ts
@@ -137,9 +137,12 @@ describe("useMeasurementUpload", () => {
   });
 
   it("transitions the pending row to failed when MQTT upload errors out", async () => {
+    const uploadError = new Error("network timeout");
     mockSaveMeasurement.mockResolvedValueOnce("row-1");
-    mockSendMqttEvent.mockRejectedValueOnce(new Error("offline"));
+    mockSendMqttEvent.mockRejectedValueOnce(uploadError);
     mockMarkFailed.mockResolvedValueOnce(undefined);
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
 
     await capturedCallback(baseArgs);
 
@@ -153,6 +156,9 @@ describe("useMeasurementUpload", () => {
       "Upload not available, upload it later from Recent",
     );
     expect(mockShowAlert).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith("Upload failed:", uploadError);
+
+    consoleSpy.mockRestore();
   });
 
   it("prompts file save when local storage fails (upload is never attempted)", async () => {
@@ -243,11 +249,10 @@ describe("useMeasurementUpload", () => {
     expect(mockSaveMeasurement).not.toHaveBeenCalled();
   });
 
-  // Regression: a markUploaded failure that happens AFTER a successful MQTT
-  // publish must not flip the row back to "failed" — the data is on the
-  // cloud, only the local status write failed. The user sees an info toast,
-  // not the "upload not available" error toast.
-  it("does not mark the row failed when markUploaded errors after a successful publish", async () => {
+  // Once the MQTT publish has succeeded the data is on the cloud, so a
+  // later local-state write failure must surface as an info toast (and
+  // leave the row's status alone) rather than the "upload failed" path.
+  it("shows an info toast and does not touch status when markUploaded errors after a successful publish", async () => {
     mockSaveMeasurement.mockResolvedValueOnce("row-1");
     mockSendMqttEvent.mockResolvedValueOnce(undefined);
     mockMarkUploaded.mockRejectedValueOnce(new Error("disk full"));
@@ -263,20 +268,6 @@ describe("useMeasurementUpload", () => {
       "Local status update failed after successful publish:",
       expect.any(Error),
     );
-
-    consoleSpy.mockRestore();
-  });
-
-  it("logs the upload error", async () => {
-    const uploadError = new Error("network timeout");
-    mockSaveMeasurement.mockResolvedValueOnce("row-1");
-    mockSendMqttEvent.mockRejectedValueOnce(uploadError);
-
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
-
-    await capturedCallback(baseArgs);
-
-    expect(consoleSpy).toHaveBeenCalledWith("Upload failed:", uploadError);
 
     consoleSpy.mockRestore();
   });

--- a/apps/mobile/src/hooks/__tests__/use-measurements.test.ts
+++ b/apps/mobile/src/hooks/__tests__/use-measurements.test.ts
@@ -155,25 +155,7 @@ describe("useMeasurements", () => {
       expect(mockPruneExpiredMeasurements).toHaveBeenCalledOnce();
     });
 
-    it("calls setQueryData with successful status on per-item success", async () => {
-      const setQueryDataSpy = vi.spyOn(queryClient, "setQueryData");
-      const { result } = renderMeasurements([{ key: "upload-key-1", data: mockMeasurement }]);
-      await waitFor(() => expect(result.current.failedUploads).toHaveLength(1));
-      mockSendMqttEvent.mockResolvedValueOnce(undefined);
-
-      await act(() => result.current.uploadAll());
-
-      expect(setQueryDataSpy).toHaveBeenCalledWith(["measurements"], expect.any(Function));
-      // Verify the updater flips the right key to "successful"
-      const updater = setQueryDataSpy.mock.calls.find(
-        ([key]) => Array.isArray(key) && key[0] === "measurements",
-      )?.[1] as (old: { key: string; status: string }[]) => { key: string; status: string }[];
-      const old = [{ key: "upload-key-1", status: "uploading" }];
-      expect(updater(old)).toEqual([{ key: "upload-key-1", status: "successful" }]);
-    });
-
-    it("calls markAsFailed and setQueryData with failed status on per-item failure", async () => {
-      const setQueryDataSpy = vi.spyOn(queryClient, "setQueryData");
+    it("calls markAsFailed on per-item failure", async () => {
       const { result } = renderMeasurements([{ key: "upload-key-1", data: mockMeasurement }]);
       await waitFor(() => expect(result.current.failedUploads).toHaveLength(1));
       mockSendMqttEvent.mockRejectedValueOnce(new Error("network error"));
@@ -183,13 +165,57 @@ describe("useMeasurements", () => {
 
       expect(mockMarkAsFailed).toHaveBeenCalledWith("upload-key-1");
 
-      const updater = setQueryDataSpy.mock.calls
-        .reverse()
-        .find(([key]) => Array.isArray(key) && key[0] === "measurements")?.[1] as (
-        old: { key: string; status: string }[],
-      ) => { key: string; status: string }[];
-      const old = [{ key: "upload-key-1", status: "uploading" }];
-      expect(updater(old)).toEqual([{ key: "upload-key-1", status: "failed" }]);
+      consoleSpy.mockRestore();
+    });
+
+    // Regression: the previous implementation called
+    // setQueryData(["measurements"], ...), which does NOT match the list cache
+    // keyed ["measurements", "list", filter] read by the Recent screen, so
+    // in-place status updates silently missed visible rows. The fix relies on
+    // invalidateQueries({ queryKey: ["measurements"] }) which prefix-matches
+    // every measurements-derived cache.
+    it("does not call setQueryData with the bare ['measurements'] key", async () => {
+      const setQueryDataSpy = vi.spyOn(queryClient, "setQueryData");
+      const { result } = renderMeasurements([{ key: "upload-key-1", data: mockMeasurement }]);
+      await waitFor(() => expect(result.current.failedUploads).toHaveLength(1));
+      mockSendMqttEvent.mockResolvedValueOnce(undefined);
+
+      await act(() => result.current.uploadAll());
+
+      const bareMeasurementsCalls = setQueryDataSpy.mock.calls.filter(
+        ([key]) => Array.isArray(key) && key.length === 1 && key[0] === "measurements",
+      );
+      expect(bareMeasurementsCalls).toHaveLength(0);
+    });
+
+    it("invalidates ['measurements'] so list and counts caches refresh", async () => {
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      const { result } = renderMeasurements([{ key: "upload-key-1", data: mockMeasurement }]);
+      await waitFor(() => expect(result.current.failedUploads).toHaveLength(1));
+      mockSendMqttEvent.mockResolvedValueOnce(undefined);
+
+      await act(() => result.current.uploadAll());
+
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["measurements"] });
+    });
+
+    // Once published, a local markAsSuccessful failure must NOT regress the
+    // row to "failed" — the data is already on the cloud. The error is
+    // logged but swallowed so the batch keeps going.
+    it("does not mark the row failed when markAsSuccessful errors after a successful publish", async () => {
+      const { result } = renderMeasurements([{ key: "upload-key-1", data: mockMeasurement }]);
+      await waitFor(() => expect(result.current.failedUploads).toHaveLength(1));
+      mockSendMqttEvent.mockResolvedValueOnce(undefined);
+      mockMarkAsSuccessful.mockRejectedValueOnce(new Error("disk full"));
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+
+      await act(() => result.current.uploadAll());
+
+      expect(mockMarkAsFailed).not.toHaveBeenCalled();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Local status update failed after successful publish"),
+        expect.any(Error),
+      );
 
       consoleSpy.mockRestore();
     });
@@ -398,6 +424,40 @@ describe("useMeasurements", () => {
       expect(mockMarkAsSuccessful).not.toHaveBeenCalled();
       expect(mockMarkAsFailed).not.toHaveBeenCalled();
       expect(mockPruneExpiredMeasurements).not.toHaveBeenCalled();
+    });
+
+    // See the matching uploadAll regression test — list caches are keyed
+    // ["measurements", "list", filter], so bare ["measurements"] writes miss
+    // every visible row. uploadOne must rely on invalidateQueries instead.
+    it("does not call setQueryData with the bare ['measurements'] key", async () => {
+      const setQueryDataSpy = vi.spyOn(queryClient, "setQueryData");
+      const { result } = renderMeasurements([{ key: "upload-key-1", data: mockMeasurement }]);
+      await waitFor(() => expect(result.current.failedUploads).toHaveLength(1));
+      mockSendMqttEvent.mockResolvedValueOnce(undefined);
+
+      await act(() => result.current.uploadOne("upload-key-1"));
+
+      const bareMeasurementsCalls = setQueryDataSpy.mock.calls.filter(
+        ([key]) => Array.isArray(key) && key.length === 1 && key[0] === "measurements",
+      );
+      expect(bareMeasurementsCalls).toHaveLength(0);
+    });
+
+    it("does not mark the row failed when markAsSuccessful errors after a successful publish", async () => {
+      const { result } = renderMeasurements([{ key: "upload-key-1", data: mockMeasurement }]);
+      await waitFor(() => expect(result.current.failedUploads).toHaveLength(1));
+      mockSendMqttEvent.mockResolvedValueOnce(undefined);
+      mockMarkAsSuccessful.mockRejectedValueOnce(new Error("disk full"));
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+
+      await act(() => result.current.uploadOne("upload-key-1"));
+
+      expect(mockMarkAsFailed).not.toHaveBeenCalled();
+      expect(mockToastInfo).not.toHaveBeenCalledWith("Failed to upload, try again later");
+      // Prune + invalidate still run via the finally so the UI refreshes.
+      expect(mockPruneExpiredMeasurements).toHaveBeenCalledOnce();
+
+      consoleSpy.mockRestore();
     });
 
     it("releases the in-flight key when transition is rejected", async () => {

--- a/apps/mobile/src/hooks/__tests__/use-measurements.test.ts
+++ b/apps/mobile/src/hooks/__tests__/use-measurements.test.ts
@@ -168,12 +168,11 @@ describe("useMeasurements", () => {
       consoleSpy.mockRestore();
     });
 
-    // Regression: the previous implementation called
-    // setQueryData(["measurements"], ...), which does NOT match the list cache
-    // keyed ["measurements", "list", filter] read by the Recent screen, so
-    // in-place status updates silently missed visible rows. The fix relies on
-    // invalidateQueries({ queryKey: ["measurements"] }) which prefix-matches
-    // every measurements-derived cache.
+    // Status changes must propagate to the list cache the Recent screen
+    // reads (["measurements", "list", filter]). Writing to ["measurements"]
+    // alone wouldn't, so this asserts we never take that shortcut and rely
+    // on prefix-matching invalidateQueries({ queryKey: ["measurements"] })
+    // instead.
     it("does not call setQueryData with the bare ['measurements'] key", async () => {
       const setQueryDataSpy = vi.spyOn(queryClient, "setQueryData");
       const { result } = renderMeasurements([{ key: "upload-key-1", data: mockMeasurement }]);
@@ -199,9 +198,9 @@ describe("useMeasurements", () => {
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["measurements"] });
     });
 
-    // Once published, a local markAsSuccessful failure must NOT regress the
-    // row to "failed" — the data is already on the cloud. The error is
-    // logged but swallowed so the batch keeps going.
+    // Once the publish succeeds the data is on the cloud, so a local
+    // markAsSuccessful failure must be swallowed (logged, not surfaced) and
+    // must not flip the row to "failed". The batch keeps going.
     it("does not mark the row failed when markAsSuccessful errors after a successful publish", async () => {
       const { result } = renderMeasurements([{ key: "upload-key-1", data: mockMeasurement }]);
       await waitFor(() => expect(result.current.failedUploads).toHaveLength(1));

--- a/apps/mobile/src/hooks/__tests__/use-measurements.test.ts
+++ b/apps/mobile/src/hooks/__tests__/use-measurements.test.ts
@@ -23,7 +23,7 @@ const {
   mockMarkAsUploading: vi.fn().mockImplementation((keys: string[]) => Promise.resolve(keys)),
   mockMarkAsFailed: vi.fn().mockResolvedValue(undefined),
   mockRemoveMeasurement: vi.fn().mockResolvedValue(undefined),
-  mockSaveMeasurement: vi.fn().mockResolvedValue(undefined),
+  mockSaveMeasurement: vi.fn().mockResolvedValue("generated-id"),
   mockUpdateMeasurement: vi.fn().mockResolvedValue(undefined),
   mockClearMeasurements: vi.fn().mockResolvedValue(undefined),
   mockSendMqttEvent: vi.fn(),
@@ -72,8 +72,27 @@ function wrapper({ children }: { children: React.ReactNode }) {
   return React.createElement(QueryClientProvider, { client: queryClient }, children);
 }
 
-function renderMeasurements(failedUploads: { key: string; data: typeof mockMeasurement }[] = []) {
-  vi.mocked(getMeasurements).mockResolvedValue(failedUploads.map(({ key, data }) => [key, data]));
+function renderMeasurements(
+  failedUploads: { key: string; data: typeof mockMeasurement }[] = [],
+  pendingUploads: { key: string; data: typeof mockMeasurement }[] = [],
+) {
+  // The hook batches pending + failed into a single getMeasurements call and
+  // expects { id, status, data } objects back.
+  vi.mocked(getMeasurements).mockImplementation((status) => {
+    const wanted = new Set(Array.isArray(status) ? status : [status]);
+    const out: { id: string; status: "pending" | "failed"; data: typeof mockMeasurement }[] = [];
+    if (wanted.has("failed")) {
+      out.push(
+        ...failedUploads.map(({ key, data }) => ({ id: key, status: "failed" as const, data })),
+      );
+    }
+    if (wanted.has("pending")) {
+      out.push(
+        ...pendingUploads.map(({ key, data }) => ({ id: key, status: "pending" as const, data })),
+      );
+    }
+    return Promise.resolve(out);
+  });
   return renderHook(() => useMeasurements(), { wrapper });
 }
 
@@ -136,7 +155,7 @@ describe("useMeasurements", () => {
       expect(mockPruneExpiredMeasurements).toHaveBeenCalledOnce();
     });
 
-    it("calls setQueryData with synced status on per-item success", async () => {
+    it("calls setQueryData with successful status on per-item success", async () => {
       const setQueryDataSpy = vi.spyOn(queryClient, "setQueryData");
       const { result } = renderMeasurements([{ key: "upload-key-1", data: mockMeasurement }]);
       await waitFor(() => expect(result.current.failedUploads).toHaveLength(1));
@@ -145,15 +164,15 @@ describe("useMeasurements", () => {
       await act(() => result.current.uploadAll());
 
       expect(setQueryDataSpy).toHaveBeenCalledWith(["measurements"], expect.any(Function));
-      // Verify the updater flips the right key to "synced"
+      // Verify the updater flips the right key to "successful"
       const updater = setQueryDataSpy.mock.calls.find(
         ([key]) => Array.isArray(key) && key[0] === "measurements",
       )?.[1] as (old: { key: string; status: string }[]) => { key: string; status: string }[];
-      const old = [{ key: "upload-key-1", status: "syncing" }];
-      expect(updater(old)).toEqual([{ key: "upload-key-1", status: "synced" }]);
+      const old = [{ key: "upload-key-1", status: "uploading" }];
+      expect(updater(old)).toEqual([{ key: "upload-key-1", status: "successful" }]);
     });
 
-    it("calls markAsFailed and setQueryData with unsynced status on per-item failure", async () => {
+    it("calls markAsFailed and setQueryData with failed status on per-item failure", async () => {
       const setQueryDataSpy = vi.spyOn(queryClient, "setQueryData");
       const { result } = renderMeasurements([{ key: "upload-key-1", data: mockMeasurement }]);
       await waitFor(() => expect(result.current.failedUploads).toHaveLength(1));
@@ -169,8 +188,8 @@ describe("useMeasurements", () => {
         .find(([key]) => Array.isArray(key) && key[0] === "measurements")?.[1] as (
         old: { key: string; status: string }[],
       ) => { key: string; status: string }[];
-      const old = [{ key: "upload-key-1", status: "syncing" }];
-      expect(updater(old)).toEqual([{ key: "upload-key-1", status: "unsynced" }]);
+      const old = [{ key: "upload-key-1", status: "uploading" }];
+      expect(updater(old)).toEqual([{ key: "upload-key-1", status: "failed" }]);
 
       consoleSpy.mockRestore();
     });
@@ -400,14 +419,19 @@ describe("useMeasurements", () => {
   // ---------------------------------------------------------------------------
 
   describe("saveMeasurement", () => {
-    it("saves as failed and invalidates measurements", async () => {
+    it("saves as failed, invalidates, and returns the new id", async () => {
+      mockSaveMeasurement.mockResolvedValueOnce("new-id");
       const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
       const { result } = renderMeasurements([]);
 
-      await act(() => result.current.saveMeasurement(mockMeasurement, "failed"));
+      let returned: string | undefined;
+      await act(async () => {
+        returned = await result.current.saveMeasurement(mockMeasurement, "failed");
+      });
 
       expect(mockSaveMeasurement).toHaveBeenCalledWith(mockMeasurement, "failed");
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["measurements"] });
+      expect(returned).toBe("new-id");
     });
 
     it("saves as successful and invalidates measurements", async () => {
@@ -418,6 +442,55 @@ describe("useMeasurements", () => {
 
       expect(mockSaveMeasurement).toHaveBeenCalledWith(mockMeasurement, "successful");
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["measurements"] });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // markUploaded
+  // ---------------------------------------------------------------------------
+
+  describe("markUploaded", () => {
+    it("marks the row as successful and invalidates measurements", async () => {
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      const { result } = renderMeasurements([]);
+
+      await act(() => result.current.markUploaded("key-1"));
+
+      expect(mockMarkAsSuccessful).toHaveBeenCalledWith("key-1");
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["measurements"] });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // markFailed
+  // ---------------------------------------------------------------------------
+
+  describe("markFailed", () => {
+    it("marks the row as failed and invalidates measurements", async () => {
+      const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+      const { result } = renderMeasurements([]);
+
+      await act(() => result.current.markFailed("key-1"));
+
+      expect(mockMarkAsFailed).toHaveBeenCalledWith("key-1");
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["measurements"] });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // failedUploads query — covers both pending and failed rows
+  // ---------------------------------------------------------------------------
+
+  describe("failedUploads query", () => {
+    it("includes both pending and failed rows", async () => {
+      const { result } = renderMeasurements(
+        [{ key: "failed-1", data: mockMeasurement }],
+        [{ key: "pending-1", data: mockMeasurement }],
+      );
+
+      await waitFor(() => expect(result.current.failedUploads).toHaveLength(2));
+      const keys = result.current.failedUploads.map((u) => u.key).sort();
+      expect(keys).toEqual(["failed-1", "pending-1"]);
     });
   });
 

--- a/apps/mobile/src/hooks/__tests__/use-questions-upload.test.ts
+++ b/apps/mobile/src/hooks/__tests__/use-questions-upload.test.ts
@@ -10,6 +10,7 @@ const {
   mockToastSuccess,
   mockToastError,
   mockToastInfo,
+  mockUseNetworkState,
 } = vi.hoisted(() => ({
   mockSaveMeasurement: vi.fn(),
   mockMarkUploaded: vi.fn(),
@@ -18,6 +19,7 @@ const {
   mockToastSuccess: vi.fn(),
   mockToastError: vi.fn(),
   mockToastInfo: vi.fn(),
+  mockUseNetworkState: vi.fn(),
 }));
 
 let capturedCallback: (...args: any[]) => Promise<any>;
@@ -49,6 +51,10 @@ vi.mock("react-async-hook", () => ({
   },
 }));
 
+vi.mock("expo-network", () => ({
+  useNetworkState: mockUseNetworkState,
+}));
+
 const baseArgs = {
   timestamp: "2026-03-02T10:00:00.000Z",
   timezone: "Europe/Amsterdam",
@@ -61,6 +67,7 @@ const baseArgs = {
 describe("useQuestionsUpload", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseNetworkState.mockReturnValue({ isInternetReachable: true });
     useQuestionsUpload();
   });
 
@@ -90,6 +97,28 @@ describe("useQuestionsUpload", () => {
     expect(mockMarkFailed).not.toHaveBeenCalled();
     expect(mockToastSuccess).toHaveBeenCalledWith("Answers uploaded!");
     expect(mockSaveMeasurement).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression: when the device is offline we must not attempt the MQTT
+  // publish (Cognito would throw) and must not flip the row to "failed".
+  it("leaves the row pending and skips MQTT when the device is offline", async () => {
+    mockSaveMeasurement.mockResolvedValueOnce("row-1");
+    mockUseNetworkState.mockReturnValue({ isInternetReachable: false });
+    useQuestionsUpload();
+
+    await capturedCallback(baseArgs);
+
+    expect(mockSaveMeasurement).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: "mock/topic" }),
+      "pending",
+    );
+    expect(mockSendMqttEvent).not.toHaveBeenCalled();
+    expect(mockMarkFailed).not.toHaveBeenCalled();
+    expect(mockMarkUploaded).not.toHaveBeenCalled();
+    expect(mockToastInfo).toHaveBeenCalledWith(
+      "Saved offline — will upload when you're back online",
+    );
+    expect(mockToastError).not.toHaveBeenCalled();
   });
 
   it("transitions the pending row to failed when MQTT upload errors out", async () => {

--- a/apps/mobile/src/hooks/__tests__/use-questions-upload.test.ts
+++ b/apps/mobile/src/hooks/__tests__/use-questions-upload.test.ts
@@ -2,19 +2,30 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { useQuestionsUpload } from "../use-questions-upload";
 
-const { mockSaveMeasurement, mockSendMqttEvent, mockToastSuccess, mockToastError } = vi.hoisted(
-  () => ({
-    mockSaveMeasurement: vi.fn(),
-    mockSendMqttEvent: vi.fn(),
-    mockToastSuccess: vi.fn(),
-    mockToastError: vi.fn(),
-  }),
-);
+const {
+  mockSaveMeasurement,
+  mockMarkUploaded,
+  mockMarkFailed,
+  mockSendMqttEvent,
+  mockToastSuccess,
+  mockToastError,
+} = vi.hoisted(() => ({
+  mockSaveMeasurement: vi.fn(),
+  mockMarkUploaded: vi.fn(),
+  mockMarkFailed: vi.fn(),
+  mockSendMqttEvent: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+}));
 
 let capturedCallback: (...args: any[]) => Promise<any>;
 
 vi.mock("~/hooks/use-measurements", () => ({
-  useMeasurements: () => ({ saveMeasurement: mockSaveMeasurement }),
+  useMeasurements: () => ({
+    saveMeasurement: mockSaveMeasurement,
+    markUploaded: mockMarkUploaded,
+    markFailed: mockMarkFailed,
+  }),
 }));
 
 vi.mock("~/services/mqtt/send-mqtt-event", () => ({
@@ -51,12 +62,17 @@ describe("useQuestionsUpload", () => {
     useQuestionsUpload();
   });
 
-  it("uploads successfully and saves as successful", async () => {
+  it("persists answers as pending first, then marks uploaded on MQTT success", async () => {
+    mockSaveMeasurement.mockResolvedValueOnce("row-1");
     mockSendMqttEvent.mockResolvedValueOnce(undefined);
-    mockSaveMeasurement.mockResolvedValueOnce(undefined);
+    mockMarkUploaded.mockResolvedValueOnce(undefined);
 
     await capturedCallback(baseArgs);
 
+    expect(mockSaveMeasurement).toHaveBeenCalledWith(
+      expect.objectContaining({ topic: "mock/topic" }),
+      "pending",
+    );
     expect(mockSendMqttEvent).toHaveBeenCalledWith(
       "mock/topic",
       expect.objectContaining({
@@ -68,24 +84,21 @@ describe("useQuestionsUpload", () => {
         device_id: null,
       }),
     );
+    expect(mockMarkUploaded).toHaveBeenCalledWith("row-1");
+    expect(mockMarkFailed).not.toHaveBeenCalled();
     expect(mockToastSuccess).toHaveBeenCalledWith("Answers uploaded!");
-    expect(mockSaveMeasurement).toHaveBeenCalledWith(
-      expect.objectContaining({ topic: "mock/topic" }),
-      "successful",
-    );
+    expect(mockSaveMeasurement).toHaveBeenCalledTimes(1);
   });
 
-  it("saves as failed when MQTT upload fails", async () => {
+  it("transitions the pending row to failed when MQTT upload errors out", async () => {
+    mockSaveMeasurement.mockResolvedValueOnce("row-1");
     mockSendMqttEvent.mockRejectedValueOnce(new Error("offline"));
-    mockSaveMeasurement.mockResolvedValueOnce(undefined);
+    mockMarkFailed.mockResolvedValueOnce(undefined);
 
     vi.spyOn(console, "error").mockImplementation(vi.fn());
 
     await capturedCallback(baseArgs);
 
-    expect(mockToastError).toHaveBeenCalledWith(
-      "Upload not available, upload it later from Recent",
-    );
     expect(mockSaveMeasurement).toHaveBeenCalledWith(
       expect.objectContaining({
         topic: "mock/topic",
@@ -95,7 +108,12 @@ describe("useQuestionsUpload", () => {
           timestamp: baseArgs.timestamp,
         }),
       }),
-      "failed",
+      "pending",
+    );
+    expect(mockMarkUploaded).not.toHaveBeenCalled();
+    expect(mockMarkFailed).toHaveBeenCalledWith("row-1");
+    expect(mockToastError).toHaveBeenCalledWith(
+      "Upload not available, upload it later from Recent",
     );
 
     vi.restoreAllMocks();
@@ -103,8 +121,8 @@ describe("useQuestionsUpload", () => {
 
   it("logs the upload error when MQTT fails", async () => {
     const uploadError = new Error("network timeout");
+    mockSaveMeasurement.mockResolvedValueOnce("row-1");
     mockSendMqttEvent.mockRejectedValueOnce(uploadError);
-    mockSaveMeasurement.mockResolvedValueOnce(undefined);
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
 
@@ -115,8 +133,7 @@ describe("useQuestionsUpload", () => {
     consoleSpy.mockRestore();
   });
 
-  it("logs storage error when both upload and local storage fail", async () => {
-    mockSendMqttEvent.mockRejectedValueOnce(new Error("offline"));
+  it("logs storage error and does not attempt MQTT when local save fails", async () => {
     mockSaveMeasurement.mockRejectedValueOnce(new Error("storage full"));
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
@@ -127,12 +144,12 @@ describe("useQuestionsUpload", () => {
       "Failed to save answers to local storage:",
       expect.any(Error),
     );
+    expect(mockSendMqttEvent).not.toHaveBeenCalled();
 
     consoleSpy.mockRestore();
   });
 
-  it("shows error toast when local storage also fails", async () => {
-    mockSendMqttEvent.mockRejectedValueOnce(new Error("offline"));
+  it("shows error toast when local storage save fails", async () => {
     mockSaveMeasurement.mockRejectedValueOnce(new Error("storage full"));
 
     vi.spyOn(console, "error").mockImplementation(vi.fn());

--- a/apps/mobile/src/hooks/__tests__/use-questions-upload.test.ts
+++ b/apps/mobile/src/hooks/__tests__/use-questions-upload.test.ts
@@ -9,6 +9,7 @@ const {
   mockSendMqttEvent,
   mockToastSuccess,
   mockToastError,
+  mockToastInfo,
 } = vi.hoisted(() => ({
   mockSaveMeasurement: vi.fn(),
   mockMarkUploaded: vi.fn(),
@@ -16,6 +17,7 @@ const {
   mockSendMqttEvent: vi.fn(),
   mockToastSuccess: vi.fn(),
   mockToastError: vi.fn(),
+  mockToastInfo: vi.fn(),
 }));
 
 let capturedCallback: (...args: any[]) => Promise<any>;
@@ -37,7 +39,7 @@ vi.mock("~/utils/get-multispeq-mqtt-topic", () => ({
 }));
 
 vi.mock("sonner-native", () => ({
-  toast: { success: mockToastSuccess, error: mockToastError },
+  toast: { success: mockToastSuccess, error: mockToastError, info: mockToastInfo },
 }));
 
 vi.mock("react-async-hook", () => ({
@@ -145,6 +147,29 @@ describe("useQuestionsUpload", () => {
       expect.any(Error),
     );
     expect(mockSendMqttEvent).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+
+  // Regression: a markUploaded failure that happens AFTER a successful MQTT
+  // publish must not flip the row back to "failed" — the answers are on the
+  // cloud, only the local status write failed.
+  it("does not mark the row failed when markUploaded errors after a successful publish", async () => {
+    mockSaveMeasurement.mockResolvedValueOnce("row-1");
+    mockSendMqttEvent.mockResolvedValueOnce(undefined);
+    mockMarkUploaded.mockRejectedValueOnce(new Error("disk full"));
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
+
+    await capturedCallback(baseArgs);
+
+    expect(mockMarkFailed).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(mockToastInfo).toHaveBeenCalledWith("Uploaded — local status will refresh on next sync");
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Local status update failed after successful publish:",
+      expect.any(Error),
+    );
 
     consoleSpy.mockRestore();
   });

--- a/apps/mobile/src/hooks/__tests__/use-questions-upload.test.ts
+++ b/apps/mobile/src/hooks/__tests__/use-questions-upload.test.ts
@@ -122,11 +122,12 @@ describe("useQuestionsUpload", () => {
   });
 
   it("transitions the pending row to failed when MQTT upload errors out", async () => {
+    const uploadError = new Error("network timeout");
     mockSaveMeasurement.mockResolvedValueOnce("row-1");
-    mockSendMqttEvent.mockRejectedValueOnce(new Error("offline"));
+    mockSendMqttEvent.mockRejectedValueOnce(uploadError);
     mockMarkFailed.mockResolvedValueOnce(undefined);
 
-    vi.spyOn(console, "error").mockImplementation(vi.fn());
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
 
     await capturedCallback(baseArgs);
 
@@ -146,25 +147,12 @@ describe("useQuestionsUpload", () => {
     expect(mockToastError).toHaveBeenCalledWith(
       "Upload not available, upload it later from Recent",
     );
-
-    vi.restoreAllMocks();
-  });
-
-  it("logs the upload error when MQTT fails", async () => {
-    const uploadError = new Error("network timeout");
-    mockSaveMeasurement.mockResolvedValueOnce("row-1");
-    mockSendMqttEvent.mockRejectedValueOnce(uploadError);
-
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
-
-    await capturedCallback(baseArgs);
-
     expect(consoleSpy).toHaveBeenCalledWith("Upload failed:", uploadError);
 
     consoleSpy.mockRestore();
   });
 
-  it("logs storage error and does not attempt MQTT when local save fails", async () => {
+  it("surfaces storage failure via toast + log and never attempts MQTT", async () => {
     mockSaveMeasurement.mockRejectedValueOnce(new Error("storage full"));
 
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
@@ -175,15 +163,18 @@ describe("useQuestionsUpload", () => {
       "Failed to save answers to local storage:",
       expect.any(Error),
     );
+    expect(mockToastError).toHaveBeenCalledWith(
+      "Answers could not be saved on this device. Please export your data now to avoid losing it.",
+    );
     expect(mockSendMqttEvent).not.toHaveBeenCalled();
 
     consoleSpy.mockRestore();
   });
 
-  // Regression: a markUploaded failure that happens AFTER a successful MQTT
-  // publish must not flip the row back to "failed" — the answers are on the
-  // cloud, only the local status write failed.
-  it("does not mark the row failed when markUploaded errors after a successful publish", async () => {
+  // Once the MQTT publish has succeeded the answers are on the cloud, so a
+  // later local-state write failure must surface as an info toast (and
+  // leave the row's status alone) rather than the "upload failed" path.
+  it("shows an info toast and does not touch status when markUploaded errors after a successful publish", async () => {
     mockSaveMeasurement.mockResolvedValueOnce("row-1");
     mockSendMqttEvent.mockResolvedValueOnce(undefined);
     mockMarkUploaded.mockRejectedValueOnce(new Error("disk full"));
@@ -201,19 +192,5 @@ describe("useQuestionsUpload", () => {
     );
 
     consoleSpy.mockRestore();
-  });
-
-  it("shows error toast when local storage save fails", async () => {
-    mockSaveMeasurement.mockRejectedValueOnce(new Error("storage full"));
-
-    vi.spyOn(console, "error").mockImplementation(vi.fn());
-
-    await capturedCallback(baseArgs);
-
-    expect(mockToastError).toHaveBeenCalledWith(
-      "Answers could not be saved on this device. Please export your data now to avoid losing it.",
-    );
-
-    vi.restoreAllMocks();
   });
 });

--- a/apps/mobile/src/hooks/__tests__/use-recent-measurements-actions.test.ts
+++ b/apps/mobile/src/hooks/__tests__/use-recent-measurements-actions.test.ts
@@ -134,25 +134,25 @@ describe("useRecentMeasurementsActions", () => {
   });
 
   describe("confirmDelete", () => {
-    it("shows 'Delete Measurement' title for synced items", () => {
+    it("shows 'Remove from phone' title for synced items", () => {
       const { result } = renderHook(() => useRecentMeasurementsActions("all"));
 
       act(() => result.current.confirmDelete(makeItem("k2", "successful")));
 
       expect(mockShowAlert).toHaveBeenCalledWith(
-        "Delete Measurement",
+        "Remove from phone",
         expect.any(String),
         expect.any(Array),
       );
     });
 
-    it("shows 'Remove Measurement' title for unsynced items", () => {
+    it("shows 'Delete unsynced measurement' title for unsynced items", () => {
       const { result } = renderHook(() => useRecentMeasurementsActions("all"));
 
       act(() => result.current.confirmDelete(makeItem("k1", "failed")));
 
       expect(mockShowAlert).toHaveBeenCalledWith(
-        "Remove Measurement",
+        "Delete unsynced measurement",
         expect.any(String),
         expect.any(Array),
       );

--- a/apps/mobile/src/hooks/__tests__/use-recent-measurements-actions.test.ts
+++ b/apps/mobile/src/hooks/__tests__/use-recent-measurements-actions.test.ts
@@ -18,7 +18,7 @@ const mockExportMeasurementsToFile = vi.fn().mockResolvedValue(undefined);
 vi.mock("~/hooks/use-all-measurements", () => ({
   useAllMeasurements: vi.fn(() => ({
     measurements: mockAllMeasurements,
-    allMeasurements: mockAllMeasurements,
+    counts: { pending: 0, uploading: 1, failed: 1, successful: 1 },
     uploadingCount: 1,
     invalidate: mockInvalidate,
   })),
@@ -68,9 +68,9 @@ const makeItem = (
 });
 
 const mockAllMeasurements: MeasurementItem[] = [
-  makeItem("k1", "unsynced", "Exp Unsynced"),
-  makeItem("k2", "synced", "Exp Synced"),
-  makeItem("k3", "syncing", "Exp Syncing"),
+  makeItem("k1", "failed", "Exp Unsynced"),
+  makeItem("k2", "successful", "Exp Synced"),
+  makeItem("k3", "uploading", "Exp Syncing"),
 ];
 
 describe("useRecentMeasurementsActions", () => {
@@ -92,7 +92,7 @@ describe("useRecentMeasurementsActions", () => {
   describe("confirmSync", () => {
     it("shows upload alert with measurement name", () => {
       const { result } = renderHook(() => useRecentMeasurementsActions("all"));
-      const m = makeItem("k1", "unsynced", "My Experiment");
+      const m = makeItem("k1", "failed", "My Experiment");
 
       act(() => result.current.confirmSync(m));
 
@@ -105,7 +105,7 @@ describe("useRecentMeasurementsActions", () => {
 
     it("calls uploadOne and invalidates on confirm", async () => {
       const { result } = renderHook(() => useRecentMeasurementsActions("all"));
-      const m = makeItem("k1", "unsynced");
+      const m = makeItem("k1", "failed");
 
       act(() => result.current.confirmSync(m));
       const [confirmBtn] = mockShowAlert.mock.calls[0][2];
@@ -119,7 +119,7 @@ describe("useRecentMeasurementsActions", () => {
       mockUploadOne.mockRejectedValueOnce(new Error("network"));
       const { result } = renderHook(() => useRecentMeasurementsActions("all"));
 
-      act(() => result.current.confirmSync(makeItem("k1", "unsynced")));
+      act(() => result.current.confirmSync(makeItem("k1", "failed")));
       const [confirmBtn] = mockShowAlert.mock.calls[0][2];
       await act(async () => {
         confirmBtn.onPress();
@@ -137,7 +137,7 @@ describe("useRecentMeasurementsActions", () => {
     it("shows 'Delete Measurement' title for synced items", () => {
       const { result } = renderHook(() => useRecentMeasurementsActions("all"));
 
-      act(() => result.current.confirmDelete(makeItem("k2", "synced")));
+      act(() => result.current.confirmDelete(makeItem("k2", "successful")));
 
       expect(mockShowAlert).toHaveBeenCalledWith(
         "Delete Measurement",
@@ -149,7 +149,7 @@ describe("useRecentMeasurementsActions", () => {
     it("shows 'Remove Measurement' title for unsynced items", () => {
       const { result } = renderHook(() => useRecentMeasurementsActions("all"));
 
-      act(() => result.current.confirmDelete(makeItem("k1", "unsynced")));
+      act(() => result.current.confirmDelete(makeItem("k1", "failed")));
 
       expect(mockShowAlert).toHaveBeenCalledWith(
         "Remove Measurement",
@@ -160,7 +160,7 @@ describe("useRecentMeasurementsActions", () => {
 
     it("calls removeMeasurement and invalidates on confirm", async () => {
       const { result } = renderHook(() => useRecentMeasurementsActions("all"));
-      const m = makeItem("k1", "unsynced");
+      const m = makeItem("k1", "failed");
 
       act(() => result.current.confirmDelete(m));
       const [confirmBtn] = mockShowAlert.mock.calls[0][2];
@@ -246,7 +246,7 @@ describe("useRecentMeasurementsActions", () => {
   describe("saveComment", () => {
     it("calls updateMeasurementComment and invalidates", async () => {
       const { result } = renderHook(() => useRecentMeasurementsActions("all"));
-      const m = makeItem("k1", "unsynced");
+      const m = makeItem("k1", "failed");
 
       await act(() => result.current.saveComment(m, "great result"));
 

--- a/apps/mobile/src/hooks/use-all-measurements.ts
+++ b/apps/mobile/src/hooks/use-all-measurements.ts
@@ -1,10 +1,11 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMemo } from "react";
-import { getMeasurements } from "~/services/measurements-storage";
+import { countMeasurementsByStatus, getMeasurements } from "~/services/measurements-storage";
+import type { MeasurementCounts } from "~/services/measurements-storage";
+import type { MeasurementStatus } from "~/services/measurements-storage";
 import { parseQuestions } from "~/utils/convert-cycle-answers-to-array";
 import type { AnswerData } from "~/utils/convert-cycle-answers-to-array";
 
-export type MeasurementStatus = "synced" | "unsynced" | "syncing";
+export type { MeasurementStatus } from "~/services/measurements-storage";
 
 export interface MeasurementItem {
   key: string;
@@ -25,78 +26,57 @@ export interface MeasurementItem {
 
 export type MeasurementFilter = "all" | "synced" | "unsynced";
 
+function statusesForFilter(filter: MeasurementFilter): MeasurementStatus[] {
+  if (filter === "synced") return ["successful"];
+  if (filter === "unsynced") return ["pending", "failed", "uploading"];
+  return ["pending", "failed", "uploading", "successful"];
+}
+
+const EMPTY_COUNTS: MeasurementCounts = {
+  pending: 0,
+  uploading: 0,
+  failed: 0,
+  successful: 0,
+};
+
 export function useAllMeasurements(filter: MeasurementFilter = "all") {
   const queryClient = useQueryClient();
 
-  const { data: allMeasurements = [] } = useQuery({
-    queryKey: ["measurements"],
+  // Only fetch the rows the filter actually wants — filtering happens in SQL.
+  const { data: measurements = [] } = useQuery({
+    queryKey: ["measurements", "list", filter],
     queryFn: async () => {
-      const [failedEntries, uploadingEntries, successfulEntries] = await Promise.all([
-        getMeasurements("failed"),
-        getMeasurements("uploading"),
-        getMeasurements("successful"),
-      ]);
-
-      const unsynced: MeasurementItem[] = failedEntries.map(([key, data]) => ({
-        key,
+      const rows = await getMeasurements(statusesForFilter(filter));
+      const items: MeasurementItem[] = rows.map(({ id, status, data }) => ({
+        key: id,
         timestamp: data.metadata.timestamp,
         experimentName: data.metadata.experimentName,
-        status: "unsynced" as MeasurementStatus,
+        status,
         questions: parseQuestions(data.measurementResult),
         data,
       }));
-
-      const syncing: MeasurementItem[] = uploadingEntries.map(([key, data]) => ({
-        key,
-        timestamp: data.metadata.timestamp,
-        experimentName: data.metadata.experimentName,
-        status: "syncing" as MeasurementStatus,
-        questions: parseQuestions(data.measurementResult),
-        data,
-      }));
-
-      const synced: MeasurementItem[] = successfulEntries.map(([key, data]) => ({
-        key,
-        timestamp: data.metadata.timestamp,
-        experimentName: data.metadata.experimentName,
-        status: "synced" as MeasurementStatus,
-        questions: parseQuestions(data.measurementResult),
-        data,
-      }));
-
-      const combined = [...unsynced, ...syncing, ...synced];
-
-      combined.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
-
-      return combined;
+      items.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+      return items;
     },
     networkMode: "always",
   });
 
-  const filteredMeasurements = useMemo(
-    () =>
-      allMeasurements.filter((item) => {
-        if (filter === "all") return true;
-        if (filter === "synced") return item.status === "synced";
-        if (filter === "unsynced") return item.status === "unsynced" || item.status === "syncing";
-        return true;
-      }),
-    [allMeasurements, filter],
-  );
-
-  const uploadingCount = useMemo(
-    () => allMeasurements.filter((item) => item.status === "syncing").length,
-    [allMeasurements],
-  );
+  // Lightweight COUNT … GROUP BY status — independent of the active filter so
+  // toolbar counts and counts shown in confirmations stay accurate.
+  const { data: counts = EMPTY_COUNTS } = useQuery({
+    queryKey: ["measurements", "counts"],
+    queryFn: countMeasurementsByStatus,
+    networkMode: "always",
+  });
 
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: ["measurements"] });
   };
 
   return {
-    measurements: filteredMeasurements,
-    allMeasurements,
-    uploadingCount,
+    measurements,
+    counts,
+    uploadingCount: counts.uploading,
     invalidate,
   };
 }

--- a/apps/mobile/src/hooks/use-measurement-upload.ts
+++ b/apps/mobile/src/hooks/use-measurement-upload.ts
@@ -1,3 +1,4 @@
+import { useNetworkState } from "expo-network";
 import { useAsyncCallback } from "react-async-hook";
 import { toast } from "sonner-native";
 import { showAlert } from "~/components/AlertDialog";
@@ -93,6 +94,7 @@ function promptMeasurementFileSave(measurement: {
 
 export function useMeasurementUpload() {
   const { saveMeasurement, markUploaded, markFailed } = useMeasurements();
+  const networkState = useNetworkState();
 
   const { loading: isUploading, execute: uploadMeasurement } = useAsyncCallback(
     async ({
@@ -157,6 +159,16 @@ export function useMeasurementUpload() {
       } catch (storageError) {
         console.error("Failed to save measurement to local storage:", storageError);
         promptMeasurementFileSave(failedUploadData);
+        return;
+      }
+
+      // If the device is offline, skip the publish entirely. Cognito's
+      // credential fetch inside sendMqttEvent would throw and we'd mark the
+      // row "failed" — but the schema reserves "failed" for rows that
+      // actually attempted a publish. Leaving it "pending" lets
+      // useAutoUpload's network-restore listener pick it up on reconnect.
+      if (networkState.isInternetReachable === false) {
+        toast.info("Saved offline — will upload when you're back online");
         return;
       }
 

--- a/apps/mobile/src/hooks/use-measurement-upload.ts
+++ b/apps/mobile/src/hooks/use-measurement-upload.ts
@@ -160,14 +160,25 @@ export function useMeasurementUpload() {
         return;
       }
 
+      // Split into two phases: a publish failure means the data didn't reach
+      // the cloud (mark failed, surface error). A local-state update failure
+      // *after* a successful publish must not flip the row back to failed —
+      // the data is already on the cloud; only log/toast the local issue.
       try {
         await sendMqttEvent(topic, measurementData);
-        await markUploaded(savedId);
-        toast.success("Measurement uploaded!");
       } catch (uploadError) {
         console.error("Upload failed:", uploadError);
         await markFailed(savedId);
         toast.error("Upload not available, upload it later from Recent");
+        return;
+      }
+
+      try {
+        await markUploaded(savedId);
+        toast.success("Measurement uploaded!");
+      } catch (localError) {
+        console.error("Local status update failed after successful publish:", localError);
+        toast.info("Uploaded — local status will refresh on next sync");
       }
     },
   );

--- a/apps/mobile/src/hooks/use-measurement-upload.ts
+++ b/apps/mobile/src/hooks/use-measurement-upload.ts
@@ -92,7 +92,7 @@ function promptMeasurementFileSave(measurement: {
 }
 
 export function useMeasurementUpload() {
-  const { saveMeasurement } = useMeasurements();
+  const { saveMeasurement, markUploaded, markFailed } = useMeasurements();
 
   const { loading: isUploading, execute: uploadMeasurement } = useAsyncCallback(
     async ({
@@ -146,21 +146,28 @@ export function useMeasurementUpload() {
         },
       };
 
+      // Save locally first so the measurement appears in Recent immediately
+      // and can be flagged on-device, regardless of upload outcome. Status
+      // starts as "pending" — only flipped to "failed" once an actual MQTT
+      // attempt errors out, so field metrics distinguish never-tried from
+      // genuinely-failed rows.
+      let savedId: string;
       try {
-        await sendMqttEvent(topic, measurementData);
-        toast.success("Measurement uploaded!");
-        await saveMeasurement(failedUploadData, "successful");
-        return;
-      } catch (uploadError) {
-        console.error("Upload failed:", uploadError);
-        toast.error("Upload not available, upload it later from Recent");
-      }
-
-      try {
-        await saveMeasurement(failedUploadData, "failed");
+        savedId = await saveMeasurement(failedUploadData, "pending");
       } catch (storageError) {
         console.error("Failed to save measurement to local storage:", storageError);
         promptMeasurementFileSave(failedUploadData);
+        return;
+      }
+
+      try {
+        await sendMqttEvent(topic, measurementData);
+        await markUploaded(savedId);
+        toast.success("Measurement uploaded!");
+      } catch (uploadError) {
+        console.error("Upload failed:", uploadError);
+        await markFailed(savedId);
+        toast.error("Upload not available, upload it later from Recent");
       }
     },
   );

--- a/apps/mobile/src/hooks/use-measurements.ts
+++ b/apps/mobile/src/hooks/use-measurements.ts
@@ -2,7 +2,6 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRef, useState } from "react";
 import { useAsyncCallback } from "react-async-hook";
 import { toast } from "sonner-native";
-import type { MeasurementItem } from "~/hooks/use-all-measurements";
 import {
   clearMeasurements,
   getMeasurements,
@@ -57,22 +56,24 @@ export function useMeasurements() {
 
     const taskFns = itemsToUpload.map(({ key, data }) => async () => {
       try {
-        await sendMqttEvent(data.topic, data.measurementResult);
-        await markAsSuccessful(key);
-        queryClient.setQueryData(["measurements"], (old: MeasurementItem[] | undefined) =>
-          old?.map((item) =>
-            item.key === key ? { ...item, status: "successful" satisfies MeasurementStatus } : item,
-          ),
-        );
-      } catch (error) {
-        console.warn(`Failed to upload item with key ${key}:`, error);
-        await markAsFailed(key);
-        queryClient.setQueryData(["measurements"], (old: MeasurementItem[] | undefined) =>
-          old?.map((item) =>
-            item.key === key ? { ...item, status: "failed" satisfies MeasurementStatus } : item,
-          ),
-        );
-        throw error;
+        try {
+          await sendMqttEvent(data.topic, data.measurementResult);
+        } catch (error) {
+          console.warn(`Failed to upload item with key ${key}:`, error);
+          await markAsFailed(key);
+          throw error;
+        }
+
+        // Publish succeeded — local-state failure must not flip the row
+        // back to failed.
+        try {
+          await markAsSuccessful(key);
+        } catch (localError) {
+          console.warn(
+            `Local status update failed after successful publish for ${key}:`,
+            localError,
+          );
+        }
       } finally {
         setUploadProgress((prev) => (prev ? { ...prev, done: prev.done + 1 } : null));
       }
@@ -116,13 +117,27 @@ export function useMeasurements() {
       if (transitioned.length === 0) return;
       await queryClient.invalidateQueries({ queryKey: ["measurements"] });
 
+      // Only a publish failure should mark the row failed — if MQTT
+      // succeeded but the local status write later fails, the data is on
+      // the cloud and we must not regress the row to "failed".
       try {
-        await sendMqttEvent(item.data.topic, item.data.measurementResult);
-        await markAsSuccessful(key);
-      } catch (error) {
-        console.warn(`Failed to upload item with key ${key}:`, error);
-        await markAsFailed(key);
-        toast.info("Failed to upload, try again later");
+        try {
+          await sendMqttEvent(item.data.topic, item.data.measurementResult);
+        } catch (error) {
+          console.warn(`Failed to upload item with key ${key}:`, error);
+          await markAsFailed(key);
+          toast.info("Failed to upload, try again later");
+          return;
+        }
+
+        try {
+          await markAsSuccessful(key);
+        } catch (localError) {
+          console.warn(
+            `Local status update failed after successful publish for ${key}:`,
+            localError,
+          );
+        }
       } finally {
         await pruneExpiredMeasurements();
         await queryClient.invalidateQueries({ queryKey: ["measurements"] });

--- a/apps/mobile/src/hooks/use-measurements.ts
+++ b/apps/mobile/src/hooks/use-measurements.ts
@@ -2,10 +2,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRef, useState } from "react";
 import { useAsyncCallback } from "react-async-hook";
 import { toast } from "sonner-native";
-import type {
-  MeasurementItem,
-  MeasurementStatus as MeasurementUiStatus,
-} from "~/hooks/use-all-measurements";
+import type { MeasurementItem } from "~/hooks/use-all-measurements";
 import {
   clearMeasurements,
   getMeasurements,
@@ -31,11 +28,15 @@ export function useMeasurements() {
   );
   const uploadingKeysRef = useRef<Set<string>>(new Set());
 
+  // Both "pending" (never tried) and "failed" (tried, errored) rows are
+  // candidates for the next upload attempt. The variable retains its old
+  // "failedUploads" name for callsite stability — semantically it's
+  // "everything-not-yet-on-the-cloud."
   const { data: failedUploads = [] } = useQuery({
-    queryKey: ["measurements", "failed"],
+    queryKey: ["measurements", "pending-or-failed"],
     queryFn: async () => {
-      const entries = await getMeasurements("failed");
-      return entries.map(([key, data]) => ({ key, data }));
+      const rows = await getMeasurements(["pending", "failed"]);
+      return rows.map(({ id, data }) => ({ key: id, data }));
     },
     networkMode: "always",
   });
@@ -44,7 +45,9 @@ export function useMeasurements() {
   failedUploadsRef.current = failedUploads;
 
   const uploadAsync = useAsyncCallback(async () => {
-    const CONCURRENCY = 10;
+    // 3 keeps a single phone's burst well below AWS Cognito Identity Pool
+    // throttling when multiple field devices come online at the same time.
+    const CONCURRENCY = 3;
     const items = [...failedUploadsRef.current];
 
     const transitioned = new Set(await markAsUploading(items.map(({ key }) => key)));
@@ -58,7 +61,7 @@ export function useMeasurements() {
         await markAsSuccessful(key);
         queryClient.setQueryData(["measurements"], (old: MeasurementItem[] | undefined) =>
           old?.map((item) =>
-            item.key === key ? { ...item, status: "synced" satisfies MeasurementUiStatus } : item,
+            item.key === key ? { ...item, status: "successful" satisfies MeasurementStatus } : item,
           ),
         );
       } catch (error) {
@@ -66,7 +69,7 @@ export function useMeasurements() {
         await markAsFailed(key);
         queryClient.setQueryData(["measurements"], (old: MeasurementItem[] | undefined) =>
           old?.map((item) =>
-            item.key === key ? { ...item, status: "unsynced" satisfies MeasurementUiStatus } : item,
+            item.key === key ? { ...item, status: "failed" satisfies MeasurementStatus } : item,
           ),
         );
         throw error;
@@ -130,7 +133,18 @@ export function useMeasurements() {
   };
 
   const saveMeasurement = async (upload: Measurement, status: MeasurementStatus) => {
-    await saveMeasurementToStorage(upload, status);
+    const id = await saveMeasurementToStorage(upload, status);
+    await queryClient.invalidateQueries({ queryKey: ["measurements"] });
+    return id;
+  };
+
+  const markUploaded = async (key: string) => {
+    await markAsSuccessful(key);
+    await queryClient.invalidateQueries({ queryKey: ["measurements"] });
+  };
+
+  const markFailed = async (key: string) => {
+    await markAsFailed(key);
     await queryClient.invalidateQueries({ queryKey: ["measurements"] });
   };
 
@@ -161,6 +175,8 @@ export function useMeasurements() {
     uploadAll: uploadAsync.execute,
     uploadOne,
     saveMeasurement,
+    markUploaded,
+    markFailed,
     removeMeasurement,
     clearSyncedMeasurements,
     updateMeasurementComment,

--- a/apps/mobile/src/hooks/use-questions-upload.ts
+++ b/apps/mobile/src/hooks/use-questions-upload.ts
@@ -65,14 +65,24 @@ export function useQuestionsUpload() {
         return;
       }
 
+      // See use-measurement-upload.ts — split publish from local-state update
+      // so a successful publish followed by a markUploaded error doesn't
+      // incorrectly flip the row to failed.
       try {
         await sendMqttEvent(topic, payload);
-        await markUploaded(savedId);
-        toast.success("Answers uploaded!");
       } catch (uploadError) {
         console.error("Upload failed:", uploadError);
         await markFailed(savedId);
         toast.error("Upload not available, upload it later from Recent");
+        return;
+      }
+
+      try {
+        await markUploaded(savedId);
+        toast.success("Answers uploaded!");
+      } catch (localError) {
+        console.error("Local status update failed after successful publish:", localError);
+        toast.info("Uploaded — local status will refresh on next sync");
       }
     },
   );

--- a/apps/mobile/src/hooks/use-questions-upload.ts
+++ b/apps/mobile/src/hooks/use-questions-upload.ts
@@ -9,7 +9,7 @@ import { buildAnnotations } from "~/utils/measurement-annotations";
 import type { AnnotationFlagType } from "@repo/api/schemas/experiment.schema";
 
 export function useQuestionsUpload() {
-  const { saveMeasurement } = useMeasurements();
+  const { saveMeasurement, markUploaded, markFailed } = useMeasurements();
 
   const { loading: isUploading, execute: uploadQuestions } = useAsyncCallback(
     async ({
@@ -53,23 +53,26 @@ export function useQuestionsUpload() {
         },
       };
 
+      // Persist before attempting MQTT (see use-measurement-upload.ts).
+      let savedId: string;
       try {
-        await sendMqttEvent(topic, payload);
-        toast.success("Answers uploaded!");
-        await saveMeasurement(failedUploadData, "successful");
-        return;
-      } catch (uploadError) {
-        console.error("Upload failed:", uploadError);
-        toast.error("Upload not available, upload it later from Recent");
-      }
-
-      try {
-        await saveMeasurement(failedUploadData, "failed");
+        savedId = await saveMeasurement(failedUploadData, "pending");
       } catch (storageError) {
         console.error("Failed to save answers to local storage:", storageError);
         toast.error(
           "Answers could not be saved on this device. Please export your data now to avoid losing it.",
         );
+        return;
+      }
+
+      try {
+        await sendMqttEvent(topic, payload);
+        await markUploaded(savedId);
+        toast.success("Answers uploaded!");
+      } catch (uploadError) {
+        console.error("Upload failed:", uploadError);
+        await markFailed(savedId);
+        toast.error("Upload not available, upload it later from Recent");
       }
     },
   );

--- a/apps/mobile/src/hooks/use-questions-upload.ts
+++ b/apps/mobile/src/hooks/use-questions-upload.ts
@@ -1,3 +1,4 @@
+import { useNetworkState } from "expo-network";
 import { useAsyncCallback } from "react-async-hook";
 import { toast } from "sonner-native";
 import { useMeasurements } from "~/hooks/use-measurements";
@@ -10,6 +11,7 @@ import type { AnnotationFlagType } from "@repo/api/schemas/experiment.schema";
 
 export function useQuestionsUpload() {
   const { saveMeasurement, markUploaded, markFailed } = useMeasurements();
+  const networkState = useNetworkState();
 
   const { loading: isUploading, execute: uploadQuestions } = useAsyncCallback(
     async ({
@@ -62,6 +64,14 @@ export function useQuestionsUpload() {
         toast.error(
           "Answers could not be saved on this device. Please export your data now to avoid losing it.",
         );
+        return;
+      }
+
+      // See use-measurement-upload.ts — when offline, leave the row pending
+      // rather than letting Cognito's credential fetch throw and trip the
+      // "failed" path. useAutoUpload retries pending rows on reconnect.
+      if (networkState.isInternetReachable === false) {
+        toast.info("Saved offline — will upload when you're back online");
         return;
       }
 

--- a/apps/mobile/src/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.tsx
+++ b/apps/mobile/src/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.tsx
@@ -66,7 +66,7 @@ export function AnalysisNode({ content }: AnalysisNodeProps) {
       key: "current", // Random key, measurement not saved or uploaded yet
       timestamp: displayTimestamp,
       experimentName,
-      status: "synced", // To hide the comment button in modal
+      status: "successful", // To hide the comment button in modal
       questions,
       data: {
         topic: "",

--- a/apps/mobile/src/screens/measurement-flow-screen/components/flow-states/completed-state.tsx
+++ b/apps/mobile/src/screens/measurement-flow-screen/components/flow-states/completed-state.tsx
@@ -12,6 +12,7 @@ import { useAllMeasurements } from "~/hooks/use-all-measurements";
 import type {
   MeasurementFilter,
   MeasurementItem as MeasurementItemType,
+  MeasurementStatus,
 } from "~/hooks/use-all-measurements";
 import { useMeasurements } from "~/hooks/use-measurements";
 import { useTheme } from "~/hooks/use-theme";
@@ -55,15 +56,15 @@ export function CompletedState() {
     ]);
   };
 
-  const handleDelete = (id: string, status: "synced" | "unsynced", experimentName: string) => {
-    const message =
-      status === "synced"
-        ? `Are you sure you want to delete "${experimentName}" from local storage?`
-        : `Are you sure you want to remove "${experimentName}"? This will delete it from local storage.`;
+  const handleDelete = (id: string, status: MeasurementStatus, experimentName: string) => {
+    const isSynced = status === "successful";
+    const message = isSynced
+      ? `Are you sure you want to delete "${experimentName}" from local storage?`
+      : `Are you sure you want to remove "${experimentName}"? This will delete it from local storage.`;
 
-    showAlert(status === "synced" ? "Delete Measurement" : "Remove Measurement", message, [
+    showAlert(isSynced ? "Delete Measurement" : "Remove Measurement", message, [
       {
-        text: status === "synced" ? "Delete" : "Remove",
+        text: isSynced ? "Delete" : "Remove",
         variant: "danger",
         onPress: () => {
           void (() => {
@@ -118,16 +119,16 @@ export function CompletedState() {
               questions={parseQuestions(measurement.data.measurementResult)}
               onPress={() => setSelectedMeasurement(measurement)}
               onComment={
-                measurement.status === "unsynced"
+                measurement.status === "pending" || measurement.status === "failed"
                   ? () => setSelectedForComment(measurement)
                   : undefined
               }
               onDelete={() => {
-                if (measurement.status === "syncing") return;
+                if (measurement.status === "uploading") return;
                 handleDelete(measurement.key, measurement.status, measurement.experimentName);
               }}
               onSync={
-                measurement.status === "unsynced"
+                measurement.status === "pending" || measurement.status === "failed"
                   ? () => handleSync(measurement.key, measurement.experimentName)
                   : undefined
               }

--- a/apps/mobile/src/screens/measurement-flow-screen/components/flow-states/completed-state.tsx
+++ b/apps/mobile/src/screens/measurement-flow-screen/components/flow-states/completed-state.tsx
@@ -59,12 +59,12 @@ export function CompletedState() {
   const handleDelete = (id: string, status: MeasurementStatus, experimentName: string) => {
     const isSynced = status === "successful";
     const message = isSynced
-      ? `Are you sure you want to delete "${experimentName}" from local storage?`
-      : `Are you sure you want to remove "${experimentName}"? This will delete it from local storage.`;
+      ? `"${experimentName}" is already uploaded to the cloud. Remove it from this phone? The cloud copy stays intact.`
+      : `"${experimentName}" has not been uploaded yet. Deleting it now means the measurement will be lost permanently.`;
 
-    showAlert(isSynced ? "Delete Measurement" : "Remove Measurement", message, [
+    showAlert(isSynced ? "Remove from phone" : "Delete unsynced measurement", message, [
       {
-        text: isSynced ? "Delete" : "Remove",
+        text: isSynced ? "Remove" : "Delete",
         variant: "danger",
         onPress: () => {
           void (() => {

--- a/apps/mobile/src/screens/measurement-flow-screen/types.ts
+++ b/apps/mobile/src/screens/measurement-flow-screen/types.ts
@@ -1,4 +1,4 @@
-export type FlowNodeType = "instruction" | "question" | "measurement" | "analysis";
+export type FlowNodeType = "instruction" | "question" | "measurement" | "analysis" | "branch";
 
 export type QuestionKind =
   | "text"

--- a/apps/mobile/src/services/__tests__/export-measurements.test.ts
+++ b/apps/mobile/src/services/__tests__/export-measurements.test.ts
@@ -46,8 +46,10 @@ describe("exportMeasurementsToFile", () => {
 
   it("creates and writes a file with correct counts", async () => {
     mockGetMeasurements
-      .mockResolvedValueOnce([["failed-1", mockStoredMeasurement()]])
-      .mockResolvedValueOnce([["synced-1", mockStoredMeasurement()]]);
+      .mockResolvedValueOnce([{ id: "failed-1", status: "failed", data: mockStoredMeasurement() }])
+      .mockResolvedValueOnce([
+        { id: "synced-1", status: "successful", data: mockStoredMeasurement() },
+      ]);
 
     await exportMeasurementsToFile();
 
@@ -59,8 +61,20 @@ describe("exportMeasurementsToFile", () => {
 
   it("marks failed entries as unsynced and successful as synced", async () => {
     mockGetMeasurements
-      .mockResolvedValueOnce([["failed-1", mockStoredMeasurement({ experimentName: "Exp A" })]])
-      .mockResolvedValueOnce([["synced-1", mockStoredMeasurement({ experimentName: "Exp B" })]]);
+      .mockResolvedValueOnce([
+        {
+          id: "failed-1",
+          status: "failed",
+          data: mockStoredMeasurement({ experimentName: "Exp A" }),
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "synced-1",
+          status: "successful",
+          data: mockStoredMeasurement({ experimentName: "Exp B" }),
+        },
+      ]);
 
     await exportMeasurementsToFile();
 
@@ -77,8 +91,16 @@ describe("exportMeasurementsToFile", () => {
   it("sorts measurements newest first", async () => {
     mockGetMeasurements
       .mockResolvedValueOnce([
-        ["old", mockStoredMeasurement({ timestamp: "2026-01-01T00:00:00.000Z" })],
-        ["new", mockStoredMeasurement({ timestamp: "2026-03-01T00:00:00.000Z" })],
+        {
+          id: "old",
+          status: "failed",
+          data: mockStoredMeasurement({ timestamp: "2026-01-01T00:00:00.000Z" }),
+        },
+        {
+          id: "new",
+          status: "failed",
+          data: mockStoredMeasurement({ timestamp: "2026-03-01T00:00:00.000Z" }),
+        },
       ])
       .mockResolvedValueOnce([]);
 

--- a/apps/mobile/src/services/__tests__/measurements-storage.test.ts
+++ b/apps/mobile/src/services/__tests__/measurements-storage.test.ts
@@ -240,6 +240,47 @@ describe("measurements-storage", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // countMeasurementsByStatus
+  // ---------------------------------------------------------------------------
+
+  describe("countMeasurementsByStatus", () => {
+    it("returns the per-status counts via a single GROUP BY query", async () => {
+      insertRow("p1", "pending");
+      insertRow("p2", "pending");
+      insertRow("f1", "failed");
+      insertRow("u1", "uploading");
+      insertRow("s1", "successful");
+      insertRow("s2", "successful");
+      insertRow("s3", "successful");
+
+      const mod = await import("../measurements-storage");
+      const counts = await mod.countMeasurementsByStatus();
+
+      expect(counts).toEqual({ pending: 2, failed: 1, uploading: 1, successful: 3 });
+    });
+
+    it("returns zeros when the table is empty", async () => {
+      const mod = await import("../measurements-storage");
+      const counts = await mod.countMeasurementsByStatus();
+      expect(counts).toEqual({ pending: 0, failed: 0, uploading: 0, successful: 0 });
+    });
+
+    it("returns zeros and logs when the underlying query throws", async () => {
+      const mod = await import("../measurements-storage");
+      // Force the count query to throw by destroying the table mid-test.
+      sqlite.prepare("DROP TABLE measurements").run();
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
+
+      const counts = await mod.countMeasurementsByStatus();
+
+      expect(counts).toEqual({ pending: 0, failed: 0, uploading: 0, successful: 0 });
+      expect(consoleSpy).toHaveBeenCalledWith("Failed to count measurements:", expect.any(Error));
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // markAsSuccessful
   // ---------------------------------------------------------------------------
 

--- a/apps/mobile/src/services/__tests__/measurements-storage.test.ts
+++ b/apps/mobile/src/services/__tests__/measurements-storage.test.ts
@@ -8,9 +8,9 @@ import { compressForStorage } from "~/utils/storage-compression";
 
 import * as schema from "../db/schema";
 
-const migrationSql = readFileSync(
-  resolve(__dirname, "../../../drizzle/0000_outgoing_firebird.sql"),
-  "utf-8",
+const migrationFiles = ["0000_outgoing_firebird.sql", "0001_add_pending_status.sql"];
+const migrationSqls = migrationFiles.map((f) =>
+  readFileSync(resolve(__dirname, "../../../drizzle", f), "utf-8"),
 );
 
 let sqlite: ReturnType<typeof Database>;
@@ -18,7 +18,12 @@ let db: ReturnType<typeof drizzle>;
 
 function createTestDb() {
   sqlite = new Database(":memory:");
-  sqlite.exec(migrationSql);
+  for (const sql of migrationSqls) {
+    // Drizzle uses "--> statement-breakpoint" markers as a hint to its mobile
+    // migrator; better-sqlite3.exec already understands ; separators, so
+    // stripping the marker is enough.
+    sqlite.exec(sql.replace(/-->\s*statement-breakpoint/g, ""));
+  }
   db = drizzle(sqlite, { schema });
 }
 
@@ -55,7 +60,7 @@ const mockMeasurement = {
 
 function insertRow(
   id: string,
-  status: "failed" | "uploading" | "successful",
+  status: "pending" | "failed" | "uploading" | "successful",
   overrides: Partial<{ topic: string; timestamp: string; createdAt: number }> = {},
 ) {
   sqlite
@@ -87,14 +92,25 @@ describe("measurements-storage", () => {
   // ---------------------------------------------------------------------------
 
   describe("saveMeasurement", () => {
-    it("inserts a failed row", async () => {
+    it("inserts a pending row and returns its id (save-first default)", async () => {
       const mod = await import("../measurements-storage");
-      await mod.saveMeasurement(mockMeasurement, "failed");
+      const id = await mod.saveMeasurement(mockMeasurement, "pending");
+
+      const rows = sqlite.prepare("SELECT * FROM measurements").all() as any[];
+      expect(rows).toHaveLength(1);
+      expect(rows[0].status).toBe("pending");
+      expect(rows[0].id).toBe("test-uuid-1234");
+      expect(id).toBe("test-uuid-1234");
+    });
+
+    it("inserts a failed row and returns its id", async () => {
+      const mod = await import("../measurements-storage");
+      const id = await mod.saveMeasurement(mockMeasurement, "failed");
 
       const rows = sqlite.prepare("SELECT * FROM measurements").all() as any[];
       expect(rows).toHaveLength(1);
       expect(rows[0].status).toBe("failed");
-      expect(rows[0].id).toBe("test-uuid-1234");
+      expect(id).toBe("test-uuid-1234");
     });
 
     it("inserts a successful row", async () => {
@@ -104,6 +120,19 @@ describe("measurements-storage", () => {
       const rows = sqlite.prepare("SELECT * FROM measurements").all() as any[];
       expect(rows).toHaveLength(1);
       expect(rows[0].status).toBe("successful");
+    });
+
+    it("rejects an unknown status at the database level (CHECK constraint)", () => {
+      // The DB-level CHECK constraint must reject anything outside the enum,
+      // even if a type-cast slips past the TS guard.
+      expect(() =>
+        sqlite
+          .prepare(
+            `INSERT INTO measurements (id, status, topic, measurement_result, experiment_name, protocol_name, timestamp, created_at)
+             VALUES ('bad', 'gibberish', 't', '{}', 'e', 'p', '2026-01-01', 0)`,
+          )
+          .run(),
+      ).toThrow(/CHECK constraint/i);
     });
   });
 
@@ -120,7 +149,8 @@ describe("measurements-storage", () => {
       const result = await mod.getMeasurements("failed");
 
       expect(result).toHaveLength(1);
-      expect(result[0][0]).toBe("f1");
+      expect(result[0].id).toBe("f1");
+      expect(result[0].status).toBe("failed");
     });
 
     it("returns only successful rows when status is successful", async () => {
@@ -131,7 +161,8 @@ describe("measurements-storage", () => {
       const result = await mod.getMeasurements("successful");
 
       expect(result).toHaveLength(1);
-      expect(result[0][0]).toBe("s1");
+      expect(result[0].id).toBe("s1");
+      expect(result[0].status).toBe("successful");
     });
 
     it("returns empty array when no rows match", async () => {
@@ -144,9 +175,33 @@ describe("measurements-storage", () => {
       insertRow("f1", "failed");
 
       const mod = await import("../measurements-storage");
-      const [[, measurement]] = await mod.getMeasurements("failed");
+      const [first] = await mod.getMeasurements("failed");
 
-      expect(measurement).toEqual(mockMeasurement);
+      expect(first.data).toEqual(mockMeasurement);
+    });
+
+    it("returns rows for multiple statuses in one query (array form)", async () => {
+      insertRow("p1", "pending");
+      insertRow("f1", "failed");
+      insertRow("s1", "successful");
+
+      const mod = await import("../measurements-storage");
+      const result = await mod.getMeasurements(["pending", "failed"]);
+
+      expect(result).toHaveLength(2);
+      const byId = new Map(result.map((r) => [r.id, r.status]));
+      expect(byId.get("p1")).toBe("pending");
+      expect(byId.get("f1")).toBe("failed");
+      expect(byId.has("s1")).toBe(false);
+    });
+
+    it("returns empty array when called with an empty status list", async () => {
+      insertRow("p1", "pending");
+
+      const mod = await import("../measurements-storage");
+      const result = await mod.getMeasurements([]);
+
+      expect(result).toEqual([]);
     });
   });
 
@@ -232,14 +287,24 @@ describe("measurements-storage", () => {
       expect(rows[0].status).toBe("successful");
     });
 
-    it("is a no-op on a failed row", async () => {
+    it("transitions a failed row directly to successful (manual retry)", async () => {
       insertRow("m1", "failed");
 
       const mod = await import("../measurements-storage");
       await mod.markAsSuccessful("m1");
 
       const row = sqlite.prepare("SELECT * FROM measurements WHERE id = 'm1'").get() as any;
-      expect(row.status).toBe("failed");
+      expect(row.status).toBe("successful");
+    });
+
+    it("transitions a pending row directly to successful (save-first flow)", async () => {
+      insertRow("m1", "pending");
+
+      const mod = await import("../measurements-storage");
+      await mod.markAsSuccessful("m1");
+
+      const row = sqlite.prepare("SELECT * FROM measurements WHERE id = 'm1'").get() as any;
+      expect(row.status).toBe("successful");
     });
   });
 
@@ -281,15 +346,28 @@ describe("measurements-storage", () => {
       expect(ids).toEqual([]);
     });
 
-    it("returns only failed rows when given a mixed batch", async () => {
+    it("returns only pending or failed rows when given a mixed batch", async () => {
+      insertRow("m0", "pending");
       insertRow("m1", "failed");
       insertRow("m2", "uploading");
       insertRow("m3", "successful");
 
       const mod = await import("../measurements-storage");
-      const ids = await mod.markAsUploading(["m1", "m2", "m3"]);
+      const ids = await mod.markAsUploading(["m0", "m1", "m2", "m3"]);
 
-      expect(ids).toEqual(["m1"]);
+      expect([...ids].sort()).toEqual(["m0", "m1"]);
+    });
+
+    it("transitions pending rows to uploading", async () => {
+      insertRow("p1", "pending");
+      insertRow("p2", "pending");
+
+      const mod = await import("../measurements-storage");
+      const ids = await mod.markAsUploading(["p1", "p2"]);
+
+      expect([...ids].sort()).toEqual(["p1", "p2"]);
+      const rows = sqlite.prepare("SELECT id, status FROM measurements ORDER BY id").all() as any[];
+      expect(rows.map((r) => r.status)).toEqual(["uploading", "uploading"]);
     });
   });
 
@@ -422,6 +500,16 @@ describe("measurements-storage", () => {
       expect(row.status).toBe("failed");
     });
 
+    it("transitions a pending row to failed (save-first MQTT errored)", async () => {
+      insertRow("m1", "pending");
+
+      const mod = await import("../measurements-storage");
+      await mod.markAsFailed("m1");
+
+      const row = sqlite.prepare("SELECT * FROM measurements WHERE id = 'm1'").get() as any;
+      expect(row.status).toBe("failed");
+    });
+
     it("is a no-op on a row that is already failed", async () => {
       insertRow("m1", "failed");
 
@@ -460,7 +548,7 @@ describe("measurements-storage", () => {
   // ---------------------------------------------------------------------------
 
   describe("resetUploadingMeasurements", () => {
-    it("reverts all uploading rows to failed", async () => {
+    it("reverts all uploading rows to pending (interrupted, not actually failed)", async () => {
       insertRow("u1", "uploading");
       insertRow("u2", "uploading");
       insertRow("f1", "failed");
@@ -470,8 +558,8 @@ describe("measurements-storage", () => {
       await mod.resetUploadingMeasurements();
 
       const rows = sqlite.prepare("SELECT id, status FROM measurements ORDER BY id").all() as any[];
-      expect(rows.find((r) => r.id === "u1")?.status).toBe("failed");
-      expect(rows.find((r) => r.id === "u2")?.status).toBe("failed");
+      expect(rows.find((r) => r.id === "u1")?.status).toBe("pending");
+      expect(rows.find((r) => r.id === "u2")?.status).toBe("pending");
       expect(rows.find((r) => r.id === "f1")?.status).toBe("failed");
       expect(rows.find((r) => r.id === "s1")?.status).toBe("successful");
     });
@@ -598,5 +686,147 @@ describe("measurements-storage", () => {
 
       expect(AsyncStorage.getAllKeys).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+// =============================================================================
+// Migration upgrade path: seed a v0 DB, run 0001, verify data + CHECK constraint
+// =============================================================================
+
+describe("0001_add_pending_status migration — upgrade path", () => {
+  const m0000Sql = readFileSync(
+    resolve(__dirname, "../../../drizzle/0000_outgoing_firebird.sql"),
+    "utf-8",
+  );
+  const m0001Sql = readFileSync(
+    resolve(__dirname, "../../../drizzle/0001_add_pending_status.sql"),
+    "utf-8",
+  );
+
+  function applyMigration(target: ReturnType<typeof Database>, sql: string) {
+    target.exec(sql.replace(/-->\s*statement-breakpoint/g, ""));
+  }
+
+  function seedV0Rows(target: ReturnType<typeof Database>) {
+    const stmt = target.prepare(
+      `INSERT INTO measurements (id, status, topic, measurement_result, experiment_name, protocol_name, timestamp, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    stmt.run("a", "failed", "topic/a", "{}", "Exp", "P", "2026-03-01T10:00:00Z", 1000);
+    stmt.run("b", "uploading", "topic/b", "{}", "Exp", "P", "2026-03-01T11:00:00Z", 2000);
+    stmt.run("c", "successful", "topic/c", "{}", "Exp", "P", "2026-03-01T12:00:00Z", 3000);
+  }
+
+  it("preserves every existing row with its original status", () => {
+    const target = new Database(":memory:");
+    applyMigration(target, m0000Sql);
+    seedV0Rows(target);
+
+    applyMigration(target, m0001Sql);
+
+    const rows = target.prepare("SELECT id, status FROM measurements ORDER BY id").all() as {
+      id: string;
+      status: string;
+    }[];
+    expect(rows).toEqual([
+      { id: "a", status: "failed" },
+      { id: "b", status: "uploading" },
+      { id: "c", status: "successful" },
+    ]);
+  });
+
+  it("preserves every non-status column (topic, measurement_result, timestamps, etc.)", () => {
+    const target = new Database(":memory:");
+    applyMigration(target, m0000Sql);
+    seedV0Rows(target);
+
+    applyMigration(target, m0001Sql);
+
+    const a = target.prepare("SELECT * FROM measurements WHERE id = 'a'").get() as any;
+    expect(a).toMatchObject({
+      id: "a",
+      status: "failed",
+      topic: "topic/a",
+      measurement_result: "{}",
+      experiment_name: "Exp",
+      protocol_name: "P",
+      timestamp: "2026-03-01T10:00:00Z",
+      created_at: 1000,
+    });
+  });
+
+  it("activates the CHECK constraint after migration (rejects unknown statuses)", () => {
+    const target = new Database(":memory:");
+    applyMigration(target, m0000Sql);
+    seedV0Rows(target);
+
+    // Pre-migration: SQLite has no CHECK so anything goes.
+    expect(() =>
+      target
+        .prepare(
+          `INSERT INTO measurements (id, status, topic, measurement_result, experiment_name, protocol_name, timestamp, created_at)
+           VALUES ('pre', 'gibberish', 't', '{}', 'e', 'p', '2026-01-01', 0)`,
+        )
+        .run(),
+    ).not.toThrow();
+    target.prepare("DELETE FROM measurements WHERE id = 'pre'").run();
+
+    applyMigration(target, m0001Sql);
+
+    // Post-migration: same gibberish is rejected.
+    expect(() =>
+      target
+        .prepare(
+          `INSERT INTO measurements (id, status, topic, measurement_result, experiment_name, protocol_name, timestamp, created_at)
+           VALUES ('post', 'gibberish', 't', '{}', 'e', 'p', '2026-01-01', 0)`,
+        )
+        .run(),
+    ).toThrow(/CHECK constraint/i);
+  });
+
+  it("accepts the new 'pending' status after migration", () => {
+    const target = new Database(":memory:");
+    applyMigration(target, m0000Sql);
+    seedV0Rows(target);
+    applyMigration(target, m0001Sql);
+
+    expect(() =>
+      target
+        .prepare(
+          `INSERT INTO measurements (id, status, topic, measurement_result, experiment_name, protocol_name, timestamp, created_at)
+           VALUES ('p1', 'pending', 't', '{}', 'e', 'p', '2026-01-01', 0)`,
+        )
+        .run(),
+    ).not.toThrow();
+    const row = target.prepare("SELECT status FROM measurements WHERE id = 'p1'").get() as any;
+    expect(row.status).toBe("pending");
+  });
+
+  it("is safely re-runnable: data + constraint survive a second apply", () => {
+    // Drizzle's mobile migrator tracks applied migrations and won't normally
+    // re-run a tagged migration, but we still want the SQL itself to be
+    // re-runnable without corrupting data — the recreate-then-rename pattern
+    // is naturally idempotent because each apply rebuilds the table fresh
+    // from the current rows.
+    const target = new Database(":memory:");
+    applyMigration(target, m0000Sql);
+    seedV0Rows(target);
+    applyMigration(target, m0001Sql);
+    applyMigration(target, m0001Sql); // second run
+
+    const rows = target.prepare("SELECT id, status FROM measurements ORDER BY id").all() as {
+      id: string;
+      status: string;
+    }[];
+    expect(rows.map((r) => r.id)).toEqual(["a", "b", "c"]);
+    // Constraint still enforced after the second apply.
+    expect(() =>
+      target
+        .prepare(
+          `INSERT INTO measurements (id, status, topic, measurement_result, experiment_name, protocol_name, timestamp, created_at)
+           VALUES ('post', 'gibberish', 't', '{}', 'e', 'p', '2026-01-01', 0)`,
+        )
+        .run(),
+    ).toThrow(/CHECK constraint/i);
   });
 });

--- a/apps/mobile/src/services/db/schema.ts
+++ b/apps/mobile/src/services/db/schema.ts
@@ -1,14 +1,37 @@
-import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+import { sql } from "drizzle-orm";
+import { check, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
-export const measurements = sqliteTable("measurements", {
-  id: text("id").primaryKey(),
-  status: text("status", { enum: ["failed", "uploading", "successful"] }).notNull(),
-  topic: text("topic").notNull(),
-  measurementResult: text("measurement_result").notNull(),
-  experimentName: text("experiment_name").notNull(),
-  protocolName: text("protocol_name").notNull(),
-  timestamp: text("timestamp").notNull(),
-  createdAt: integer("created_at", { mode: "timestamp_ms" })
-    .notNull()
-    .$defaultFn(() => new Date()),
-});
+/**
+ * Measurement lifecycle:
+ *   pending     — saved locally, never attempted upload yet (default for
+ *                 newly-recorded measurements in the save-first flow).
+ *   uploading   — MQTT publish in progress.
+ *   failed      — upload was attempted and failed.
+ *   successful  — uploaded to AWS IoT.
+ *
+ * "pending" is distinct from "failed" so field metrics don't conflate
+ * never-attempted rows with rows that genuinely failed.
+ */
+export const MEASUREMENT_STATUSES = ["pending", "uploading", "failed", "successful"] as const;
+
+export const measurements = sqliteTable(
+  "measurements",
+  {
+    id: text("id").primaryKey(),
+    status: text("status", { enum: MEASUREMENT_STATUSES }).notNull(),
+    topic: text("topic").notNull(),
+    measurementResult: text("measurement_result").notNull(),
+    experimentName: text("experiment_name").notNull(),
+    protocolName: text("protocol_name").notNull(),
+    timestamp: text("timestamp").notNull(),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [
+    check(
+      "measurements_status_check",
+      sql`${table.status} IN ('pending', 'uploading', 'failed', 'successful')`,
+    ),
+  ],
+);

--- a/apps/mobile/src/services/export-measurements.ts
+++ b/apps/mobile/src/services/export-measurements.ts
@@ -9,15 +9,15 @@ export async function exportMeasurementsToFile(): Promise<void> {
   ]);
 
   const measurements = [
-    ...failedEntries.map(([key, data]) => ({
-      key,
+    ...failedEntries.map(({ id, data }) => ({
+      key: id,
       status: "unsynced" as const,
       timestamp: data.metadata.timestamp,
       experimentName: data.metadata.experimentName,
       data,
     })),
-    ...successfulEntries.map(([key, data]) => ({
-      key,
+    ...successfulEntries.map(({ id, data }) => ({
+      key: id,
       status: "synced" as const,
       timestamp: data.metadata.timestamp,
       experimentName: data.metadata.experimentName,

--- a/apps/mobile/src/services/measurements-storage.ts
+++ b/apps/mobile/src/services/measurements-storage.ts
@@ -1,5 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { eq, and, lt, inArray } from "drizzle-orm";
+import { eq, and, lt, inArray, count } from "drizzle-orm";
 import { Duration } from "luxon";
 import { v4 as uuidv4 } from "uuid";
 import { compressForStorage, decompressFromStorage } from "~/utils/storage-compression";
@@ -14,7 +14,7 @@ const LEGACY_PREFIXES = [
 
 const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
-export type MeasurementStatus = "failed" | "uploading" | "successful";
+export type MeasurementStatus = "pending" | "uploading" | "failed" | "successful";
 
 export interface Measurement {
   topic: string;
@@ -89,11 +89,12 @@ async function ensureMigrated(): Promise<void> {
 export async function saveMeasurement(
   upload: Measurement,
   status: MeasurementStatus,
-): Promise<void> {
+): Promise<string> {
   await ensureMigrated();
+  const id = uuidv4();
   db.insert(measurements)
     .values({
-      id: uuidv4(),
+      id,
       status,
       topic: upload.topic,
       measurementResult: compressForStorage(upload.measurementResult),
@@ -102,31 +103,70 @@ export async function saveMeasurement(
       timestamp: upload.metadata.timestamp,
     })
     .run();
+  return id;
 }
 
-export async function getMeasurements(status: MeasurementStatus): Promise<[string, Measurement][]> {
+export interface StoredMeasurement {
+  id: string;
+  status: MeasurementStatus;
+  data: Measurement;
+}
+
+export type MeasurementCounts = Record<MeasurementStatus, number>;
+
+export async function countMeasurementsByStatus(): Promise<MeasurementCounts> {
+  await ensureMigrated();
+  try {
+    const rows = db
+      .select({ status: measurements.status, total: count() })
+      .from(measurements)
+      .groupBy(measurements.status)
+      .all();
+    const out: MeasurementCounts = { pending: 0, uploading: 0, failed: 0, successful: 0 };
+    for (const r of rows) {
+      out[r.status] = r.total;
+    }
+    return out;
+  } catch (error) {
+    console.error("Failed to count measurements:", error);
+    return { pending: 0, uploading: 0, failed: 0, successful: 0 };
+  }
+}
+
+export async function getMeasurements(
+  status: MeasurementStatus | MeasurementStatus[],
+): Promise<StoredMeasurement[]> {
   try {
     await ensureMigrated();
-    const rows = db.select().from(measurements).where(eq(measurements.status, status)).all();
+    const statusList = Array.isArray(status) ? status : [status];
+    if (statusList.length === 0) return [];
+    const whereClause =
+      statusList.length === 1
+        ? eq(measurements.status, statusList[0])
+        : inArray(measurements.status, statusList);
+    const rows = db.select().from(measurements).where(whereClause).all();
 
     return rows
-      .map((row) => {
+      .map((row): StoredMeasurement | null => {
         try {
-          const measurement: Measurement = {
-            topic: row.topic,
-            measurementResult: decompressFromStorage(row.measurementResult),
-            metadata: {
-              experimentName: row.experimentName,
-              protocolName: row.protocolName,
-              timestamp: row.timestamp,
+          return {
+            id: row.id,
+            status: row.status,
+            data: {
+              topic: row.topic,
+              measurementResult: decompressFromStorage(row.measurementResult),
+              metadata: {
+                experimentName: row.experimentName,
+                protocolName: row.protocolName,
+                timestamp: row.timestamp,
+              },
             },
           };
-          return [row.id, measurement] as [string, Measurement];
         } catch {
           return null;
         }
       })
-      .filter(Boolean) as [string, Measurement][];
+      .filter((m): m is StoredMeasurement => m !== null);
   } catch (error) {
     console.error("Failed to fetch measurements:", error);
     throw error;
@@ -155,10 +195,14 @@ export async function markAsUploading(keys: string[]): Promise<string[]> {
   if (keys.length === 0) return [];
   await ensureMigrated();
   try {
+    // Both "pending" (never tried) and "failed" (tried before) rows are
+    // eligible for an upload attempt.
     const rows = db
       .update(measurements)
       .set({ status: "uploading" })
-      .where(and(inArray(measurements.id, keys), eq(measurements.status, "failed")))
+      .where(
+        and(inArray(measurements.id, keys), inArray(measurements.status, ["pending", "failed"])),
+      )
       .returning({ id: measurements.id })
       .all();
     return rows.map((r) => r.id);
@@ -171,20 +215,25 @@ export async function markAsUploading(keys: string[]): Promise<string[]> {
 export async function markAsFailed(key: string): Promise<void> {
   await ensureMigrated();
   try {
+    // Accept transitions from uploading (batch flow) or pending (save-first
+    // single-measurement flow whose MQTT publish errored).
     db.update(measurements)
       .set({ status: "failed" })
-      .where(and(eq(measurements.id, key), eq(measurements.status, "uploading")))
+      .where(and(eq(measurements.id, key), inArray(measurements.status, ["uploading", "pending"])))
       .run();
   } catch (error) {
-    console.error("Failed to revert measurement to failed:", error);
+    console.error("Failed to mark measurement as failed:", error);
   }
 }
 
 export async function resetUploadingMeasurements(): Promise<void> {
   await ensureMigrated();
   try {
+    // A row stuck in "uploading" was interrupted (app killed mid-publish);
+    // it never confirmed a failure, so return it to "pending" rather than
+    // marking it as failed.
     db.update(measurements)
-      .set({ status: "failed" })
+      .set({ status: "pending" })
       .where(eq(measurements.status, "uploading"))
       .run();
   } catch (error) {
@@ -195,9 +244,17 @@ export async function resetUploadingMeasurements(): Promise<void> {
 export async function markAsSuccessful(key: string): Promise<void> {
   await ensureMigrated();
   try {
+    // Accept any pre-success state. "pending" covers the save-first single
+    // flow that goes pending → successful directly, "uploading" the batch
+    // flow, "failed" a retry that finally went through.
     db.update(measurements)
       .set({ status: "successful" })
-      .where(and(eq(measurements.id, key), eq(measurements.status, "uploading")))
+      .where(
+        and(
+          eq(measurements.id, key),
+          inArray(measurements.status, ["pending", "uploading", "failed"]),
+        ),
+      )
       .run();
   } catch (error) {
     console.error("Failed to mark measurement as successful:", error);

--- a/apps/mobile/src/services/mqtt/__tests__/create-mqtt-connection.test.ts
+++ b/apps/mobile/src/services/mqtt/__tests__/create-mqtt-connection.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetItem = vi.fn();
+const mockSetItem = vi.fn();
+const mockRemoveItem = vi.fn();
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: {
+    getItem: mockGetItem,
+    setItem: mockSetItem,
+    removeItem: mockRemoveItem,
+  },
+}));
+
+class MockGetIdCommand {
+  constructor(public readonly input: { IdentityPoolId: string }) {}
+}
+class MockGetCredentialsForIdentityCommand {
+  constructor(public readonly input: { IdentityId: string }) {}
+}
+
+const mockSend = vi.fn();
+class MockCognitoIdentityClient {
+  send = mockSend;
+}
+vi.mock("@aws-sdk/client-cognito-identity", () => ({
+  CognitoIdentityClient: MockCognitoIdentityClient,
+  GetIdCommand: MockGetIdCommand,
+  GetCredentialsForIdentityCommand: MockGetCredentialsForIdentityCommand,
+}));
+
+// Stub out the rest of the module's heavy/native imports.
+vi.mock("paho-mqtt", () => ({ Client: vi.fn(), Message: vi.fn() }));
+vi.mock("react-native-get-random-values", () => ({}));
+vi.mock("~/stores/environment-store", () => ({ getEnvVar: () => "stub" }));
+vi.mock("~/utils/time-sync", () => ({
+  ensureSynced: vi.fn(),
+  getSyncedUtcDateTime: vi.fn(),
+  getTimeSyncState: vi.fn(),
+}));
+vi.mock("~/utils/emitter", () => ({ Emitter: vi.fn() }));
+vi.mock("~/utils/generate-random-string", () => ({ generateRandomString: () => "rand" }));
+vi.mock("crypto-js", () => ({
+  HmacSHA256: () => ({ toString: () => "h" }),
+  SHA256: () => ({ toString: () => "s" }),
+  enc: { Hex: {} },
+  lib: { WordArray: class {} },
+}));
+
+const POOL = "eu-central-1:test-pool";
+const REGION = "eu-central-1";
+
+const validCreds = (expiration: Date) => ({
+  AccessKeyId: "AKIA-EXAMPLE",
+  SecretKey: "secret-example",
+  SessionToken: "session-example",
+  Expiration: expiration,
+});
+
+interface Mod {
+  getCredentials: (args: { region: string; identityPoolId: string }) => Promise<{
+    accessKeyId: string;
+    secretAccessKey: string;
+    sessionToken: string;
+  }>;
+  _resetIdentityIdCacheForTests: () => void;
+  _resetCredentialsCacheForTests: () => void;
+}
+
+async function freshModule(): Promise<Mod> {
+  return (await import("../create-mqtt-connection")) as unknown as Mod;
+}
+
+describe("getCredentials — Cognito IdentityId persistence", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    mockGetItem.mockResolvedValue(null);
+    mockSetItem.mockResolvedValue(undefined);
+    mockRemoveItem.mockResolvedValue(undefined);
+    const mod = await freshModule();
+    mod._resetIdentityIdCacheForTests();
+    mod._resetCredentialsCacheForTests();
+  });
+
+  it("calls GetIdCommand once and persists the IdentityId to AsyncStorage on first fetch", async () => {
+    mockSend.mockImplementation((cmd: object) => {
+      if (cmd instanceof MockGetIdCommand) return Promise.resolve({ IdentityId: "id-1" });
+      return Promise.resolve({ Credentials: validCreds(new Date(Date.now() + 3600_000)) });
+    });
+
+    const mod = await freshModule();
+    await mod.getCredentials({ region: REGION, identityPoolId: POOL });
+
+    const getIdCalls = mockSend.mock.calls.filter((c) => c[0] instanceof MockGetIdCommand);
+    expect(getIdCalls).toHaveLength(1);
+    expect(mockSetItem).toHaveBeenCalledWith(`cognito_identity_id:${POOL}`, "id-1");
+  });
+
+  it("reuses the persisted IdentityId on a fresh process (AsyncStorage hit) — no GetId call", async () => {
+    mockGetItem.mockResolvedValueOnce("persisted-id");
+    mockSend.mockResolvedValue({
+      Credentials: validCreds(new Date(Date.now() + 3600_000)),
+    });
+
+    const mod = await freshModule();
+    await mod.getCredentials({ region: REGION, identityPoolId: POOL });
+
+    const getIdCalls = mockSend.mock.calls.filter((c) => c[0] instanceof MockGetIdCommand);
+    expect(getIdCalls).toHaveLength(0);
+
+    const credCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof MockGetCredentialsForIdentityCommand,
+    );
+    expect(credCalls[0][0].input.IdentityId).toBe("persisted-id");
+  });
+
+  it("clears the cached IdentityId and re-fetches when ResourceNotFoundException is raised", async () => {
+    mockGetItem.mockResolvedValueOnce("stale-id");
+
+    const stale = Object.assign(new Error("not found"), { name: "ResourceNotFoundException" });
+    let getCredsCalls = 0;
+    mockSend.mockImplementation((cmd: object) => {
+      if (cmd instanceof MockGetIdCommand) return Promise.resolve({ IdentityId: "fresh-id" });
+      if (cmd instanceof MockGetCredentialsForIdentityCommand) {
+        getCredsCalls += 1;
+        if (getCredsCalls === 1) return Promise.reject(stale);
+        return Promise.resolve({ Credentials: validCreds(new Date(Date.now() + 3600_000)) });
+      }
+      return Promise.reject(new Error("unexpected"));
+    });
+
+    const mod = await freshModule();
+    const creds = await mod.getCredentials({ region: REGION, identityPoolId: POOL });
+
+    expect(creds.accessKeyId).toBe("AKIA-EXAMPLE");
+    expect(mockRemoveItem).toHaveBeenCalledWith(`cognito_identity_id:${POOL}`);
+    const getIdCalls = mockSend.mock.calls.filter((c) => c[0] instanceof MockGetIdCommand);
+    expect(getIdCalls).toHaveLength(1); // refresh after eviction
+  });
+
+  it("collapses concurrent first-time callers into one GetId + one GetCredentials", async () => {
+    let resolveCreds: (v: unknown) => void = () => undefined;
+    const credsPromise = new Promise((r) => {
+      resolveCreds = r;
+    });
+    mockSend.mockImplementation((cmd: object) => {
+      if (cmd instanceof MockGetIdCommand) return Promise.resolve({ IdentityId: "id-1" });
+      return credsPromise;
+    });
+
+    const mod = await freshModule();
+    const a = mod.getCredentials({ region: REGION, identityPoolId: POOL });
+    const b = mod.getCredentials({ region: REGION, identityPoolId: POOL });
+    const c = mod.getCredentials({ region: REGION, identityPoolId: POOL });
+
+    resolveCreds({ Credentials: validCreds(new Date(Date.now() + 3600_000)) });
+    await Promise.all([a, b, c]);
+
+    const getIdCalls = mockSend.mock.calls.filter((c) => c[0] instanceof MockGetIdCommand);
+    const credCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof MockGetCredentialsForIdentityCommand,
+    );
+    expect(getIdCalls).toHaveLength(1);
+    expect(credCalls).toHaveLength(1);
+  });
+});
+
+describe("getCredentials — in-memory credential cache", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    mockGetItem.mockResolvedValue("id-1"); // simulate IdentityId already persisted
+    mockSetItem.mockResolvedValue(undefined);
+    mockRemoveItem.mockResolvedValue(undefined);
+    const mod = await freshModule();
+    mod._resetIdentityIdCacheForTests();
+    mod._resetCredentialsCacheForTests();
+  });
+
+  it("returns cached credentials on a second call without hitting Cognito", async () => {
+    mockSend.mockResolvedValue({
+      Credentials: validCreds(new Date(Date.now() + 3600_000)),
+    });
+
+    const mod = await freshModule();
+    await mod.getCredentials({ region: REGION, identityPoolId: POOL });
+    const sendCallsAfterFirst = mockSend.mock.calls.length;
+
+    await mod.getCredentials({ region: REGION, identityPoolId: POOL });
+    expect(mockSend.mock.calls.length).toBe(sendCallsAfterFirst); // no additional SDK calls
+  });
+
+  it("re-fetches credentials once the SDK-reported Expiration has passed", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-13T12:00:00Z"));
+
+    mockSend.mockImplementation((cmd: object) => {
+      if (cmd instanceof MockGetIdCommand) return Promise.resolve({ IdentityId: "id-1" });
+      return Promise.resolve({
+        // 30 minutes from "now"
+        Credentials: validCreds(new Date(Date.now() + 30 * 60_000)),
+      });
+    });
+
+    const mod = await freshModule();
+    await mod.getCredentials({ region: REGION, identityPoolId: POOL });
+
+    // Jump past expiration
+    vi.setSystemTime(new Date("2026-05-13T12:31:00Z"));
+    await mod.getCredentials({ region: REGION, identityPoolId: POOL });
+
+    const credCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof MockGetCredentialsForIdentityCommand,
+    );
+    expect(credCalls).toHaveLength(2);
+  });
+
+  it("re-fetches credentials when within the safety margin of expiration (under 60s remaining)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-13T12:00:00Z"));
+
+    mockSend.mockImplementation((cmd: object) => {
+      if (cmd instanceof MockGetIdCommand) return Promise.resolve({ IdentityId: "id-1" });
+      return Promise.resolve({
+        Credentials: validCreds(new Date(Date.now() + 60 * 60_000)),
+      });
+    });
+
+    const mod = await freshModule();
+    await mod.getCredentials({ region: REGION, identityPoolId: POOL });
+
+    // 30 seconds before expiration — within the 60s safety margin
+    vi.setSystemTime(new Date("2026-05-13T12:59:30Z"));
+    await mod.getCredentials({ region: REGION, identityPoolId: POOL });
+
+    const credCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof MockGetCredentialsForIdentityCommand,
+    );
+    expect(credCalls).toHaveLength(2);
+  });
+
+  it("collapses concurrent in-flight credential fetches into one SDK call", async () => {
+    let resolveCreds: (v: unknown) => void = () => undefined;
+    const credsPromise = new Promise((r) => {
+      resolveCreds = r;
+    });
+    mockSend.mockImplementation((cmd: object) => {
+      if (cmd instanceof MockGetIdCommand) return Promise.resolve({ IdentityId: "id-1" });
+      return credsPromise;
+    });
+
+    const mod = await freshModule();
+    const promises = [
+      mod.getCredentials({ region: REGION, identityPoolId: POOL }),
+      mod.getCredentials({ region: REGION, identityPoolId: POOL }),
+      mod.getCredentials({ region: REGION, identityPoolId: POOL }),
+    ];
+
+    resolveCreds({ Credentials: validCreds(new Date(Date.now() + 3600_000)) });
+    const results = await Promise.all(promises);
+
+    expect(results).toHaveLength(3);
+    const credCalls = mockSend.mock.calls.filter(
+      (c) => c[0] instanceof MockGetCredentialsForIdentityCommand,
+    );
+    expect(credCalls).toHaveLength(1);
+  });
+
+  it("evicts the cache on failure so the next caller can retry cleanly", async () => {
+    mockSend.mockImplementationOnce((cmd: object) => {
+      if (cmd instanceof MockGetCredentialsForIdentityCommand) {
+        return Promise.reject(new Error("network down"));
+      }
+      return Promise.resolve({});
+    });
+
+    const mod = await freshModule();
+    await expect(mod.getCredentials({ region: REGION, identityPoolId: POOL })).rejects.toThrow(
+      "network down",
+    );
+
+    // Subsequent call should retry the SDK rather than returning a poisoned cache.
+    mockSend.mockImplementation((cmd: object) => {
+      if (cmd instanceof MockGetIdCommand) return Promise.resolve({ IdentityId: "id-1" });
+      return Promise.resolve({ Credentials: validCreds(new Date(Date.now() + 3600_000)) });
+    });
+    const creds = await mod.getCredentials({ region: REGION, identityPoolId: POOL });
+    expect(creds.accessKeyId).toBe("AKIA-EXAMPLE");
+  });
+});

--- a/apps/mobile/src/services/mqtt/__tests__/create-mqtt-connection.test.ts
+++ b/apps/mobile/src/services/mqtt/__tests__/create-mqtt-connection.test.ts
@@ -139,6 +139,59 @@ describe("getCredentials — Cognito IdentityId persistence", () => {
     expect(getIdCalls).toHaveLength(1); // refresh after eviction
   });
 
+  it("still caches in memory if AsyncStorage.setItem throws when persisting a new IdentityId", async () => {
+    mockSend.mockImplementation((cmd: object) => {
+      if (cmd instanceof MockGetIdCommand) return Promise.resolve({ IdentityId: "minted" });
+      return Promise.resolve({ Credentials: validCreds(new Date(Date.now() + 3600_000)) });
+    });
+    mockSetItem.mockRejectedValueOnce(new Error("disk full"));
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+
+    const mod = await freshModule();
+    const creds = await mod.getCredentials({ region: REGION, identityPoolId: POOL });
+    expect(creds.accessKeyId).toBe("AKIA-EXAMPLE");
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[mqtt] Failed to persist Cognito IdentityId:",
+      expect.any(Error),
+    );
+
+    // Second call within the same process uses the in-memory cache — no extra GetId.
+    await mod.getCredentials({ region: REGION, identityPoolId: POOL });
+    const getIdCalls = mockSend.mock.calls.filter((c) => c[0] instanceof MockGetIdCommand);
+    expect(getIdCalls).toHaveLength(1);
+
+    consoleSpy.mockRestore();
+  });
+
+  it("continues when AsyncStorage.removeItem throws while clearing a stale IdentityId", async () => {
+    mockGetItem.mockResolvedValueOnce("stale-id");
+    mockRemoveItem.mockRejectedValueOnce(new Error("disk error"));
+
+    const stale = Object.assign(new Error("not found"), { name: "ResourceNotFoundException" });
+    let getCredsCalls = 0;
+    mockSend.mockImplementation((cmd: object) => {
+      if (cmd instanceof MockGetIdCommand) return Promise.resolve({ IdentityId: "fresh-id" });
+      if (cmd instanceof MockGetCredentialsForIdentityCommand) {
+        getCredsCalls += 1;
+        if (getCredsCalls === 1) return Promise.reject(stale);
+        return Promise.resolve({ Credentials: validCreds(new Date(Date.now() + 3600_000)) });
+      }
+      return Promise.reject(new Error("unexpected"));
+    });
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+
+    const mod = await freshModule();
+    const creds = await mod.getCredentials({ region: REGION, identityPoolId: POOL });
+
+    expect(creds.accessKeyId).toBe("AKIA-EXAMPLE");
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[mqtt] Failed to clear persisted Cognito IdentityId:",
+      expect.any(Error),
+    );
+
+    consoleSpy.mockRestore();
+  });
+
   it("collapses concurrent first-time callers into one GetId + one GetCredentials", async () => {
     let resolveCreds: (v: unknown) => void = () => undefined;
     const credsPromise = new Promise((r) => {

--- a/apps/mobile/src/services/mqtt/create-mqtt-connection.ts
+++ b/apps/mobile/src/services/mqtt/create-mqtt-connection.ts
@@ -3,6 +3,7 @@ import {
   GetIdCommand,
   GetCredentialsForIdentityCommand,
 } from "@aws-sdk/client-cognito-identity";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { HmacSHA256, SHA256, enc, lib } from "crypto-js";
 import { Client, Message, MQTTError } from "paho-mqtt";
 import "react-native-get-random-values";
@@ -89,36 +90,184 @@ export async function createSignedUrl(params: {
   return `wss://${params.endpoint}${canonicalUri}?${query}`;
 }
 
-async function getCredentials({
+// Cognito IdentityId is durable per device + pool — once issued it can be
+// reused forever. Calling GetId on every connection creates a brand-new
+// identity each time (driving the pool's identity count up indefinitely)
+// and adds a serial request to every upload. Persist it once and reuse.
+const IDENTITY_ID_STORAGE_PREFIX = "cognito_identity_id:";
+
+let cachedIdentityId: string | null = null;
+let inflightIdentityIdPromise: Promise<string> | null = null;
+
+function storageKeyFor(identityPoolId: string): string {
+  return `${IDENTITY_ID_STORAGE_PREFIX}${identityPoolId}`;
+}
+
+async function fetchAndPersistIdentityId(
+  identityClient: CognitoIdentityClient,
+  identityPoolId: string,
+): Promise<string> {
+  const { IdentityId } = await identityClient.send(
+    new GetIdCommand({ IdentityPoolId: identityPoolId }),
+  );
+  if (!IdentityId) throw new Error("Missing identity ID");
+  try {
+    await AsyncStorage.setItem(storageKeyFor(identityPoolId), IdentityId);
+  } catch (e) {
+    console.warn("[mqtt] Failed to persist Cognito IdentityId:", e);
+  }
+  cachedIdentityId = IdentityId;
+  return IdentityId;
+}
+
+async function getOrCreateIdentityId(
+  identityClient: CognitoIdentityClient,
+  identityPoolId: string,
+): Promise<string> {
+  if (cachedIdentityId) return cachedIdentityId;
+  if (inflightIdentityIdPromise) return inflightIdentityIdPromise;
+
+  inflightIdentityIdPromise = (async () => {
+    const stored = await AsyncStorage.getItem(storageKeyFor(identityPoolId));
+    if (stored) {
+      cachedIdentityId = stored;
+      return stored;
+    }
+    return fetchAndPersistIdentityId(identityClient, identityPoolId);
+  })();
+
+  try {
+    return await inflightIdentityIdPromise;
+  } finally {
+    inflightIdentityIdPromise = null;
+  }
+}
+
+async function clearCachedIdentityId(identityPoolId: string): Promise<void> {
+  cachedIdentityId = null;
+  try {
+    await AsyncStorage.removeItem(storageKeyFor(identityPoolId));
+  } catch (e) {
+    console.warn("[mqtt] Failed to clear persisted Cognito IdentityId:", e);
+  }
+}
+
+// Cognito unauth credentials are valid for ~1h. Reuse the same set across
+// every MQTT publish in that window — kept in memory only (never on disk:
+// these *are* secrets, unlike the IdentityId above). Refresh ~1 min before
+// the SDK-reported Expiration so a publish in flight doesn't race expiry.
+const CREDENTIALS_SAFETY_MARGIN_MS = 60_000;
+// Fallback TTL if the SDK doesn't populate Expiration (shouldn't happen for
+// Cognito, but defend against an undefined slipping through to NaN math).
+const CREDENTIALS_FALLBACK_TTL_MS = 50 * 60_000;
+
+interface CachedCredentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken: string;
+  expiresAt: number;
+}
+
+let cachedCredentials: CachedCredentials | null = null;
+let inflightCredentialsPromise: Promise<CachedCredentials> | null = null;
+
+function isStillValid(c: CachedCredentials): boolean {
+  return c.expiresAt - Date.now() > CREDENTIALS_SAFETY_MARGIN_MS;
+}
+
+function toReturnShape(c: CachedCredentials) {
+  return {
+    accessKeyId: c.accessKeyId,
+    secretAccessKey: c.secretAccessKey,
+    sessionToken: c.sessionToken,
+  };
+}
+
+// Test seam — lets unit tests reset module-level cache state between runs.
+export function _resetIdentityIdCacheForTests(): void {
+  cachedIdentityId = null;
+  inflightIdentityIdPromise = null;
+}
+
+export function _resetCredentialsCacheForTests(): void {
+  cachedCredentials = null;
+  inflightCredentialsPromise = null;
+}
+
+export async function getCredentials({
   region,
   identityPoolId,
 }: {
   region: string;
   identityPoolId: string;
 }) {
-  const identityClient = new CognitoIdentityClient({ region });
-  const { IdentityId } = await identityClient.send(
-    new GetIdCommand({ IdentityPoolId: identityPoolId }),
-  );
-  if (!IdentityId) throw new Error("Missing identity ID");
-
-  const { Credentials } = await identityClient.send(
-    new GetCredentialsForIdentityCommand({ IdentityId }),
-  );
-
-  if (!Credentials) throw new Error("Missing credentials");
-
-  const {
-    AccessKeyId: accessKeyId,
-    SecretKey: secretAccessKey,
-    SessionToken: sessionToken,
-  } = Credentials;
-
-  if (!accessKeyId || !secretAccessKey || !sessionToken) {
-    throw new Error("Missing one or more required environment variables.");
+  if (cachedCredentials && isStillValid(cachedCredentials)) {
+    return toReturnShape(cachedCredentials);
+  }
+  if (inflightCredentialsPromise) {
+    return toReturnShape(await inflightCredentialsPromise);
   }
 
-  return { accessKeyId, secretAccessKey, sessionToken };
+  inflightCredentialsPromise = (async () => {
+    const identityClient = new CognitoIdentityClient({ region });
+
+    const fetchCredentialsFor = async (IdentityId: string) => {
+      const { Credentials } = await identityClient.send(
+        new GetCredentialsForIdentityCommand({ IdentityId }),
+      );
+      if (!Credentials) throw new Error("Missing credentials");
+      return Credentials;
+    };
+
+    let IdentityId = await getOrCreateIdentityId(identityClient, identityPoolId);
+    let Credentials;
+    try {
+      Credentials = await fetchCredentialsFor(IdentityId);
+    } catch (err) {
+      // The cached identity may have been deleted out from under us (manual
+      // pool cleanup, expired unauth identity, etc). Drop the cache, mint a
+      // fresh one, and try exactly once more.
+      const name = (err as { name?: string })?.name;
+      if (name === "ResourceNotFoundException" || name === "NotAuthorizedException") {
+        console.warn(`[mqtt] Cached IdentityId rejected (${name}); refreshing.`);
+        await clearCachedIdentityId(identityPoolId);
+        IdentityId = await fetchAndPersistIdentityId(identityClient, identityPoolId);
+        Credentials = await fetchCredentialsFor(IdentityId);
+      } else {
+        throw err;
+      }
+    }
+
+    const {
+      AccessKeyId: accessKeyId,
+      SecretKey: secretAccessKey,
+      SessionToken: sessionToken,
+      Expiration,
+    } = Credentials;
+
+    if (!accessKeyId || !secretAccessKey || !sessionToken) {
+      throw new Error("Missing one or more required AWS credential fields.");
+    }
+
+    const expiresAt = Expiration
+      ? new Date(Expiration).getTime()
+      : Date.now() + CREDENTIALS_FALLBACK_TTL_MS;
+
+    const next: CachedCredentials = { accessKeyId, secretAccessKey, sessionToken, expiresAt };
+    cachedCredentials = next;
+    return next;
+  })();
+
+  try {
+    const fresh = await inflightCredentialsPromise;
+    return toReturnShape(fresh);
+  } catch (err) {
+    // Don't leave a poisoned cache pinned — let the next caller retry.
+    cachedCredentials = null;
+    throw err;
+  } finally {
+    inflightCredentialsPromise = null;
+  }
 }
 
 function connectToMqtt(url: string, clientId: string) {

--- a/apps/mobile/src/services/mqtt/send-mqtt-event.ts
+++ b/apps/mobile/src/services/mqtt/send-mqtt-event.ts
@@ -1,8 +1,8 @@
 import { createMqttConnection, ReceivedMessage } from "~/services/mqtt/create-mqtt-connection";
 
-// paho-mqtt + the Cognito handshake can hang silently when the device is
-// offline or AWS is throttling. Without a hard ceiling the caller's promise
-// never settles, leaving the measurement in limbo (not saved, not failed).
+// paho-mqtt + the Cognito handshake can hang silently when AWS is throttling
+// or the network is flapping. Without a hard ceiling the caller's promise
+// never settles, blocking the UI on a row that's already saved as "pending".
 const DEFAULT_TIMEOUT_MS = 15_000;
 
 export async function sendMqttEvent(

--- a/apps/mobile/src/services/mqtt/send-mqtt-event.ts
+++ b/apps/mobile/src/services/mqtt/send-mqtt-event.ts
@@ -1,6 +1,15 @@
 import { createMqttConnection, ReceivedMessage } from "~/services/mqtt/create-mqtt-connection";
 
-export async function sendMqttEvent(topic: string, payload: object) {
+// paho-mqtt + the Cognito handshake can hang silently when the device is
+// offline or AWS is throttling. Without a hard ceiling the caller's promise
+// never settles, leaving the measurement in limbo (not saved, not failed).
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+export async function sendMqttEvent(
+  topic: string,
+  payload: object,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+) {
   const emitter = await createMqttConnection();
   await emitter.emit("sendMessage", {
     topic,
@@ -14,9 +23,18 @@ export async function sendMqttEvent(topic: string, payload: object) {
     emitter.on("connectionLost", (error) => reject(new Error(error.errorMessage)));
   });
 
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(
+      () => reject(new Error(`MQTT publish timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+  });
+
   try {
-    await resultPromise;
+    await Promise.race([resultPromise, timeoutPromise]);
   } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
     emitter.emit("destroy").catch((e) => console.log("connection already destroyed", e));
   }
 

--- a/apps/mobile/src/utils/uniq.ts
+++ b/apps/mobile/src/utils/uniq.ts
@@ -1,5 +1,5 @@
 export function uniq<T>(items: readonly T[]): T[] {
-  return [...new Set(items)];
+  return Array.from(new Set(items));
 }
 
 export function uniqBy<T, K>(items: readonly T[], key: (item: T) => K): T[] {

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "lib": ["es2017"],
     "module": "ESNext",
+    "declaration": false,
+    "declarationMap": false,
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "baseUrl": ".",


### PR DESCRIPTION
## Summary

Three connected fixes for the bug Tom reported after the Grebbedijk field session (~2000 measurements/day), plus a small CI gate added at the end so the next typecheck regression doesn't slip through.

- **OJD-1514** — Offline measurements vanished from Recent until reconnect, by which point they had synced and the flag UI was gone.
- **OJD-1515** — Post-field upload burst saturated AWS Cognito; the Identity Pool had accumulated ~20K junk identities and credentials were re-fetched on every publish.
- **OJD-1516** — New `pending` measurement status (distinct from `failed`) + DB-level CHECK constraint via a SQLite migration.

Linked tickets:
- https://linear.app/openjii/issue/OJD-1514
- https://linear.app/openjii/issue/OJD-1515
- https://linear.app/openjii/issue/OJD-1516

## OJD-1514 — Save-before-upload

`use-measurement-upload.ts` and `use-questions-upload.ts` now persist the measurement to local SQLite **as `pending`** *before* the MQTT publish. On success → `markUploaded` flips to `successful`; on failure → `markFailed` flips to `failed`. The row appears in Recent immediately, regardless of network state, and the flag UI is reachable until the upload confirms.

The publish path and the local-state write are in separate try/catch blocks: a `markUploaded` failure that fires *after* a successful MQTT publish no longer regresses the row to `failed` — the data is already on the cloud, so we only surface a soft info toast and log the local issue.

`sendMqttEvent` got a 15s hard timeout (`Promise.race`) so AWS Cognito / paho-mqtt hangs surface as normal failures instead of silent limbo.

## OJD-1515 — Stop saturating AWS Cognito

Three issues in `create-mqtt-connection.ts`:

1. `GetIdCommand` was called on **every** MQTT publish. Each call mints a fresh Cognito identity. Now persisted in AsyncStorage keyed by `cognito_identity_id:<IdentityPoolId>`; stale identities are cleared and re-minted on `ResourceNotFoundException` / `NotAuthorizedException`.
2. AWS credentials were re-fetched on every publish too. New in-memory cache respects SDK-reported `Expiration` minus a 60s safety margin; refresh-once-then-share promise lock for concurrent callers. **Credentials never persisted to disk** — only the public `IdentityId` is on disk.
3. Mobile batch uploader concurrency 10 → 3 to flatten the post-field burst.

A phone uploading 200 measurements in a session: was 200 `GetId` + 200 `GetCredentials` → now 0 + 1.

## OJD-1516 — `pending` status + CHECK constraint

`MeasurementStatus` enum is now `pending | uploading | failed | successful`. `pending` distinguishes never-attempted from genuinely-failed so field metrics stop conflating them.

`apps/mobile/drizzle/0001_add_pending_status.sql` — SQLite table-recreate (SQLite can't add CHECK in place). Existing rows keep their statuses (all still valid). The CHECK enforces the four values at the DB level.

Side improvements:
- `getMeasurements` accepts `MeasurementStatus | MeasurementStatus[]` and returns `{ id, status, data }` rows.
- `useAllMeasurements` now pushes the active filter into the SQL query (no JS-side filtering) and reads counts from a dedicated `COUNT GROUP BY` SQL query (`countMeasurementsByStatus`). No JS state duplicating DB data.
- UI surfaces the raw storage status — no lossy `synced`/`unsynced`/`syncing` mapping. `pending` rows get their own `CloudUpload` icon distinct from `failed`'s alert.
- `resetUploadingMeasurements` resets interrupted `uploading` rows to `pending` (they were never confirmed failed) instead of `failed`.
- List-cache query keys: `setQueryData(["measurements"], …)` was a no-op against the new `["measurements", "list", filter]` cache; replaced with `invalidateQueries({ queryKey: ["measurements"] })` which prefix-matches every measurements-derived cache.

## UX polish

Delete-confirmation copy now distinguishes the two outcomes — they were both reading as "delete from local storage" but the consequences are very different:
- **Synced** → *"Remove from phone"* — explains the cloud copy stays intact.
- **Unsynced** → *"Delete unsynced measurement"* — warns the measurement will be lost permanently.

## CI gate for typecheck

A latent typecheck regression on this branch was caught only after running `tsc` locally — CI ran lint + test but never type-checked the mobile app. To prevent recurrence:

- Added a **Type Check Packages** step to `pr.yml` that runs `pnpm turbo run check-types` for the affected apps.
- `apps/mobile/package.json` now exposes a `check-types` alias (`tsc --noEmit`) so the existing turbo task picks it up — matches `apps/web`'s convention.
- Fixed three latent type errors that this exposed on `main`:
  - `FlowNodeType` was missing `"branch"` (the API schema already emits it).
  - `uniq()` used `[...new Set(...)]` which needs `target >= es2015`; switched to `Array.from(...)`.
  - Mobile tsconfig now disables `declaration`/`declarationMap` (mobile is an app, not a library — the `@ts-rest` contract type defeats declaration emit with TS2742 + TS7056).

## Test plan

- [x] `pnpm vitest run` — **362/362 passing**.
- [x] `pnpm lint` — clean.
- [x] `pnpm turbo run check-types --filter=mobile` — clean.
- [x] Migration upgrade-path test: seed v0 schema, apply `0001`, verify (a) rows preserved with original statuses, (b) non-status columns preserved verbatim, (c) CHECK activates post-migration, (d) `pending` accepted, (e) safely re-runnable.
- [x] Cognito caches: 9 cases covering GetId persistence, AsyncStorage hit, stale-identity recovery, concurrent first-time callers sharing one fetch, credentials reuse, expiration refresh (fake timers), safety-margin refresh, concurrent-fetch dedup, eviction-on-failure.
- [x] Regression test: `markUploaded` failure after successful publish does NOT flip row to `failed` (covered in `use-measurements`, `use-measurement-upload`, `use-questions-upload` test suites).
- [x] Manual: install on device, take measurements with airplane mode on → confirm they appear in Recent instantly with `pending` icon → toggle airplane mode off → confirm they flip to `successful`.
- [ ] Manual: confirm flag UI is reachable on `pending` rows.
- [ ] After deploy: monitor Cognito Identity Pool size to confirm no new junk identities are minted per publish.

## Notes / follow-ups (not in this PR)

- **Flag-after-sync** — once flagged on the device fails (currently you can't flag a `successful` row). Petar mentioned a ticket may already be in flight; out of scope here.
- **New filtering / visualization view** — exists per Petar; not wired up in this PR.
- The four-value enum opens the door to surfacing pending count separately in the toolbar if useful for field operations.