### PR TITLE
feat(web): add filters shelf to the visualization inspector data tab

### DIFF
--- a/apps/web/components/experiment-visualizations/workspace/shelves/filters-shelf.test.tsx
+++ b/apps/web/components/experiment-visualizations/workspace/shelves/filters-shelf.test.tsx
@@ -1,0 +1,168 @@
+import { server } from "@/test/msw/server";
+import { renderWithForm, screen, userEvent } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import { contract } from "@repo/api/contract";
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+
+import { lineChartType } from "../../charts/basic/line";
+import type { ChartFormValues } from "../../charts/chart-config";
+import { FiltersShelf } from "./filters-shelf";
+
+function defaults(overrides: Partial<ChartFormValues> = {}): ChartFormValues {
+  return {
+    name: "Untitled",
+    description: "",
+    chartFamily: lineChartType.family,
+    chartType: lineChartType.type,
+    config: lineChartType.defaultConfig(),
+    dataConfig: {
+      tableName: "readings",
+      dataSources: [
+        { tableName: "readings", columnName: "time", role: "x" },
+        { tableName: "readings", columnName: "temp", role: "y" },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+const columns: DataColumn[] = [
+  { name: "site", type_name: "STRING", type_text: "STRING" },
+  { name: "value", type_name: "DOUBLE", type_text: "DOUBLE" },
+];
+
+function mountDistinct() {
+  server.mount(contract.experiments.getDistinctColumnValues, {
+    body: { values: [], truncated: false },
+  });
+}
+
+describe("FiltersShelf", () => {
+  it("renders the section heading and starts collapsed", () => {
+    mountDistinct();
+    renderWithForm<ChartFormValues>(
+      (form) => (
+        <FiltersShelf form={form} columns={columns} experimentId="exp-1" tableName="readings" />
+      ),
+      { useFormProps: { defaultValues: defaults() } },
+    );
+
+    expect(screen.getByRole("heading", { name: "workspace.shelves.filters" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "dataFilters.addFilter" })).not.toBeInTheDocument();
+  });
+
+  it("expands to show the filter chip list (with add button) when toggled", async () => {
+    mountDistinct();
+    const user = userEvent.setup();
+    renderWithForm<ChartFormValues>(
+      (form) => (
+        <FiltersShelf form={form} columns={columns} experimentId="exp-1" tableName="readings" />
+      ),
+      { useFormProps: { defaultValues: defaults() } },
+    );
+
+    await user.click(screen.getByRole("button", { name: /workspace\.shelves\.filters/ }));
+    expect(
+      await screen.findByRole("button", { name: "dataFilters.addFilter" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the filter count badge when filters exist", () => {
+    mountDistinct();
+    renderWithForm<ChartFormValues>(
+      (form) => (
+        <FiltersShelf form={form} columns={columns} experimentId="exp-1" tableName="readings" />
+      ),
+      {
+        useFormProps: {
+          defaultValues: defaults({
+            dataConfig: {
+              tableName: "readings",
+              dataSources: [{ tableName: "readings", columnName: "temp", role: "y" }],
+              filters: [
+                { column: "site", operator: "equals", value: "alpha" },
+                { column: "value", operator: "greater_than", value: 5 },
+              ],
+            },
+          }),
+        },
+      },
+    );
+
+    // Header shows the active count.
+    expect(screen.getByText("(2)")).toBeInTheDocument();
+  });
+
+  it("does not render the count badge when no filters are set", () => {
+    mountDistinct();
+    renderWithForm<ChartFormValues>(
+      (form) => (
+        <FiltersShelf form={form} columns={columns} experimentId="exp-1" tableName="readings" />
+      ),
+      { useFormProps: { defaultValues: defaults() } },
+    );
+
+    expect(screen.queryByText(/^\(\d+\)$/)).not.toBeInTheDocument();
+  });
+
+  it("collapses the filters back to undefined when the last filter is removed", async () => {
+    mountDistinct();
+    const user = userEvent.setup();
+    const { form } = renderWithForm<ChartFormValues>(
+      (form) => (
+        <FiltersShelf form={form} columns={columns} experimentId="exp-1" tableName="readings" />
+      ),
+      {
+        useFormProps: {
+          defaultValues: defaults({
+            dataConfig: {
+              tableName: "readings",
+              dataSources: [{ tableName: "readings", columnName: "temp", role: "y" }],
+              filters: [{ column: "site", operator: "equals", value: "alpha" }],
+            },
+          }),
+        },
+      },
+    );
+
+    await user.click(screen.getByRole("button", { name: /workspace\.shelves\.filters/ }));
+    await user.click(await screen.findByRole("button", { name: "dataFilters.removeFilterOn" }));
+
+    expect(form.getValues("dataConfig.filters")).toBeUndefined();
+  });
+
+  it("keeps the remaining filters in form state when one of several is removed", async () => {
+    mountDistinct();
+    const user = userEvent.setup();
+    const { form } = renderWithForm<ChartFormValues>(
+      (form) => (
+        <FiltersShelf form={form} columns={columns} experimentId="exp-1" tableName="readings" />
+      ),
+      {
+        useFormProps: {
+          defaultValues: defaults({
+            dataConfig: {
+              tableName: "readings",
+              dataSources: [{ tableName: "readings", columnName: "temp", role: "y" }],
+              filters: [
+                { column: "site", operator: "equals", value: "alpha" },
+                { column: "value", operator: "greater_than", value: 5 },
+              ],
+            },
+          }),
+        },
+      },
+    );
+
+    await user.click(screen.getByRole("button", { name: /workspace\.shelves\.filters/ }));
+    const removeButtons = await screen.findAllByRole("button", {
+      name: "dataFilters.removeFilterOn",
+    });
+    await user.click(removeButtons[0]);
+
+    const remaining = form.getValues("dataConfig.filters") ?? [];
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].column).toBe("value");
+  });
+});

--- a/apps/web/components/experiment-visualizations/workspace/shelves/filters-shelf.tsx
+++ b/apps/web/components/experiment-visualizations/workspace/shelves/filters-shelf.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { useState } from "react";
+import type { UseFormReturn } from "react-hook-form";
+import { useFieldArray } from "react-hook-form";
+
+import type { DataColumn, DataFilter } from "@repo/api/schemas/experiment.schema";
+import { useTranslation } from "@repo/i18n";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@repo/ui/components/collapsible";
+import { cn } from "@repo/ui/lib/utils";
+
+import { FilterChipList } from "../../../data-filters/chips/filter-chip-list";
+import type { ChartFormValues } from "../../charts/chart-config";
+
+interface FiltersShelfProps {
+  form: UseFormReturn<ChartFormValues>;
+  columns: DataColumn[];
+  experimentId: string;
+  tableName: string;
+  /** Render inline with no Collapsible chrome (for popover-hosted shelves). */
+  flat?: boolean;
+}
+
+export function FiltersShelf({
+  form,
+  columns,
+  experimentId,
+  tableName,
+  flat = false,
+}: FiltersShelfProps) {
+  const { t } = useTranslation("experimentVisualizations");
+
+  const { fields } = useFieldArray({
+    control: form.control,
+    name: "dataConfig.filters",
+  });
+
+  const [open, setOpen] = useState(false);
+
+  const filters = (form.watch("dataConfig.filters") ?? []) as DataFilter[];
+
+  const list = (
+    <FilterChipList
+      value={filters}
+      onChange={(next) =>
+        form.setValue("dataConfig.filters", next.length > 0 ? next : undefined, {
+          shouldDirty: true,
+        })
+      }
+      columns={columns}
+      experimentId={experimentId}
+      tableName={tableName}
+    />
+  );
+
+  if (flat) {
+    return <div className="space-y-3">{list}</div>;
+  }
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} asChild>
+      <section className="space-y-3">
+        <CollapsibleTrigger className="flex w-full items-center gap-2 text-left">
+          <h3 className="text-sm font-semibold">{t("workspace.shelves.filters")}</h3>
+          {fields.length > 0 && (
+            <span className="text-muted-foreground text-xs">({fields.length})</span>
+          )}
+          <ChevronDown
+            className={cn(
+              "text-muted-foreground ml-auto h-4 w-4 transition-transform",
+              open && "rotate-180",
+            )}
+          />
+        </CollapsibleTrigger>
+
+        <CollapsibleContent>{list}</CollapsibleContent>
+      </section>
+    </Collapsible>
+  );
+}

--- a/apps/web/components/experiment-visualizations/workspace/tabs/data-tab-content.test.tsx
+++ b/apps/web/components/experiment-visualizations/workspace/tabs/data-tab-content.test.tsx
@@ -54,6 +54,7 @@ function Harness({
       <DataSourcesFieldArrayProvider form={form}>
         <DataTabContent
           form={form}
+          experimentId="exp-1"
           tables={tables}
           isTablesLoading={isTablesLoading}
           tablesError={tablesError}
@@ -112,6 +113,36 @@ describe("DataTabContent", () => {
     mountDistinct();
     render(<Harness selectedTableName="readings" />);
     expect(screen.getByText("workspace.inspector.noValidColumns")).toBeInTheDocument();
+  });
+
+  it("renders the data panel and filters shelf once columns are available", async () => {
+    mountDistinct();
+    const columns: DataColumn[] = [
+      { name: "time", type_name: "TIMESTAMP", type_text: "TIMESTAMP" },
+      { name: "temp", type_name: "DOUBLE", type_text: "DOUBLE" },
+    ];
+
+    render(
+      <Harness
+        selectedTableName="readings"
+        columns={columns}
+        formDefaults={defaults({
+          dataConfig: {
+            tableName: "readings",
+            dataSources: [
+              { tableName: "readings", columnName: "time", role: "x" },
+              { tableName: "readings", columnName: "temp", role: "y" },
+            ],
+          },
+        })}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: "workspace.shelves.filters" }),
+      ).toBeInTheDocument(),
+    );
   });
 
   it("shows the failed-to-load-tables note inside the dropdown when tablesError is set", async () => {

--- a/apps/web/components/experiment-visualizations/workspace/tabs/data-tab-content.tsx
+++ b/apps/web/components/experiment-visualizations/workspace/tabs/data-tab-content.tsx
@@ -18,9 +18,11 @@ import { Separator } from "@repo/ui/components/separator";
 
 import type { ChartFormValues } from "../../charts/chart-config";
 import { getChartTypeDef } from "../../charts/chart-registry";
+import { FiltersShelf } from "../shelves/filters-shelf";
 
 export interface DataTabContentProps {
   form: UseFormReturn<ChartFormValues>;
+  experimentId: string;
   tables: ExperimentTableMetadata[];
   isTablesLoading?: boolean;
   tablesError?: unknown;
@@ -33,6 +35,7 @@ export interface DataTabContentProps {
 
 export function DataTabContent({
   form,
+  experimentId,
   tables,
   isTablesLoading = false,
   tablesError,
@@ -112,6 +115,19 @@ export function DataTabContent({
       >
         {def ? <def.DataPanel form={form} columns={columns} /> : <UnsupportedPanel />}
       </ColumnsState>
+
+      {Boolean(selectedTableName) && columns.length > 0 && (
+        <>
+          <Separator />
+          <FiltersShelf
+            form={form}
+            columns={columns}
+            experimentId={experimentId}
+            tableName={selectedTableName}
+          />
+          <Separator />
+        </>
+      )}
     </>
   );
 }

--- a/apps/web/components/experiment-visualizations/workspace/visualization-workspace.tsx
+++ b/apps/web/components/experiment-visualizations/workspace/visualization-workspace.tsx
@@ -177,6 +177,7 @@ export function VisualizationWorkspace({
           <div className="w-full lg:w-[320px] lg:shrink-0 xl:w-[380px] 2xl:w-[440px]">
             <WorkspaceInspector
               form={form}
+              experimentId={experimentId}
               tables={tables ?? []}
               isTablesLoading={isLoadingTables}
               tablesError={tablesError}

--- a/apps/web/components/experiment-visualizations/workspace/workspace-inspector.test.tsx
+++ b/apps/web/components/experiment-visualizations/workspace/workspace-inspector.test.tsx
@@ -49,6 +49,7 @@ function renderInspector(opts: RenderOpts = {}) {
         <DataSourcesFieldArrayProvider form={form}>
           <WorkspaceInspector
             form={form}
+            experimentId="test-experiment"
             tables={opts.tablesError ? [] : tables}
             isTablesLoading={opts.isTablesLoading ?? false}
             tablesError={opts.tablesError}
@@ -113,6 +114,7 @@ describe("WorkspaceInspector", () => {
         <DataSourcesFieldArrayProvider form={form}>
           <WorkspaceInspector
             form={form}
+            experimentId="test-experiment"
             tables={[]}
             selectedTableName=""
             onTableChange={vi.fn()}

--- a/apps/web/components/experiment-visualizations/workspace/workspace-inspector.tsx
+++ b/apps/web/components/experiment-visualizations/workspace/workspace-inspector.tsx
@@ -21,6 +21,7 @@ const tabTriggerClass = cn(
 
 interface WorkspaceInspectorProps {
   form: UseFormReturn<ChartFormValues>;
+  experimentId: string;
   tables: ExperimentTableMetadata[];
   isTablesLoading?: boolean;
   tablesError?: unknown;
@@ -45,6 +46,7 @@ interface WorkspaceInspectorBodyProps extends WorkspaceInspectorProps {
 
 export function WorkspaceInspectorBody({
   form,
+  experimentId,
   tables,
   isTablesLoading = false,
   tablesError,
@@ -83,6 +85,7 @@ export function WorkspaceInspectorBody({
         <TabsContent value="data" className="mt-0 space-y-6">
           <DataTabContent
             form={form}
+            experimentId={experimentId}
             tables={tables}
             isTablesLoading={isTablesLoading}
             tablesError={tablesError}


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Adds a Filters shelf to the visualization inspector's Data tab so chart filters can be configured alongside the data sources, instead of only from the table view.

The shelf is a collapsible section that hosts the existing `FilterChipList`, with a count badge in the header when filters are active. It only mounts once a table is selected and columns are loaded. Filter changes write to `dataConfig.filters` on the chart form, with empty arrays normalized back to `undefined` so the field stays clean when the last filter is removed.

A `flat` prop is included for future popover-hosted usage that skips the Collapsible chrome.

To reach the shelf, `experimentId` is now threaded from `VisualizationWorkspace` through `WorkspaceInspector` into `DataTabContent`, which the chip list needs to fetch distinct column values.
