### PR TITLE
feat(web): wire data-filter chip bar into the experiment data table with URL-persisted filters

### DIFF
--- a/apps/web/components/experiment-data/experiment-data-table.tsx
+++ b/apps/web/components/experiment-data/experiment-data-table.tsx
@@ -20,6 +20,7 @@ import {
   formatValue,
   LoadingRows,
 } from "~/components/experiment-data/experiment-data-utils";
+import { useUrlDataFilters } from "~/hooks/useUrlDataFilters";
 
 import type { AnnotationType } from "@repo/api/schemas/experiment.schema";
 import { useTranslation } from "@repo/i18n";
@@ -44,12 +45,11 @@ import { Skeleton } from "@repo/ui/components/skeleton";
 import { Table, TableBody } from "@repo/ui/components/table";
 import { cn } from "@repo/ui/lib/utils";
 
+import { FilterChipBar } from "../data-filters/filter-chip-bar";
 import { DataExportModal } from "./data-export-modal/data-export-modal";
 import { ExperimentDataTableChart } from "./table-chart/experiment-data-table-chart";
 
-// Helper function to map column names for sorting
 function getSortColumnName(columnName: string, columnType?: string): string {
-  // For USER columns, sort by user_name instead of the column name
   if (columnType === "USER") {
     return "user_name";
   }
@@ -82,7 +82,8 @@ export function ExperimentDataTable({
   const [sortColumn, setSortColumn] = useState<string | undefined>(defaultSortColumn);
   const [sortDirection, setSortDirection] = useState<"ASC" | "DESC">("DESC");
 
-  // Annotation dialog states
+  const { filters, setFilters, completeFilters: activeFilters } = useUrlDataFilters(tableName);
+
   const [addAnnotationDialogOpen, setAddAnnotationDialogOpen] = useState(false);
   const [addAnnotationRowIds, setAddAnnotationRowIds] = useState<string[]>([]);
   const [addAnnotationType, setAddAnnotationType] = useState<AnnotationType>("comment");
@@ -90,49 +91,38 @@ export function ExperimentDataTable({
   const [deleteAnnotationRowIds, setDeleteAnnotationRowIds] = useState<string[]>([]);
   const [deleteAnnotationType, setDeleteAnnotationType] = useState<AnnotationType>("comment");
 
-  // Row selection state (TanStack Table)
   const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({});
 
-  // Form to track selection for bulk actions
   const selectionForm = useForm<BulkSelectionFormType>({
     resolver: zodResolver(bulkSelectionFormSchema),
     defaultValues: { selectedRowIds: [] },
   });
 
-  // Chart state
   const [chartDisplay, setChartDisplay] = useState<{
     data: number[];
     columnName: string;
     isPinned: boolean;
   } | null>(null);
 
-  // Expandable cell state - only one cell can be expanded at a time
   const [expandedCell, setExpandedCell] = useState<{ rowId: string; columnName: string } | null>(
     null,
   );
 
   const { t } = useTranslation();
 
-  // Remove hover functionality - chart only shows on click
-
-  // Toggle chart pinning on click
   const toggleChartPin = useCallback((data: number[], columnName: string) => {
     setChartDisplay((prev) => {
-      // If clicking the same pinned chart, unpin it
       if (prev?.isPinned && prev.columnName === columnName) {
         return null;
       }
-      // Otherwise, pin this chart
       return { data, columnName, isPinned: true };
     });
   }, []);
 
-  // Close pinned chart
   const closePinnedChart = useCallback(() => {
     setChartDisplay(null);
   }, []);
 
-  // Expandable cell handlers
   const toggleCellExpansion = useCallback((rowId: string, columnName: string) => {
     setExpandedCell((prev) =>
       prev?.rowId === rowId && prev.columnName === columnName ? null : { rowId, columnName },
@@ -146,7 +136,6 @@ export function ExperimentDataTable({
     [expandedCell],
   );
 
-  // Annotation dialog handlers
   const openAddAnnotationDialog = useCallback(
     (rowIds: string[], type: AnnotationType = "comment") => {
       setAddAnnotationRowIds(rowIds);
@@ -165,15 +154,12 @@ export function ExperimentDataTable({
     [],
   );
 
-  // Toggle sorting for a column
   const handleSort = useCallback(
     (columnName: string, columnType?: string) => {
       const actualSortColumn = getSortColumnName(columnName, columnType);
       if (sortColumn === actualSortColumn) {
-        // Toggle direction if same column
         setSortDirection((prev) => (prev === "ASC" ? "DESC" : "ASC"));
       } else {
-        // New column, default to ASC
         setSortColumn(actualSortColumn);
         setSortDirection("ASC");
       }
@@ -181,7 +167,6 @@ export function ExperimentDataTable({
     [sortColumn],
   );
 
-  // Use traditional pagination with improved column persistence
   const { tableMetadata, tableRows, isLoading, error } = useExperimentData({
     experimentId,
     page: pagination.pageIndex + 1,
@@ -189,6 +174,7 @@ export function ExperimentDataTable({
     tableName,
     orderBy: sortColumn,
     orderDirection: sortDirection,
+    filters: activeFilters,
     formatFunction: formatValue,
     onChartClick: toggleChartPin,
     onAddAnnotation: openAddAnnotationDialog,
@@ -198,6 +184,12 @@ export function ExperimentDataTable({
     errorColumn,
   });
 
+  // Filters drop totalPages to 1; snap pageIndex back so the UI doesn't show "page 5 of 1".
+  const filtersKey = JSON.stringify(activeFilters);
+  useEffect(() => {
+    setPagination((prev) => (prev.pageIndex === 0 ? prev : { ...prev, pageIndex: 0 }));
+  }, [filtersKey]);
+
   const onPaginationChange = useCallback(
     (updaterOrValue: Updater<PaginationState>) => {
       if (typeof updaterOrValue === "function") {
@@ -206,7 +198,6 @@ export function ExperimentDataTable({
       } else {
         setPagination(updaterOrValue);
       }
-      // Clear selection on page change
       setRowSelection({});
     },
     [pagination],
@@ -217,7 +208,6 @@ export function ExperimentDataTable({
     setPagination(newPagination);
   }
 
-  // Update persisted metadata when we get new data
   useEffect(() => {
     if (tableMetadata) {
       setPersistedMetaData(tableMetadata);
@@ -228,9 +218,10 @@ export function ExperimentDataTable({
   const totalPages = persistedMetaData?.totalPages ?? 0;
   const totalRows = persistedMetaData?.totalRows ?? 0;
 
-  // Create columns with checkbox column
   const columns = React.useMemo(() => {
-    if (!persistedMetaData?.columns) return [];
+    if (!persistedMetaData?.columns) {
+      return [];
+    }
 
     return [
       {
@@ -295,7 +286,6 @@ export function ExperimentDataTable({
     },
   });
 
-  // Derive selected row IDs from table state
   const selectedRowIds = Object.keys(rowSelection);
 
   useEffect(() => {
@@ -339,7 +329,6 @@ export function ExperimentDataTable({
     return <div>{t("experimentDataTable.noData")}</div>;
   }
 
-  // Calculate column count for empty state
   const loadingRowCount =
     pagination.pageIndex + 1 == totalPages ? totalRows % pagination.pageSize : pagination.pageSize;
 
@@ -347,6 +336,17 @@ export function ExperimentDataTable({
     <Form {...selectionForm}>
       <form className="grid max-w-full">
         <h5 className="mb-3 text-base font-medium">{displayName}</h5>
+        {persistedMetaData?.rawColumns && persistedMetaData.rawColumns.length > 0 && (
+          <div className="mb-4">
+            <FilterChipBar
+              experimentId={experimentId}
+              tableName={tableName}
+              columns={persistedMetaData.rawColumns}
+              value={filters}
+              onChange={setFilters}
+            />
+          </div>
+        )}
         <BulkActionsBar
           rowIds={selectedRowIds}
           tableRows={tableRows}
@@ -379,7 +379,6 @@ export function ExperimentDataTable({
             </TableBody>
           </Table>
         </div>
-        {/* Traditional pagination controls */}
         <div className="mt-4 flex w-full flex-col items-center justify-between gap-4 overflow-auto p-1 text-sm sm:flex-row sm:gap-8">
           <div className="flex-1 whitespace-nowrap">
             {t("experimentDataTable.totalRows")}: {totalRows}

--- a/apps/web/components/experiment-data/experiment-data-table.tsx
+++ b/apps/web/components/experiment-data/experiment-data-table.tsx
@@ -185,9 +185,11 @@ export function ExperimentDataTable({
   });
 
   // Filters drop totalPages to 1; snap pageIndex back so the UI doesn't show "page 5 of 1".
+  // Selection is keyed by row id and would point at rows that no longer exist after a filter change.
   const filtersKey = JSON.stringify(activeFilters);
   useEffect(() => {
     setPagination((prev) => (prev.pageIndex === 0 ? prev : { ...prev, pageIndex: 0 }));
+    setRowSelection({});
   }, [filtersKey]);
 
   const onPaginationChange = useCallback(

--- a/apps/web/hooks/experiment/useExperimentData/useExperimentData.ts
+++ b/apps/web/hooks/experiment/useExperimentData/useExperimentData.ts
@@ -8,7 +8,9 @@ import type {
   ExperimentData,
   AnnotationType,
   DataColumn,
+  DataFilter,
 } from "@repo/api/schemas/experiment.schema";
+import { zDataFilter } from "@repo/api/schemas/experiment.schema";
 import {
   isTimestampType,
   isStringType,
@@ -39,19 +41,90 @@ export type DataRenderFunction = (
 // Time in ms before data is removed from the cache
 const STALE_TIME = 2 * 60 * 1000;
 
+// Pinned to the front in a fixed display order. Shared across the rendered
+// table columns AND the `rawColumns` array so consumers like the dashboard
+// table-widget column picker see the same default order the data tab
+// presents (timestamps first, then variants, structs, ...).
+const PINNED_TIME_COLUMNS = ["measurement_time_local", "local_time", "measurement_time_utc"];
+
+function getTypePrecedence(typeText: string): number {
+  if (isTimestampType(typeText)) {
+    return 1;
+  }
+  if (isVariantType(typeText)) {
+    return 2;
+  }
+  if (
+    isWellKnownType(typeText) ||
+    isMapType(typeText) ||
+    isStructArrayType(typeText) ||
+    isStructType(typeText)
+  ) {
+    return 3;
+  }
+  if (isStringType(typeText)) {
+    return 4;
+  }
+  if (isNumericType(typeText) || isDecimalType(typeText)) {
+    return 5;
+  }
+  if (isArrayType(typeText)) {
+    return 6;
+  }
+  return 7;
+}
+
+/**
+ * Default display order for an experiment's columns. The pinned-time
+ * columns (measurement_time_*) come first in their fixed order, then
+ * remaining columns are grouped by type precedence (timestamps, variants,
+ * structs, strings, numerics, arrays, other). Used as the canonical
+ * starting order whenever the user hasn't explicitly reordered.
+ */
+export function sortColumnsForDisplay<T extends DataColumn>(columns: readonly T[]): T[] {
+  return [...columns].sort((a, b) => {
+    const pinnedA = PINNED_TIME_COLUMNS.indexOf(a.name);
+    const pinnedB = PINNED_TIME_COLUMNS.indexOf(b.name);
+    if (pinnedA !== -1 && pinnedB !== -1) {
+      return pinnedA - pinnedB;
+    }
+    if (pinnedA !== -1) {
+      return -1;
+    }
+    if (pinnedB !== -1) {
+      return 1;
+    }
+    return getTypePrecedence(a.type_text) - getTypePrecedence(b.type_text);
+  });
+}
+
 export function getColumnWidth(typeText: string, columnName?: string): number | undefined {
   // Fixed widths for local time columns
-  if (columnName === "measurement_time_local") return 220;
-  if (columnName === "local_time") return 90;
-  if (columnName === "measurement_time_utc") return 175;
+  if (columnName === "measurement_time_local") {
+    return 220;
+  }
+  if (columnName === "local_time") {
+    return 90;
+  }
+  if (columnName === "measurement_time_utc") {
+    return 175;
+  }
   // Set medium width for well-known columns (user columns with avatar + name)
-  if (isWellKnownType(typeText)) return 180;
+  if (isWellKnownType(typeText)) {
+    return 180;
+  }
   // Set medium width for struct/map columns that contain collapsible JSON
-  if (isStructArrayType(typeText) || isMapType(typeText) || isStructType(typeText)) return 180;
+  if (isStructArrayType(typeText) || isMapType(typeText) || isStructType(typeText)) {
+    return 180;
+  }
   // Set smaller width for array columns that contain charts
-  if (isArrayType(typeText)) return 120;
+  if (isArrayType(typeText)) {
+    return 120;
+  }
   // Set medium width for VARIANT columns that contain collapsible JSON
-  if (isVariantType(typeText)) return 180;
+  if (isVariantType(typeText)) {
+    return 180;
+  }
   return undefined;
 }
 
@@ -79,63 +152,11 @@ function createTableColumns({
   const columnHelper = createColumnHelper<DataRow>();
 
   const columns: AccessorKeyColumnDef<DataRow, unknown>[] = [];
-  if (!data) return columns;
+  if (!data) {
+    return columns;
+  }
 
-  // Define type precedence for sorting
-  const getTypePrecedence = (typeText: string): number => {
-    // Timestamp types (precedence 1)
-    if (isTimestampType(typeText)) {
-      return 1;
-    }
-
-    // Variant types (precedence 2)
-    if (isVariantType(typeText)) {
-      return 2;
-    }
-
-    // Well-known types (CONTRIBUTOR, etc.), MAP, and ARRAY<STRUCT< types (precedence 3)
-    if (
-      isWellKnownType(typeText) ||
-      isMapType(typeText) ||
-      isStructArrayType(typeText) ||
-      isStructType(typeText)
-    ) {
-      return 3;
-    }
-
-    // String types (precedence 4)
-    if (isStringType(typeText)) {
-      return 4;
-    }
-
-    // Numeric types (precedence 5)
-    if (isNumericType(typeText) || isDecimalType(typeText)) {
-      return 5;
-    }
-
-    // Array types (precedence 6)
-    if (isArrayType(typeText)) {
-      return 6;
-    }
-
-    // Other types (precedence 7)
-    return 7;
-  };
-
-  // These columns are pinned to the front in a fixed display order
-  const PINNED_TIME_COLUMNS = ["measurement_time_local", "local_time", "measurement_time_utc"];
-
-  // Sort columns: pinned time columns first (in defined order), then by type precedence
-  const sortedColumns = [...data.columns].sort((a, b) => {
-    const pinnedA = PINNED_TIME_COLUMNS.indexOf(a.name);
-    const pinnedB = PINNED_TIME_COLUMNS.indexOf(b.name);
-    if (pinnedA !== -1 && pinnedB !== -1) return pinnedA - pinnedB;
-    if (pinnedA !== -1) return -1;
-    if (pinnedB !== -1) return 1;
-    const precedenceA = getTypePrecedence(a.type_text);
-    const precedenceB = getTypePrecedence(b.type_text);
-    return precedenceA - precedenceB;
-  });
+  const sortedColumns = sortColumnsForDisplay(data.columns);
 
   function getHeader(columnName: string) {
     return columnName;
@@ -195,6 +216,15 @@ export interface UseExperimentDataParams {
   tableName: string;
   orderBy?: string;
   orderDirection?: "ASC" | "DESC";
+  /**
+   * Optional structured filter conditions. Forwarded to the backend as a
+   * JSON-encoded query param. When non-empty the backend's ad-hoc path
+   * takes over from the paginated read: the response is the full filtered
+   * result capped by the server's hard limit, `totalPages` is always 1,
+   * and `totalRows` reports the row count returned (not the unfiltered
+   * table size).
+   */
+  filters?: DataFilter[];
   formatFunction?: DataRenderFunction;
   onChartClick?: (data: number[], columnName: string) => void;
   onAddAnnotation?: (rowIds: string[]) => void;
@@ -203,6 +233,14 @@ export interface UseExperimentDataParams {
   isCellExpanded?: (rowId: string, columnName: string) => boolean;
   errorColumn?: string;
   enabled?: boolean;
+}
+
+function compactFilters(filters: DataFilter[] | undefined): DataFilter[] | undefined {
+  if (!filters || filters.length === 0) {
+    return undefined;
+  }
+  const compact = filters.filter((f) => zDataFilter.safeParse(f).success);
+  return compact.length > 0 ? compact : undefined;
 }
 
 /**
@@ -231,6 +269,7 @@ export const useExperimentData = (params: UseExperimentDataParams) => {
     tableName,
     orderBy,
     orderDirection,
+    filters,
     formatFunction,
     onChartClick,
     onAddAnnotation,
@@ -240,12 +279,42 @@ export const useExperimentData = (params: UseExperimentDataParams) => {
     errorColumn,
     enabled = true,
   } = params;
+
+  const cleanedFilters = compactFilters(filters);
+  // Stable JSON for both cache key and request encoding so semantically
+  // identical filter sets share a query cache entry.
+  const filtersJson = useMemo(
+    () =>
+      cleanedFilters && cleanedFilters.length > 0 ? JSON.stringify(cleanedFilters) : undefined,
+    [cleanedFilters],
+  );
+  // When filters are active the backend switches off the paginated path.
+  // Sending page/pageSize would be ignored; stripping them keeps the cache
+  // key tight and the URL readable.
+  const hasFilters = filtersJson !== undefined;
+
   const { data, isLoading, error } = tsr.experiments.getExperimentData.useQuery({
     queryData: {
       params: { id: experimentId },
-      query: { tableName, page, pageSize, orderBy, orderDirection },
+      query: {
+        tableName,
+        page: hasFilters ? undefined : page,
+        pageSize: hasFilters ? undefined : pageSize,
+        orderBy,
+        orderDirection,
+        filters: filtersJson,
+      },
     },
-    queryKey: ["experiment", experimentId, page, pageSize, tableName, orderBy, orderDirection],
+    queryKey: [
+      "experiment",
+      experimentId,
+      page,
+      pageSize,
+      tableName,
+      orderBy,
+      orderDirection,
+      filtersJson,
+    ],
     staleTime: STALE_TIME,
     enabled,
   });
@@ -267,11 +336,20 @@ export const useExperimentData = (params: UseExperimentDataParams) => {
           }),
           totalPages: tableData.totalPages,
           totalRows: tableData.totalRows,
-          rawColumns: tableData.data?.columns.map((col) => ({
-            name: col.name,
-            type_name: col.type_name,
-            type_text: col.type_text,
-          })),
+          // Same display order as `columns` above so downstream consumers
+          // (filter pickers, dashboard table-widget column picker, etc.)
+          // present columns in the canonical "timestamps first, then by
+          // type" sequence rather than whatever raw order Databricks
+          // returned.
+          rawColumns: tableData.data
+            ? sortColumnsForDisplay(
+                tableData.data.columns.map((col) => ({
+                  name: col.name,
+                  type_name: col.type_name,
+                  type_text: col.type_text,
+                })),
+              )
+            : undefined,
           errorColumn,
         }
       : undefined;

--- a/apps/web/hooks/experiment/useExperimentData/useExperimentData.ts
+++ b/apps/web/hooks/experiment/useExperimentData/useExperimentData.ts
@@ -305,15 +305,17 @@ export const useExperimentData = (params: UseExperimentDataParams) => {
         filters: filtersJson,
       },
     },
+    // page/pageSize are stripped from the request when filters are active, so
+    // they must not appear in the key or we'd split the cache on a value the
+    // server never sees.
     queryKey: [
       "experiment",
       experimentId,
-      page,
-      pageSize,
       tableName,
       orderBy,
       orderDirection,
       filtersJson,
+      ...(hasFilters ? [] : [page, pageSize]),
     ],
     staleTime: STALE_TIME,
     enabled,

--- a/apps/web/hooks/useUrlDataFilters.test.tsx
+++ b/apps/web/hooks/useUrlDataFilters.test.tsx
@@ -1,0 +1,122 @@
+import { act, renderHook } from "@/test/test-utils";
+import * as nav from "next/navigation";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DataFilter } from "@repo/api/schemas/experiment.schema";
+
+import { useUrlDataFilters } from "./useUrlDataFilters";
+
+function setSearchParams(qs: string): void {
+  vi.mocked(nav.useSearchParams).mockReturnValue(new nav.ReadonlyURLSearchParams(qs));
+}
+
+const mockedReplace = vi.mocked(nav.useRouter()).replace;
+
+const encodeFilters = (f: DataFilter[]) => encodeURIComponent(JSON.stringify(f));
+
+describe("useUrlDataFilters", () => {
+  beforeEach(() => {
+    mockedReplace.mockClear();
+    setSearchParams("");
+    vi.mocked(nav.usePathname).mockReturnValue("/platform/experiments/abc/data");
+  });
+
+  afterEach(() => {
+    vi.mocked(nav.useSearchParams).mockReset();
+  });
+
+  it("starts empty when the URL has no filter param", () => {
+    const { result } = renderHook(() => useUrlDataFilters("raw_data"));
+    expect(result.current.filters).toEqual([]);
+    expect(result.current.completeFilters).toEqual([]);
+  });
+
+  it("seeds filters from the f_<table> URL param", () => {
+    const seed: DataFilter[] = [{ column: "device_id", operator: "equals", value: "D1" }];
+    setSearchParams(`f_raw_data=${encodeFilters(seed)}`);
+
+    const { result } = renderHook(() => useUrlDataFilters("raw_data"));
+
+    expect(result.current.filters).toEqual(seed);
+    expect(result.current.completeFilters).toEqual(seed);
+  });
+
+  it("namespaces filters per table so two tabs don't collide", () => {
+    const a: DataFilter[] = [{ column: "device_id", operator: "equals", value: "D1" }];
+    const b: DataFilter[] = [{ column: "lot", operator: "equals", value: "L42" }];
+    setSearchParams(`f_raw_data=${encodeFilters(a)}&f_device=${encodeFilters(b)}`);
+
+    const rawHook = renderHook(() => useUrlDataFilters("raw_data"));
+    expect(rawHook.result.current.filters).toEqual(a);
+
+    const deviceHook = renderHook(() => useUrlDataFilters("device"));
+    expect(deviceHook.result.current.filters).toEqual(b);
+  });
+
+  it("falls back to empty when the URL JSON is malformed", () => {
+    setSearchParams("f_raw_data=not-json");
+    const { result } = renderHook(() => useUrlDataFilters("raw_data"));
+    expect(result.current.filters).toEqual([]);
+  });
+
+  it("writes the complete-filter subset to the URL when filters change", () => {
+    const { result } = renderHook(() => useUrlDataFilters("raw_data"));
+
+    const next: DataFilter[] = [{ column: "device_id", operator: "equals", value: "D1" }];
+    act(() => {
+      result.current.setFilters(next);
+    });
+
+    expect(mockedReplace).toHaveBeenCalled();
+    const written = mockedReplace.mock.calls.at(-1)?.[0];
+    expect(typeof written).toBe("string");
+    if (typeof written === "string") {
+      expect(written).toContain(`f_raw_data=${encodeFilters(next)}`);
+    }
+  });
+
+  it("keeps a draft row visible without writing it to the URL", () => {
+    const { result } = renderHook(() => useUrlDataFilters("raw_data"));
+    mockedReplace.mockClear();
+
+    act(() => {
+      result.current.setFilters([{ column: "device_id", operator: "equals", value: "" }]);
+    });
+
+    expect(result.current.filters).toHaveLength(1);
+    expect(result.current.completeFilters).toEqual([]);
+    expect(mockedReplace).not.toHaveBeenCalled();
+  });
+
+  it("clears the URL param when the last complete filter is removed", () => {
+    const seed: DataFilter[] = [{ column: "device_id", operator: "equals", value: "D1" }];
+    setSearchParams(`f_raw_data=${encodeFilters(seed)}`);
+    const { result } = renderHook(() => useUrlDataFilters("raw_data"));
+    mockedReplace.mockClear();
+
+    act(() => {
+      result.current.setFilters([]);
+    });
+
+    expect(mockedReplace).toHaveBeenCalled();
+    const written = mockedReplace.mock.calls.at(-1)?.[0];
+    expect(typeof written).toBe("string");
+    if (typeof written === "string") {
+      expect(written).not.toContain("f_raw_data=");
+    }
+  });
+
+  it("re-seeds local state when the URL param changes externally (back/forward)", () => {
+    const seed: DataFilter[] = [{ column: "device_id", operator: "equals", value: "D1" }];
+    const next: DataFilter[] = [{ column: "device_id", operator: "equals", value: "D2" }];
+    setSearchParams(`f_raw_data=${encodeFilters(seed)}`);
+
+    const { result, rerender } = renderHook(() => useUrlDataFilters("raw_data"));
+    expect(result.current.filters).toEqual(seed);
+
+    setSearchParams(`f_raw_data=${encodeFilters(next)}`);
+    rerender();
+
+    expect(result.current.filters).toEqual(next);
+  });
+});

--- a/apps/web/hooks/useUrlDataFilters.ts
+++ b/apps/web/hooks/useUrlDataFilters.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useMemo } from "react";
+import { z } from "zod";
+
+import type { DataFilter } from "@repo/api/schemas/experiment.schema";
+import { zDataFilter } from "@repo/api/schemas/experiment.schema";
+
+import { useUrlState } from "./useUrlState";
+
+const zDataFilterArray = z.array(zDataFilter);
+
+interface UseUrlDataFiltersResult {
+  filters: DataFilter[];
+  setFilters: (next: DataFilter[]) => void;
+  completeFilters: DataFilter[];
+}
+
+/** URL-synced filter state, namespaced per table. */
+export function useUrlDataFilters(tableName: string): UseUrlDataFiltersResult {
+  const [filters, setFilters] = useUrlState<DataFilter[]>({
+    key: `f_${tableName}`,
+    serialize: (next) => {
+      const complete = next.filter((f) => zDataFilter.safeParse(f).success);
+      return complete.length > 0 ? JSON.stringify(complete) : null;
+    },
+    parse: (raw) => {
+      if (!raw) return [];
+      const result = zDataFilterArray.safeParse(safeJsonParse(raw));
+      return result.success ? result.data : [];
+    },
+  });
+
+  const completeFilters = useMemo<DataFilter[]>(
+    () => filters.filter((f) => zDataFilter.safeParse(f).success),
+    [filters],
+  );
+
+  return { filters, setFilters, completeFilters };
+}
+
+function safeJsonParse(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/web/hooks/useUrlState.test.tsx
+++ b/apps/web/hooks/useUrlState.test.tsx
@@ -1,0 +1,140 @@
+import { act, renderHook } from "@/test/test-utils";
+import * as nav from "next/navigation";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useUrlState } from "./useUrlState";
+
+function setSearchParams(qs: string): void {
+  vi.mocked(nav.useSearchParams).mockReturnValue(new nav.ReadonlyURLSearchParams(qs));
+}
+
+const mockedRouter = nav.useRouter();
+const mockedReplace = vi.mocked(mockedRouter.replace);
+const mockedPush = vi.mocked(mockedRouter.push);
+
+const stringSerializer = (value: string) => (value === "" ? null : value);
+const stringParser = (raw: string | null) => raw ?? "";
+
+describe("useUrlState", () => {
+  beforeEach(() => {
+    mockedReplace.mockClear();
+    mockedPush.mockClear();
+    setSearchParams("");
+    vi.mocked(nav.usePathname).mockReturnValue("/page");
+  });
+
+  afterEach(() => {
+    vi.mocked(nav.useSearchParams).mockReset();
+    vi.mocked(nav.usePathname).mockReset();
+  });
+
+  it("seeds state from the URL on first render", () => {
+    setSearchParams("q=hello");
+    const { result } = renderHook(() =>
+      useUrlState({ key: "q", serialize: stringSerializer, parse: stringParser }),
+    );
+    expect(result.current[0]).toBe("hello");
+  });
+
+  it("does not write the URL on mount when state already matches", () => {
+    setSearchParams("q=hello");
+    renderHook(() => useUrlState({ key: "q", serialize: stringSerializer, parse: stringParser }));
+    expect(mockedReplace).not.toHaveBeenCalled();
+  });
+
+  it("writes via router.replace when state changes", () => {
+    const { result } = renderHook(() =>
+      useUrlState({ key: "q", serialize: stringSerializer, parse: stringParser }),
+    );
+
+    act(() => {
+      result.current[1]("hi");
+    });
+
+    expect(mockedReplace).toHaveBeenCalledWith("/page?q=hi", { scroll: false });
+  });
+
+  it("uses router.push when method is push", () => {
+    const { result } = renderHook(() =>
+      useUrlState({
+        key: "q",
+        serialize: stringSerializer,
+        parse: stringParser,
+        method: "push",
+      }),
+    );
+
+    act(() => {
+      result.current[1]("hi");
+    });
+
+    expect(mockedPush).toHaveBeenCalledWith("/page?q=hi", { scroll: false });
+    expect(mockedReplace).not.toHaveBeenCalled();
+  });
+
+  it("deletes the key from the URL when serializer returns null", () => {
+    setSearchParams("q=hello");
+    const { result } = renderHook(() =>
+      useUrlState({ key: "q", serialize: stringSerializer, parse: stringParser }),
+    );
+
+    act(() => {
+      result.current[1]("");
+    });
+
+    const target = mockedReplace.mock.calls.at(-1)?.[0];
+    expect(typeof target).toBe("string");
+    if (typeof target === "string") {
+      expect(target).not.toContain("q=");
+    }
+  });
+
+  it("re-seeds state when the URL param changes externally (bidirectional)", () => {
+    setSearchParams("q=v1");
+    const { result, rerender } = renderHook(() =>
+      useUrlState({ key: "q", serialize: stringSerializer, parse: stringParser }),
+    );
+    expect(result.current[0]).toBe("v1");
+
+    setSearchParams("q=v2");
+    rerender();
+
+    expect(result.current[0]).toBe("v2");
+  });
+
+  it("ignores external URL changes when bidirectional is false", () => {
+    setSearchParams("q=v1");
+    const { result, rerender } = renderHook(() =>
+      useUrlState({
+        key: "q",
+        serialize: stringSerializer,
+        parse: stringParser,
+        bidirectional: false,
+      }),
+    );
+    expect(result.current[0]).toBe("v1");
+
+    setSearchParams("q=v2");
+    rerender();
+
+    expect(result.current[0]).toBe("v1");
+  });
+
+  it("preserves unrelated URL params during write", () => {
+    setSearchParams("other=keep&q=hello");
+    const { result } = renderHook(() =>
+      useUrlState({ key: "q", serialize: stringSerializer, parse: stringParser }),
+    );
+
+    act(() => {
+      result.current[1]("world");
+    });
+
+    const target = mockedReplace.mock.calls.at(-1)?.[0];
+    expect(typeof target).toBe("string");
+    if (typeof target === "string") {
+      expect(target).toContain("other=keep");
+      expect(target).toContain("q=world");
+    }
+  });
+});

--- a/apps/web/hooks/useUrlState.ts
+++ b/apps/web/hooks/useUrlState.ts
@@ -26,7 +26,6 @@ export function useUrlState<T>(options: UseUrlStateOptions<T>): readonly [T, (ne
   const [value, setValue] = useState<T>(initial);
 
   const serialized = serialize(value);
-  const serializedKey = serialized ?? "";
 
   const navigate = useCallback(
     (qs: string) => {
@@ -50,8 +49,8 @@ export function useUrlState<T>(options: UseUrlStateOptions<T>): readonly [T, (ne
   useEffect(() => {
     if (isInitialEffectRef.current) {
       isInitialEffectRef.current = false;
-      const current = searchParamsRef.current.get(key) ?? "";
-      if (current === serializedKey) return;
+      // null and "" are distinct: null means "no key in URL", "" means "key present with empty value".
+      if (searchParamsRef.current.get(key) === serialized) return;
     }
     const next = new URLSearchParams(searchParamsRef.current.toString());
     if (serialized === null) {
@@ -60,18 +59,17 @@ export function useUrlState<T>(options: UseUrlStateOptions<T>): readonly [T, (ne
       next.set(key, serialized);
     }
     navigate(next.toString());
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- load-bearing signal is `serializedKey`; depending on searchParams would re-fire on every identity churn.
-  }, [serializedKey, key, navigate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- load-bearing signal is `serialized`; depending on searchParams would re-fire on every identity churn.
+  }, [serialized, key, navigate]);
 
   // Back/forward replay.
   const urlRaw = searchParams.get(key);
-  const urlKey = urlRaw ?? "";
   useEffect(() => {
     if (!bidirectional) return;
-    if (urlKey === serializedKey) return;
+    if (urlRaw === serialized) return;
     setValue(parse(urlRaw));
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally drives off URL change only.
-  }, [urlKey, bidirectional]);
+  }, [urlRaw, bidirectional]);
 
   return [value, setValue] as const;
 }

--- a/apps/web/hooks/useUrlState.ts
+++ b/apps/web/hooks/useUrlState.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+export interface UseUrlStateOptions<T> {
+  key: string;
+  serialize: (value: T) => string | null;
+  parse: (raw: string | null) => T;
+  method?: "replace" | "push";
+  bidirectional?: boolean;
+}
+
+export function useUrlState<T>(options: UseUrlStateOptions<T>): readonly [T, (next: T) => void] {
+  const { key, serialize, parse, method = "replace", bidirectional = true } = options;
+
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const initial = useMemo<T>(
+    () => parse(searchParams.get(key)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- first mount only; later syncing flows through the effect below.
+    [],
+  );
+  const [value, setValue] = useState<T>(initial);
+
+  const serialized = serialize(value);
+  const serializedKey = serialized ?? "";
+
+  const navigate = useCallback(
+    (qs: string) => {
+      const target = qs ? `${pathname}?${qs}` : pathname;
+      if (method === "push") {
+        router.push(target, { scroll: false });
+      } else {
+        router.replace(target, { scroll: false });
+      }
+    },
+    [pathname, router, method],
+  );
+
+  // Ref so the write effect doesn't refire on searchParams identity churn.
+  const searchParamsRef = useRef(searchParams);
+  searchParamsRef.current = searchParams;
+
+  // Skip the initial write when local already matches the URL.
+  const isInitialEffectRef = useRef(true);
+
+  useEffect(() => {
+    if (isInitialEffectRef.current) {
+      isInitialEffectRef.current = false;
+      const current = searchParamsRef.current.get(key) ?? "";
+      if (current === serializedKey) return;
+    }
+    const next = new URLSearchParams(searchParamsRef.current.toString());
+    if (serialized === null) {
+      next.delete(key);
+    } else {
+      next.set(key, serialized);
+    }
+    navigate(next.toString());
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- load-bearing signal is `serializedKey`; depending on searchParams would re-fire on every identity churn.
+  }, [serializedKey, key, navigate]);
+
+  // Back/forward replay.
+  const urlRaw = searchParams.get(key);
+  const urlKey = urlRaw ?? "";
+  useEffect(() => {
+    if (!bidirectional) return;
+    if (urlKey === serializedKey) return;
+    setValue(parse(urlRaw));
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally drives off URL change only.
+  }, [urlKey, bidirectional]);
+
+  return [value, setValue] as const;
+}

--- a/apps/web/test/setup.ts
+++ b/apps/web/test/setup.ts
@@ -110,6 +110,9 @@ vi.mock("next/navigation", () => ({
   useParams: vi.fn(() => ({ locale: "en-US" })),
   redirect: vi.fn(),
   notFound: vi.fn(),
+  // Real next/navigation re-exports a RURP subclass; tests construct one via
+  // `new nav.ReadonlyURLSearchParams(qs)` to feed mockReturnValue without casts.
+  ReadonlyURLSearchParams: URLSearchParams,
 }));
 
 // `clearAllMocks` leaves per-test `mockReturnValue(...)` in place, so


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Wires the existing `FilterChipBar` into the experiment data table and persists filter state in the URL, so deep links and back/forward navigation reproduce the filtered view.

The table now reads filters from `useUrlDataFilters`, forwards them through `useExperimentData`, and snaps pagination back to page 0 whenever the active filter set changes (otherwise the UI shows "page 5 of 1" since the filtered backend path collapses to a single page).

`useExperimentData` gains a `filters` parameter. When non-empty, it JSON-encodes them into the request, drops `page`/`pageSize` (the ad-hoc backend path ignores them), and includes the serialized filters in the React Query key so distinct filter sets cache independently. Empty/draft filters are stripped via `zDataFilter.safeParse` before being sent or written to the URL.

Column ordering logic that previously lived inside `createTableColumns` is extracted to an exported `sortColumnsForDisplay` and also applied to `rawColumns` in the hook result. This keeps downstream consumers (filter picker, dashboard table-widget column picker) on the same "timestamps first, then by type precedence" order the data tab renders, instead of whatever raw order Databricks returns.

Two new hooks:

- `useUrlState`: generic URL-synced state with pluggable `serialize`/`parse`, `replace`/`push` method, and an opt-out for bidirectional sync. Preserves unrelated query params on write and skips the initial write when local state already matches the URL.
- `useUrlDataFilters`: thin wrapper that namespaces the param per table (`f_<tableName>`) and exposes a `completeFilters` view that excludes draft rows.