### PR TITLE
feat(web): adds remainder of basic chart family (area, bar, bubble, dot-plot, lollipop, and pie chart)

### DIFF
--- a/apps/web/components/experiment-visualizations/charts/basic/area/defaults.ts
+++ b/apps/web/components/experiment-visualizations/charts/basic/area/defaults.ts
@@ -1,0 +1,32 @@
+import type { ChartFormConfig, ChartFormDataConfig } from "../../chart-config";
+import { DEFAULT_PRIMARY_COLOR } from "../../colors/palettes";
+import { makeDataSource } from "../../data/data-sources";
+
+export function areaDefaultConfig(): ChartFormConfig {
+  return {
+    title: "",
+    xAxisTitle: "",
+    xAxisType: "linear",
+    yAxisType: "linear",
+    yAxisTitle: "",
+    showLegend: true,
+    showGrid: true,
+    useWebGL: false,
+    color: [DEFAULT_PRIMARY_COLOR],
+    mode: "lines",
+    // Shared AreaChart wrapper defaults `line.width: 0`; in our editor that
+    // looks unfinished, so set an explicit width to keep the boundary visible.
+    line: { width: 2, smoothing: 0 },
+    connectgaps: true,
+    stackMode: "none",
+    fillOpacity: 0.4,
+  };
+}
+
+export function areaDefaultDataConfig(tableName?: string): ChartFormDataConfig {
+  const table = tableName ?? "";
+  return {
+    tableName: table,
+    dataSources: [makeDataSource(table, "x"), makeDataSource(table, "y")],
+  };
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/area/index.ts
+++ b/apps/web/components/experiment-visualizations/charts/basic/area/index.ts
@@ -1,0 +1,24 @@
+import { AreaChart } from "lucide-react";
+
+import type { ChartTypeDef } from "../../types";
+import { areaDefaultConfig, areaDefaultDataConfig } from "./defaults";
+import { AreaDataPanel } from "./panels/data-panel";
+import { AreaStylePanel } from "./panels/style-panel";
+import { AreaRenderer } from "./renderer";
+import { areaDataShelves } from "./shelves/data-shelves";
+import { areaStyleShelves } from "./shelves/style-shelves";
+
+export const areaChartType: ChartTypeDef = {
+  type: "area",
+  family: "basic",
+  labelKey: "workspace.charts.types.area",
+  descriptionKey: "workspace.charts.descriptions.area",
+  icon: AreaChart,
+  defaultConfig: areaDefaultConfig,
+  defaultDataConfig: areaDefaultDataConfig,
+  DataPanel: AreaDataPanel,
+  StylePanel: AreaStylePanel,
+  Renderer: AreaRenderer,
+  dataShelves: areaDataShelves,
+  styleShelves: areaStyleShelves,
+};

--- a/apps/web/components/experiment-visualizations/charts/basic/area/options.ts
+++ b/apps/web/components/experiment-visualizations/charts/basic/area/options.ts
@@ -1,0 +1,8 @@
+/**
+ * Area-family options. `stackMode` is a UI-only abstraction the renderer
+ * translates into Plotly's `stackgroup` + `groupnorm` pair.
+ */
+export interface AreaChartOptions {
+  stackMode?: "none" | "stacked" | "percent";
+  fillOpacity?: number;
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/area/panels/data-panel.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/area/panels/data-panel.test.tsx
@@ -1,0 +1,104 @@
+import { renderWithForm, screen, userEvent } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+
+import { areaChartType } from "../";
+import { DataSourcesFieldArrayProvider } from "../../../../workspace/context/data-sources-field-array-context";
+import type { ChartFormValues } from "../../../chart-config";
+import { AreaDataPanel } from "../panels/data-panel";
+
+function defaults(overrides: Partial<ChartFormValues> = {}): ChartFormValues {
+  return {
+    name: "Untitled",
+    description: "",
+    chartFamily: areaChartType.family,
+    chartType: areaChartType.type,
+    config: areaChartType.defaultConfig(),
+    dataConfig: areaChartType.defaultDataConfig(),
+    ...overrides,
+  };
+}
+
+const columns: DataColumn[] = [
+  { name: "time", type_name: "TIMESTAMP", type_text: "TIMESTAMP" },
+  { name: "load", type_name: "DOUBLE", type_text: "DOUBLE" },
+  { name: "lab", type_name: "STRING", type_text: "STRING" },
+];
+
+function renderPanel(formDefaults?: ChartFormValues) {
+  return renderWithForm<ChartFormValues>(
+    (form) => (
+      <DataSourcesFieldArrayProvider form={form}>
+        <AreaDataPanel form={form} columns={columns} />
+      </DataSourcesFieldArrayProvider>
+    ),
+    { useFormProps: { defaultValues: formDefaults ?? defaults() } },
+  );
+}
+
+describe("AreaDataPanel", () => {
+  it("renders X, Y, group-by, and facet shelves", () => {
+    renderPanel();
+    expect(screen.getByRole("heading", { name: "workspace.shelves.xAxis" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "workspace.shelves.yAxis" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "workspace.shelves.groupBy" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "workspace.shelves.facetDimension" }),
+    ).toBeInTheDocument();
+  });
+
+  it("seeds the X-axis trigger from the existing data source", () => {
+    renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "readings",
+          dataSources: [
+            { tableName: "readings", columnName: "time", role: "x" },
+            { tableName: "readings", columnName: "load", role: "y" },
+          ],
+        },
+      }),
+    );
+    const triggers = screen.getAllByRole("combobox");
+    expect(triggers[0]).toHaveTextContent("time");
+  });
+
+  it("writes the picked X column into the data sources", async () => {
+    const user = userEvent.setup();
+    const { form } = renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "readings",
+          dataSources: [
+            { tableName: "readings", columnName: "", role: "x" },
+            { tableName: "readings", columnName: "load", role: "y" },
+          ],
+        },
+      }),
+    );
+
+    await user.click(screen.getAllByRole("combobox")[0]);
+    await user.click(await screen.findByText("time"));
+
+    const xSource = form.getValues("dataConfig.dataSources").find((ds) => ds.role === "x");
+    expect(xSource).toEqual(expect.objectContaining({ columnName: "time", tableName: "readings" }));
+  });
+
+  it("exposes the Add series button on the Y shelf", () => {
+    renderPanel();
+    expect(screen.getByRole("button", { name: "workspace.shelves.addSeries" })).toBeInTheDocument();
+  });
+
+  it("filters group-by columns to categorical only", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+    const before = screen.getAllByRole("combobox").length;
+    await user.click(screen.getByRole("button", { name: /workspace.shelves.groupBy/i }));
+    const combos = await screen.findAllByRole("combobox");
+    const groupCombo = combos[before];
+    await user.click(groupCombo);
+    expect(await screen.findByText("lab")).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /^load/i })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/area/panels/data-panel.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/area/panels/data-panel.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Fragment } from "react";
+
+import { Separator } from "@repo/ui/components/separator";
+
+import type { ChartPanelProps } from "../../../types";
+import { areaDataShelves } from "../shelves/data-shelves";
+
+export function AreaDataPanel({ form, columns }: ChartPanelProps) {
+  return (
+    <div className="space-y-6">
+      {areaDataShelves
+        .filter((shelf) => !shelf.visible || shelf.visible(form))
+        .map((shelf, index) => {
+          const Comp = shelf.Component;
+          return (
+            <Fragment key={shelf.key}>
+              {index > 0 && <Separator />}
+              <Comp form={form} columns={columns} />
+            </Fragment>
+          );
+        })}
+    </div>
+  );
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/area/panels/style-panel.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/area/panels/style-panel.test.tsx
@@ -1,0 +1,109 @@
+import { renderWithForm, screen } from "@/test/test-utils";
+import { fireEvent } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+
+import { areaChartType } from "../";
+import type { ChartFormValues } from "../../../chart-config";
+import { AreaStylePanel } from "../panels/style-panel";
+
+function defaults(overrides: Partial<ChartFormValues> = {}): ChartFormValues {
+  return {
+    name: "Untitled",
+    description: "",
+    chartFamily: areaChartType.family,
+    chartType: areaChartType.type,
+    config: areaChartType.defaultConfig(),
+    dataConfig: areaChartType.defaultDataConfig(),
+    ...overrides,
+  };
+}
+
+const columns: DataColumn[] = [
+  { name: "x", type_name: "DOUBLE", type_text: "DOUBLE" },
+  { name: "y", type_name: "DOUBLE", type_text: "DOUBLE" },
+];
+
+function renderPanel(formDefaults?: ChartFormValues) {
+  return renderWithForm<ChartFormValues>(
+    (form) => <AreaStylePanel form={form} columns={columns} />,
+    { useFormProps: { defaultValues: formDefaults ?? defaults() } },
+  );
+}
+
+function expandSection(name: string) {
+  fireEvent.click(screen.getByRole("button", { name }));
+}
+
+describe("AreaStylePanel", () => {
+  it("shows stack mode, drawing mode and fill opacity by default", () => {
+    renderPanel();
+    expandSection("workspace.style.areaOptions");
+    expect(screen.getByText("workspace.style.stackMode")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.fillOpacity")).toBeInTheDocument();
+    // `mode` lives in `LineStyleSection` after the refactor (it's a
+    // line/scatter concern, area inherits it). Open that section too.
+    expandSection("workspace.style.lineOptions");
+    expect(screen.getByText("workspace.style.mode")).toBeInTheDocument();
+  });
+
+  it("shows the line subsection when mode is lines (default)", () => {
+    renderPanel();
+    expandSection("workspace.style.lineOptions");
+    expect(screen.getByText("workspace.style.lineWidth")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.connectGaps")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.smoothing")).toBeInTheDocument();
+  });
+
+  it("hides the marker subsection when mode is lines only", () => {
+    renderPanel();
+    expandSection("workspace.style.lineOptions");
+    expect(screen.queryByText("workspace.style.markerOpacity")).not.toBeInTheDocument();
+  });
+
+  it("shows both line and marker subsections when mode is lines+markers", () => {
+    renderPanel(defaults({ config: { ...areaChartType.defaultConfig(), mode: "lines+markers" } }));
+    expandSection("workspace.style.lineOptions");
+    expect(screen.getByText("workspace.style.lineWidth")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.markerOpacity")).toBeInTheDocument();
+  });
+
+  it("hides both line and marker subsections in fill-only mode", () => {
+    renderPanel(defaults({ config: { ...areaChartType.defaultConfig(), mode: "none" } }));
+    expandSection("workspace.style.lineOptions");
+    expect(screen.queryByText("workspace.style.lineWidth")).not.toBeInTheDocument();
+    expect(screen.queryByText("workspace.style.markerOpacity")).not.toBeInTheDocument();
+  });
+
+  it("renders the scatter-series subsection when any Y source has traceType=scatter", () => {
+    renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "readings",
+          dataSources: [
+            { tableName: "readings", columnName: "time", role: "x" },
+            { tableName: "readings", columnName: "temp", role: "y" },
+            { tableName: "readings", columnName: "humidity", role: "y", traceType: "scatter" },
+          ],
+        },
+      }),
+    );
+    expect(screen.getByText("workspace.style.scatterSeriesOptions")).toBeInTheDocument();
+  });
+
+  it("renders the bar-series subsection when any Y source has traceType=bar", () => {
+    renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "readings",
+          dataSources: [
+            { tableName: "readings", columnName: "time", role: "x" },
+            { tableName: "readings", columnName: "temp", role: "y", traceType: "bar" },
+          ],
+        },
+      }),
+    );
+    expect(screen.getByText("workspace.style.barSeriesOptions")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/area/panels/style-panel.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/area/panels/style-panel.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Fragment } from "react";
+import { useWatch } from "react-hook-form";
+
+import { Separator } from "@repo/ui/components/separator";
+
+import type { ChartPanelProps } from "../../../types";
+import { areaStyleShelves } from "../shelves/style-shelves";
+
+export function AreaStylePanel({ form, columns }: ChartPanelProps) {
+  // Broad subscription so `visible(form)` predicates re-evaluate when the
+  // user toggles trace types. Each predicate reads with `form.getValues()`
+  // inside.
+  useWatch({ control: form.control, name: "dataConfig.dataSources" });
+
+  const visibleShelves = areaStyleShelves.filter((shelf) => !shelf.visible || shelf.visible(form));
+
+  return (
+    <div className="space-y-6">
+      {visibleShelves.map((shelf, index) => {
+        const Comp = shelf.Component;
+        return (
+          <Fragment key={shelf.key}>
+            {index > 0 && <Separator />}
+            <Comp form={form} columns={columns} />
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/area/renderer.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/area/renderer.test.tsx
@@ -1,0 +1,126 @@
+import { createVisualization } from "@/test/factories";
+import { render, screen } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import { areaDefaultConfig } from "./defaults";
+import { AreaRenderer } from "./renderer";
+
+function buildViz(overrides: Parameters<typeof createVisualization>[0] = {}) {
+  return createVisualization({
+    chartType: "area",
+    chartFamily: "basic",
+    config: { ...areaDefaultConfig() },
+    dataConfig: {
+      tableName: "readings",
+      dataSources: [
+        { tableName: "readings", columnName: "time", role: "x" },
+        { tableName: "readings", columnName: "load", role: "y" },
+      ],
+    },
+    ...overrides,
+  });
+}
+
+describe("AreaRenderer", () => {
+  it("shows a config error when the visualization isn't an area chart", () => {
+    const viz = buildViz({ chartType: "line" });
+    render(<AreaRenderer visualization={viz} experimentId="exp-1" data={[]} />);
+    expect(screen.getByText("errors.configuration")).toBeInTheDocument();
+    expect(screen.getByText("errors.invalidConfiguration")).toBeInTheDocument();
+  });
+
+  it("shows the empty-state when there are no rows", () => {
+    const viz = buildViz();
+    render(<AreaRenderer visualization={viz} experimentId="exp-1" data={[]} />);
+    expect(screen.getByText("errors.noData")).toBeInTheDocument();
+  });
+
+  it("renders the chart frame with rows + both axes configured", () => {
+    const viz = buildViz();
+    const rows = [
+      { time: 1, load: 21 },
+      { time: 2, load: 22 },
+    ];
+    const { container } = render(
+      <AreaRenderer visualization={viz} experimentId="exp-1" data={rows} />,
+    );
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+    expect(screen.queryByText("errors.noData")).not.toBeInTheDocument();
+    expect(container.querySelector(".flex.h-full.w-full.flex-col")).toBeInTheDocument();
+  });
+
+  it("renders multiple Y series (one trace per series)", () => {
+    const viz = buildViz({
+      dataConfig: {
+        tableName: "readings",
+        dataSources: [
+          { tableName: "readings", columnName: "time", role: "x" },
+          { tableName: "readings", columnName: "load", role: "y" },
+          { tableName: "readings", columnName: "saturation", role: "y" },
+        ],
+      },
+    });
+    const rows = [
+      { time: 1, load: 21, saturation: 40 },
+      { time: 2, load: 22, saturation: 41 },
+    ];
+    render(<AreaRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+  });
+
+  it("renders when only Y is configured (X synthesised from row indices)", () => {
+    const viz = buildViz({
+      dataConfig: {
+        tableName: "readings",
+        dataSources: [
+          { tableName: "readings", columnName: "", role: "x" },
+          { tableName: "readings", columnName: "load", role: "y" },
+        ],
+      },
+    });
+    const rows = [{ load: 21 }, { load: 22 }];
+    render(<AreaRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+    expect(screen.queryByText("errors.noData")).not.toBeInTheDocument();
+  });
+
+  it("renders in stacked mode without throwing", () => {
+    const viz = buildViz({
+      config: { ...areaDefaultConfig(), stackMode: "stacked" },
+      dataConfig: {
+        tableName: "readings",
+        dataSources: [
+          { tableName: "readings", columnName: "time", role: "x" },
+          { tableName: "readings", columnName: "load", role: "y" },
+          { tableName: "readings", columnName: "saturation", role: "y" },
+        ],
+      },
+    });
+    const rows = [
+      { time: 1, load: 21, saturation: 40 },
+      { time: 2, load: 22, saturation: 41 },
+    ];
+    render(<AreaRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+  });
+
+  it("renders in percent-stacked mode without throwing", () => {
+    const viz = buildViz({
+      config: { ...areaDefaultConfig(), stackMode: "percent" },
+      dataConfig: {
+        tableName: "readings",
+        dataSources: [
+          { tableName: "readings", columnName: "time", role: "x" },
+          { tableName: "readings", columnName: "load", role: "y" },
+          { tableName: "readings", columnName: "saturation", role: "y" },
+        ],
+      },
+    });
+    const rows = [
+      { time: 1, load: 21, saturation: 40 },
+      { time: 2, load: 22, saturation: 41 },
+    ];
+    render(<AreaRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/area/renderer.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/area/renderer.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useTranslation } from "@repo/i18n";
+
+import { CartesianRenderer } from "../../cartesian/cartesian-renderer";
+import { ChartConfigError } from "../../chart-frame";
+import type { ChartRendererProps } from "../../types";
+
+export function AreaRenderer(props: ChartRendererProps) {
+  const { t } = useTranslation("experimentVisualizations");
+
+  if (props.visualization.chartType !== "area") {
+    return <ChartConfigError message={t("errors.invalidConfiguration")} />;
+  }
+
+  return <CartesianRenderer {...props} defaultTraceType="area" />;
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/area/shelves/data-shelves.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/area/shelves/data-shelves.test.tsx
@@ -1,0 +1,58 @@
+import { renderWithForm } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import { areaChartType } from "..";
+import type { ChartFormValues } from "../../../chart-config";
+import type { ShelfSummaryT } from "../../../types";
+import { areaDataShelves } from "./data-shelves";
+
+const t: ShelfSummaryT = (key, options) => (options ? `${key}:${JSON.stringify(options)}` : key);
+
+function form(dataSources: ChartFormValues["dataConfig"]["dataSources"]) {
+  return renderWithForm<ChartFormValues>(() => <div />, {
+    useFormProps: {
+      defaultValues: {
+        name: "",
+        description: "",
+        chartFamily: areaChartType.family,
+        chartType: areaChartType.type,
+        config: areaChartType.defaultConfig(),
+        dataConfig: { tableName: "t", dataSources },
+      },
+    },
+  }).form;
+}
+
+describe("areaDataShelves summaries", () => {
+  const [x, y, group, facet] = areaDataShelves;
+
+  it("X falls back to INDEX when unset, returns the column when set", () => {
+    expect(x.summary?.(form([]), t)).toBe("INDEX");
+    expect(x.summary?.(form([{ tableName: "t", columnName: "time", role: "x" }]), t)).toBe("time");
+  });
+
+  it("Y is undefined / column / count by series count", () => {
+    expect(y.summary?.(form([]), t)).toBeUndefined();
+    expect(y.summary?.(form([{ tableName: "t", columnName: "load", role: "y" }]), t)).toBe("load");
+    expect(
+      y.summary?.(
+        form([
+          { tableName: "t", columnName: "a", role: "y" },
+          { tableName: "t", columnName: "b", role: "y" },
+        ]),
+        t,
+      ),
+    ).toBe(`workspace.shelves.seriesCount:{"count":2}`);
+  });
+
+  it("groupBy + facet return the column when set, undefined otherwise", () => {
+    expect(group.summary?.(form([]), t)).toBeUndefined();
+    expect(facet.summary?.(form([]), t)).toBeUndefined();
+    expect(group.summary?.(form([{ tableName: "t", columnName: "dev", role: "color" }]), t)).toBe(
+      "dev",
+    );
+    expect(facet.summary?.(form([{ tableName: "t", columnName: "site", role: "facet" }]), t)).toBe(
+      "site",
+    );
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/area/shelves/data-shelves.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/area/shelves/data-shelves.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { Layers, LayoutGrid } from "lucide-react";
+import { useMemo } from "react";
+
+import { filterColumnsForRole } from "@repo/api/utils/visualization-contracts";
+
+import { FacetShelf } from "../../../../workspace/shelves/facet-shelf";
+import { GroupByShelf } from "../../../../workspace/shelves/group-by-shelf";
+import { XAxisShelf } from "../../../../workspace/shelves/x-axis-shelf";
+import { YAxisShelf } from "../../../../workspace/shelves/y-axis-shelf";
+import { dataSourcesByRole, firstDataSourceByRole } from "../../../data/data-sources";
+import { XAxisGlyph, YAxisGlyph } from "../../../shelf-axis-glyphs";
+import type { ChartPanelProps, ShelfDef } from "../../../types";
+
+const X_AXIS_NONE_INDEX = "INDEX";
+
+function AreaXShelf({ form, columns }: ChartPanelProps) {
+  const xColumns = useMemo(() => filterColumnsForRole(columns, "area", "x"), [columns]);
+  return <XAxisShelf form={form} columns={xColumns} allowNone />;
+}
+
+function AreaYShelf({ form, columns }: ChartPanelProps) {
+  const yColumns = useMemo(() => filterColumnsForRole(columns, "area", "y"), [columns]);
+  return (
+    <YAxisShelf
+      form={form}
+      columns={yColumns}
+      showCartesianControls
+      defaultTraceType="area"
+      showErrorColumn
+    />
+  );
+}
+
+function AreaGroupShelf({ form, columns, flat }: ChartPanelProps) {
+  // Color follows from categorical splitting on area charts, surfaced
+  // as Group by because the gradient encoding doesn't apply here.
+  const groupColumns = useMemo(() => filterColumnsForRole(columns, "area", "color"), [columns]);
+  return <GroupByShelf form={form} columns={groupColumns} flat={flat} />;
+}
+
+function AreaFacetShelfWrapper({ form, columns, flat }: ChartPanelProps) {
+  const facetColumns = useMemo(() => filterColumnsForRole(columns, "area", "facet"), [columns]);
+  return <FacetShelf form={form} columns={facetColumns} flat={flat} />;
+}
+
+export const areaDataShelves: ShelfDef[] = [
+  {
+    key: "x",
+    labelKey: "workspace.shelves.xAxis",
+    icon: XAxisGlyph,
+    Component: AreaXShelf,
+    summary: (form) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const x = firstDataSourceByRole(sources, "x");
+      const col = x?.source.columnName;
+      return col && col.length > 0 ? col : X_AXIS_NONE_INDEX;
+    },
+  },
+  {
+    key: "y",
+    labelKey: "workspace.shelves.yAxis",
+    icon: YAxisGlyph,
+    Component: AreaYShelf,
+    summary: (form, t) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const ys = dataSourcesByRole(sources, "y").filter(
+        (entry) => entry.source.columnName && entry.source.columnName.length > 0,
+      );
+      if (ys.length === 0) return undefined;
+      if (ys.length === 1) return ys[0]?.source.columnName;
+      return t("workspace.shelves.seriesCount", { count: ys.length });
+    },
+  },
+  {
+    key: "groupBy",
+    labelKey: "workspace.shelves.groupBy",
+    icon: Layers,
+    Component: AreaGroupShelf,
+    summary: (form) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const col = firstDataSourceByRole(sources, "color")?.source.columnName;
+      return col && col.length > 0 ? col : undefined;
+    },
+  },
+  {
+    key: "facet",
+    labelKey: "workspace.shelves.facetDimension",
+    icon: LayoutGrid,
+    Component: AreaFacetShelfWrapper,
+    summary: (form) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const col = firstDataSourceByRole(sources, "facet")?.source.columnName;
+      return col && col.length > 0 ? col : undefined;
+    },
+  },
+];

--- a/apps/web/components/experiment-visualizations/charts/basic/area/shelves/style-shelves.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/area/shelves/style-shelves.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import {
+  AreaChart,
+  BarChart3,
+  Circle,
+  LayoutGrid,
+  Minus,
+  MoveVertical,
+  Settings2,
+  Spline,
+} from "lucide-react";
+
+import { AreaStyleSection } from "../../../../workspace/style-sections/area-style-section";
+import { BarStyleSection } from "../../../../workspace/style-sections/bar-style-section";
+import { DisplayOptionsSection } from "../../../../workspace/style-sections/display-options-section";
+import { ErrorBarStyleSection } from "../../../../workspace/style-sections/error-bar-style-section";
+import { FacetStyleSection } from "../../../../workspace/style-sections/facet-style-section";
+import { LineStyleSection } from "../../../../workspace/style-sections/line-style-section";
+import { MarkerStyleSection } from "../../../../workspace/style-sections/marker-style-section";
+import { ReferenceLinesSection } from "../../../../workspace/style-sections/reference-lines-section";
+import { hasTraceType } from "../../../shelf-visibility";
+import type { ChartPanelProps, ShelfDef } from "../../../types";
+
+function AreaDisplay({ form, flat }: ChartPanelProps) {
+  return <DisplayOptionsSection form={form} flat={flat} />;
+}
+
+function AreaPrimaryStyle({ form, flat }: ChartPanelProps) {
+  return <AreaStyleSection form={form} flat={flat} />;
+}
+
+function AreaLineStyle({ form, flat }: ChartPanelProps) {
+  // Area's outline + markers are styled via the line/marker controls;
+  // mirrors the standalone area panel.
+  return <LineStyleSection form={form} titleKey="workspace.style.lineOptions" flat={flat} />;
+}
+
+function AreaScatterSeries({ form, flat }: ChartPanelProps) {
+  return (
+    <MarkerStyleSection
+      form={form}
+      titleKey="workspace.style.scatterSeriesOptions"
+      defaultTitle="Scatter series"
+      flat={flat}
+    />
+  );
+}
+
+function AreaBarSeries({ form, flat }: ChartPanelProps) {
+  return (
+    <BarStyleSection
+      form={form}
+      titleKey="workspace.style.barSeriesOptions"
+      defaultTitle="Bar series"
+      showOrientation={false}
+      flat={flat}
+    />
+  );
+}
+
+function AreaErrorBar({ form, flat }: ChartPanelProps) {
+  return <ErrorBarStyleSection form={form} flat={flat} />;
+}
+
+function AreaReferenceLines({ form, flat }: ChartPanelProps) {
+  return <ReferenceLinesSection form={form} flat={flat} />;
+}
+
+function AreaFacetStyle({ form, flat }: ChartPanelProps) {
+  return <FacetStyleSection form={form} flat={flat} />;
+}
+
+export const areaStyleShelves: ShelfDef[] = [
+  {
+    key: "display",
+    labelKey: "workspace.style.display",
+    icon: Settings2,
+    Component: AreaDisplay,
+  },
+  {
+    key: "area",
+    labelKey: "workspace.style.areaOptions",
+    icon: AreaChart,
+    Component: AreaPrimaryStyle,
+  },
+  {
+    key: "line",
+    labelKey: "workspace.style.lineOptions",
+    icon: Spline,
+    Component: AreaLineStyle,
+  },
+  {
+    key: "scatter",
+    labelKey: "workspace.style.scatterSeriesOptions",
+    icon: Circle,
+    Component: AreaScatterSeries,
+    visible: (form) => hasTraceType(form, "scatter"),
+  },
+  {
+    key: "bar",
+    labelKey: "workspace.style.barSeriesOptions",
+    icon: BarChart3,
+    Component: AreaBarSeries,
+    visible: (form) => hasTraceType(form, "bar"),
+  },
+  {
+    key: "errorBar",
+    labelKey: "workspace.style.errorBarOptions",
+    icon: MoveVertical,
+    Component: AreaErrorBar,
+  },
+  {
+    key: "referenceLines",
+    labelKey: "workspace.style.referenceLines",
+    icon: Minus,
+    Component: AreaReferenceLines,
+  },
+  {
+    key: "facet",
+    labelKey: "workspace.style.facetOptions",
+    icon: LayoutGrid,
+    Component: AreaFacetStyle,
+  },
+];

--- a/apps/web/components/experiment-visualizations/charts/basic/bar/defaults.ts
+++ b/apps/web/components/experiment-visualizations/charts/basic/bar/defaults.ts
@@ -1,0 +1,31 @@
+import type { ChartFormConfig, ChartFormDataConfig } from "../../chart-config";
+import { DEFAULT_PRIMARY_COLOR } from "../../colors/palettes";
+import { makeDataSource } from "../../data/data-sources";
+
+export function barDefaultConfig(): ChartFormConfig {
+  return {
+    title: "",
+    xAxisTitle: "",
+    xAxisType: "category",
+    yAxisType: "linear",
+    yAxisTitle: "",
+    showLegend: true,
+    showGrid: true,
+    useWebGL: false,
+    color: [DEFAULT_PRIMARY_COLOR],
+    orientation: "v",
+    barmode: "group",
+    barnorm: "",
+    bargap: 0.15,
+    bargroupgap: 0.05,
+    marker: { opacity: 0.85 },
+  };
+}
+
+export function barDefaultDataConfig(tableName?: string): ChartFormDataConfig {
+  const table = tableName ?? "";
+  return {
+    tableName: table,
+    dataSources: [makeDataSource(table, "x"), makeDataSource(table, "y")],
+  };
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/bar/index.ts
+++ b/apps/web/components/experiment-visualizations/charts/basic/bar/index.ts
@@ -1,0 +1,24 @@
+import { BarChart3 } from "lucide-react";
+
+import type { ChartTypeDef } from "../../types";
+import { barDefaultConfig, barDefaultDataConfig } from "./defaults";
+import { BarDataPanel } from "./panels/data-panel";
+import { BarStylePanel } from "./panels/style-panel";
+import { BarRenderer } from "./renderer";
+import { barDataShelves } from "./shelves/data-shelves";
+import { barStyleShelves } from "./shelves/style-shelves";
+
+export const barChartType: ChartTypeDef = {
+  type: "bar",
+  family: "basic",
+  labelKey: "workspace.charts.types.bar",
+  descriptionKey: "workspace.charts.descriptions.bar",
+  icon: BarChart3,
+  defaultConfig: barDefaultConfig,
+  defaultDataConfig: barDefaultDataConfig,
+  DataPanel: BarDataPanel,
+  StylePanel: BarStylePanel,
+  Renderer: BarRenderer,
+  dataShelves: barDataShelves,
+  styleShelves: barStyleShelves,
+};

--- a/apps/web/components/experiment-visualizations/charts/basic/bar/panels/data-panel.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bar/panels/data-panel.test.tsx
@@ -1,0 +1,97 @@
+import { renderWithForm, screen, userEvent } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+
+import { barChartType } from "../";
+import { DataSourcesFieldArrayProvider } from "../../../../workspace/context/data-sources-field-array-context";
+import type { ChartFormValues } from "../../../chart-config";
+import { BarDataPanel } from "../panels/data-panel";
+
+function defaults(overrides: Partial<ChartFormValues> = {}): ChartFormValues {
+  return {
+    name: "Untitled",
+    description: "",
+    chartFamily: barChartType.family,
+    chartType: barChartType.type,
+    config: barChartType.defaultConfig(),
+    dataConfig: barChartType.defaultDataConfig(),
+    ...overrides,
+  };
+}
+
+const columns: DataColumn[] = [
+  { name: "country", type_name: "STRING", type_text: "STRING" },
+  { name: "sales", type_name: "DOUBLE", type_text: "DOUBLE" },
+  { name: "region", type_name: "STRING", type_text: "STRING" },
+];
+
+function renderPanel(formDefaults?: ChartFormValues) {
+  return renderWithForm<ChartFormValues>(
+    (form) => (
+      <DataSourcesFieldArrayProvider form={form}>
+        <BarDataPanel form={form} columns={columns} />
+      </DataSourcesFieldArrayProvider>
+    ),
+    { useFormProps: { defaultValues: formDefaults ?? defaults() } },
+  );
+}
+
+describe("BarDataPanel", () => {
+  it("renders X, Y, group-by, and facet shelves", () => {
+    renderPanel();
+    expect(screen.getByRole("heading", { name: "workspace.shelves.xAxis" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "workspace.shelves.yAxis" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "workspace.shelves.groupBy" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "workspace.shelves.facetDimension" }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the X-axis type picker (bar forces categorical) and keeps Y's", () => {
+    renderPanel();
+    // Only one axis-type select remains: Y axis.
+    expect(screen.getAllByText("workspace.shelves.axisType")).toHaveLength(1);
+  });
+
+  it("seeds the X-axis trigger from the existing data source", () => {
+    renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "sales",
+          dataSources: [
+            { tableName: "sales", columnName: "country", role: "x" },
+            { tableName: "sales", columnName: "sales", role: "y" },
+          ],
+        },
+      }),
+    );
+    expect(screen.getAllByRole("combobox")[0]).toHaveTextContent("country");
+  });
+
+  it("writes the picked X column into the data sources", async () => {
+    const user = userEvent.setup();
+    const { form } = renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "sales",
+          dataSources: [
+            { tableName: "sales", columnName: "", role: "x" },
+            { tableName: "sales", columnName: "sales", role: "y" },
+          ],
+        },
+      }),
+    );
+
+    await user.click(screen.getAllByRole("combobox")[0]);
+    await user.click(await screen.findByText("country"));
+
+    const xSource = form.getValues("dataConfig.dataSources").find((ds) => ds.role === "x");
+    expect(xSource).toEqual(expect.objectContaining({ columnName: "country", tableName: "sales" }));
+  });
+
+  it("exposes the Add series button on the Y shelf", () => {
+    renderPanel();
+    expect(screen.getByRole("button", { name: "workspace.shelves.addSeries" })).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/bar/panels/data-panel.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bar/panels/data-panel.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Fragment } from "react";
+
+import { Separator } from "@repo/ui/components/separator";
+
+import type { ChartPanelProps } from "../../../types";
+import { barDataShelves } from "../shelves/data-shelves";
+
+export function BarDataPanel({ form, columns }: ChartPanelProps) {
+  return (
+    <div className="space-y-6">
+      {barDataShelves
+        .filter((shelf) => !shelf.visible || shelf.visible(form))
+        .map((shelf, index) => {
+          const Comp = shelf.Component;
+          return (
+            <Fragment key={shelf.key}>
+              {index > 0 && <Separator />}
+              <Comp form={form} columns={columns} />
+            </Fragment>
+          );
+        })}
+    </div>
+  );
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/bar/panels/style-panel.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bar/panels/style-panel.test.tsx
@@ -1,0 +1,117 @@
+import { renderWithForm, screen } from "@/test/test-utils";
+import { fireEvent } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+
+import { barChartType } from "../";
+import type { ChartFormValues } from "../../../chart-config";
+import { BarStylePanel } from "../panels/style-panel";
+
+function defaults(overrides: Partial<ChartFormValues> = {}): ChartFormValues {
+  return {
+    name: "Untitled",
+    description: "",
+    chartFamily: barChartType.family,
+    chartType: barChartType.type,
+    config: barChartType.defaultConfig(),
+    dataConfig: barChartType.defaultDataConfig(),
+    ...overrides,
+  };
+}
+
+const columns: DataColumn[] = [
+  { name: "variety", type_name: "VARCHAR", type_text: "STRING" },
+  { name: "yield", type_name: "DOUBLE", type_text: "DOUBLE" },
+];
+
+function renderPanel(formDefaults?: ChartFormValues) {
+  return renderWithForm<ChartFormValues>(
+    (form) => <BarStylePanel form={form} columns={columns} />,
+    { useFormProps: { defaultValues: formDefaults ?? defaults() } },
+  );
+}
+
+function expandSection(name: string) {
+  fireEvent.click(screen.getByRole("button", { name }));
+}
+
+describe("BarStylePanel", () => {
+  it("shows orientation, barmode, gap and opacity by default", () => {
+    renderPanel();
+    expandSection("workspace.style.barOptions");
+    expect(screen.getByText("workspace.style.orientation")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.barmode")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.bargap")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.markerOpacity")).toBeInTheDocument();
+  });
+
+  it("hides the normalisation control when bars are grouped (default)", () => {
+    renderPanel();
+    expandSection("workspace.style.barOptions");
+    expect(screen.queryByText("workspace.style.barnorm")).not.toBeInTheDocument();
+  });
+
+  it("shows the normalisation control when bars are stacked", () => {
+    renderPanel(defaults({ config: { ...barChartType.defaultConfig(), barmode: "stack" } }));
+    expandSection("workspace.style.barOptions");
+    expect(screen.getByText("workspace.style.barnorm")).toBeInTheDocument();
+  });
+
+  it("shows the normalisation control when bars are relative", () => {
+    renderPanel(defaults({ config: { ...barChartType.defaultConfig(), barmode: "relative" } }));
+    expandSection("workspace.style.barOptions");
+    expect(screen.getByText("workspace.style.barnorm")).toBeInTheDocument();
+  });
+
+  it("hides the normalisation control when bars overlay", () => {
+    renderPanel(defaults({ config: { ...barChartType.defaultConfig(), barmode: "overlay" } }));
+    expandSection("workspace.style.barOptions");
+    expect(screen.queryByText("workspace.style.barnorm")).not.toBeInTheDocument();
+  });
+
+  it("renders the line-series subsection when any Y source has traceType=line", () => {
+    renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "harvest",
+          dataSources: [
+            { tableName: "harvest", columnName: "variety", role: "x" },
+            { tableName: "harvest", columnName: "yield", role: "y", traceType: "line" },
+          ],
+        },
+      }),
+    );
+    expect(screen.getByText("workspace.style.lineSeriesOptions")).toBeInTheDocument();
+  });
+
+  it("renders the scatter-series subsection when any Y source has traceType=scatter", () => {
+    renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "harvest",
+          dataSources: [
+            { tableName: "harvest", columnName: "variety", role: "x" },
+            { tableName: "harvest", columnName: "yield", role: "y", traceType: "scatter" },
+          ],
+        },
+      }),
+    );
+    expect(screen.getByText("workspace.style.scatterSeriesOptions")).toBeInTheDocument();
+  });
+
+  it("renders the area-series subsection when any Y source has traceType=area", () => {
+    renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "harvest",
+          dataSources: [
+            { tableName: "harvest", columnName: "variety", role: "x" },
+            { tableName: "harvest", columnName: "yield", role: "y", traceType: "area" },
+          ],
+        },
+      }),
+    );
+    expect(screen.getByText("workspace.style.areaSeriesOptions")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/bar/panels/style-panel.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bar/panels/style-panel.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Fragment } from "react";
+import { useWatch } from "react-hook-form";
+
+import { Separator } from "@repo/ui/components/separator";
+
+import type { ChartPanelProps } from "../../../types";
+import { barStyleShelves } from "../shelves/style-shelves";
+
+export function BarStylePanel({ form, columns }: ChartPanelProps) {
+  // Broad subscription so `visible(form)` predicates re-evaluate when the
+  // user toggles trace types. Each predicate reads with `form.getValues()`
+  // inside.
+  useWatch({ control: form.control, name: "dataConfig.dataSources" });
+
+  const visibleShelves = barStyleShelves.filter((shelf) => !shelf.visible || shelf.visible(form));
+
+  return (
+    <div className="space-y-6">
+      {visibleShelves.map((shelf, index) => {
+        const Comp = shelf.Component;
+        return (
+          <Fragment key={shelf.key}>
+            {index > 0 && <Separator />}
+            <Comp form={form} columns={columns} />
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/bar/renderer.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bar/renderer.test.tsx
@@ -1,0 +1,100 @@
+import { createVisualization } from "@/test/factories";
+import { render, screen } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import { barDefaultConfig } from "./defaults";
+import { BarRenderer } from "./renderer";
+
+function buildViz(overrides: Parameters<typeof createVisualization>[0] = {}) {
+  return createVisualization({
+    chartType: "bar",
+    chartFamily: "basic",
+    config: { ...barDefaultConfig() },
+    dataConfig: {
+      tableName: "harvest",
+      dataSources: [
+        { tableName: "harvest", columnName: "variety", role: "x" },
+        { tableName: "harvest", columnName: "yield", role: "y" },
+      ],
+    },
+    ...overrides,
+  });
+}
+
+describe("BarRenderer", () => {
+  it("shows a config error when the visualization isn't a bar chart", () => {
+    const viz = buildViz({ chartType: "line" });
+    render(<BarRenderer visualization={viz} experimentId="exp-1" data={[]} />);
+    expect(screen.getByText("errors.configuration")).toBeInTheDocument();
+    expect(screen.getByText("errors.invalidConfiguration")).toBeInTheDocument();
+  });
+
+  it("shows the empty-state when there are no rows", () => {
+    const viz = buildViz();
+    render(<BarRenderer visualization={viz} experimentId="exp-1" data={[]} />);
+    expect(screen.getByText("errors.noData")).toBeInTheDocument();
+  });
+
+  it("renders the chart frame with rows + both axes configured", () => {
+    const viz = buildViz();
+    const rows = [
+      { variety: "Tomato", yield: 12 },
+      { variety: "Cucumber", yield: 8 },
+    ];
+    const { container } = render(
+      <BarRenderer visualization={viz} experimentId="exp-1" data={rows} />,
+    );
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+    expect(screen.queryByText("errors.noData")).not.toBeInTheDocument();
+    expect(container.querySelector(".flex.h-full.w-full.flex-col")).toBeInTheDocument();
+  });
+
+  it("renders multiple Y series (one trace per series)", () => {
+    const viz = buildViz({
+      dataConfig: {
+        tableName: "harvest",
+        dataSources: [
+          { tableName: "harvest", columnName: "variety", role: "x" },
+          { tableName: "harvest", columnName: "yield", role: "y" },
+          { tableName: "harvest", columnName: "weight", role: "y" },
+        ],
+      },
+    });
+    const rows = [
+      { variety: "Tomato", yield: 12, weight: 4.2 },
+      { variety: "Cucumber", yield: 8, weight: 3.0 },
+    ];
+    render(<BarRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+  });
+
+  it("renders the empty axes (no traces) when X is not configured", () => {
+    // Bar charts can't synthesize X from row indices the way line/scatter do;
+    // numbered-bar fallbacks don't carry meaning. The renderer should still
+    // mount the frame but emit zero traces; we assert the no-error path.
+    const viz = buildViz({
+      dataConfig: {
+        tableName: "harvest",
+        dataSources: [
+          { tableName: "harvest", columnName: "", role: "x" },
+          { tableName: "harvest", columnName: "yield", role: "y" },
+        ],
+      },
+    });
+    const rows = [{ yield: 12 }, { yield: 8 }];
+    render(<BarRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+  });
+
+  it("renders in horizontal orientation without throwing", () => {
+    const viz = buildViz({
+      config: { ...barDefaultConfig(), orientation: "h" },
+    });
+    const rows = [
+      { variety: "Tomato", yield: 12 },
+      { variety: "Cucumber", yield: 8 },
+    ];
+    render(<BarRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/bar/renderer.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bar/renderer.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useTranslation } from "@repo/i18n";
+import type { PlotlyChartConfig } from "@repo/ui/components/charts/types";
+
+import { CartesianRenderer } from "../../cartesian/cartesian-renderer";
+import { narrowChartConfig } from "../../chart-config";
+import type { ChartFormConfig } from "../../chart-config";
+import { ChartConfigError } from "../../chart-frame";
+import type { ChartRendererProps } from "../../types";
+
+export function BarRenderer(props: ChartRendererProps) {
+  const { t } = useTranslation("experimentVisualizations");
+
+  if (props.visualization.chartType !== "bar") {
+    return <ChartConfigError message={t("errors.invalidConfiguration")} />;
+  }
+
+  const chartConfig = narrowChartConfig(props.visualization);
+  const orientation = chartConfig.orientation === "h" ? "h" : "v";
+
+  // Mirror axis title/type swap in horizontal mode; form keeps X=categories.
+  const swappedConfig: ChartFormConfig & PlotlyChartConfig =
+    orientation === "h"
+      ? {
+          ...chartConfig,
+          xAxisTitle: chartConfig.yAxisTitle,
+          yAxisTitle: chartConfig.xAxisTitle,
+          xAxisType: chartConfig.yAxisType,
+          yAxisType: chartConfig.xAxisType,
+        }
+      : chartConfig;
+
+  const swapped =
+    orientation === "h"
+      ? {
+          ...props.visualization,
+          config: { ...swappedConfig },
+        }
+      : props.visualization;
+
+  return <CartesianRenderer {...props} visualization={swapped} defaultTraceType="bar" />;
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/bar/shelves/data-shelves.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bar/shelves/data-shelves.test.tsx
@@ -1,0 +1,62 @@
+import { renderWithForm } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import { barChartType } from "..";
+import type { ChartFormValues } from "../../../chart-config";
+import type { ShelfSummaryT } from "../../../types";
+import { barDataShelves } from "./data-shelves";
+
+const t: ShelfSummaryT = (key, options) => (options ? `${key}:${JSON.stringify(options)}` : key);
+
+function form(dataSources: ChartFormValues["dataConfig"]["dataSources"]) {
+  return renderWithForm<ChartFormValues>(() => <div />, {
+    useFormProps: {
+      defaultValues: {
+        name: "",
+        description: "",
+        chartFamily: barChartType.family,
+        chartType: barChartType.type,
+        config: barChartType.defaultConfig(),
+        dataConfig: { tableName: "t", dataSources },
+      },
+    },
+  }).form;
+}
+
+describe("barDataShelves summaries", () => {
+  const [x, y, group, facet] = barDataShelves;
+
+  it("X falls back to INDEX when unset, returns the column when set", () => {
+    expect(x.summary?.(form([]), t)).toBe("INDEX");
+    expect(x.summary?.(form([{ tableName: "t", columnName: "variety", role: "x" }]), t)).toBe(
+      "variety",
+    );
+  });
+
+  it("Y is undefined / column / count by series count", () => {
+    expect(y.summary?.(form([]), t)).toBeUndefined();
+    expect(y.summary?.(form([{ tableName: "t", columnName: "yield", role: "y" }]), t)).toBe(
+      "yield",
+    );
+    expect(
+      y.summary?.(
+        form([
+          { tableName: "t", columnName: "a", role: "y" },
+          { tableName: "t", columnName: "b", role: "y" },
+        ]),
+        t,
+      ),
+    ).toBe(`workspace.shelves.seriesCount:{"count":2}`);
+  });
+
+  it("groupBy + facet return the column when set, undefined otherwise", () => {
+    expect(group.summary?.(form([]), t)).toBeUndefined();
+    expect(facet.summary?.(form([]), t)).toBeUndefined();
+    expect(group.summary?.(form([{ tableName: "t", columnName: "site", role: "color" }]), t)).toBe(
+      "site",
+    );
+    expect(
+      facet.summary?.(form([{ tableName: "t", columnName: "season", role: "facet" }]), t),
+    ).toBe("season");
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/bar/shelves/data-shelves.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bar/shelves/data-shelves.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Layers, LayoutGrid } from "lucide-react";
+import { useMemo } from "react";
+
+import { filterColumnsForRole } from "@repo/api/utils/visualization-contracts";
+
+import { FacetShelf } from "../../../../workspace/shelves/facet-shelf";
+import { GroupByShelf } from "../../../../workspace/shelves/group-by-shelf";
+import { XAxisShelf } from "../../../../workspace/shelves/x-axis-shelf";
+import { YAxisShelf } from "../../../../workspace/shelves/y-axis-shelf";
+import { dataSourcesByRole, firstDataSourceByRole } from "../../../data/data-sources";
+import { XAxisGlyph, YAxisGlyph } from "../../../shelf-axis-glyphs";
+import type { ChartPanelProps, ShelfDef } from "../../../types";
+
+const X_AXIS_NONE_INDEX = "INDEX";
+
+function BarXShelf({ form, columns }: ChartPanelProps) {
+  const xColumns = useMemo(() => filterColumnsForRole(columns, "bar", "x"), [columns]);
+  // Bar is "magnitude per category"; the wrapper force-overrides the
+  // category axis to "category" in horizontal mode, so the picker would
+  // be misleading.
+  return <XAxisShelf form={form} columns={xColumns} hideAxisType allowNone />;
+}
+
+function BarYShelf({ form, columns }: ChartPanelProps) {
+  const yColumns = useMemo(() => filterColumnsForRole(columns, "bar", "y"), [columns]);
+  return (
+    <YAxisShelf
+      form={form}
+      columns={yColumns}
+      showCartesianControls
+      defaultTraceType="bar"
+      showErrorColumn
+    />
+  );
+}
+
+function BarGroupShelf({ form, columns, flat }: ChartPanelProps) {
+  // Seaborn `hue=` slot: splits each X category into one bar per unique
+  // value. The chart-level barmode picks how the sub-bars lay out.
+  const groupColumns = useMemo(() => filterColumnsForRole(columns, "bar", "color"), [columns]);
+  return <GroupByShelf form={form} columns={groupColumns} flat={flat} />;
+}
+
+function BarFacetShelfWrapper({ form, columns, flat }: ChartPanelProps) {
+  const facetColumns = useMemo(() => filterColumnsForRole(columns, "bar", "facet"), [columns]);
+  return <FacetShelf form={form} columns={facetColumns} flat={flat} />;
+}
+
+export const barDataShelves: ShelfDef[] = [
+  {
+    key: "x",
+    labelKey: "workspace.shelves.xAxis",
+    icon: XAxisGlyph,
+    Component: BarXShelf,
+    summary: (form) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const x = firstDataSourceByRole(sources, "x");
+      const col = x?.source.columnName;
+      return col && col.length > 0 ? col : X_AXIS_NONE_INDEX;
+    },
+  },
+  {
+    key: "y",
+    labelKey: "workspace.shelves.yAxis",
+    icon: YAxisGlyph,
+    Component: BarYShelf,
+    summary: (form, t) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const ys = dataSourcesByRole(sources, "y").filter(
+        (entry) => entry.source.columnName && entry.source.columnName.length > 0,
+      );
+      if (ys.length === 0) return undefined;
+      if (ys.length === 1) return ys[0]?.source.columnName;
+      return t("workspace.shelves.seriesCount", { count: ys.length });
+    },
+  },
+  {
+    key: "groupBy",
+    labelKey: "workspace.shelves.groupBy",
+    icon: Layers,
+    Component: BarGroupShelf,
+    summary: (form) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const col = firstDataSourceByRole(sources, "color")?.source.columnName;
+      return col && col.length > 0 ? col : undefined;
+    },
+  },
+  {
+    key: "facet",
+    labelKey: "workspace.shelves.facetDimension",
+    icon: LayoutGrid,
+    Component: BarFacetShelfWrapper,
+    summary: (form) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const col = firstDataSourceByRole(sources, "facet")?.source.columnName;
+      return col && col.length > 0 ? col : undefined;
+    },
+  },
+];

--- a/apps/web/components/experiment-visualizations/charts/basic/bar/shelves/style-shelves.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bar/shelves/style-shelves.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import {
+  AreaChart,
+  BarChart3,
+  Circle,
+  LayoutGrid,
+  Minus,
+  MoveVertical,
+  Settings2,
+  Spline,
+} from "lucide-react";
+
+import { AreaStyleSection } from "../../../../workspace/style-sections/area-style-section";
+import { BarStyleSection } from "../../../../workspace/style-sections/bar-style-section";
+import { DisplayOptionsSection } from "../../../../workspace/style-sections/display-options-section";
+import { ErrorBarStyleSection } from "../../../../workspace/style-sections/error-bar-style-section";
+import { FacetStyleSection } from "../../../../workspace/style-sections/facet-style-section";
+import { LineStyleSection } from "../../../../workspace/style-sections/line-style-section";
+import { MarkerStyleSection } from "../../../../workspace/style-sections/marker-style-section";
+import { ReferenceLinesSection } from "../../../../workspace/style-sections/reference-lines-section";
+import { hasTraceType } from "../../../shelf-visibility";
+import type { ChartPanelProps, ShelfDef } from "../../../types";
+
+function BarDisplay({ form, flat }: ChartPanelProps) {
+  return <DisplayOptionsSection form={form} flat={flat} />;
+}
+
+function BarPrimaryStyle({ form, flat }: ChartPanelProps) {
+  return <BarStyleSection form={form} flat={flat} />;
+}
+
+function BarLineSeries({ form, flat }: ChartPanelProps) {
+  return (
+    <LineStyleSection
+      form={form}
+      titleKey="workspace.style.lineSeriesOptions"
+      defaultTitle="Line series"
+      flat={flat}
+    />
+  );
+}
+
+function BarScatterSeries({ form, flat }: ChartPanelProps) {
+  return (
+    <MarkerStyleSection
+      form={form}
+      titleKey="workspace.style.scatterSeriesOptions"
+      defaultTitle="Scatter series"
+      flat={flat}
+    />
+  );
+}
+
+function BarAreaSeries({ form, flat }: ChartPanelProps) {
+  return (
+    <AreaStyleSection
+      form={form}
+      titleKey="workspace.style.areaSeriesOptions"
+      defaultTitle="Area series"
+      flat={flat}
+    />
+  );
+}
+
+function BarErrorBar({ form, flat }: ChartPanelProps) {
+  return <ErrorBarStyleSection form={form} flat={flat} />;
+}
+
+function BarReferenceLines({ form, flat }: ChartPanelProps) {
+  return <ReferenceLinesSection form={form} flat={flat} />;
+}
+
+function BarFacetStyle({ form, flat }: ChartPanelProps) {
+  return <FacetStyleSection form={form} flat={flat} />;
+}
+
+export const barStyleShelves: ShelfDef[] = [
+  {
+    key: "display",
+    labelKey: "workspace.style.display",
+    icon: Settings2,
+    Component: BarDisplay,
+  },
+  {
+    key: "bar",
+    labelKey: "workspace.style.barOptions",
+    icon: BarChart3,
+    Component: BarPrimaryStyle,
+  },
+  {
+    key: "line",
+    labelKey: "workspace.style.lineSeriesOptions",
+    icon: Spline,
+    Component: BarLineSeries,
+    visible: (form) => hasTraceType(form, "line"),
+  },
+  {
+    key: "scatter",
+    labelKey: "workspace.style.scatterSeriesOptions",
+    icon: Circle,
+    Component: BarScatterSeries,
+    visible: (form) => hasTraceType(form, "scatter"),
+  },
+  {
+    key: "area",
+    labelKey: "workspace.style.areaSeriesOptions",
+    icon: AreaChart,
+    Component: BarAreaSeries,
+    visible: (form) => hasTraceType(form, "area"),
+  },
+  {
+    key: "errorBar",
+    labelKey: "workspace.style.errorBarOptions",
+    icon: MoveVertical,
+    Component: BarErrorBar,
+  },
+  {
+    key: "referenceLines",
+    labelKey: "workspace.style.referenceLines",
+    icon: Minus,
+    Component: BarReferenceLines,
+  },
+  {
+    key: "facet",
+    labelKey: "workspace.style.facetOptions",
+    icon: LayoutGrid,
+    Component: BarFacetStyle,
+  },
+];

--- a/apps/web/components/experiment-visualizations/charts/basic/bubble/defaults.ts
+++ b/apps/web/components/experiment-visualizations/charts/basic/bubble/defaults.ts
@@ -1,0 +1,46 @@
+import type { ChartFormConfig, ChartFormDataConfig } from "../../chart-config";
+import { DEFAULT_PRIMARY_COLOR } from "../../colors/palettes";
+import { makeDataSource } from "../../data/data-sources";
+
+export function bubbleDefaultConfig(): ChartFormConfig {
+  return {
+    title: "",
+    xAxisTitle: "",
+    xAxisType: "linear",
+    yAxisType: "linear",
+    yAxisTitle: "",
+    showLegend: true,
+    showGrid: true,
+    useWebGL: false,
+    color: [DEFAULT_PRIMARY_COLOR],
+    mode: "markers",
+    colorMode: "continuous",
+    colorMap: {},
+    marker: {
+      // Used as the fallback uniform size when no `size` column is picked
+      // yet (draft state). Once the size column is chosen, the renderer
+      // replaces this with per-row sizes scaled by `sizeref`.
+      size: 12,
+      symbol: "circle",
+      opacity: 0.7,
+      showscale: true,
+      colorscale: "Viridis",
+      colorbar: { title: { side: "right", text: "" } },
+    },
+    sizemode: "area",
+    bubbleMaxSize: 40,
+    bubbleMinSize: 4,
+  };
+}
+
+export function bubbleDefaultDataConfig(tableName?: string): ChartFormDataConfig {
+  const table = tableName ?? "";
+  return {
+    tableName: table,
+    dataSources: [
+      makeDataSource(table, "x"),
+      makeDataSource(table, "y"),
+      makeDataSource(table, "size"),
+    ],
+  };
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/bubble/index.ts
+++ b/apps/web/components/experiment-visualizations/charts/basic/bubble/index.ts
@@ -1,0 +1,24 @@
+import { CircleDot } from "lucide-react";
+
+import type { ChartTypeDef } from "../../types";
+import { bubbleDefaultConfig, bubbleDefaultDataConfig } from "./defaults";
+import { BubbleDataPanel } from "./panels/data-panel";
+import { BubbleStylePanel } from "./panels/style-panel";
+import { BubbleRenderer } from "./renderer";
+import { bubbleDataShelves } from "./shelves/data-shelves";
+import { bubbleStyleShelves } from "./shelves/style-shelves";
+
+export const bubbleChartType: ChartTypeDef = {
+  type: "bubble",
+  family: "basic",
+  labelKey: "workspace.charts.types.bubble",
+  descriptionKey: "workspace.charts.descriptions.bubble",
+  icon: CircleDot,
+  defaultConfig: bubbleDefaultConfig,
+  defaultDataConfig: bubbleDefaultDataConfig,
+  DataPanel: BubbleDataPanel,
+  StylePanel: BubbleStylePanel,
+  Renderer: BubbleRenderer,
+  dataShelves: bubbleDataShelves,
+  styleShelves: bubbleStyleShelves,
+};

--- a/apps/web/components/experiment-visualizations/charts/basic/bubble/options.ts
+++ b/apps/web/components/experiment-visualizations/charts/basic/bubble/options.ts
@@ -1,0 +1,9 @@
+/**
+ * Bubble sizing options. The renderer computes Plotly's `sizeref` from
+ * `bubbleMaxSize` and the actual data so users think in pixels, not sizeref.
+ */
+export interface BubbleChartOptions {
+  sizemode?: "diameter" | "area";
+  bubbleMaxSize?: number;
+  bubbleMinSize?: number;
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/bubble/panels/data-panel.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bubble/panels/data-panel.test.tsx
@@ -1,0 +1,108 @@
+import { renderWithForm, screen, userEvent } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+
+import { bubbleChartType } from "../";
+import { DataSourcesFieldArrayProvider } from "../../../../workspace/context/data-sources-field-array-context";
+import type { ChartFormValues } from "../../../chart-config";
+import { BubbleDataPanel } from "../panels/data-panel";
+
+function defaults(overrides: Partial<ChartFormValues> = {}): ChartFormValues {
+  return {
+    name: "Untitled",
+    description: "",
+    chartFamily: bubbleChartType.family,
+    chartType: bubbleChartType.type,
+    config: bubbleChartType.defaultConfig(),
+    dataConfig: bubbleChartType.defaultDataConfig(),
+    ...overrides,
+  };
+}
+
+const columns: DataColumn[] = [
+  { name: "x", type_name: "DOUBLE", type_text: "DOUBLE" },
+  { name: "y", type_name: "DOUBLE", type_text: "DOUBLE" },
+  { name: "size", type_name: "DOUBLE", type_text: "DOUBLE" },
+  { name: "grp", type_name: "STRING", type_text: "STRING" },
+];
+
+function renderPanel(formDefaults?: ChartFormValues) {
+  return renderWithForm<ChartFormValues>(
+    (form) => (
+      <DataSourcesFieldArrayProvider form={form}>
+        <BubbleDataPanel form={form} columns={columns} />
+      </DataSourcesFieldArrayProvider>
+    ),
+    { useFormProps: { defaultValues: formDefaults ?? defaults() } },
+  );
+}
+
+describe("BubbleDataPanel", () => {
+  it("renders X, Y, size, color-dimension, and facet shelves", () => {
+    renderPanel();
+    expect(screen.getByRole("heading", { name: "workspace.shelves.xAxis" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "workspace.shelves.yAxis" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "workspace.shelves.sizeDimension" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "workspace.shelves.colorDimension" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "workspace.shelves.facetDimension" }),
+    ).toBeInTheDocument();
+  });
+
+  it("seeds the X-axis trigger from the existing data source", () => {
+    renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "pts",
+          dataSources: [
+            { tableName: "pts", columnName: "x", role: "x" },
+            { tableName: "pts", columnName: "y", role: "y" },
+          ],
+        },
+      }),
+    );
+    expect(screen.getAllByRole("combobox")[0]).toHaveTextContent("x");
+  });
+
+  it("writes the picked X column into the data sources", async () => {
+    const user = userEvent.setup();
+    const { form } = renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "pts",
+          dataSources: [
+            { tableName: "pts", columnName: "", role: "x" },
+            { tableName: "pts", columnName: "y", role: "y" },
+          ],
+        },
+      }),
+    );
+
+    await user.click(screen.getAllByRole("combobox")[0]);
+    await user.click(await screen.findByText("x"));
+
+    const xSource = form.getValues("dataConfig.dataSources").find((ds) => ds.role === "x");
+    expect(xSource).toEqual(expect.objectContaining({ columnName: "x", tableName: "pts" }));
+  });
+
+  it("opens the size shelf and exposes its aggregate dropdown", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+    const before = screen.queryAllByText("workspace.shelves.aggregate").length;
+    await user.click(screen.getByRole("button", { name: /workspace.shelves.sizeDimension/i }));
+    expect(screen.getAllByText("workspace.shelves.aggregate").length).toBeGreaterThan(before);
+  });
+
+  it("opens the color shelf and exposes its column picker", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+    await user.click(screen.getByRole("button", { name: /workspace.shelves.colorDimension/i }));
+    const labels = await screen.findAllByText("workspace.shelves.column");
+    expect(labels.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/bubble/panels/data-panel.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bubble/panels/data-panel.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Fragment } from "react";
+
+import { Separator } from "@repo/ui/components/separator";
+
+import type { ChartPanelProps } from "../../../types";
+import { bubbleDataShelves } from "../shelves/data-shelves";
+
+export function BubbleDataPanel({ form, columns }: ChartPanelProps) {
+  return (
+    <div className="space-y-6">
+      {bubbleDataShelves
+        .filter((shelf) => !shelf.visible || shelf.visible(form))
+        .map((shelf, index) => {
+          const Comp = shelf.Component;
+          return (
+            <Fragment key={shelf.key}>
+              {index > 0 && <Separator />}
+              <Comp form={form} columns={columns} />
+            </Fragment>
+          );
+        })}
+    </div>
+  );
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/bubble/panels/style-panel.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bubble/panels/style-panel.test.tsx
@@ -1,0 +1,116 @@
+import { renderWithForm, screen } from "@/test/test-utils";
+import { fireEvent } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+
+import { bubbleChartType } from "../";
+import type { ChartFormValues } from "../../../chart-config";
+import { BubbleStylePanel } from "../panels/style-panel";
+
+function defaults(overrides: Partial<ChartFormValues> = {}): ChartFormValues {
+  return {
+    name: "Untitled",
+    description: "",
+    chartFamily: bubbleChartType.family,
+    chartType: bubbleChartType.type,
+    config: bubbleChartType.defaultConfig(),
+    dataConfig: bubbleChartType.defaultDataConfig(),
+    ...overrides,
+  };
+}
+
+const columns: DataColumn[] = [
+  { name: "x", type_name: "DOUBLE", type_text: "DOUBLE" },
+  { name: "y", type_name: "DOUBLE", type_text: "DOUBLE" },
+  { name: "weight", type_name: "DOUBLE", type_text: "DOUBLE" },
+];
+
+function renderPanel(formDefaults?: ChartFormValues) {
+  return renderWithForm<ChartFormValues>(
+    (form) => <BubbleStylePanel form={form} columns={columns} />,
+    { useFormProps: { defaultValues: formDefaults ?? defaults() } },
+  );
+}
+
+function expandSection(name: string) {
+  fireEvent.click(screen.getByRole("button", { name }));
+}
+
+describe("BubbleStylePanel", () => {
+  it("shows sizemode, max/min sizing and marker controls", () => {
+    renderPanel();
+    expandSection("workspace.style.bubbleOptions");
+    expect(screen.getByText("workspace.style.sizemode")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.maxBubbleSize")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.minBubbleSize")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.markerShape")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.markerOpacity")).toBeInTheDocument();
+  });
+
+  it("does not surface line-only options", () => {
+    renderPanel();
+    expandSection("workspace.style.bubbleOptions");
+    expect(screen.queryByText("workspace.style.lineWidth")).not.toBeInTheDocument();
+    expect(screen.queryByText("workspace.style.smoothing")).not.toBeInTheDocument();
+    expect(screen.queryByText("workspace.style.connectGaps")).not.toBeInTheDocument();
+  });
+
+  it("renders the line-series subsection when any Y source has traceType=line", () => {
+    renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "cells",
+          dataSources: [
+            { tableName: "cells", columnName: "x", role: "x" },
+            { tableName: "cells", columnName: "y", role: "y", traceType: "line" },
+            { tableName: "cells", columnName: "weight", role: "size" },
+          ],
+        },
+      }),
+    );
+    expect(screen.getByText("workspace.style.lineSeriesOptions")).toBeInTheDocument();
+  });
+
+  it("renders the bar-series subsection when any Y source has traceType=bar", () => {
+    renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "cells",
+          dataSources: [
+            { tableName: "cells", columnName: "x", role: "x" },
+            { tableName: "cells", columnName: "y", role: "y", traceType: "bar" },
+            { tableName: "cells", columnName: "weight", role: "size" },
+          ],
+        },
+      }),
+    );
+    expect(screen.getByText("workspace.style.barSeriesOptions")).toBeInTheDocument();
+  });
+
+  it("renders the area-series subsection when any Y source has traceType=area", () => {
+    renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "cells",
+          dataSources: [
+            { tableName: "cells", columnName: "x", role: "x" },
+            { tableName: "cells", columnName: "y", role: "y", traceType: "area" },
+            { tableName: "cells", columnName: "weight", role: "size" },
+          ],
+        },
+      }),
+    );
+    expect(screen.getByText("workspace.style.areaSeriesOptions")).toBeInTheDocument();
+  });
+
+  it("renders with an empty config", () => {
+    renderPanel(defaults({ config: {} }));
+    expandSection("workspace.style.bubbleOptions");
+    expect(screen.getByText("workspace.style.sizemode")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.maxBubbleSize")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.minBubbleSize")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.markerShape")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.markerOpacity")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/bubble/panels/style-panel.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bubble/panels/style-panel.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Fragment } from "react";
+import { useWatch } from "react-hook-form";
+
+import { Separator } from "@repo/ui/components/separator";
+
+import type { ChartPanelProps } from "../../../types";
+import { bubbleStyleShelves } from "../shelves/style-shelves";
+
+export function BubbleStylePanel({ form, columns }: ChartPanelProps) {
+  // Broad subscription so `visible(form)` predicates re-evaluate when the
+  // user toggles trace types. Each predicate reads with `form.getValues()`
+  // inside.
+  useWatch({ control: form.control, name: "dataConfig.dataSources" });
+
+  const visibleShelves = bubbleStyleShelves.filter(
+    (shelf) => !shelf.visible || shelf.visible(form),
+  );
+
+  return (
+    <div className="space-y-6">
+      {visibleShelves.map((shelf, index) => {
+        const Comp = shelf.Component;
+        return (
+          <Fragment key={shelf.key}>
+            {index > 0 && <Separator />}
+            <Comp form={form} columns={columns} />
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/bubble/renderer.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bubble/renderer.test.tsx
@@ -1,0 +1,144 @@
+import { createVisualization } from "@/test/factories";
+import { render, screen } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import { bubbleDefaultConfig } from "./defaults";
+import { BubbleRenderer } from "./renderer";
+
+function buildViz(overrides: Parameters<typeof createVisualization>[0] = {}) {
+  return createVisualization({
+    chartType: "bubble",
+    chartFamily: "basic",
+    config: { ...bubbleDefaultConfig() },
+    dataConfig: {
+      tableName: "metrics",
+      dataSources: [
+        { tableName: "metrics", columnName: "x", role: "x" },
+        { tableName: "metrics", columnName: "y", role: "y" },
+        { tableName: "metrics", columnName: "weight", role: "size" },
+      ],
+    },
+    ...overrides,
+  });
+}
+
+describe("BubbleRenderer", () => {
+  it("shows a config error when the visualization isn't a bubble chart", () => {
+    const viz = buildViz({ chartType: "scatter" });
+    render(<BubbleRenderer visualization={viz} experimentId="exp-1" data={[]} />);
+    expect(screen.getByText("errors.configuration")).toBeInTheDocument();
+    expect(screen.getByText("errors.invalidConfiguration")).toBeInTheDocument();
+  });
+
+  it("shows the empty-state when there are no rows", () => {
+    const viz = buildViz();
+    render(<BubbleRenderer visualization={viz} experimentId="exp-1" data={[]} />);
+    expect(screen.getByText("errors.noData")).toBeInTheDocument();
+  });
+
+  it("renders the chart frame with rows + x/y/size configured", () => {
+    const viz = buildViz();
+    const rows = [
+      { x: 1, y: 21, weight: 5 },
+      { x: 2, y: 22, weight: 12 },
+      { x: 3, y: 23, weight: 7 },
+    ];
+    const { container } = render(
+      <BubbleRenderer visualization={viz} experimentId="exp-1" data={rows} />,
+    );
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+    expect(screen.queryByText("errors.noData")).not.toBeInTheDocument();
+    expect(container.querySelector(".flex.h-full.w-full.flex-col")).toBeInTheDocument();
+  });
+
+  it("renders without a size column (draft state, falls back to scalar size)", () => {
+    const viz = buildViz({
+      dataConfig: {
+        tableName: "metrics",
+        dataSources: [
+          { tableName: "metrics", columnName: "x", role: "x" },
+          { tableName: "metrics", columnName: "y", role: "y" },
+          { tableName: "metrics", columnName: "", role: "size" },
+        ],
+      },
+    });
+    const rows = [
+      { x: 1, y: 21 },
+      { x: 2, y: 22 },
+    ];
+    render(<BubbleRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+  });
+
+  it("renders multiple Y series each carrying the same size encoding", () => {
+    const viz = buildViz({
+      dataConfig: {
+        tableName: "metrics",
+        dataSources: [
+          { tableName: "metrics", columnName: "x", role: "x" },
+          { tableName: "metrics", columnName: "y1", role: "y" },
+          { tableName: "metrics", columnName: "y2", role: "y" },
+          { tableName: "metrics", columnName: "weight", role: "size" },
+        ],
+      },
+    });
+    const rows = [
+      { x: 1, y1: 10, y2: 5, weight: 8 },
+      { x: 2, y1: 12, y2: 6, weight: 14 },
+    ];
+    render(<BubbleRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+  });
+
+  it("renders with a continuous color column", () => {
+    const viz = buildViz({
+      dataConfig: {
+        tableName: "metrics",
+        dataSources: [
+          { tableName: "metrics", columnName: "x", role: "x" },
+          { tableName: "metrics", columnName: "y", role: "y" },
+          { tableName: "metrics", columnName: "weight", role: "size" },
+          { tableName: "metrics", columnName: "score", role: "color" },
+        ],
+      },
+    });
+    const rows = [
+      { x: 1, y: 10, weight: 8, score: 0.3 },
+      { x: 2, y: 12, weight: 14, score: 0.7 },
+    ];
+    render(<BubbleRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+  });
+
+  it("renders with a categorical color column (multi-trace)", () => {
+    const viz = buildViz({
+      config: { ...bubbleDefaultConfig(), colorMode: "categorical" },
+      dataConfig: {
+        tableName: "metrics",
+        dataSources: [
+          { tableName: "metrics", columnName: "x", role: "x" },
+          { tableName: "metrics", columnName: "y", role: "y" },
+          { tableName: "metrics", columnName: "weight", role: "size" },
+          { tableName: "metrics", columnName: "group", role: "color" },
+        ],
+      },
+    });
+    const rows = [
+      { x: 1, y: 10, weight: 8, group: "A" },
+      { x: 2, y: 12, weight: 14, group: "B" },
+      { x: 3, y: 11, weight: 9, group: "A" },
+    ];
+    render(<BubbleRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+  });
+
+  it("renders in diameter sizemode without throwing", () => {
+    const viz = buildViz({ config: { ...bubbleDefaultConfig(), sizemode: "diameter" } });
+    const rows = [
+      { x: 1, y: 10, weight: 5 },
+      { x: 2, y: 12, weight: 15 },
+    ];
+    render(<BubbleRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/bubble/renderer.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bubble/renderer.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useTranslation } from "@repo/i18n";
+
+import { CartesianRenderer } from "../../cartesian/cartesian-renderer";
+import { ChartConfigError } from "../../chart-frame";
+import type { ChartRendererProps } from "../../types";
+
+export function BubbleRenderer(props: ChartRendererProps) {
+  const { t } = useTranslation("experimentVisualizations");
+
+  if (props.visualization.chartType !== "bubble") {
+    return <ChartConfigError message={t("errors.invalidConfiguration")} />;
+  }
+
+  return (
+    <CartesianRenderer {...props} defaultTraceType="scatter" supportsContinuousColor supportsSize />
+  );
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/bubble/shelves/data-shelves.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bubble/shelves/data-shelves.test.tsx
@@ -1,0 +1,50 @@
+import { renderWithForm } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import { bubbleChartType } from "..";
+import type { ChartFormValues } from "../../../chart-config";
+import type { ShelfSummaryT } from "../../../types";
+import { bubbleDataShelves } from "./data-shelves";
+
+const t: ShelfSummaryT = (key, options) => (options ? `${key}:${JSON.stringify(options)}` : key);
+
+function form(dataSources: ChartFormValues["dataConfig"]["dataSources"]) {
+  return renderWithForm<ChartFormValues>(() => <div />, {
+    useFormProps: {
+      defaultValues: {
+        name: "",
+        description: "",
+        chartFamily: bubbleChartType.family,
+        chartType: bubbleChartType.type,
+        config: bubbleChartType.defaultConfig(),
+        dataConfig: { tableName: "t", dataSources },
+      },
+    },
+  }).form;
+}
+
+describe("bubbleDataShelves summaries", () => {
+  const [x, y, size, color, facet] = bubbleDataShelves;
+
+  it("each shelf returns its column when set, undefined otherwise", () => {
+    const empty = form([]);
+    expect(x.summary?.(empty, t)).toBeUndefined();
+    expect(y.summary?.(empty, t)).toBeUndefined();
+    expect(size.summary?.(empty, t)).toBeUndefined();
+    expect(color.summary?.(empty, t)).toBeUndefined();
+    expect(facet.summary?.(empty, t)).toBeUndefined();
+
+    const populated = form([
+      { tableName: "t", columnName: "x_col", role: "x" },
+      { tableName: "t", columnName: "y_col", role: "y" },
+      { tableName: "t", columnName: "size_col", role: "size" },
+      { tableName: "t", columnName: "color_col", role: "color" },
+      { tableName: "t", columnName: "facet_col", role: "facet" },
+    ]);
+    expect(x.summary?.(populated, t)).toBe("x_col");
+    expect(y.summary?.(populated, t)).toBe("y_col");
+    expect(size.summary?.(populated, t)).toBe("size_col");
+    expect(color.summary?.(populated, t)).toBe("color_col");
+    expect(facet.summary?.(populated, t)).toBe("facet_col");
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/bubble/shelves/data-shelves.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bubble/shelves/data-shelves.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { CircleDot, LayoutGrid, Palette } from "lucide-react";
+import { useMemo } from "react";
+
+import { filterColumnsForRole } from "@repo/api/utils/visualization-contracts";
+
+import { ColorDimensionShelf } from "../../../../workspace/shelves/color/color-dimension-shelf";
+import { FacetShelf } from "../../../../workspace/shelves/facet-shelf";
+import { XAxisShelf } from "../../../../workspace/shelves/x-axis-shelf";
+import { YAxisShelf } from "../../../../workspace/shelves/y-axis-shelf";
+import { firstDataSourceByRole } from "../../../data/data-sources";
+import { XAxisGlyph, YAxisGlyph } from "../../../shelf-axis-glyphs";
+import type { ChartPanelProps, ShelfDef } from "../../../types";
+import { BubbleSizeShelf } from "./size-shelf";
+
+function BubbleXShelf({ form, columns }: ChartPanelProps) {
+  const xColumns = useMemo(() => filterColumnsForRole(columns, "bubble", "x"), [columns]);
+  return <XAxisShelf form={form} columns={xColumns} />;
+}
+
+function BubbleYShelf({ form, columns }: ChartPanelProps) {
+  const yColumns = useMemo(() => filterColumnsForRole(columns, "bubble", "y"), [columns]);
+  return (
+    <YAxisShelf form={form} columns={yColumns} showCartesianControls defaultTraceType="scatter" />
+  );
+}
+
+function BubbleSizeShelfWrapper({ form, columns }: ChartPanelProps) {
+  const sizeColumns = useMemo(() => filterColumnsForRole(columns, "bubble", "size"), [columns]);
+  // Size is a measure channel like Y; pairs column + aggregate so server-side
+  // aggregation includes the size value in its projection.
+  return <BubbleSizeShelf form={form} columns={sizeColumns} />;
+}
+
+function BubbleColorShelf({ form, columns, flat }: ChartPanelProps) {
+  const colorColumns = useMemo(() => filterColumnsForRole(columns, "bubble", "color"), [columns]);
+  return <ColorDimensionShelf form={form} columns={colorColumns} flat={flat} />;
+}
+
+function BubbleFacetShelfWrapper({ form, columns, flat }: ChartPanelProps) {
+  const facetColumns = useMemo(() => filterColumnsForRole(columns, "bubble", "facet"), [columns]);
+  return <FacetShelf form={form} columns={facetColumns} flat={flat} />;
+}
+
+export const bubbleDataShelves: ShelfDef[] = [
+  {
+    key: "x",
+    labelKey: "workspace.shelves.xAxis",
+    icon: XAxisGlyph,
+    Component: BubbleXShelf,
+    summary: (form) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const col = firstDataSourceByRole(sources, "x")?.source.columnName;
+      return col && col.length > 0 ? col : undefined;
+    },
+  },
+  {
+    key: "y",
+    labelKey: "workspace.shelves.yAxis",
+    icon: YAxisGlyph,
+    Component: BubbleYShelf,
+    summary: (form) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const col = firstDataSourceByRole(sources, "y")?.source.columnName;
+      return col && col.length > 0 ? col : undefined;
+    },
+  },
+  {
+    key: "size",
+    labelKey: "workspace.shelves.sizeDimension",
+    icon: CircleDot,
+    Component: BubbleSizeShelfWrapper,
+    summary: (form) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const col = firstDataSourceByRole(sources, "size")?.source.columnName;
+      return col && col.length > 0 ? col : undefined;
+    },
+  },
+  {
+    key: "color",
+    labelKey: "workspace.shelves.colorDimension",
+    icon: Palette,
+    Component: BubbleColorShelf,
+    summary: (form) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const col = firstDataSourceByRole(sources, "color")?.source.columnName;
+      return col && col.length > 0 ? col : undefined;
+    },
+  },
+  {
+    key: "facet",
+    labelKey: "workspace.shelves.facetDimension",
+    icon: LayoutGrid,
+    Component: BubbleFacetShelfWrapper,
+    summary: (form) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const col = firstDataSourceByRole(sources, "facet")?.source.columnName;
+      return col && col.length > 0 ? col : undefined;
+    },
+  },
+];

--- a/apps/web/components/experiment-visualizations/charts/basic/bubble/shelves/size-shelf.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bubble/shelves/size-shelf.test.tsx
@@ -1,0 +1,142 @@
+import { renderWithForm, screen, userEvent } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+
+import { bubbleChartType } from "../";
+import type { ChartFormValues } from "../../../chart-config";
+import { BubbleSizeShelf } from "./size-shelf";
+
+function defaults(overrides: Partial<ChartFormValues> = {}): ChartFormValues {
+  return {
+    name: "Untitled",
+    description: "",
+    chartFamily: bubbleChartType.family,
+    chartType: bubbleChartType.type,
+    config: bubbleChartType.defaultConfig(),
+    dataConfig: bubbleChartType.defaultDataConfig(),
+    ...overrides,
+  };
+}
+
+const columns: DataColumn[] = [
+  { name: "size", type_name: "DOUBLE", type_text: "DOUBLE" },
+  { name: "weight", type_name: "DOUBLE", type_text: "DOUBLE" },
+];
+
+function renderShelf(formDefaults?: ChartFormValues) {
+  return renderWithForm<ChartFormValues>(
+    (form) => <BubbleSizeShelf form={form} columns={columns} />,
+    { useFormProps: { defaultValues: formDefaults ?? defaults() } },
+  );
+}
+
+describe("BubbleSizeShelf", () => {
+  it("renders the heading collapsed by default", () => {
+    renderShelf();
+    expect(
+      screen.getByRole("heading", { name: "workspace.shelves.sizeDimension" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("workspace.shelves.column")).not.toBeInTheDocument();
+  });
+
+  it("shows the configured size column next to the heading", () => {
+    renderShelf(
+      defaults({
+        dataConfig: {
+          tableName: "pts",
+          dataSources: [
+            { tableName: "pts", columnName: "x", role: "x" },
+            { tableName: "pts", columnName: "y", role: "y" },
+            { tableName: "pts", columnName: "size", role: "size" },
+          ],
+        },
+      }),
+    );
+    expect(screen.getByText("(size)")).toBeInTheDocument();
+  });
+
+  it("expands the shelf and exposes the column + aggregate controls", async () => {
+    const user = userEvent.setup();
+    renderShelf();
+    await user.click(screen.getByRole("button", { name: /workspace.shelves.sizeDimension/i }));
+    expect(await screen.findByText("workspace.shelves.column")).toBeInTheDocument();
+    expect(screen.getByText("workspace.shelves.aggregate")).toBeInTheDocument();
+  });
+
+  it("writes the picked size column back into the size data source", async () => {
+    const user = userEvent.setup();
+    const { form } = renderShelf(
+      defaults({
+        dataConfig: {
+          tableName: "pts",
+          dataSources: [
+            { tableName: "pts", columnName: "x", role: "x" },
+            { tableName: "pts", columnName: "y", role: "y" },
+            { tableName: "pts", columnName: "", role: "size" },
+          ],
+        },
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: /workspace.shelves.sizeDimension/i }));
+    const combos = await screen.findAllByRole("combobox");
+    await user.click(combos[0]);
+    await user.click(await screen.findByText("weight"));
+
+    const sizeSource = form.getValues("dataConfig.dataSources").find((ds) => ds.role === "size");
+    expect(sizeSource).toEqual(expect.objectContaining({ columnName: "weight", tableName: "pts" }));
+  });
+
+  it("disables the aggregate select until a column is picked", async () => {
+    const user = userEvent.setup();
+    renderShelf();
+    await user.click(screen.getByRole("button", { name: /workspace.shelves.sizeDimension/i }));
+    const combos = await screen.findAllByRole("combobox");
+    expect(combos[1]).toBeDisabled();
+  });
+
+  it("defaults the size aggregate to avg when another source is already aggregating", async () => {
+    const user = userEvent.setup();
+    const { form } = renderShelf(
+      defaults({
+        dataConfig: {
+          tableName: "pts",
+          dataSources: [
+            { tableName: "pts", columnName: "x", role: "x" },
+            { tableName: "pts", columnName: "y", role: "y", aggregate: "sum" },
+            { tableName: "pts", columnName: "", role: "size" },
+          ],
+        },
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: /workspace.shelves.sizeDimension/i }));
+    const combos = await screen.findAllByRole("combobox");
+    await user.click(combos[0]);
+    await user.click(await screen.findByText("weight"));
+    const sizeSource = form.getValues("dataConfig.dataSources").find((ds) => ds.role === "size");
+    expect(sizeSource?.aggregate).toBe("avg");
+  });
+
+  it("rewrites the size aggregate when the user picks one explicitly", async () => {
+    const user = userEvent.setup();
+    const { form } = renderShelf(
+      defaults({
+        dataConfig: {
+          tableName: "pts",
+          dataSources: [
+            { tableName: "pts", columnName: "x", role: "x" },
+            { tableName: "pts", columnName: "y", role: "y" },
+            { tableName: "pts", columnName: "size", role: "size" },
+          ],
+        },
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: /workspace.shelves.sizeDimension/i }));
+    const combos = await screen.findAllByRole("combobox");
+    await user.click(combos[1]);
+    await user.click(await screen.findByText("Sum"));
+    const sizeSource = form.getValues("dataConfig.dataSources").find((ds) => ds.role === "size");
+    expect(sizeSource?.aggregate).toBe("sum");
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/bubble/shelves/size-shelf.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bubble/shelves/size-shelf.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { useState } from "react";
+import type { UseFormReturn } from "react-hook-form";
+import { useWatch } from "react-hook-form";
+
+import type { AggregationFunction, DataColumn } from "@repo/api/schemas/experiment.schema";
+import { useTranslation } from "@repo/i18n";
+import { Badge } from "@repo/ui/components/badge";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@repo/ui/components/collapsible";
+import { FormControl, FormItem, FormLabel } from "@repo/ui/components/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui/components/select";
+import { cn } from "@repo/ui/lib/utils";
+
+import type { ChartFormValues } from "../../../chart-config";
+import { getDataSourceAggregate, setDataSourceAggregate } from "../../../data/aggregation";
+import { firstDataSourceByRole } from "../../../data/data-sources";
+
+interface BubbleSizeShelfProps {
+  form: UseFormReturn<ChartFormValues>;
+  columns: DataColumn[];
+}
+
+const AGG_NONE = "__none__";
+
+const SIZE_FUNCTIONS: { value: AggregationFunction; label: string }[] = [
+  { value: "sum", label: "Sum" },
+  { value: "avg", label: "Average" },
+  { value: "count", label: "Count" },
+  { value: "min", label: "Min" },
+  { value: "max", label: "Max" },
+];
+
+/** Bubble's size channel: measure column + aggregate dropdown (mirrors the Y-axis aggregate UX). */
+export function BubbleSizeShelf({ form, columns }: BubbleSizeShelfProps) {
+  const { t } = useTranslation("experimentVisualizations");
+
+  const sources = useWatch({ control: form.control, name: "dataConfig.dataSources" });
+  const indexed = firstDataSourceByRole(sources, "size");
+  const sourceIndex = indexed?.index ?? 0;
+  const currentColumn = indexed?.source.columnName ?? "";
+  const xColumnName = firstDataSourceByRole(sources, "x")?.source.columnName ?? "";
+
+  const currentFunction = getDataSourceAggregate(sources, sourceIndex) ?? AGG_NONE;
+
+  const handleColumnChange = (value: string) => {
+    const tableName = form.getValues("dataConfig.tableName");
+    form.setValue(`dataConfig.dataSources.${sourceIndex}.tableName`, tableName);
+    form.setValue(`dataConfig.dataSources.${sourceIndex}.columnName`, value);
+
+    // The size channel's aggregate is stored on its data source so a
+    // column swap doesn't need a "move aggregate" dance.
+
+    // If aggregation is otherwise active and the size column has no
+    // explicit aggregate yet, default to AVG so SQL doesn't drop the
+    // column from the projection (which would zero-size all bubbles).
+    if (value) {
+      const currentAgg = form.getValues("dataConfig.aggregation");
+      const xBucket = currentAgg?.groupBy?.find((g) => g.column === xColumnName)?.timeBucket;
+      const otherSourcesAggregating = form
+        .getValues("dataConfig.dataSources")
+        .some((ds, i) => i !== sourceIndex && Boolean(ds.aggregate));
+      const aggregationActive = Boolean(xBucket) || otherSourcesAggregating;
+      if (
+        aggregationActive &&
+        form.getValues(`dataConfig.dataSources.${sourceIndex}.aggregate`) === undefined
+      ) {
+        setDataSourceAggregate(form, sourceIndex, "avg", xColumnName);
+      }
+    }
+  };
+
+  const handleAggregateChange = (raw: string) => {
+    const fn = raw === AGG_NONE ? undefined : (raw as AggregationFunction);
+    setDataSourceAggregate(form, sourceIndex, fn, xColumnName);
+  };
+
+  // Always start collapsed (mirrors Filters/Group by); the header chip
+  // surfaces the configured column so state reads without expanding.
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} asChild>
+      <section className="space-y-3">
+        <CollapsibleTrigger className="flex w-full items-center gap-2 text-left">
+          <h3 className="text-sm font-semibold">{t("workspace.shelves.sizeDimension")}</h3>
+          {currentColumn && (
+            <span className="text-muted-foreground text-xs">({currentColumn})</span>
+          )}
+          <ChevronDown
+            className={cn(
+              "text-muted-foreground ml-auto h-4 w-4 transition-transform",
+              open && "rotate-180",
+            )}
+          />
+        </CollapsibleTrigger>
+
+        <CollapsibleContent className="space-y-3">
+          <div className="grid grid-cols-[1fr_auto] items-end gap-3">
+            <FormItem className="min-w-0">
+              <FormLabel className="text-xs font-medium">{t("workspace.shelves.column")}</FormLabel>
+              <Select value={currentColumn || undefined} onValueChange={handleColumnChange}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder={t("workspace.shelves.selectColumn")} />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {columns.map((column) => (
+                    <SelectItem key={column.name} value={column.name}>
+                      <div className="flex items-center gap-2">
+                        <span>{column.name}</span>
+                        <Badge
+                          variant="outline"
+                          className="text-muted-foreground h-4 px-1.5 py-0 font-mono text-[10px] font-normal leading-none"
+                        >
+                          {column.type_name}
+                        </Badge>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </FormItem>
+
+            <FormItem className="w-[140px]">
+              <FormLabel className="text-xs font-medium">
+                {t("workspace.shelves.aggregate")}
+              </FormLabel>
+              <Select
+                value={currentFunction}
+                onValueChange={handleAggregateChange}
+                disabled={!currentColumn}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder={t("workspace.shelves.aggregateNone")} />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value={AGG_NONE}>
+                    <span className="text-muted-foreground italic">
+                      {t("workspace.shelves.aggregateNone")}
+                    </span>
+                  </SelectItem>
+                  {SIZE_FUNCTIONS.map((fn) => (
+                    <SelectItem key={fn.value} value={fn.value}>
+                      {fn.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </FormItem>
+          </div>
+        </CollapsibleContent>
+      </section>
+    </Collapsible>
+  );
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/bubble/shelves/style-shelves.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/bubble/shelves/style-shelves.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import {
+  AreaChart,
+  BarChart3,
+  CircleDot,
+  LayoutGrid,
+  Minus,
+  Settings2,
+  Spline,
+} from "lucide-react";
+
+import { useTranslation } from "@repo/i18n";
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@repo/ui/components/form";
+import { FormSlider } from "@repo/ui/components/form-slider";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui/components/select";
+
+import { AreaStyleSection } from "../../../../workspace/style-sections/area-style-section";
+import { BarStyleSection } from "../../../../workspace/style-sections/bar-style-section";
+import { DisplayOptionsSection } from "../../../../workspace/style-sections/display-options-section";
+import { FacetStyleSection } from "../../../../workspace/style-sections/facet-style-section";
+import { LineStyleSection } from "../../../../workspace/style-sections/line-style-section";
+import { ReferenceLinesSection } from "../../../../workspace/style-sections/reference-lines-section";
+import { CollapsibleStyleSection } from "../../../../workspace/style-sections/shared/collapsible-style-section";
+import { StyleSubsection } from "../../../../workspace/style-sections/shared/style-subsection";
+import { hasTraceType } from "../../../shelf-visibility";
+import type { ChartPanelProps, ShelfDef } from "../../../types";
+
+function BubbleDisplay({ form, flat }: ChartPanelProps) {
+  return <DisplayOptionsSection form={form} flat={flat} />;
+}
+
+function BubbleOptions({ form, flat }: ChartPanelProps) {
+  const { t } = useTranslation("experimentVisualizations");
+
+  return (
+    <CollapsibleStyleSection title={t("workspace.style.bubbleOptions")} flat={flat}>
+      <FormField
+        control={form.control}
+        name="config.sizemode"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-xs font-medium">{t("workspace.style.sizemode")}</FormLabel>
+            <Select value={String(field.value ?? "area")} onValueChange={field.onChange}>
+              <FormControl>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                <SelectItem value="area">{t("workspace.sizemodes.area")}</SelectItem>
+                <SelectItem value="diameter">{t("workspace.sizemodes.diameter")}</SelectItem>
+              </SelectContent>
+            </Select>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <StyleSubsection title={t("workspace.style.bubbleSizingSubsection")}>
+        <FormField
+          control={form.control}
+          name="config.bubbleMaxSize"
+          render={({ field }) => (
+            <FormSlider
+              label={t("workspace.style.maxBubbleSize")}
+              value={typeof field.value === "number" ? field.value : undefined}
+              fallback={40}
+              min={10}
+              max={80}
+              step={2}
+              onCommit={field.onChange}
+              formatBadge={(v) => `${v}px`}
+            />
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="config.bubbleMinSize"
+          render={({ field }) => (
+            <FormSlider
+              label={t("workspace.style.minBubbleSize")}
+              value={typeof field.value === "number" ? field.value : undefined}
+              fallback={4}
+              min={0}
+              max={20}
+              step={1}
+              onCommit={field.onChange}
+              formatBadge={(v) => `${v}px`}
+            />
+          )}
+        />
+      </StyleSubsection>
+
+      <StyleSubsection title={t("workspace.style.markerSubsection")}>
+        <FormField
+          control={form.control}
+          name="config.marker.symbol"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-xs font-medium">
+                {t("workspace.style.markerShape")}
+              </FormLabel>
+              <Select value={String(field.value ?? "circle")} onValueChange={field.onChange}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="circle">{t("workspace.markerSymbols.circle")}</SelectItem>
+                  <SelectItem value="square">{t("workspace.markerSymbols.square")}</SelectItem>
+                  <SelectItem value="diamond">{t("workspace.markerSymbols.diamond")}</SelectItem>
+                  <SelectItem value="triangle-up">
+                    {t("workspace.markerSymbols.triangleUp")}
+                  </SelectItem>
+                  <SelectItem value="hexagon">{t("workspace.markerSymbols.hexagon")}</SelectItem>
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="config.marker.opacity"
+          render={({ field }) => (
+            <FormSlider
+              label={t("workspace.style.markerOpacity")}
+              value={typeof field.value === "number" ? field.value : undefined}
+              fallback={0.7}
+              min={0.05}
+              max={1}
+              step={0.05}
+              onCommit={field.onChange}
+              formatBadge={(v) => `${Math.round(v * 100)}%`}
+            />
+          )}
+        />
+      </StyleSubsection>
+    </CollapsibleStyleSection>
+  );
+}
+
+function BubbleLineSeries({ form, flat }: ChartPanelProps) {
+  return (
+    <LineStyleSection
+      form={form}
+      titleKey="workspace.style.lineSeriesOptions"
+      defaultTitle="Line series"
+      flat={flat}
+    />
+  );
+}
+
+function BubbleBarSeries({ form, flat }: ChartPanelProps) {
+  return (
+    <BarStyleSection
+      form={form}
+      titleKey="workspace.style.barSeriesOptions"
+      defaultTitle="Bar series"
+      showOrientation={false}
+      flat={flat}
+    />
+  );
+}
+
+function BubbleAreaSeries({ form, flat }: ChartPanelProps) {
+  return (
+    <AreaStyleSection
+      form={form}
+      titleKey="workspace.style.areaSeriesOptions"
+      defaultTitle="Area series"
+      flat={flat}
+    />
+  );
+}
+
+function BubbleReferenceLines({ form, flat }: ChartPanelProps) {
+  return <ReferenceLinesSection form={form} flat={flat} />;
+}
+
+function BubbleFacetStyle({ form, flat }: ChartPanelProps) {
+  return <FacetStyleSection form={form} flat={flat} />;
+}
+
+export const bubbleStyleShelves: ShelfDef[] = [
+  {
+    key: "display",
+    labelKey: "workspace.style.display",
+    icon: Settings2,
+    Component: BubbleDisplay,
+  },
+  {
+    key: "bubble",
+    labelKey: "workspace.style.bubbleOptions",
+    icon: CircleDot,
+    Component: BubbleOptions,
+  },
+  {
+    key: "line",
+    labelKey: "workspace.style.lineSeriesOptions",
+    icon: Spline,
+    Component: BubbleLineSeries,
+    visible: (form) => hasTraceType(form, "line"),
+  },
+  {
+    key: "bar",
+    labelKey: "workspace.style.barSeriesOptions",
+    icon: BarChart3,
+    Component: BubbleBarSeries,
+    visible: (form) => hasTraceType(form, "bar"),
+  },
+  {
+    key: "area",
+    labelKey: "workspace.style.areaSeriesOptions",
+    icon: AreaChart,
+    Component: BubbleAreaSeries,
+    visible: (form) => hasTraceType(form, "area"),
+  },
+  {
+    key: "referenceLines",
+    labelKey: "workspace.style.referenceLines",
+    icon: Minus,
+    Component: BubbleReferenceLines,
+  },
+  {
+    key: "facet",
+    labelKey: "workspace.style.facetOptions",
+    icon: LayoutGrid,
+    Component: BubbleFacetStyle,
+  },
+];

--- a/apps/web/components/experiment-visualizations/charts/basic/dot-plot/defaults.ts
+++ b/apps/web/components/experiment-visualizations/charts/basic/dot-plot/defaults.ts
@@ -1,0 +1,31 @@
+import type { ChartFormConfig, ChartFormDataConfig } from "../../chart-config";
+import { DEFAULT_PRIMARY_COLOR } from "../../colors/palettes";
+import { makeDataSource } from "../../data/data-sources";
+
+export function dotPlotDefaultConfig(): ChartFormConfig {
+  return {
+    title: "",
+    xAxisTitle: "",
+    xAxisType: "category",
+    yAxisType: "linear",
+    yAxisTitle: "",
+    showLegend: true,
+    showGrid: true,
+    useWebGL: false,
+    color: [DEFAULT_PRIMARY_COLOR],
+    orientation: "v",
+    marker: {
+      size: 10,
+      symbol: "circle",
+      opacity: 1,
+    },
+  };
+}
+
+export function dotPlotDefaultDataConfig(tableName?: string): ChartFormDataConfig {
+  const table = tableName ?? "";
+  return {
+    tableName: table,
+    dataSources: [makeDataSource(table, "x"), makeDataSource(table, "y")],
+  };
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/dot-plot/index.ts
+++ b/apps/web/components/experiment-visualizations/charts/basic/dot-plot/index.ts
@@ -1,0 +1,24 @@
+import { Circle } from "lucide-react";
+
+import type { ChartTypeDef } from "../../types";
+import { dotPlotDefaultConfig, dotPlotDefaultDataConfig } from "./defaults";
+import { DotPlotDataPanel } from "./panels/data-panel";
+import { DotPlotStylePanel } from "./panels/style-panel";
+import { DotPlotRenderer } from "./renderer";
+import { dotPlotDataShelves } from "./shelves/data-shelves";
+import { dotPlotStyleShelves } from "./shelves/style-shelves";
+
+export const dotPlotChartType: ChartTypeDef = {
+  type: "dot-plot",
+  family: "basic",
+  labelKey: "workspace.charts.types.dot-plot",
+  descriptionKey: "workspace.charts.descriptions.dot-plot",
+  icon: Circle,
+  defaultConfig: dotPlotDefaultConfig,
+  defaultDataConfig: dotPlotDefaultDataConfig,
+  DataPanel: DotPlotDataPanel,
+  StylePanel: DotPlotStylePanel,
+  Renderer: DotPlotRenderer,
+  dataShelves: dotPlotDataShelves,
+  styleShelves: dotPlotStyleShelves,
+};

--- a/apps/web/components/experiment-visualizations/charts/basic/dot-plot/panels/data-panel.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/dot-plot/panels/data-panel.test.tsx
@@ -1,0 +1,96 @@
+import { renderWithForm, screen, userEvent } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+
+import { dotPlotChartType } from "../";
+import { DataSourcesFieldArrayProvider } from "../../../../workspace/context/data-sources-field-array-context";
+import type { ChartFormValues } from "../../../chart-config";
+import { DotPlotDataPanel } from "../panels/data-panel";
+
+function defaults(overrides: Partial<ChartFormValues> = {}): ChartFormValues {
+  return {
+    name: "Untitled",
+    description: "",
+    chartFamily: dotPlotChartType.family,
+    chartType: dotPlotChartType.type,
+    config: dotPlotChartType.defaultConfig(),
+    dataConfig: dotPlotChartType.defaultDataConfig(),
+    ...overrides,
+  };
+}
+
+const columns: DataColumn[] = [
+  { name: "category", type_name: "STRING", type_text: "STRING" },
+  { name: "value", type_name: "DOUBLE", type_text: "DOUBLE" },
+  { name: "grp", type_name: "STRING", type_text: "STRING" },
+];
+
+function renderPanel(formDefaults?: ChartFormValues) {
+  return renderWithForm<ChartFormValues>(
+    (form) => (
+      <DataSourcesFieldArrayProvider form={form}>
+        <DotPlotDataPanel form={form} columns={columns} />
+      </DataSourcesFieldArrayProvider>
+    ),
+    { useFormProps: { defaultValues: formDefaults ?? defaults() } },
+  );
+}
+
+describe("DotPlotDataPanel", () => {
+  it("renders X, Y, and group-by shelves (no facet)", () => {
+    renderPanel();
+    expect(screen.getByRole("heading", { name: "workspace.shelves.xAxis" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "workspace.shelves.yAxis" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "workspace.shelves.groupBy" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "workspace.shelves.facetDimension" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the X-axis type picker (dot-plot forces categorical) and keeps Y's", () => {
+    renderPanel();
+    expect(screen.getAllByText("workspace.shelves.axisType")).toHaveLength(1);
+  });
+
+  it("seeds the X-axis trigger from the existing data source", () => {
+    renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "obs",
+          dataSources: [
+            { tableName: "obs", columnName: "category", role: "x" },
+            { tableName: "obs", columnName: "value", role: "y" },
+          ],
+        },
+      }),
+    );
+    expect(screen.getAllByRole("combobox")[0]).toHaveTextContent("category");
+  });
+
+  it("writes the picked X column into the data sources", async () => {
+    const user = userEvent.setup();
+    const { form } = renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "obs",
+          dataSources: [
+            { tableName: "obs", columnName: "", role: "x" },
+            { tableName: "obs", columnName: "value", role: "y" },
+          ],
+        },
+      }),
+    );
+
+    await user.click(screen.getAllByRole("combobox")[0]);
+    await user.click(await screen.findByText("category"));
+
+    const xSource = form.getValues("dataConfig.dataSources").find((ds) => ds.role === "x");
+    expect(xSource).toEqual(expect.objectContaining({ columnName: "category", tableName: "obs" }));
+  });
+
+  it("exposes the Add series button on the Y shelf", () => {
+    renderPanel();
+    expect(screen.getByRole("button", { name: "workspace.shelves.addSeries" })).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/dot-plot/panels/data-panel.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/dot-plot/panels/data-panel.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Fragment } from "react";
+
+import { Separator } from "@repo/ui/components/separator";
+
+import type { ChartPanelProps } from "../../../types";
+import { dotPlotDataShelves } from "../shelves/data-shelves";
+
+export function DotPlotDataPanel({ form, columns }: ChartPanelProps) {
+  return (
+    <div className="space-y-6">
+      {dotPlotDataShelves
+        .filter((shelf) => !shelf.visible || shelf.visible(form))
+        .map((shelf, index) => {
+          const Comp = shelf.Component;
+          return (
+            <Fragment key={shelf.key}>
+              {index > 0 && <Separator />}
+              <Comp form={form} columns={columns} />
+            </Fragment>
+          );
+        })}
+    </div>
+  );
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/dot-plot/panels/style-panel.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/dot-plot/panels/style-panel.test.tsx
@@ -1,0 +1,64 @@
+import { renderWithForm, screen } from "@/test/test-utils";
+import { fireEvent } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+
+import { dotPlotChartType } from "../";
+import type { ChartFormValues } from "../../../chart-config";
+import { DotPlotStylePanel } from "../panels/style-panel";
+
+function defaults(overrides: Partial<ChartFormValues> = {}): ChartFormValues {
+  return {
+    name: "Untitled",
+    description: "",
+    chartFamily: dotPlotChartType.family,
+    chartType: dotPlotChartType.type,
+    config: dotPlotChartType.defaultConfig(),
+    dataConfig: dotPlotChartType.defaultDataConfig(),
+    ...overrides,
+  };
+}
+
+const columns: DataColumn[] = [
+  { name: "variety", type_name: "VARCHAR", type_text: "STRING" },
+  { name: "yield", type_name: "DOUBLE", type_text: "DOUBLE" },
+];
+
+function renderPanel(formDefaults?: ChartFormValues) {
+  return renderWithForm<ChartFormValues>(
+    (form) => <DotPlotStylePanel form={form} columns={columns} />,
+    { useFormProps: { defaultValues: formDefaults ?? defaults() } },
+  );
+}
+
+function expandSection(name: string) {
+  fireEvent.click(screen.getByRole("button", { name }));
+}
+
+describe("DotPlotStylePanel", () => {
+  it("shows orientation, dot size, shape and opacity by default", () => {
+    renderPanel();
+    expandSection("workspace.style.dotPlotOptions");
+    expect(screen.getByText("workspace.style.orientation")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.dotSize")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.markerShape")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.markerOpacity")).toBeInTheDocument();
+  });
+
+  it("does not surface line-only options", () => {
+    renderPanel();
+    expandSection("workspace.style.dotPlotOptions");
+    expect(screen.queryByText("workspace.style.lineWidth")).not.toBeInTheDocument();
+    expect(screen.queryByText("workspace.style.smoothing")).not.toBeInTheDocument();
+  });
+
+  it("renders with an empty config", () => {
+    renderPanel(defaults({ config: {} }));
+    expandSection("workspace.style.dotPlotOptions");
+    expect(screen.getByText("workspace.style.orientation")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.dotSize")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.markerShape")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.markerOpacity")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/dot-plot/panels/style-panel.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/dot-plot/panels/style-panel.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Fragment } from "react";
+
+import { Separator } from "@repo/ui/components/separator";
+
+import type { ChartPanelProps } from "../../../types";
+import { dotPlotStyleShelves } from "../shelves/style-shelves";
+
+export function DotPlotStylePanel({ form, columns }: ChartPanelProps) {
+  return (
+    <div className="space-y-6">
+      {dotPlotStyleShelves
+        .filter((shelf) => !shelf.visible || shelf.visible(form))
+        .map((shelf, index) => {
+          const Comp = shelf.Component;
+          return (
+            <Fragment key={shelf.key}>
+              {index > 0 && <Separator />}
+              <Comp form={form} columns={columns} />
+            </Fragment>
+          );
+        })}
+    </div>
+  );
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/dot-plot/renderer.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/dot-plot/renderer.test.tsx
@@ -1,0 +1,183 @@
+import { createVisualization } from "@/test/factories";
+import { render, screen } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import { dotPlotDefaultConfig } from "./defaults";
+import { DotPlotRenderer } from "./renderer";
+
+function buildViz(overrides: Parameters<typeof createVisualization>[0] = {}) {
+  return createVisualization({
+    chartType: "dot-plot",
+    chartFamily: "basic",
+    config: { ...dotPlotDefaultConfig() },
+    dataConfig: {
+      tableName: "harvest",
+      dataSources: [
+        { tableName: "harvest", columnName: "variety", role: "x" },
+        { tableName: "harvest", columnName: "yield", role: "y" },
+      ],
+    },
+    ...overrides,
+  });
+}
+
+describe("DotPlotRenderer", () => {
+  it("shows a config error when the visualization isn't a dot-plot", () => {
+    const viz = buildViz({ chartType: "line" });
+    render(<DotPlotRenderer visualization={viz} experimentId="exp-1" data={[]} />);
+    expect(screen.getByText("errors.configuration")).toBeInTheDocument();
+    expect(screen.getByText("errors.invalidConfiguration")).toBeInTheDocument();
+  });
+
+  it("shows the empty-state when there are no rows", () => {
+    const viz = buildViz();
+    render(<DotPlotRenderer visualization={viz} experimentId="exp-1" data={[]} />);
+    expect(screen.getByText("errors.noData")).toBeInTheDocument();
+  });
+
+  it("renders the chart frame with rows + both axes configured", () => {
+    const viz = buildViz();
+    const rows = [
+      { variety: "Tomato", yield: 12 },
+      { variety: "Cucumber", yield: 8 },
+    ];
+    const { container } = render(
+      <DotPlotRenderer visualization={viz} experimentId="exp-1" data={rows} />,
+    );
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+    expect(screen.queryByText("errors.noData")).not.toBeInTheDocument();
+    expect(container.querySelector(".flex.h-full.w-full.flex-col")).toBeInTheDocument();
+  });
+
+  it("renders multiple Y series (one trace per series)", () => {
+    const viz = buildViz({
+      dataConfig: {
+        tableName: "harvest",
+        dataSources: [
+          { tableName: "harvest", columnName: "variety", role: "x" },
+          { tableName: "harvest", columnName: "yield", role: "y" },
+          { tableName: "harvest", columnName: "weight", role: "y" },
+        ],
+      },
+    });
+    const rows = [
+      { variety: "Tomato", yield: 12, weight: 4.2 },
+      { variety: "Cucumber", yield: 8, weight: 3.0 },
+    ];
+    render(<DotPlotRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing-but-frame when X is not configured", () => {
+    // Dot plots don't synthesize X from row indices; there's no meaningful
+    // category fallback. The renderer should still mount without erroring.
+    const viz = buildViz({
+      dataConfig: {
+        tableName: "harvest",
+        dataSources: [
+          { tableName: "harvest", columnName: "", role: "x" },
+          { tableName: "harvest", columnName: "yield", role: "y" },
+        ],
+      },
+    });
+    const rows = [{ yield: 12 }, { yield: 8 }];
+    render(<DotPlotRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+  });
+
+  it("renders in horizontal orientation without throwing", () => {
+    const viz = buildViz({
+      config: { ...dotPlotDefaultConfig(), orientation: "h" },
+    });
+    const rows = [
+      { variety: "Tomato", yield: 12 },
+      { variety: "Cucumber", yield: 8 },
+    ];
+    render(<DotPlotRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+  });
+
+  it("emits one trace per (Y x color category) when a color column is set", () => {
+    const viz = buildViz({
+      dataConfig: {
+        tableName: "harvest",
+        dataSources: [
+          { tableName: "harvest", columnName: "variety", role: "x" },
+          { tableName: "harvest", columnName: "yield", role: "y" },
+          { tableName: "harvest", columnName: "region", role: "color" },
+        ],
+      },
+    });
+    const rows = [
+      { variety: "Tomato", yield: 12, region: "north" },
+      { variety: "Cucumber", yield: 8, region: "north" },
+      { variety: "Tomato", yield: 15, region: "south" },
+      { variety: "Cucumber", yield: 9, region: "south" },
+      // Row with a null category exercises the labelValue = null branch.
+      { variety: "Pepper", yield: 6, region: null },
+    ];
+    render(<DotPlotRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    // The chart mounts (no config error); the group-by codepath was the bug here.
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+    expect(screen.queryByText("errors.noData")).not.toBeInTheDocument();
+  });
+
+  it("falls through the non-scalar color value branch (toBucketKey-derived label)", () => {
+    const viz = buildViz({
+      dataConfig: {
+        tableName: "harvest",
+        dataSources: [
+          { tableName: "harvest", columnName: "variety", role: "x" },
+          { tableName: "harvest", columnName: "yield", role: "y" },
+          { tableName: "harvest", columnName: "tags", role: "color" },
+        ],
+      },
+    });
+    const rows = [
+      // Object-valued color cell hits the else branch where labelValue = key.
+      { variety: "Tomato", yield: 12, tags: { ripe: true } },
+      { variety: "Cucumber", yield: 8, tags: { ripe: false } },
+    ];
+    render(<DotPlotRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+  });
+
+  it("attaches error bars when a Y source has an errorColumn (vertical orientation -> error_y)", () => {
+    const viz = buildViz({
+      dataConfig: {
+        tableName: "harvest",
+        dataSources: [
+          { tableName: "harvest", columnName: "variety", role: "x" },
+          { tableName: "harvest", columnName: "yield", role: "y", errorColumn: "yield_err" },
+        ],
+      },
+    });
+    const rows = [
+      { variety: "Tomato", yield: 12, yield_err: 0.5 },
+      { variety: "Cucumber", yield: 8, yield_err: "0.4" }, // string coerces via Number(v)
+      { variety: "Pepper", yield: 6, yield_err: "nan" }, // non-finite falls through to 0
+    ];
+    render(<DotPlotRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+    expect(screen.queryByText("errors.noData")).not.toBeInTheDocument();
+  });
+
+  it("attaches error bars on the X axis in horizontal orientation (error_x)", () => {
+    const viz = buildViz({
+      config: { ...dotPlotDefaultConfig(), orientation: "h" },
+      dataConfig: {
+        tableName: "harvest",
+        dataSources: [
+          { tableName: "harvest", columnName: "variety", role: "x" },
+          { tableName: "harvest", columnName: "yield", role: "y", errorColumn: "yield_err" },
+        ],
+      },
+    });
+    const rows = [
+      { variety: "Tomato", yield: 12, yield_err: 0.5 },
+      { variety: "Cucumber", yield: 8, yield_err: 0.4 },
+    ];
+    render(<DotPlotRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/dot-plot/renderer.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/dot-plot/renderer.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { useTranslation } from "@repo/i18n";
+import type { DotSeriesData } from "@repo/ui/components/charts/dot-plot";
+import { DotPlot } from "@repo/ui/components/charts/dot-plot";
+import type { PlotlyChartConfig } from "@repo/ui/components/charts/types";
+
+import { narrowChartConfig } from "../../chart-config";
+import type { ChartFormConfig } from "../../chart-config";
+import { ChartConfigError, ChartFrame } from "../../chart-frame";
+import { getCategoryColor } from "../../colors/palettes";
+import { rowKeyForSource } from "../../data/aggregation";
+import { coerceCell, toBucketKey } from "../../data/cell-coercion";
+import { dataSourcesByRole } from "../../data/data-sources";
+import { useChartData } from "../../hooks/use-chart-data";
+import type { ChartRendererProps } from "../../types";
+
+function pairedCells(
+  rows: Record<string, unknown>[],
+  xKey: string,
+  yKey: string,
+): {
+  x: (string | number)[];
+  y: (string | number)[];
+  rows: Record<string, unknown>[];
+} {
+  const x: (string | number)[] = [];
+  const y: (string | number)[] = [];
+  const keptRows: Record<string, unknown>[] = [];
+  for (const row of rows) {
+    const xv = coerceCell(row[xKey]);
+    const yv = coerceCell(row[yKey]);
+    if (xv === null || yv === null) {
+      continue;
+    }
+    x.push(xv);
+    y.push(yv);
+    keptRows.push(row);
+  }
+  return { x, y, rows: keptRows };
+}
+
+export function DotPlotRenderer({
+  visualization,
+  experimentId,
+  data: providedData,
+}: ChartRendererProps) {
+  const { t } = useTranslation("experimentVisualizations");
+
+  const xColumn = dataSourcesByRole(visualization.dataConfig.dataSources, "x")[0]?.source
+    .columnName;
+  const yEntries = useMemo(
+    () => dataSourcesByRole(visualization.dataConfig.dataSources, "y"),
+    [visualization.dataConfig.dataSources],
+  );
+  const colorColumn = dataSourcesByRole(visualization.dataConfig.dataSources, "color")[0]?.source
+    .columnName;
+
+  const { rows, isLoading, error } = useChartData(visualization, experimentId, providedData, {
+    orderBy: xColumn,
+  });
+
+  const chartConfig = narrowChartConfig(visualization);
+  const orientation = chartConfig.orientation === "h" ? "h" : "v";
+
+  const chartSeries = useMemo<DotSeriesData[]>(() => {
+    if (visualization.chartType !== "dot-plot") {
+      return [];
+    }
+    if (yEntries.length === 0 || !xColumn) {
+      return [];
+    }
+
+    // Wrapper takes a scalar symbol; drop array values (panel only edits scalars).
+    const symbol =
+      typeof chartConfig.marker?.symbol === "string" ? chartConfig.marker.symbol : undefined;
+    const colorMap = chartConfig.colorMap;
+
+    // No Group by: one trace per Y series.
+    if (!colorColumn) {
+      return yEntries.map(({ source, index: dsIndex }, index) => {
+        const yRowKey = rowKeyForSource(source, dsIndex);
+        const { x, y, rows: pairedRows } = pairedCells(rows, xColumn, yRowKey);
+        const seriesColor = Array.isArray(chartConfig.color)
+          ? chartConfig.color[index]
+          : chartConfig.color;
+        return {
+          x,
+          y,
+          name: source.alias ?? source.columnName,
+          color: seriesColor,
+          orientation,
+          marker: {
+            size: chartConfig.marker?.size,
+            symbol,
+            color: seriesColor,
+            opacity: chartConfig.marker?.opacity,
+          },
+          ...buildErrorBars(pairedRows, source.errorColumn, orientation, chartConfig, seriesColor),
+        };
+      });
+    }
+
+    // Group by: one trace per (Y series x color category).
+    const categoryValues: (string | number | null)[] = [];
+    const rowsByCategory = new Map<string, Record<string, unknown>[]>();
+    for (const row of rows) {
+      const raw = row[colorColumn];
+      const key = toBucketKey(raw);
+      let bucket = rowsByCategory.get(key);
+      if (!bucket) {
+        bucket = [];
+        rowsByCategory.set(key, bucket);
+        let labelValue: string | number | null;
+        if (typeof raw === "string" || typeof raw === "number") {
+          labelValue = raw;
+        } else if (raw == null) {
+          labelValue = null;
+        } else {
+          // toBucketKey already serialized the row into `key`; reuse it
+          // rather than calling String() on an unknown value.
+          labelValue = key;
+        }
+        categoryValues.push(labelValue);
+      }
+      bucket.push(row);
+    }
+
+    return yEntries.flatMap(({ source, index: dsIndex }, yIndex) => {
+      const baseName = source.alias ?? source.columnName;
+      const yRowKey = rowKeyForSource(source, dsIndex);
+      return categoryValues.map((categoryValue, catIndex) => {
+        const key = categoryValue == null ? "" : String(categoryValue);
+        const groupRows = rowsByCategory.get(key) ?? [];
+        const categoryLabel = categoryValue == null ? "(none)" : String(categoryValue);
+        const seriesColor = getCategoryColor(
+          catIndex + yIndex * categoryValues.length,
+          colorMap,
+          key,
+        );
+        const { x, y, rows: pairedRows } = pairedCells(groupRows, xColumn, yRowKey);
+        return {
+          x,
+          y,
+          name: yEntries.length === 1 ? categoryLabel : `${baseName} - ${categoryLabel}`,
+          color: seriesColor,
+          orientation,
+          marker: {
+            size: chartConfig.marker?.size,
+            symbol,
+            color: seriesColor,
+            opacity: chartConfig.marker?.opacity,
+          },
+          ...buildErrorBars(pairedRows, source.errorColumn, orientation, chartConfig, seriesColor),
+        };
+      });
+    });
+  }, [rows, xColumn, yEntries, colorColumn, orientation, chartConfig, visualization.chartType]);
+
+  if (visualization.chartType !== "dot-plot") {
+    return <ChartConfigError message={t("errors.invalidConfiguration")} />;
+  }
+
+  // Mirror axis title/type swap in horizontal mode (see bar renderer).
+  const effectiveConfig: PlotlyChartConfig =
+    orientation === "h"
+      ? {
+          ...chartConfig,
+          xAxisTitle: chartConfig.yAxisTitle,
+          yAxisTitle: chartConfig.xAxisTitle,
+          xAxisType: chartConfig.yAxisType,
+          yAxisType: chartConfig.xAxisType,
+        }
+      : chartConfig;
+
+  return (
+    <ChartFrame
+      visualization={visualization}
+      experimentId={experimentId}
+      isLoading={isLoading}
+      error={error}
+      hasRows={rows.length > 0}
+    >
+      <div className="flex h-full w-full flex-col">
+        <DotPlot data={chartSeries} config={effectiveConfig} orientation={orientation} />
+      </div>
+    </ChartFrame>
+  );
+}
+
+function buildErrorBars(
+  rows: Record<string, unknown>[],
+  errorColumn: string | undefined,
+  orientation: "v" | "h",
+  chartConfig: ChartFormConfig,
+  color: string | undefined,
+): Partial<Pick<DotSeriesData, "error_x" | "error_y">> {
+  if (!errorColumn) {
+    return {};
+  }
+  const array = rows.map((row) => {
+    const v = row[errorColumn];
+    const n = typeof v === "number" ? v : Number(v);
+    return Number.isFinite(n) ? n : 0;
+  });
+  // DotSeriesData's error_x/error_y type omits color/thickness/width, but
+  // Plotly accepts them at runtime, hence the cast.
+  const block = {
+    type: "data" as const,
+    array,
+    visible: true,
+    thickness: chartConfig.errorBarThickness ?? 1.5,
+    width: chartConfig.errorBarCapWidth ?? 4,
+    color,
+  } as DotSeriesData["error_x"];
+  return orientation === "h" ? { error_x: block } : { error_y: block };
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/dot-plot/shelves/data-shelves.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/dot-plot/shelves/data-shelves.test.tsx
@@ -1,0 +1,58 @@
+import { renderWithForm } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import { dotPlotChartType } from "..";
+import type { ChartFormValues } from "../../../chart-config";
+import type { ShelfSummaryT } from "../../../types";
+import { dotPlotDataShelves } from "./data-shelves";
+
+const t: ShelfSummaryT = (key, options) => (options ? `${key}:${JSON.stringify(options)}` : key);
+
+function form(dataSources: ChartFormValues["dataConfig"]["dataSources"]) {
+  return renderWithForm<ChartFormValues>(() => <div />, {
+    useFormProps: {
+      defaultValues: {
+        name: "",
+        description: "",
+        chartFamily: dotPlotChartType.family,
+        chartType: dotPlotChartType.type,
+        config: dotPlotChartType.defaultConfig(),
+        dataConfig: { tableName: "t", dataSources },
+      },
+    },
+  }).form;
+}
+
+describe("dotPlotDataShelves summaries", () => {
+  const [x, y, group] = dotPlotDataShelves;
+
+  it("X returns the column when set, undefined otherwise", () => {
+    expect(x.summary?.(form([]), t)).toBeUndefined();
+    expect(x.summary?.(form([{ tableName: "t", columnName: "variety", role: "x" }]), t)).toBe(
+      "variety",
+    );
+  });
+
+  it("Y is undefined / column / count by series count", () => {
+    expect(y.summary?.(form([]), t)).toBeUndefined();
+    expect(y.summary?.(form([{ tableName: "t", columnName: "yield", role: "y" }]), t)).toBe(
+      "yield",
+    );
+    expect(
+      y.summary?.(
+        form([
+          { tableName: "t", columnName: "a", role: "y" },
+          { tableName: "t", columnName: "b", role: "y" },
+        ]),
+        t,
+      ),
+    ).toBe(`workspace.shelves.seriesCount:{"count":2}`);
+  });
+
+  it("groupBy returns the color column when set, undefined otherwise", () => {
+    expect(group.summary?.(form([]), t)).toBeUndefined();
+    expect(group.summary?.(form([{ tableName: "t", columnName: "site", role: "color" }]), t)).toBe(
+      "site",
+    );
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/dot-plot/shelves/data-shelves.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/dot-plot/shelves/data-shelves.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Layers } from "lucide-react";
+import { useMemo } from "react";
+
+import { filterColumnsForRole } from "@repo/api/utils/visualization-contracts";
+
+import { GroupByShelf } from "../../../../workspace/shelves/group-by-shelf";
+import { XAxisShelf } from "../../../../workspace/shelves/x-axis-shelf";
+import { YAxisShelf } from "../../../../workspace/shelves/y-axis-shelf";
+import { dataSourcesByRole, firstDataSourceByRole } from "../../../data/data-sources";
+import { XAxisGlyph, YAxisGlyph } from "../../../shelf-axis-glyphs";
+import type { ChartPanelProps, ShelfDef } from "../../../types";
+
+function DotPlotXShelf({ form, columns }: ChartPanelProps) {
+  const xColumns = useMemo(() => filterColumnsForRole(columns, "dot-plot", "x"), [columns]);
+  // Wrapper force-overrides the category axis to "category" in both
+  // orientations, so the axis-type picker is misleading.
+  return <XAxisShelf form={form} columns={xColumns} hideAxisType />;
+}
+
+function DotPlotYShelf({ form, columns }: ChartPanelProps) {
+  const yColumns = useMemo(() => filterColumnsForRole(columns, "dot-plot", "y"), [columns]);
+  return <YAxisShelf form={form} columns={yColumns} showErrorColumn />;
+}
+
+function DotPlotGroupShelf({ form, columns, flat }: ChartPanelProps) {
+  // Hue equivalent: one dot per category per Y series per group value.
+  const groupColumns = useMemo(() => filterColumnsForRole(columns, "dot-plot", "color"), [columns]);
+  return <GroupByShelf form={form} columns={groupColumns} flat={flat} />;
+}
+
+export const dotPlotDataShelves: ShelfDef[] = [
+  {
+    key: "x",
+    labelKey: "workspace.shelves.xAxis",
+    icon: XAxisGlyph,
+    Component: DotPlotXShelf,
+    summary: (form) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const col = firstDataSourceByRole(sources, "x")?.source.columnName;
+      return col && col.length > 0 ? col : undefined;
+    },
+  },
+  {
+    key: "y",
+    labelKey: "workspace.shelves.yAxis",
+    icon: YAxisGlyph,
+    Component: DotPlotYShelf,
+    summary: (form, t) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const ys = dataSourcesByRole(sources, "y").filter(
+        (entry) => entry.source.columnName && entry.source.columnName.length > 0,
+      );
+      if (ys.length === 0) return undefined;
+      if (ys.length === 1) return ys[0]?.source.columnName;
+      return t("workspace.shelves.seriesCount", { count: ys.length });
+    },
+  },
+  {
+    key: "groupBy",
+    labelKey: "workspace.shelves.groupBy",
+    icon: Layers,
+    Component: DotPlotGroupShelf,
+    summary: (form) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const col = firstDataSourceByRole(sources, "color")?.source.columnName;
+      return col && col.length > 0 ? col : undefined;
+    },
+  },
+];

--- a/apps/web/components/experiment-visualizations/charts/basic/dot-plot/shelves/style-shelves.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/dot-plot/shelves/style-shelves.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { Circle, Minus, MoveVertical, Settings2 } from "lucide-react";
+
+import { useTranslation } from "@repo/i18n";
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@repo/ui/components/form";
+import { FormSlider } from "@repo/ui/components/form-slider";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui/components/select";
+
+import { DisplayOptionsSection } from "../../../../workspace/style-sections/display-options-section";
+import { ErrorBarStyleSection } from "../../../../workspace/style-sections/error-bar-style-section";
+import { ReferenceLinesSection } from "../../../../workspace/style-sections/reference-lines-section";
+import { CollapsibleStyleSection } from "../../../../workspace/style-sections/shared/collapsible-style-section";
+import { StyleSubsection } from "../../../../workspace/style-sections/shared/style-subsection";
+import type { ChartPanelProps, ShelfDef } from "../../../types";
+
+function DotPlotDisplay({ form, flat }: ChartPanelProps) {
+  return <DisplayOptionsSection form={form} flat={flat} />;
+}
+
+function DotPlotOptions({ form, flat }: ChartPanelProps) {
+  const { t } = useTranslation("experimentVisualizations");
+
+  return (
+    <CollapsibleStyleSection title={t("workspace.style.dotPlotOptions")} flat={flat}>
+      <FormField
+        control={form.control}
+        name="config.orientation"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-xs font-medium">
+              {t("workspace.style.orientation")}
+            </FormLabel>
+            <Select value={String(field.value ?? "v")} onValueChange={field.onChange}>
+              <FormControl>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                <SelectItem value="v">{t("workspace.orientations.vertical")}</SelectItem>
+                <SelectItem value="h">{t("workspace.orientations.horizontal")}</SelectItem>
+              </SelectContent>
+            </Select>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <StyleSubsection title={t("workspace.style.markerSubsection")}>
+        <FormField
+          control={form.control}
+          name="config.marker.size"
+          render={({ field }) => (
+            <FormSlider
+              label={t("workspace.style.dotSize")}
+              // marker.size is `number | number[]` in Plotly's types; the
+              // slider only edits the scalar form, so fall back when an
+              // array happens to be in there.
+              value={typeof field.value === "number" ? field.value : undefined}
+              fallback={10}
+              min={4}
+              max={30}
+              step={1}
+              onCommit={field.onChange}
+              formatBadge={(v) => `${v}px`}
+            />
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="config.marker.symbol"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-xs font-medium">
+                {t("workspace.style.markerShape")}
+              </FormLabel>
+              <Select value={String(field.value ?? "circle")} onValueChange={field.onChange}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="circle">{t("workspace.markerSymbols.circle")}</SelectItem>
+                  <SelectItem value="square">{t("workspace.markerSymbols.square")}</SelectItem>
+                  <SelectItem value="diamond">{t("workspace.markerSymbols.diamond")}</SelectItem>
+                  <SelectItem value="triangle-up">
+                    {t("workspace.markerSymbols.triangleUp")}
+                  </SelectItem>
+                  <SelectItem value="triangle-down">
+                    {t("workspace.markerSymbols.triangleDown")}
+                  </SelectItem>
+                  <SelectItem value="star">{t("workspace.markerSymbols.star")}</SelectItem>
+                  <SelectItem value="hexagon">{t("workspace.markerSymbols.hexagon")}</SelectItem>
+                  <SelectItem value="cross">{t("workspace.markerSymbols.cross")}</SelectItem>
+                  <SelectItem value="x">{t("workspace.markerSymbols.x")}</SelectItem>
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="config.marker.opacity"
+          render={({ field }) => (
+            <FormSlider
+              label={t("workspace.style.markerOpacity")}
+              value={typeof field.value === "number" ? field.value : undefined}
+              fallback={1}
+              min={0.05}
+              max={1}
+              step={0.05}
+              onCommit={field.onChange}
+              formatBadge={(v) => `${Math.round(v * 100)}%`}
+            />
+          )}
+        />
+      </StyleSubsection>
+    </CollapsibleStyleSection>
+  );
+}
+
+function DotPlotErrorBar({ form, flat }: ChartPanelProps) {
+  return <ErrorBarStyleSection form={form} flat={flat} />;
+}
+
+function DotPlotReferenceLines({ form, flat }: ChartPanelProps) {
+  return <ReferenceLinesSection form={form} flat={flat} />;
+}
+
+export const dotPlotStyleShelves: ShelfDef[] = [
+  {
+    key: "display",
+    labelKey: "workspace.style.display",
+    icon: Settings2,
+    Component: DotPlotDisplay,
+  },
+  {
+    key: "dotPlot",
+    labelKey: "workspace.style.dotPlotOptions",
+    icon: Circle,
+    Component: DotPlotOptions,
+  },
+  {
+    key: "errorBar",
+    labelKey: "workspace.style.errorBarOptions",
+    icon: MoveVertical,
+    Component: DotPlotErrorBar,
+  },
+  {
+    key: "referenceLines",
+    labelKey: "workspace.style.referenceLines",
+    icon: Minus,
+    Component: DotPlotReferenceLines,
+  },
+];

--- a/apps/web/components/experiment-visualizations/charts/basic/lollipop/defaults.ts
+++ b/apps/web/components/experiment-visualizations/charts/basic/lollipop/defaults.ts
@@ -1,0 +1,28 @@
+import type { ChartFormConfig, ChartFormDataConfig } from "../../chart-config";
+import { DEFAULT_PRIMARY_COLOR } from "../../colors/palettes";
+import { makeDataSource } from "../../data/data-sources";
+
+export function lollipopDefaultConfig(): ChartFormConfig {
+  return {
+    title: "",
+    xAxisTitle: "",
+    xAxisType: "category",
+    yAxisType: "linear",
+    yAxisTitle: "",
+    showLegend: true,
+    showGrid: true,
+    useWebGL: false,
+    color: [DEFAULT_PRIMARY_COLOR],
+    orientation: "v",
+    marker: { size: 12 },
+    stemWidth: 2,
+  };
+}
+
+export function lollipopDefaultDataConfig(tableName?: string): ChartFormDataConfig {
+  const table = tableName ?? "";
+  return {
+    tableName: table,
+    dataSources: [makeDataSource(table, "x"), makeDataSource(table, "y")],
+  };
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/lollipop/index.ts
+++ b/apps/web/components/experiment-visualizations/charts/basic/lollipop/index.ts
@@ -1,0 +1,24 @@
+import { Candy } from "lucide-react";
+
+import type { ChartTypeDef } from "../../types";
+import { lollipopDefaultConfig, lollipopDefaultDataConfig } from "./defaults";
+import { LollipopDataPanel } from "./panels/data-panel";
+import { LollipopStylePanel } from "./panels/style-panel";
+import { LollipopRenderer } from "./renderer";
+import { lollipopDataShelves } from "./shelves/data-shelves";
+import { lollipopStyleShelves } from "./shelves/style-shelves";
+
+export const lollipopChartType: ChartTypeDef = {
+  type: "lollipop",
+  family: "basic",
+  labelKey: "workspace.charts.types.lollipop",
+  descriptionKey: "workspace.charts.descriptions.lollipop",
+  icon: Candy,
+  defaultConfig: lollipopDefaultConfig,
+  defaultDataConfig: lollipopDefaultDataConfig,
+  DataPanel: LollipopDataPanel,
+  StylePanel: LollipopStylePanel,
+  Renderer: LollipopRenderer,
+  dataShelves: lollipopDataShelves,
+  styleShelves: lollipopStyleShelves,
+};

--- a/apps/web/components/experiment-visualizations/charts/basic/lollipop/options.ts
+++ b/apps/web/components/experiment-visualizations/charts/basic/lollipop/options.ts
@@ -1,0 +1,4 @@
+/** Lollipop options. Dot size reuses `marker.size`; only the stem needs its own field. */
+export interface LollipopChartOptions {
+  stemWidth?: number;
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/lollipop/panels/data-panel.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/lollipop/panels/data-panel.test.tsx
@@ -1,0 +1,99 @@
+import { renderWithForm, screen, userEvent } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+
+import { lollipopChartType } from "../";
+import { DataSourcesFieldArrayProvider } from "../../../../workspace/context/data-sources-field-array-context";
+import type { ChartFormValues } from "../../../chart-config";
+import { LollipopDataPanel } from "../panels/data-panel";
+
+function defaults(overrides: Partial<ChartFormValues> = {}): ChartFormValues {
+  return {
+    name: "Untitled",
+    description: "",
+    chartFamily: lollipopChartType.family,
+    chartType: lollipopChartType.type,
+    config: lollipopChartType.defaultConfig(),
+    dataConfig: lollipopChartType.defaultDataConfig(),
+    ...overrides,
+  };
+}
+
+const columns: DataColumn[] = [
+  { name: "category", type_name: "STRING", type_text: "STRING" },
+  { name: "value", type_name: "DOUBLE", type_text: "DOUBLE" },
+];
+
+function renderPanel(formDefaults?: ChartFormValues) {
+  return renderWithForm<ChartFormValues>(
+    (form) => (
+      <DataSourcesFieldArrayProvider form={form}>
+        <LollipopDataPanel form={form} columns={columns} />
+      </DataSourcesFieldArrayProvider>
+    ),
+    { useFormProps: { defaultValues: formDefaults ?? defaults() } },
+  );
+}
+
+describe("LollipopDataPanel", () => {
+  it("renders X and Y shelves (no group-by, no facet)", () => {
+    renderPanel();
+    expect(screen.getByRole("heading", { name: "workspace.shelves.xAxis" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "workspace.shelves.yAxis" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "workspace.shelves.groupBy" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "workspace.shelves.facetDimension" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the X-axis type picker (lollipop forces categorical) and keeps Y's", () => {
+    renderPanel();
+    expect(screen.getAllByText("workspace.shelves.axisType")).toHaveLength(1);
+  });
+
+  it("hides the Add series button (single-series only)", () => {
+    renderPanel();
+    expect(
+      screen.queryByRole("button", { name: "workspace.shelves.addSeries" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("seeds the X-axis trigger from the existing data source", () => {
+    renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "obs",
+          dataSources: [
+            { tableName: "obs", columnName: "category", role: "x" },
+            { tableName: "obs", columnName: "value", role: "y" },
+          ],
+        },
+      }),
+    );
+    expect(screen.getAllByRole("combobox")[0]).toHaveTextContent("category");
+  });
+
+  it("writes the picked X column into the data sources", async () => {
+    const user = userEvent.setup();
+    const { form } = renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "obs",
+          dataSources: [
+            { tableName: "obs", columnName: "", role: "x" },
+            { tableName: "obs", columnName: "value", role: "y" },
+          ],
+        },
+      }),
+    );
+
+    await user.click(screen.getAllByRole("combobox")[0]);
+    await user.click(await screen.findByText("category"));
+
+    const xSource = form.getValues("dataConfig.dataSources").find((ds) => ds.role === "x");
+    expect(xSource).toEqual(expect.objectContaining({ columnName: "category", tableName: "obs" }));
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/lollipop/panels/data-panel.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/lollipop/panels/data-panel.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Fragment } from "react";
+
+import { Separator } from "@repo/ui/components/separator";
+
+import type { ChartPanelProps } from "../../../types";
+import { lollipopDataShelves } from "../shelves/data-shelves";
+
+export function LollipopDataPanel({ form, columns }: ChartPanelProps) {
+  return (
+    <div className="space-y-6">
+      {lollipopDataShelves
+        .filter((shelf) => !shelf.visible || shelf.visible(form))
+        .map((shelf, index) => {
+          const Comp = shelf.Component;
+          return (
+            <Fragment key={shelf.key}>
+              {index > 0 && <Separator />}
+              <Comp form={form} columns={columns} />
+            </Fragment>
+          );
+        })}
+    </div>
+  );
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/lollipop/panels/style-panel.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/lollipop/panels/style-panel.test.tsx
@@ -1,0 +1,63 @@
+import { renderWithForm, screen } from "@/test/test-utils";
+import { fireEvent } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+
+import { lollipopChartType } from "../";
+import type { ChartFormValues } from "../../../chart-config";
+import { LollipopStylePanel } from "../panels/style-panel";
+
+function defaults(overrides: Partial<ChartFormValues> = {}): ChartFormValues {
+  return {
+    name: "Untitled",
+    description: "",
+    chartFamily: lollipopChartType.family,
+    chartType: lollipopChartType.type,
+    config: lollipopChartType.defaultConfig(),
+    dataConfig: lollipopChartType.defaultDataConfig(),
+    ...overrides,
+  };
+}
+
+const columns: DataColumn[] = [
+  { name: "variety", type_name: "VARCHAR", type_text: "STRING" },
+  { name: "yield", type_name: "DOUBLE", type_text: "DOUBLE" },
+];
+
+function renderPanel(formDefaults?: ChartFormValues) {
+  return renderWithForm<ChartFormValues>(
+    (form) => <LollipopStylePanel form={form} columns={columns} />,
+    { useFormProps: { defaultValues: formDefaults ?? defaults() } },
+  );
+}
+
+function expandSection(name: string) {
+  fireEvent.click(screen.getByRole("button", { name }));
+}
+
+describe("LollipopStylePanel", () => {
+  it("shows orientation, dot size and stem width", () => {
+    renderPanel();
+    expandSection("workspace.style.lollipopOptions");
+    expect(screen.getByText("workspace.style.orientation")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.dotSize")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.stemWidth")).toBeInTheDocument();
+  });
+
+  it("does not surface line/scatter-only options", () => {
+    renderPanel();
+    expandSection("workspace.style.lollipopOptions");
+    expect(screen.queryByText("workspace.style.smoothing")).not.toBeInTheDocument();
+    expect(screen.queryByText("workspace.style.lineDash")).not.toBeInTheDocument();
+    expect(screen.queryByText("workspace.style.markerShape")).not.toBeInTheDocument();
+  });
+
+  it("renders with an empty config", () => {
+    renderPanel(defaults({ config: {} }));
+    expandSection("workspace.style.lollipopOptions");
+    expect(screen.getByText("workspace.style.orientation")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.dotSize")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.stemWidth")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/lollipop/panels/style-panel.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/lollipop/panels/style-panel.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Fragment } from "react";
+
+import { Separator } from "@repo/ui/components/separator";
+
+import type { ChartPanelProps } from "../../../types";
+import { lollipopStyleShelves } from "../shelves/style-shelves";
+
+export function LollipopStylePanel({ form, columns }: ChartPanelProps) {
+  return (
+    <div className="space-y-6">
+      {lollipopStyleShelves
+        .filter((shelf) => !shelf.visible || shelf.visible(form))
+        .map((shelf, index) => {
+          const Comp = shelf.Component;
+          return (
+            <Fragment key={shelf.key}>
+              {index > 0 && <Separator />}
+              <Comp form={form} columns={columns} />
+            </Fragment>
+          );
+        })}
+    </div>
+  );
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/lollipop/renderer.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/lollipop/renderer.test.tsx
@@ -1,0 +1,115 @@
+import { createVisualization } from "@/test/factories";
+import { render, screen } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import { lollipopDefaultConfig } from "./defaults";
+import { LollipopRenderer } from "./renderer";
+
+function buildViz(overrides: Parameters<typeof createVisualization>[0] = {}) {
+  return createVisualization({
+    chartType: "lollipop",
+    chartFamily: "basic",
+    config: { ...lollipopDefaultConfig() },
+    dataConfig: {
+      tableName: "harvest",
+      dataSources: [
+        { tableName: "harvest", columnName: "variety", role: "x" },
+        { tableName: "harvest", columnName: "yield", role: "y" },
+      ],
+    },
+    ...overrides,
+  });
+}
+
+describe("LollipopRenderer", () => {
+  it("shows a config error when the visualization isn't a lollipop chart", () => {
+    const viz = buildViz({ chartType: "line" });
+    render(<LollipopRenderer visualization={viz} experimentId="exp-1" data={[]} />);
+    expect(screen.getByText("errors.configuration")).toBeInTheDocument();
+    expect(screen.getByText("errors.invalidConfiguration")).toBeInTheDocument();
+  });
+
+  it("shows the empty-state when there are no rows", () => {
+    const viz = buildViz();
+    render(<LollipopRenderer visualization={viz} experimentId="exp-1" data={[]} />);
+    expect(screen.getByText("errors.noData")).toBeInTheDocument();
+  });
+
+  it("renders the chart frame with rows + both axes configured", () => {
+    const viz = buildViz();
+    const rows = [
+      { variety: "Tomato", yield: 12 },
+      { variety: "Cucumber", yield: 8 },
+    ];
+    const { container } = render(
+      <LollipopRenderer visualization={viz} experimentId="exp-1" data={rows} />,
+    );
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+    expect(screen.queryByText("errors.noData")).not.toBeInTheDocument();
+    expect(container.querySelector(".flex.h-full.w-full.flex-col")).toBeInTheDocument();
+  });
+
+  it("falls back to the empty-state when X is not configured", () => {
+    // Lollipop is single-series and has no row-index fallback for X; without
+    // a category column there's nothing to anchor stems to. The frame stays
+    // mounted but renders the no-data placeholder.
+    const viz = buildViz({
+      dataConfig: {
+        tableName: "harvest",
+        dataSources: [
+          { tableName: "harvest", columnName: "", role: "x" },
+          { tableName: "harvest", columnName: "yield", role: "y" },
+        ],
+      },
+    });
+    const rows = [{ yield: 12 }, { yield: 8 }];
+    render(<LollipopRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.getByText("errors.noData")).toBeInTheDocument();
+  });
+
+  it("falls back to the empty-state when Y is not configured", () => {
+    const viz = buildViz({
+      dataConfig: {
+        tableName: "harvest",
+        dataSources: [
+          { tableName: "harvest", columnName: "variety", role: "x" },
+          { tableName: "harvest", columnName: "", role: "y" },
+        ],
+      },
+    });
+    render(<LollipopRenderer visualization={viz} experimentId="exp-1" data={[{ variety: "T" }]} />);
+    expect(screen.getByText("errors.noData")).toBeInTheDocument();
+  });
+
+  it("computes per-row error magnitudes when the Y source declares an errorColumn", () => {
+    const viz = buildViz({
+      dataConfig: {
+        tableName: "harvest",
+        dataSources: [
+          { tableName: "harvest", columnName: "variety", role: "x" },
+          { tableName: "harvest", columnName: "yield", role: "y", errorColumn: "yield_err" },
+        ],
+      },
+    });
+    const rows = [
+      { variety: "Tomato", yield: 12, yield_err: 0.5 },
+      { variety: "Cucumber", yield: 8, yield_err: "0.4" },
+      { variety: "Pepper", yield: 6, yield_err: "nan" },
+    ];
+    render(<LollipopRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+    expect(screen.queryByText("errors.noData")).not.toBeInTheDocument();
+  });
+
+  it("renders in horizontal orientation without throwing", () => {
+    const viz = buildViz({
+      config: { ...lollipopDefaultConfig(), orientation: "h" },
+    });
+    const rows = [
+      { variety: "Tomato", yield: 12 },
+      { variety: "Cucumber", yield: 8 },
+    ];
+    render(<LollipopRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/lollipop/renderer.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/lollipop/renderer.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { useTranslation } from "@repo/i18n";
+import { LollipopChart } from "@repo/ui/components/charts/dot-plot";
+import type { PlotlyChartConfig } from "@repo/ui/components/charts/types";
+
+import { narrowChartConfig } from "../../chart-config";
+import { ChartConfigError, ChartFrame } from "../../chart-frame";
+import { rowKeyForSource } from "../../data/aggregation";
+import { toBucketKey } from "../../data/cell-coercion";
+import { dataSourcesByRole } from "../../data/data-sources";
+import { useChartData } from "../../hooks/use-chart-data";
+import type { ChartRendererProps } from "../../types";
+
+export function LollipopRenderer({
+  visualization,
+  experimentId,
+  data: providedData,
+}: ChartRendererProps) {
+  const { t } = useTranslation("experimentVisualizations");
+
+  const xColumn = dataSourcesByRole(visualization.dataConfig.dataSources, "x")[0]?.source
+    .columnName;
+  const yEntry = dataSourcesByRole(visualization.dataConfig.dataSources, "y")[0];
+  const yColumn = yEntry.source.columnName;
+  // When the Y series carries a per-series aggregate (sum/avg/cumsum/…),
+  // the SQL projects it under `aggregateAliasForSource`'s alias scheme,
+  // not under the bare column name. Reading via `rowKeyForSource` keeps
+  // raw + aggregated rows working without a special-case branch here.
+  const yRowKey = rowKeyForSource(yEntry.source, yEntry.index);
+
+  const { rows, isLoading, error } = useChartData(visualization, experimentId, providedData, {
+    orderBy: xColumn,
+  });
+
+  const chartConfig = narrowChartConfig(visualization);
+  const orientation = chartConfig.orientation === "h" ? "h" : "v";
+
+  // Lollipop is strictly single-series; the wrapper takes scalar
+  // categories[]/values[] and synthesises N stems + 1 dot internally.
+  const categories = useMemo<string[]>(() => {
+    if (!xColumn) {
+      return [];
+    }
+    return rows.map((row) => toBucketKey(row[xColumn]));
+  }, [rows, xColumn]);
+
+  const values = useMemo<number[]>(() => {
+    if (!yRowKey) {
+      return [];
+    }
+    // Plotly tolerates NaN as missing data on numeric axes, so coercing a
+    // non-numeric Y cell to NaN is preferable to silently dropping the row
+    // (which would misalign the categories array). The role contract
+    // restricts Y to numeric kinds, so this case is rare in practice.
+    return rows.map((row) => Number(row[yRowKey]));
+  }, [rows, yRowKey]);
+
+  // Per-category error magnitudes when the Y series has an `errorColumn`
+  // set. `undefined` when unset so the wrapper skips the error block.
+  const errors = useMemo<number[] | undefined>(() => {
+    const errorColumn = yEntry.source.errorColumn;
+    if (!errorColumn) {
+      return undefined;
+    }
+    return rows.map((row) => {
+      const v = row[errorColumn];
+      const n = typeof v === "number" ? v : Number(v);
+      return Number.isFinite(n) ? n : 0;
+    });
+  }, [rows, yEntry.source.errorColumn]);
+
+  const seriesColor = Array.isArray(chartConfig.color) ? chartConfig.color[0] : chartConfig.color;
+  const dotSize = typeof chartConfig.marker?.size === "number" ? chartConfig.marker.size : 12;
+
+  if (visualization.chartType !== "lollipop") {
+    return <ChartConfigError message={t("errors.invalidConfiguration")} />;
+  }
+
+  // Swap axis titles/types when horizontal so the form's "X axis" label
+  // (the user's mental model: X = categories) follows the category axis to
+  // the left side. Same convention used by bar/dot-plot. The LollipopChart
+  // wrapper falls back to placeholder titles ("Category" / "Value") when
+  // empty, which fills in nicely if the user hasn't named anything.
+  const effectiveConfig: PlotlyChartConfig =
+    orientation === "h"
+      ? {
+          ...chartConfig,
+          xAxisTitle: chartConfig.yAxisTitle,
+          yAxisTitle: chartConfig.xAxisTitle,
+          xAxisType: chartConfig.yAxisType,
+          yAxisType: chartConfig.xAxisType,
+        }
+      : chartConfig;
+
+  const hasRows = rows.length > 0 && Boolean(xColumn) && Boolean(yColumn);
+
+  return (
+    <ChartFrame
+      visualization={visualization}
+      experimentId={experimentId}
+      isLoading={isLoading}
+      error={error}
+      hasRows={hasRows}
+    >
+      <div className="flex h-full w-full flex-col">
+        <LollipopChart
+          categories={categories}
+          values={values}
+          name={yEntry.source.alias ?? yColumn}
+          color={seriesColor}
+          orientation={orientation}
+          stemWidth={chartConfig.stemWidth}
+          dotSize={dotSize}
+          errors={errors}
+          errorBarThickness={chartConfig.errorBarThickness}
+          errorBarCapWidth={chartConfig.errorBarCapWidth}
+          config={effectiveConfig}
+        />
+      </div>
+    </ChartFrame>
+  );
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/lollipop/shelves/data-shelves.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/lollipop/shelves/data-shelves.test.tsx
@@ -1,0 +1,41 @@
+import { renderWithForm } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import { lollipopChartType } from "..";
+import type { ChartFormValues } from "../../../chart-config";
+import type { ShelfSummaryT } from "../../../types";
+import { lollipopDataShelves } from "./data-shelves";
+
+const t: ShelfSummaryT = (key, options) => (options ? `${key}:${JSON.stringify(options)}` : key);
+
+function form(dataSources: ChartFormValues["dataConfig"]["dataSources"]) {
+  return renderWithForm<ChartFormValues>(() => <div />, {
+    useFormProps: {
+      defaultValues: {
+        name: "",
+        description: "",
+        chartFamily: lollipopChartType.family,
+        chartType: lollipopChartType.type,
+        config: lollipopChartType.defaultConfig(),
+        dataConfig: { tableName: "t", dataSources },
+      },
+    },
+  }).form;
+}
+
+describe("lollipopDataShelves summaries", () => {
+  const [x, y] = lollipopDataShelves;
+
+  it("X and Y return their column when set, undefined otherwise", () => {
+    const empty = form([]);
+    expect(x.summary?.(empty, t)).toBeUndefined();
+    expect(y.summary?.(empty, t)).toBeUndefined();
+
+    const populated = form([
+      { tableName: "t", columnName: "variety", role: "x" },
+      { tableName: "t", columnName: "yield", role: "y" },
+    ]);
+    expect(x.summary?.(populated, t)).toBe("variety");
+    expect(y.summary?.(populated, t)).toBe("yield");
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/lollipop/shelves/data-shelves.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/lollipop/shelves/data-shelves.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { filterColumnsForRole } from "@repo/api/utils/visualization-contracts";
+
+import { XAxisShelf } from "../../../../workspace/shelves/x-axis-shelf";
+import { YAxisShelf } from "../../../../workspace/shelves/y-axis-shelf";
+import { firstDataSourceByRole } from "../../../data/data-sources";
+import { XAxisGlyph, YAxisGlyph } from "../../../shelf-axis-glyphs";
+import type { ChartPanelProps, ShelfDef } from "../../../types";
+
+function LollipopXShelf({ form, columns }: ChartPanelProps) {
+  const xColumns = useMemo(() => filterColumnsForRole(columns, "lollipop", "x"), [columns]);
+  // Renderer coerces categories to `String()`, so the wrapper always
+  // forces axis type "category"; the X axis-type picker is misleading.
+  return <XAxisShelf form={form} columns={xColumns} hideAxisType />;
+}
+
+function LollipopYShelf({ form, columns }: ChartPanelProps) {
+  const yColumns = useMemo(() => filterColumnsForRole(columns, "lollipop", "y"), [columns]);
+  // LollipopChart wrapper is single-series only; `maxSeries={1}` keeps the
+  // shelf in sync with the role contract.
+  return (
+    <YAxisShelf
+      form={form}
+      columns={yColumns}
+      maxSeries={1}
+      showSeriesColor={false}
+      showErrorColumn
+    />
+  );
+}
+
+export const lollipopDataShelves: ShelfDef[] = [
+  {
+    key: "x",
+    labelKey: "workspace.shelves.xAxis",
+    icon: XAxisGlyph,
+    Component: LollipopXShelf,
+    summary: (form) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const col = firstDataSourceByRole(sources, "x")?.source.columnName;
+      return col && col.length > 0 ? col : undefined;
+    },
+  },
+  {
+    key: "y",
+    labelKey: "workspace.shelves.yAxis",
+    icon: YAxisGlyph,
+    Component: LollipopYShelf,
+    summary: (form) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const col = firstDataSourceByRole(sources, "y")?.source.columnName;
+      return col && col.length > 0 ? col : undefined;
+    },
+  },
+];

--- a/apps/web/components/experiment-visualizations/charts/basic/lollipop/shelves/style-shelves.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/lollipop/shelves/style-shelves.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { Candy, Minus, MoveVertical, Settings2 } from "lucide-react";
+
+import { useTranslation } from "@repo/i18n";
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@repo/ui/components/form";
+import { FormSlider } from "@repo/ui/components/form-slider";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui/components/select";
+
+import { DisplayOptionsSection } from "../../../../workspace/style-sections/display-options-section";
+import { ErrorBarStyleSection } from "../../../../workspace/style-sections/error-bar-style-section";
+import { ReferenceLinesSection } from "../../../../workspace/style-sections/reference-lines-section";
+import { CollapsibleStyleSection } from "../../../../workspace/style-sections/shared/collapsible-style-section";
+import { StyleSubsection } from "../../../../workspace/style-sections/shared/style-subsection";
+import type { ChartPanelProps, ShelfDef } from "../../../types";
+
+function LollipopDisplay({ form, flat }: ChartPanelProps) {
+  return <DisplayOptionsSection form={form} flat={flat} />;
+}
+
+function LollipopOptions({ form, flat }: ChartPanelProps) {
+  const { t } = useTranslation("experimentVisualizations");
+
+  return (
+    <CollapsibleStyleSection title={t("workspace.style.lollipopOptions")} flat={flat}>
+      <FormField
+        control={form.control}
+        name="config.orientation"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-xs font-medium">
+              {t("workspace.style.orientation")}
+            </FormLabel>
+            <Select value={String(field.value ?? "v")} onValueChange={field.onChange}>
+              <FormControl>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                <SelectItem value="v">{t("workspace.orientations.vertical")}</SelectItem>
+                <SelectItem value="h">{t("workspace.orientations.horizontal")}</SelectItem>
+              </SelectContent>
+            </Select>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <StyleSubsection title={t("workspace.style.markerSubsection")}>
+        <FormField
+          control={form.control}
+          name="config.marker.size"
+          render={({ field }) => (
+            <FormSlider
+              label={t("workspace.style.dotSize")}
+              // marker.size is `number | number[]` in Plotly's types; the
+              // slider only edits the scalar form.
+              value={typeof field.value === "number" ? field.value : undefined}
+              fallback={12}
+              min={4}
+              max={30}
+              step={1}
+              onCommit={field.onChange}
+              formatBadge={(v) => `${v}px`}
+            />
+          )}
+        />
+      </StyleSubsection>
+
+      <StyleSubsection title={t("workspace.style.stemSubsection")}>
+        <FormField
+          control={form.control}
+          name="config.stemWidth"
+          render={({ field }) => (
+            <FormSlider
+              label={t("workspace.style.stemWidth")}
+              value={typeof field.value === "number" ? field.value : undefined}
+              fallback={2}
+              min={1}
+              max={6}
+              step={1}
+              onCommit={field.onChange}
+              formatBadge={(v) => `${v}px`}
+            />
+          )}
+        />
+      </StyleSubsection>
+    </CollapsibleStyleSection>
+  );
+}
+
+function LollipopErrorBar({ form, flat }: ChartPanelProps) {
+  return <ErrorBarStyleSection form={form} flat={flat} />;
+}
+
+function LollipopReferenceLines({ form, flat }: ChartPanelProps) {
+  return <ReferenceLinesSection form={form} flat={flat} />;
+}
+
+export const lollipopStyleShelves: ShelfDef[] = [
+  {
+    key: "display",
+    labelKey: "workspace.style.display",
+    icon: Settings2,
+    Component: LollipopDisplay,
+  },
+  {
+    key: "lollipop",
+    labelKey: "workspace.style.lollipopOptions",
+    icon: Candy,
+    Component: LollipopOptions,
+  },
+  {
+    key: "errorBar",
+    labelKey: "workspace.style.errorBarOptions",
+    icon: MoveVertical,
+    Component: LollipopErrorBar,
+  },
+  {
+    key: "referenceLines",
+    labelKey: "workspace.style.referenceLines",
+    icon: Minus,
+    Component: LollipopReferenceLines,
+  },
+];

--- a/apps/web/components/experiment-visualizations/charts/basic/pie/defaults.ts
+++ b/apps/web/components/experiment-visualizations/charts/basic/pie/defaults.ts
@@ -1,0 +1,30 @@
+import type { ChartFormConfig, ChartFormDataConfig } from "../../chart-config";
+import { makeDataSource } from "../../data/data-sources";
+
+export function pieDefaultConfig(): ChartFormConfig {
+  return {
+    title: "",
+    showLegend: true,
+    showGrid: false,
+    useWebGL: false,
+    // Each slice gets its own colour from CATEGORY_PALETTE at render time;
+    // `colorMap` is exposed so future per-category overrides slot in the
+    // same way scatter's categorical colouring does.
+    colorMap: {},
+    hole: 0,
+    textinfo: "percent",
+    pieTextPosition: "auto",
+    sortSlices: true,
+  };
+}
+
+export function pieDefaultDataConfig(tableName?: string): ChartFormDataConfig {
+  const table = tableName ?? "";
+  return {
+    tableName: table,
+    dataSources: [makeDataSource(table, "labels"), makeDataSource(table, "values")],
+    // Aggregation isn't seeded; the values shelf writes the function the
+    // moment a column or function is chosen, and the labels shelf writes
+    // the groupBy. An empty aggregation here would fail validation on save.
+  };
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/pie/index.ts
+++ b/apps/web/components/experiment-visualizations/charts/basic/pie/index.ts
@@ -1,0 +1,24 @@
+import { PieChart } from "lucide-react";
+
+import type { ChartTypeDef } from "../../types";
+import { pieDefaultConfig, pieDefaultDataConfig } from "./defaults";
+import { PieDataPanel } from "./panels/data-panel";
+import { PieStylePanel } from "./panels/style-panel";
+import { PieRenderer } from "./renderer";
+import { pieDataShelves } from "./shelves/data-shelves";
+import { pieStyleShelves } from "./shelves/style-shelves";
+
+export const pieChartType: ChartTypeDef = {
+  type: "pie",
+  family: "basic",
+  labelKey: "workspace.charts.types.pie",
+  descriptionKey: "workspace.charts.descriptions.pie",
+  icon: PieChart,
+  defaultConfig: pieDefaultConfig,
+  defaultDataConfig: pieDefaultDataConfig,
+  DataPanel: PieDataPanel,
+  StylePanel: PieStylePanel,
+  Renderer: PieRenderer,
+  dataShelves: pieDataShelves,
+  styleShelves: pieStyleShelves,
+};

--- a/apps/web/components/experiment-visualizations/charts/basic/pie/options.ts
+++ b/apps/web/components/experiment-visualizations/charts/basic/pie/options.ts
@@ -1,0 +1,19 @@
+/**
+ * Pie options. `pieTextPosition` is aliased away from line/scatter's
+ * `textposition` (compass directions) to avoid a `never` at the intersection
+ * of `ChartFormConfig`; the renderer maps it back at render time.
+ */
+export interface PieChartOptions {
+  hole?: number;
+  textinfo?:
+    | "label"
+    | "value"
+    | "percent"
+    | "label+percent"
+    | "label+value"
+    | "value+percent"
+    | "label+value+percent"
+    | "none";
+  pieTextPosition?: "inside" | "outside" | "auto" | "none";
+  sortSlices?: boolean;
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/pie/panels/data-panel.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/pie/panels/data-panel.test.tsx
@@ -1,0 +1,120 @@
+import { renderWithForm, screen, userEvent } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+
+import { pieChartType } from "../";
+import type { ChartFormValues } from "../../../chart-config";
+import { PieDataPanel } from "../panels/data-panel";
+
+function defaults(overrides: Partial<ChartFormValues> = {}): ChartFormValues {
+  return {
+    name: "Untitled",
+    description: "",
+    chartFamily: pieChartType.family,
+    chartType: pieChartType.type,
+    config: pieChartType.defaultConfig(),
+    dataConfig: pieChartType.defaultDataConfig(),
+    ...overrides,
+  };
+}
+
+const columns: DataColumn[] = [
+  { name: "category", type_name: "STRING", type_text: "STRING" },
+  { name: "amount", type_name: "DOUBLE", type_text: "DOUBLE" },
+];
+
+function renderPanel(formDefaults?: ChartFormValues) {
+  return renderWithForm<ChartFormValues>((form) => <PieDataPanel form={form} columns={columns} />, {
+    useFormProps: { defaultValues: formDefaults ?? defaults() },
+  });
+}
+
+describe("PieDataPanel", () => {
+  it("renders the labels and values shelves", () => {
+    renderPanel();
+    expect(screen.getByRole("heading", { name: "workspace.shelves.labels" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "workspace.shelves.values" })).toBeInTheDocument();
+  });
+
+  it("seeds the labels trigger from the existing data source", () => {
+    renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "sales",
+          dataSources: [
+            { tableName: "sales", columnName: "category", role: "labels" },
+            { tableName: "sales", columnName: "amount", role: "values" },
+          ],
+        },
+      }),
+    );
+    expect(screen.getAllByRole("combobox")[0]).toHaveTextContent("category");
+  });
+
+  it("writes the picked labels column into the data sources and groupBy", async () => {
+    const user = userEvent.setup();
+    const { form } = renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "sales",
+          dataSources: [
+            { tableName: "sales", columnName: "", role: "labels" },
+            { tableName: "sales", columnName: "amount", role: "values" },
+          ],
+        },
+      }),
+    );
+
+    await user.click(screen.getAllByRole("combobox")[0]);
+    await user.click(await screen.findByText("category"));
+
+    const labelSource = form.getValues("dataConfig.dataSources").find((ds) => ds.role === "labels");
+    expect(labelSource).toEqual(
+      expect.objectContaining({ columnName: "category", tableName: "sales" }),
+    );
+    expect(form.getValues("dataConfig.aggregation")?.groupBy).toEqual([{ column: "category" }]);
+  });
+
+  it("writes the picked values column and seeds Sum as the default aggregate", async () => {
+    const user = userEvent.setup();
+    const { form } = renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "sales",
+          dataSources: [
+            { tableName: "sales", columnName: "category", role: "labels" },
+            { tableName: "sales", columnName: "", role: "values" },
+          ],
+        },
+      }),
+    );
+
+    const combos = screen.getAllByRole("combobox");
+    await user.click(combos[1]);
+    await user.click(await screen.findByText("amount"));
+
+    expect(form.getValues("dataConfig.aggregation")?.functions).toEqual([
+      { column: "amount", function: "sum" },
+    ]);
+  });
+
+  it("shows the count hint when the aggregate is count", () => {
+    renderPanel(
+      defaults({
+        dataConfig: {
+          tableName: "sales",
+          dataSources: [
+            { tableName: "sales", columnName: "category", role: "labels" },
+            { tableName: "sales", columnName: "", role: "values" },
+          ],
+          aggregation: {
+            groupBy: [{ column: "category" }],
+            functions: [{ column: "*", function: "count" }],
+          },
+        },
+      }),
+    );
+    expect(screen.getByText("workspace.shelves.pieValuesCountHint")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/pie/panels/data-panel.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/pie/panels/data-panel.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Fragment } from "react";
+
+import { Separator } from "@repo/ui/components/separator";
+
+import type { ChartPanelProps } from "../../../types";
+import { pieDataShelves } from "../shelves/data-shelves";
+
+export function PieDataPanel({ form, columns }: ChartPanelProps) {
+  return (
+    <div className="space-y-6">
+      {pieDataShelves
+        .filter((shelf) => !shelf.visible || shelf.visible(form))
+        .map((shelf, index) => {
+          const Comp = shelf.Component;
+          return (
+            <Fragment key={shelf.key}>
+              {index > 0 && <Separator />}
+              <Comp form={form} columns={columns} />
+            </Fragment>
+          );
+        })}
+    </div>
+  );
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/pie/panels/style-panel.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/pie/panels/style-panel.test.tsx
@@ -1,0 +1,65 @@
+import { renderWithForm, screen } from "@/test/test-utils";
+import { fireEvent } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+
+import { pieChartType } from "../";
+import type { ChartFormValues } from "../../../chart-config";
+import { PieStylePanel } from "../panels/style-panel";
+
+function defaults(overrides: Partial<ChartFormValues> = {}): ChartFormValues {
+  return {
+    name: "Untitled",
+    description: "",
+    chartFamily: pieChartType.family,
+    chartType: pieChartType.type,
+    config: pieChartType.defaultConfig(),
+    dataConfig: pieChartType.defaultDataConfig(),
+    ...overrides,
+  };
+}
+
+const columns: DataColumn[] = [
+  { name: "variety", type_name: "VARCHAR", type_text: "STRING" },
+  { name: "yield", type_name: "DOUBLE", type_text: "DOUBLE" },
+];
+
+function renderPanel(formDefaults?: ChartFormValues) {
+  return renderWithForm<ChartFormValues>(
+    (form) => <PieStylePanel form={form} columns={columns} />,
+    { useFormProps: { defaultValues: formDefaults ?? defaults() } },
+  );
+}
+
+function expandSection(name: string) {
+  fireEvent.click(screen.getByRole("button", { name }));
+}
+
+describe("PieStylePanel", () => {
+  it("shows hole, text info, text position and sort", () => {
+    renderPanel();
+    expandSection("workspace.style.pieOptions");
+    expect(screen.getByText("workspace.style.pieHole")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.pieTextInfo")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.pieTextPosition")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.pieSortSlices")).toBeInTheDocument();
+  });
+
+  it("does not surface axis-bound options like line/scatter modes", () => {
+    renderPanel();
+    expandSection("workspace.style.pieOptions");
+    expect(screen.queryByText("workspace.style.lineWidth")).not.toBeInTheDocument();
+    expect(screen.queryByText("workspace.style.markerShape")).not.toBeInTheDocument();
+    expect(screen.queryByText("workspace.style.orientation")).not.toBeInTheDocument();
+  });
+
+  it("renders with an empty config", () => {
+    renderPanel(defaults({ config: {} }));
+    expandSection("workspace.style.pieOptions");
+    expect(screen.getByText("workspace.style.pieHole")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.pieTextInfo")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.pieTextPosition")).toBeInTheDocument();
+    expect(screen.getByText("workspace.style.pieSortSlices")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/pie/panels/style-panel.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/pie/panels/style-panel.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Fragment } from "react";
+
+import { Separator } from "@repo/ui/components/separator";
+
+import type { ChartPanelProps } from "../../../types";
+import { pieStyleShelves } from "../shelves/style-shelves";
+
+export function PieStylePanel({ form, columns }: ChartPanelProps) {
+  return (
+    <div className="space-y-6">
+      {pieStyleShelves
+        .filter((shelf) => !shelf.visible || shelf.visible(form))
+        .map((shelf, index) => {
+          const Comp = shelf.Component;
+          return (
+            <Fragment key={shelf.key}>
+              {index > 0 && <Separator />}
+              <Comp form={form} columns={columns} />
+            </Fragment>
+          );
+        })}
+    </div>
+  );
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/pie/renderer.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/pie/renderer.test.tsx
@@ -1,0 +1,109 @@
+import { createVisualization } from "@/test/factories";
+import { render, screen } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import { pieDefaultConfig } from "./defaults";
+import { PieRenderer } from "./renderer";
+
+function buildViz(overrides: Parameters<typeof createVisualization>[0] = {}) {
+  return createVisualization({
+    chartType: "pie",
+    chartFamily: "basic",
+    config: { ...pieDefaultConfig() },
+    dataConfig: {
+      tableName: "harvest",
+      dataSources: [
+        { tableName: "harvest", columnName: "variety", role: "labels" },
+        { tableName: "harvest", columnName: "yield", role: "values" },
+      ],
+    },
+    ...overrides,
+  });
+}
+
+describe("PieRenderer", () => {
+  it("shows a config error when the visualization isn't a pie chart", () => {
+    const viz = buildViz({ chartType: "line" });
+    render(<PieRenderer visualization={viz} experimentId="exp-1" data={[]} />);
+    expect(screen.getByText("errors.configuration")).toBeInTheDocument();
+    expect(screen.getByText("errors.invalidConfiguration")).toBeInTheDocument();
+  });
+
+  it("shows the empty-state when there are no rows", () => {
+    const viz = buildViz();
+    render(<PieRenderer visualization={viz} experimentId="exp-1" data={[]} />);
+    expect(screen.getByText("errors.noData")).toBeInTheDocument();
+  });
+
+  it("renders the chart frame with rows + labels/values configured", () => {
+    const viz = buildViz();
+    const rows = [
+      { variety: "Tomato", yield: 12 },
+      { variety: "Cucumber", yield: 8 },
+      { variety: "Pepper", yield: 5 },
+    ];
+    const { container } = render(
+      <PieRenderer visualization={viz} experimentId="exp-1" data={rows} />,
+    );
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+    expect(screen.queryByText("errors.noData")).not.toBeInTheDocument();
+    expect(container.querySelector(".flex.h-full.w-full.flex-col")).toBeInTheDocument();
+  });
+
+  it("falls back to the empty-state when labels column is unset", () => {
+    // Pie has no axis fallback the way line/scatter synthesise an X index;
+    // without a labels column the slices aren't meaningful, so the frame
+    // mounts but renders the no-data placeholder.
+    const viz = buildViz({
+      dataConfig: {
+        tableName: "harvest",
+        dataSources: [
+          { tableName: "harvest", columnName: "", role: "labels" },
+          { tableName: "harvest", columnName: "yield", role: "values" },
+        ],
+      },
+    });
+    render(<PieRenderer visualization={viz} experimentId="exp-1" data={[{ yield: 12 }]} />);
+    expect(screen.getByText("errors.noData")).toBeInTheDocument();
+  });
+
+  it("falls back to the empty-state when values column is unset", () => {
+    const viz = buildViz({
+      dataConfig: {
+        tableName: "harvest",
+        dataSources: [
+          { tableName: "harvest", columnName: "variety", role: "labels" },
+          { tableName: "harvest", columnName: "", role: "values" },
+        ],
+      },
+    });
+    render(<PieRenderer visualization={viz} experimentId="exp-1" data={[{ variety: "A" }]} />);
+    expect(screen.getByText("errors.noData")).toBeInTheDocument();
+  });
+
+  it("renders pre-aggregated rows directly (one row per slice)", () => {
+    // Pie expects server-side aggregation: `PieValuesShelf` writes the
+    // aggregation entry on every column pick, so production rows always
+    // arrive pre-aggregated (one row per category). The renderer no
+    // longer collapses duplicates client-side; that responsibility is
+    // upstream. Contract here is just "doesn't crash on the happy path".
+    const viz = buildViz();
+    const rows = [
+      { variety: "Tomato", yield: 17 },
+      { variety: "Cucumber", yield: 8 },
+    ];
+    render(<PieRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+    expect(screen.queryByText("errors.noData")).not.toBeInTheDocument();
+  });
+
+  it("renders in donut mode (hole > 0)", () => {
+    const viz = buildViz({ config: { ...pieDefaultConfig(), hole: 0.4 } });
+    const rows = [
+      { variety: "A", yield: 10 },
+      { variety: "B", yield: 20 },
+    ];
+    render(<PieRenderer visualization={viz} experimentId="exp-1" data={rows} />);
+    expect(screen.queryByText("errors.invalidConfiguration")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/pie/renderer.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/pie/renderer.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { useTranslation } from "@repo/i18n";
+import { PieChart } from "@repo/ui/components/charts/pie-chart";
+
+import { narrowChartConfig } from "../../chart-config";
+import { ChartConfigError, ChartFrame } from "../../chart-frame";
+import { rowKeyForFunction } from "../../data/aggregation";
+import { useChartData } from "../../hooks/use-chart-data";
+import type { ChartRendererProps } from "../../types";
+import { transformPieData } from "./transform";
+
+export function PieRenderer({
+  visualization,
+  experimentId,
+  data: providedData,
+}: ChartRendererProps) {
+  const { t } = useTranslation("experimentVisualizations");
+
+  // No `orderBy` for pie: slice ordering is decided by Plotly's `sort`
+  // setting (largest-first by default), not row order.
+  const { rows, isLoading, error } = useChartData(visualization, experimentId, providedData);
+  const chartConfig = narrowChartConfig(visualization);
+  const dataSources = visualization.dataConfig.dataSources;
+  const aggregation = visualization.dataConfig.aggregation;
+
+  // KEEP IN SYNC with the field reads in `transformPieData`.
+  const slices = useMemo(() => {
+    if (visualization.chartType !== "pie") {
+      return [];
+    }
+    return transformPieData(rows, dataSources, aggregation, chartConfig);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- leaf-listed; see KEEP IN SYNC comment.
+  }, [
+    rows,
+    dataSources,
+    aggregation,
+    visualization.chartType,
+    chartConfig.colorMap,
+    chartConfig.hole,
+    chartConfig.textinfo,
+    chartConfig.pieTextPosition,
+    chartConfig.sortSlices,
+  ]);
+
+  if (visualization.chartType !== "pie") {
+    return <ChartConfigError message={t("errors.invalidConfiguration")} />;
+  }
+
+  const labelsColumn = dataSources.find((ds) => ds.role === "labels")?.columnName;
+  const valuesColumn = dataSources.find((ds) => ds.role === "values")?.columnName;
+  const aggregateFn = aggregation?.functions?.[0];
+  const valueRowKey = aggregateFn ? rowKeyForFunction(aggregateFn) : valuesColumn;
+  const canDraw = Boolean(labelsColumn) && Boolean(valueRowKey);
+
+  return (
+    <ChartFrame
+      visualization={visualization}
+      experimentId={experimentId}
+      isLoading={isLoading}
+      error={error}
+      hasRows={rows.length > 0 && canDraw}
+    >
+      <div className="flex h-full w-full flex-col">
+        <PieChart data={slices} config={chartConfig} />
+      </div>
+    </ChartFrame>
+  );
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/pie/shelves/data-shelves.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/pie/shelves/data-shelves.test.tsx
@@ -1,0 +1,41 @@
+import { renderWithForm } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import { pieChartType } from "..";
+import type { ChartFormValues } from "../../../chart-config";
+import type { ShelfSummaryT } from "../../../types";
+import { pieDataShelves } from "./data-shelves";
+
+const t: ShelfSummaryT = (key, options) => (options ? `${key}:${JSON.stringify(options)}` : key);
+
+function form(dataSources: ChartFormValues["dataConfig"]["dataSources"]) {
+  return renderWithForm<ChartFormValues>(() => <div />, {
+    useFormProps: {
+      defaultValues: {
+        name: "",
+        description: "",
+        chartFamily: pieChartType.family,
+        chartType: pieChartType.type,
+        config: pieChartType.defaultConfig(),
+        dataConfig: { tableName: "t", dataSources },
+      },
+    },
+  }).form;
+}
+
+describe("pieDataShelves summaries", () => {
+  const [labels, values] = pieDataShelves;
+
+  it("labels and values return their column when set, undefined otherwise", () => {
+    const empty = form([]);
+    expect(labels.summary?.(empty, t)).toBeUndefined();
+    expect(values.summary?.(empty, t)).toBeUndefined();
+
+    const populated = form([
+      { tableName: "t", columnName: "category", role: "labels" },
+      { tableName: "t", columnName: "amount", role: "values" },
+    ]);
+    expect(labels.summary?.(populated, t)).toBe("category");
+    expect(values.summary?.(populated, t)).toBe("amount");
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/pie/shelves/data-shelves.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/pie/shelves/data-shelves.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Sigma, Tag } from "lucide-react";
+import { useMemo } from "react";
+
+import { filterColumnsForRole } from "@repo/api/utils/visualization-contracts";
+
+import { firstDataSourceByRole } from "../../../data/data-sources";
+import type { ChartPanelProps, ShelfDef } from "../../../types";
+import { PieLabelsShelf } from "./labels-shelf";
+import { PieValuesShelf } from "./values-shelf";
+
+function PieLabelsShelfWrapper({ form, columns }: ChartPanelProps) {
+  const labelColumns = useMemo(() => filterColumnsForRole(columns, "pie", "labels"), [columns]);
+  return <PieLabelsShelf form={form} columns={labelColumns} />;
+}
+
+function PieValuesShelfWrapper({ form, columns }: ChartPanelProps) {
+  const valueColumns = useMemo(() => filterColumnsForRole(columns, "pie", "values"), [columns]);
+  return <PieValuesShelf form={form} columns={valueColumns} />;
+}
+
+export const pieDataShelves: ShelfDef[] = [
+  {
+    key: "labels",
+    labelKey: "workspace.shelves.labels",
+    icon: Tag,
+    Component: PieLabelsShelfWrapper,
+    summary: (form) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const col = firstDataSourceByRole(sources, "labels")?.source.columnName;
+      return col && col.length > 0 ? col : undefined;
+    },
+  },
+  {
+    key: "values",
+    labelKey: "workspace.shelves.values",
+    icon: Sigma,
+    Component: PieValuesShelfWrapper,
+    summary: (form) => {
+      const sources = form.getValues("dataConfig.dataSources");
+      const col = firstDataSourceByRole(sources, "values")?.source.columnName;
+      return col && col.length > 0 ? col : undefined;
+    },
+  },
+];

--- a/apps/web/components/experiment-visualizations/charts/basic/pie/shelves/labels-shelf.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/pie/shelves/labels-shelf.test.tsx
@@ -1,0 +1,124 @@
+import { renderWithForm, screen, userEvent } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+
+import { pieChartType } from "../";
+import type { ChartFormValues } from "../../../chart-config";
+import { PieLabelsShelf } from "./labels-shelf";
+
+function defaults(overrides: Partial<ChartFormValues> = {}): ChartFormValues {
+  return {
+    name: "Untitled",
+    description: "",
+    chartFamily: pieChartType.family,
+    chartType: pieChartType.type,
+    config: pieChartType.defaultConfig(),
+    dataConfig: pieChartType.defaultDataConfig(),
+    ...overrides,
+  };
+}
+
+const columns: DataColumn[] = [
+  { name: "category", type_name: "STRING", type_text: "STRING" },
+  { name: "region", type_name: "STRING", type_text: "STRING" },
+];
+
+function renderShelf(formDefaults?: ChartFormValues) {
+  return renderWithForm<ChartFormValues>(
+    (form) => <PieLabelsShelf form={form} columns={columns} />,
+    { useFormProps: { defaultValues: formDefaults ?? defaults() } },
+  );
+}
+
+describe("PieLabelsShelf", () => {
+  it("renders heading and column picker", () => {
+    renderShelf();
+    expect(screen.getByRole("heading", { name: "workspace.shelves.labels" })).toBeInTheDocument();
+    expect(screen.getByText("workspace.shelves.column")).toBeInTheDocument();
+  });
+
+  it("writes the picked column into the labels data source", async () => {
+    const user = userEvent.setup();
+    const { form } = renderShelf(
+      defaults({
+        dataConfig: {
+          tableName: "sales",
+          dataSources: [
+            { tableName: "sales", columnName: "", role: "labels" },
+            { tableName: "sales", columnName: "amount", role: "values" },
+          ],
+        },
+      }),
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("category"));
+
+    const labelSource = form.getValues("dataConfig.dataSources").find((ds) => ds.role === "labels");
+    expect(labelSource).toEqual(
+      expect.objectContaining({ columnName: "category", tableName: "sales" }),
+    );
+  });
+
+  it("sets aggregation.groupBy to the picked column", async () => {
+    const user = userEvent.setup();
+    const { form } = renderShelf(
+      defaults({
+        dataConfig: {
+          tableName: "sales",
+          dataSources: [
+            { tableName: "sales", columnName: "", role: "labels" },
+            { tableName: "sales", columnName: "amount", role: "values" },
+          ],
+        },
+      }),
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("region"));
+
+    expect(form.getValues("dataConfig.aggregation")?.groupBy).toEqual([{ column: "region" }]);
+  });
+
+  it("preserves existing functions when groupBy is overwritten", async () => {
+    const user = userEvent.setup();
+    const { form } = renderShelf(
+      defaults({
+        dataConfig: {
+          tableName: "sales",
+          dataSources: [
+            { tableName: "sales", columnName: "category", role: "labels" },
+            { tableName: "sales", columnName: "amount", role: "values" },
+          ],
+          aggregation: {
+            groupBy: [{ column: "category" }],
+            functions: [{ column: "amount", function: "sum" }],
+          },
+        },
+      }),
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByText("region"));
+
+    expect(form.getValues("dataConfig.aggregation")?.functions).toEqual([
+      { column: "amount", function: "sum" },
+    ]);
+  });
+
+  it("seeds the trigger from the existing labels data source", () => {
+    renderShelf(
+      defaults({
+        dataConfig: {
+          tableName: "sales",
+          dataSources: [
+            { tableName: "sales", columnName: "category", role: "labels" },
+            { tableName: "sales", columnName: "amount", role: "values" },
+          ],
+        },
+      }),
+    );
+    expect(screen.getByRole("combobox")).toHaveTextContent("category");
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/pie/shelves/labels-shelf.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/pie/shelves/labels-shelf.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import type { UseFormReturn } from "react-hook-form";
+import { useWatch } from "react-hook-form";
+
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+import { useTranslation } from "@repo/i18n";
+import { Badge } from "@repo/ui/components/badge";
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@repo/ui/components/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui/components/select";
+
+import type { ChartFormValues } from "../../../chart-config";
+import { firstDataSourceByRole } from "../../../data/data-sources";
+
+interface PieLabelsShelfProps {
+  form: UseFormReturn<ChartFormValues>;
+  columns: DataColumn[];
+}
+
+/** Pie's labels column picker. Also rewrites `dataConfig.aggregation.groupBy` so the SQL groups by this column. */
+export function PieLabelsShelf({ form, columns }: PieLabelsShelfProps) {
+  const { t } = useTranslation("experimentVisualizations");
+
+  const sources = useWatch({ control: form.control, name: "dataConfig.dataSources" });
+  const indexed = firstDataSourceByRole(sources, "labels");
+  const sourceIndex = indexed?.index ?? 0;
+
+  const handleColumnChange = (value: string) => {
+    const tableName = form.getValues("dataConfig.tableName");
+    form.setValue(`dataConfig.dataSources.${sourceIndex}.tableName`, tableName, {
+      shouldDirty: true,
+    });
+    form.setValue(`dataConfig.dataSources.${sourceIndex}.columnName`, value, {
+      shouldDirty: true,
+    });
+
+    // Rewrite groupBy: pie groups by exactly one column. Replace rather
+    // than upsert because changing the label invalidates any prior entry.
+    // Cleared label drops groupBy; functions kept so the user's aggregate
+    // choice survives a brief unset/reset.
+    const existingFns = form.getValues("dataConfig.aggregation")?.functions;
+    const hasLabel = value.length > 0;
+    const hasFns = (existingFns?.length ?? 0) > 0;
+    let nextAggregation: ChartFormValues["dataConfig"]["aggregation"];
+    if (hasLabel) {
+      nextAggregation = { groupBy: [{ column: value }], functions: existingFns };
+    } else if (hasFns) {
+      nextAggregation = { functions: existingFns };
+    } else {
+      nextAggregation = undefined;
+    }
+    form.setValue("dataConfig.aggregation", nextAggregation, { shouldDirty: true });
+  };
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">{t("workspace.shelves.labels")}</h3>
+
+      <FormField
+        control={form.control}
+        name={`dataConfig.dataSources.${sourceIndex}.columnName` as const}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-xs font-medium">{t("workspace.shelves.column")}</FormLabel>
+            <Select value={field.value} onValueChange={handleColumnChange}>
+              <FormControl>
+                <SelectTrigger>
+                  <SelectValue placeholder={t("workspace.shelves.selectColumn")} />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                {columns.map((column) => (
+                  <SelectItem key={column.name} value={column.name}>
+                    <div className="flex items-center gap-2">
+                      <span>{column.name}</span>
+                      <Badge
+                        variant="outline"
+                        className="text-muted-foreground h-4 px-1.5 py-0 font-mono text-[10px] font-normal leading-none"
+                      >
+                        {column.type_name}
+                      </Badge>
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </section>
+  );
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/pie/shelves/style-shelves.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/pie/shelves/style-shelves.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { PieChart, Settings2 } from "lucide-react";
+import { useId } from "react";
+
+import { useTranslation } from "@repo/i18n";
+import { Checkbox } from "@repo/ui/components/checkbox";
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@repo/ui/components/form";
+import { FormSlider } from "@repo/ui/components/form-slider";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui/components/select";
+
+import { DisplayOptionsSection } from "../../../../workspace/style-sections/display-options-section";
+import { CollapsibleStyleSection } from "../../../../workspace/style-sections/shared/collapsible-style-section";
+import { StyleSubsection } from "../../../../workspace/style-sections/shared/style-subsection";
+import type { ChartPanelProps, ShelfDef } from "../../../types";
+
+function PieDisplay({ form, flat }: ChartPanelProps) {
+  return <DisplayOptionsSection form={form} flat={flat} />;
+}
+
+function PieOptions({ form, flat }: ChartPanelProps) {
+  const { t } = useTranslation("experimentVisualizations");
+  const sortSlicesId = useId();
+
+  return (
+    <CollapsibleStyleSection title={t("workspace.style.pieOptions")} flat={flat}>
+      <FormField
+        control={form.control}
+        name="config.hole"
+        render={({ field }) => (
+          <FormSlider
+            label={t("workspace.style.pieHole")}
+            // Donut hole as a fraction of the radius. The wrapper passes
+            // `hole > 0` as a donut; this slider exposes the same scalar.
+            value={typeof field.value === "number" ? field.value : undefined}
+            fallback={0}
+            min={0}
+            max={0.9}
+            step={0.05}
+            onCommit={field.onChange}
+            formatBadge={(v) => `${Math.round(v * 100)}%`}
+          />
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="config.textinfo"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-xs font-medium">
+              {t("workspace.style.pieTextInfo")}
+            </FormLabel>
+            <Select value={String(field.value ?? "percent")} onValueChange={field.onChange}>
+              <FormControl>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                <SelectItem value="percent">{t("workspace.textinfos.percent")}</SelectItem>
+                <SelectItem value="value">{t("workspace.textinfos.value")}</SelectItem>
+                <SelectItem value="label">{t("workspace.textinfos.label")}</SelectItem>
+                <SelectItem value="label+percent">
+                  {t("workspace.textinfos.labelPercent")}
+                </SelectItem>
+                <SelectItem value="label+value">{t("workspace.textinfos.labelValue")}</SelectItem>
+                <SelectItem value="value+percent">
+                  {t("workspace.textinfos.valuePercent")}
+                </SelectItem>
+                <SelectItem value="none">
+                  <span className="text-muted-foreground italic">
+                    {t("workspace.textinfos.none")}
+                  </span>
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={form.control}
+        name="config.pieTextPosition"
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-xs font-medium">
+              {t("workspace.style.pieTextPosition")}
+            </FormLabel>
+            <Select value={String(field.value ?? "auto")} onValueChange={field.onChange}>
+              <FormControl>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                <SelectItem value="auto">{t("workspace.pieTextPositions.auto")}</SelectItem>
+                <SelectItem value="inside">{t("workspace.pieTextPositions.inside")}</SelectItem>
+                <SelectItem value="outside">{t("workspace.pieTextPositions.outside")}</SelectItem>
+                <SelectItem value="none">
+                  <span className="text-muted-foreground italic">
+                    {t("workspace.pieTextPositions.none")}
+                  </span>
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <StyleSubsection title={t("workspace.style.pieOrderingSubsection")}>
+        <FormField
+          control={form.control}
+          name="config.sortSlices"
+          render={({ field }) => (
+            <FormItem className="flex items-center gap-2 space-y-0">
+              <FormControl>
+                <Checkbox
+                  id={sortSlicesId}
+                  // Wrapper defaults `sort` to true; treat undefined as
+                  // checked so the control reflects the rendered state.
+                  checked={field.value !== false}
+                  onCheckedChange={field.onChange}
+                />
+              </FormControl>
+              <FormLabel htmlFor={sortSlicesId} className="text-xs font-medium">
+                {t("workspace.style.pieSortSlices")}
+              </FormLabel>
+            </FormItem>
+          )}
+        />
+      </StyleSubsection>
+    </CollapsibleStyleSection>
+  );
+}
+
+export const pieStyleShelves: ShelfDef[] = [
+  {
+    key: "display",
+    labelKey: "workspace.style.display",
+    icon: Settings2,
+    Component: PieDisplay,
+  },
+  {
+    key: "pie",
+    labelKey: "workspace.style.pieOptions",
+    icon: PieChart,
+    Component: PieOptions,
+  },
+];

--- a/apps/web/components/experiment-visualizations/charts/basic/pie/shelves/values-shelf.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/pie/shelves/values-shelf.test.tsx
@@ -1,0 +1,159 @@
+import { renderWithForm, screen, userEvent } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+
+import { pieChartType } from "../";
+import type { ChartFormValues } from "../../../chart-config";
+import { PieValuesShelf } from "./values-shelf";
+
+function defaults(overrides: Partial<ChartFormValues> = {}): ChartFormValues {
+  return {
+    name: "Untitled",
+    description: "",
+    chartFamily: pieChartType.family,
+    chartType: pieChartType.type,
+    config: pieChartType.defaultConfig(),
+    dataConfig: pieChartType.defaultDataConfig(),
+    ...overrides,
+  };
+}
+
+const columns: DataColumn[] = [
+  { name: "amount", type_name: "DOUBLE", type_text: "DOUBLE" },
+  { name: "weight", type_name: "DOUBLE", type_text: "DOUBLE" },
+];
+
+function renderShelf(formDefaults?: ChartFormValues) {
+  return renderWithForm<ChartFormValues>(
+    (form) => <PieValuesShelf form={form} columns={columns} />,
+    { useFormProps: { defaultValues: formDefaults ?? defaults() } },
+  );
+}
+
+describe("PieValuesShelf", () => {
+  it("renders heading, column picker, and aggregate dropdown", () => {
+    renderShelf();
+    expect(screen.getByRole("heading", { name: "workspace.shelves.values" })).toBeInTheDocument();
+    expect(screen.getByText("workspace.shelves.column")).toBeInTheDocument();
+    expect(screen.getByText("workspace.shelves.aggregate")).toBeInTheDocument();
+  });
+
+  it("writes the picked column + Sum aggregate into the aggregation config", async () => {
+    const user = userEvent.setup();
+    const { form } = renderShelf(
+      defaults({
+        dataConfig: {
+          tableName: "sales",
+          dataSources: [
+            { tableName: "sales", columnName: "category", role: "labels" },
+            { tableName: "sales", columnName: "", role: "values" },
+          ],
+        },
+      }),
+    );
+
+    await user.click(screen.getAllByRole("combobox")[0]);
+    await user.click(await screen.findByText("amount"));
+
+    expect(form.getValues("dataConfig.aggregation")?.functions).toEqual([
+      { column: "amount", function: "sum" },
+    ]);
+  });
+
+  it("rewrites the function when the aggregate changes", async () => {
+    const user = userEvent.setup();
+    const { form } = renderShelf(
+      defaults({
+        dataConfig: {
+          tableName: "sales",
+          dataSources: [
+            { tableName: "sales", columnName: "category", role: "labels" },
+            { tableName: "sales", columnName: "amount", role: "values" },
+          ],
+          aggregation: {
+            groupBy: [{ column: "category" }],
+            functions: [{ column: "amount", function: "sum" }],
+          },
+        },
+      }),
+    );
+
+    await user.click(screen.getAllByRole("combobox")[1]);
+    await user.click(await screen.findByText("Average"));
+
+    expect(form.getValues("dataConfig.aggregation")?.functions).toEqual([
+      { column: "amount", function: "avg" },
+    ]);
+  });
+
+  it("falls back to COUNT(*) when count is selected without a values column", async () => {
+    const user = userEvent.setup();
+    const { form } = renderShelf(
+      defaults({
+        dataConfig: {
+          tableName: "sales",
+          dataSources: [
+            { tableName: "sales", columnName: "category", role: "labels" },
+            { tableName: "sales", columnName: "", role: "values" },
+          ],
+          aggregation: {
+            groupBy: [{ column: "category" }],
+          },
+        },
+      }),
+    );
+
+    await user.click(screen.getAllByRole("combobox")[1]);
+    await user.click(await screen.findByText("Count"));
+
+    expect(form.getValues("dataConfig.aggregation")?.functions).toEqual([
+      { column: "*", function: "count" },
+    ]);
+  });
+
+  it("drops the function entry when switching off Count without a values column", async () => {
+    const user = userEvent.setup();
+    const { form } = renderShelf(
+      defaults({
+        dataConfig: {
+          tableName: "sales",
+          dataSources: [
+            { tableName: "sales", columnName: "category", role: "labels" },
+            { tableName: "sales", columnName: "", role: "values" },
+          ],
+          aggregation: {
+            groupBy: [{ column: "category" }],
+            functions: [{ column: "*", function: "count" }],
+          },
+        },
+      }),
+    );
+
+    await user.click(screen.getAllByRole("combobox")[1]);
+    await user.click(await screen.findByText("Sum"));
+
+    expect(form.getValues("dataConfig.aggregation")).toEqual({
+      groupBy: [{ column: "category" }],
+    });
+  });
+
+  it("surfaces the count hint when current function is count", () => {
+    renderShelf(
+      defaults({
+        dataConfig: {
+          tableName: "sales",
+          dataSources: [
+            { tableName: "sales", columnName: "category", role: "labels" },
+            { tableName: "sales", columnName: "", role: "values" },
+          ],
+          aggregation: {
+            groupBy: [{ column: "category" }],
+            functions: [{ column: "*", function: "count" }],
+          },
+        },
+      }),
+    );
+    expect(screen.getByText("workspace.shelves.pieValuesCountHint")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/pie/shelves/values-shelf.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/pie/shelves/values-shelf.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import type { UseFormReturn } from "react-hook-form";
+import { useWatch } from "react-hook-form";
+
+import type { AggregationFunction, DataColumn } from "@repo/api/schemas/experiment.schema";
+import { useTranslation } from "@repo/i18n";
+import { Badge } from "@repo/ui/components/badge";
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@repo/ui/components/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui/components/select";
+
+import type { ChartFormValues } from "../../../chart-config";
+import { firstDataSourceByRole } from "../../../data/data-sources";
+
+interface PieValuesShelfProps {
+  form: UseFormReturn<ChartFormValues>;
+  columns: DataColumn[];
+}
+
+const PIE_FUNCTIONS: { value: AggregationFunction; label: string }[] = [
+  { value: "sum", label: "Sum" },
+  { value: "avg", label: "Average" },
+  { value: "count", label: "Count" },
+  { value: "min", label: "Min" },
+  { value: "max", label: "Max" },
+];
+
+/** Pie's values shelf: pairs a column picker with an aggregate function and writes into `dataConfig.aggregation.functions`. */
+export function PieValuesShelf({ form, columns }: PieValuesShelfProps) {
+  const { t } = useTranslation("experimentVisualizations");
+
+  const sources = useWatch({ control: form.control, name: "dataConfig.dataSources" });
+  const aggregation = useWatch({ control: form.control, name: "dataConfig.aggregation" });
+  const indexed = firstDataSourceByRole(sources, "values");
+  const sourceIndex = indexed?.index ?? 0;
+
+  // Pie has at most one aggregate function. Default to Sum on first interaction.
+  const currentFunction = aggregation?.functions?.[0]?.function ?? "sum";
+  const isCount = currentFunction === "count";
+
+  const writeFunction = (fn: AggregationFunction, column: string) => {
+    // Count without a values column uses COUNT(*); otherwise the column
+    // gates which rows contribute (COUNT(yield) skips nulls, etc.).
+    const functionColumn = fn === "count" && column === "" ? "*" : column;
+    if (!functionColumn) {
+      // No column and not count: can't form a valid function. Drop the
+      // entry and let the renderer's empty-state surface "pick a column".
+      form.setValue(
+        "dataConfig.aggregation",
+        aggregation?.groupBy && aggregation.groupBy.length > 0
+          ? { groupBy: aggregation.groupBy }
+          : undefined,
+        { shouldDirty: true },
+      );
+      return;
+    }
+    form.setValue(
+      "dataConfig.aggregation",
+      {
+        groupBy: aggregation?.groupBy,
+        functions: [{ column: functionColumn, function: fn }],
+      },
+      { shouldDirty: true },
+    );
+  };
+
+  const handleColumnChange = (value: string) => {
+    const tableName = form.getValues("dataConfig.tableName");
+    form.setValue(`dataConfig.dataSources.${sourceIndex}.tableName`, tableName);
+    form.setValue(`dataConfig.dataSources.${sourceIndex}.columnName`, value);
+    writeFunction(currentFunction, value);
+  };
+
+  const handleFunctionChange = (raw: string) => {
+    const fn = raw as AggregationFunction;
+    const currentColumn = form.getValues(`dataConfig.dataSources.${sourceIndex}.columnName`);
+    writeFunction(fn, currentColumn);
+  };
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">{t("workspace.shelves.values")}</h3>
+
+      <div className="grid grid-cols-[1fr_auto] items-end gap-3">
+        <FormField
+          control={form.control}
+          name={`dataConfig.dataSources.${sourceIndex}.columnName` as const}
+          render={({ field }) => (
+            <FormItem className="min-w-0">
+              <FormLabel className="text-xs font-medium">{t("workspace.shelves.column")}</FormLabel>
+              <Select
+                value={field.value}
+                onValueChange={handleColumnChange}
+                disabled={isCount && field.value.length === 0}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue
+                      placeholder={
+                        isCount
+                          ? t("workspace.shelves.pieValuesCountPlaceholder")
+                          : t("workspace.shelves.selectColumn")
+                      }
+                    />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {columns.map((column) => (
+                    <SelectItem key={column.name} value={column.name}>
+                      <div className="flex items-center gap-2">
+                        <span>{column.name}</span>
+                        <Badge
+                          variant="outline"
+                          className="text-muted-foreground h-4 px-1.5 py-0 font-mono text-[10px] font-normal leading-none"
+                        >
+                          {column.type_name}
+                        </Badge>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormItem className="w-[140px]">
+          <FormLabel className="text-xs font-medium">{t("workspace.shelves.aggregate")}</FormLabel>
+          <Select value={currentFunction} onValueChange={handleFunctionChange}>
+            <FormControl>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              {PIE_FUNCTIONS.map((fn) => (
+                <SelectItem key={fn.value} value={fn.value}>
+                  {fn.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </FormItem>
+      </div>
+
+      {isCount && (
+        <p className="text-muted-foreground text-xs">{t("workspace.shelves.pieValuesCountHint")}</p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/pie/transform.test.ts
+++ b/apps/web/components/experiment-visualizations/charts/basic/pie/transform.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import type { DataSourceConfig } from "@repo/api/schemas/experiment.schema";
+
+import type { ChartFormConfig } from "../../chart-config";
+import { rowKeyForFunction } from "../../data/aggregation";
+import { transformPieData } from "./transform";
+
+const baseConfig: ChartFormConfig = {};
+
+function ds(role: DataSourceConfig["role"], columnName: string): DataSourceConfig {
+  return { tableName: "t", columnName, role };
+}
+
+describe("transformPieData", () => {
+  it("returns empty when labels or values column is missing", () => {
+    expect(transformPieData([{ a: 1 }], [], undefined, baseConfig)).toEqual([]);
+    expect(transformPieData([{ a: 1 }], [ds("labels", "a")], undefined, baseConfig)).toEqual([]);
+  });
+
+  it("returns empty when no rows survive", () => {
+    const sources = [ds("labels", "lbl"), ds("values", "val")];
+    const result = transformPieData([], sources, undefined, baseConfig);
+    expect(result).toEqual([]);
+  });
+
+  it("renders rows row-by-row when no aggregation is configured (no client-side summing)", () => {
+    // Aggregation is a server responsibility; the transform doesn't
+    // collapse duplicate labels. `PieValuesShelf` writes the aggregation
+    // entry on every column pick, so production configs always arrive
+    // pre-aggregated; raw-row passthrough renders as-is.
+    const rows = [
+      { lbl: "A", val: 10 },
+      { lbl: "B", val: 20 },
+      { lbl: "A", val: 5 },
+      { lbl: "C", val: 7 },
+    ];
+    const sources = [ds("labels", "lbl"), ds("values", "val")];
+    const result = transformPieData(rows, sources, undefined, baseConfig);
+    expect(result).toHaveLength(1);
+    expect(result[0].labels).toEqual(["A", "B", "A", "C"]);
+    expect(result[0].values).toEqual([10, 20, 5, 7]);
+  });
+
+  it("reads pre-aggregated rows via rowKeyForFunction when aggregation is configured", () => {
+    const sources = [ds("labels", "lbl"), ds("values", "val")];
+    const aggregation = {
+      functions: [{ column: "val", function: "sum" as const }],
+    };
+    const alias = rowKeyForFunction(aggregation.functions[0]);
+    const rows = [
+      { lbl: "A", [alias]: 100 },
+      { lbl: "B", [alias]: 50 },
+    ];
+    const result = transformPieData(rows, sources, aggregation, baseConfig);
+    expect(result[0].labels).toEqual(["A", "B"]);
+    expect(result[0].values).toEqual([100, 50]);
+  });
+
+  it("drops rows whose value coerces to NaN in either path", () => {
+    const sources = [ds("labels", "lbl"), ds("values", "val")];
+    const rows = [
+      { lbl: "A", val: 1 },
+      { lbl: "B", val: "not-a-number" },
+      { lbl: "C", val: 3 },
+    ];
+    const result = transformPieData(rows, sources, undefined, baseConfig);
+    expect(result[0].labels).toEqual(["A", "C"]);
+    expect(result[0].values).toEqual([1, 3]);
+  });
+
+  it("derives one marker color per slice", () => {
+    const sources = [ds("labels", "lbl"), ds("values", "val")];
+    const rows = [
+      { lbl: "A", val: 1 },
+      { lbl: "B", val: 2 },
+      { lbl: "C", val: 3 },
+    ];
+    const result = transformPieData(rows, sources, undefined, baseConfig);
+    expect(result[0].marker?.colors).toHaveLength(3);
+  });
+
+  it("threads pie-specific style options through (hole, textinfo, textposition, sort)", () => {
+    const sources = [ds("labels", "lbl"), ds("values", "val")];
+    const cfg: ChartFormConfig = {
+      hole: 0.5,
+      textinfo: "label+percent",
+      pieTextPosition: "outside",
+      sortSlices: false,
+    };
+    const result = transformPieData([{ lbl: "A", val: 1 }], sources, undefined, cfg);
+    expect(result[0].hole).toBe(0.5);
+    expect(result[0].textinfo).toBe("label+percent");
+    expect(result[0].textposition).toBe("outside");
+    expect(result[0].sort).toBe(false);
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/basic/pie/transform.ts
+++ b/apps/web/components/experiment-visualizations/charts/basic/pie/transform.ts
@@ -1,0 +1,59 @@
+import type { DataAggregation, DataSourceConfig } from "@repo/api/schemas/experiment.schema";
+import type { PieSeriesData } from "@repo/ui/components/charts/pie-chart";
+
+import type { ChartFormConfig } from "../../chart-config";
+import { getCategoryColor } from "../../colors/palettes";
+import { rowKeyForFunction } from "../../data/aggregation";
+import { toBucketKey } from "../../data/cell-coercion";
+import { dataSourcesByRole } from "../../data/data-sources";
+
+/** Pure data transform for the pie chart. Expects rows pre-aggregated by the SQL pipeline (one row per label). */
+export function transformPieData(
+  rows: Record<string, unknown>[],
+  dataSources: DataSourceConfig[],
+  aggregation: DataAggregation | undefined,
+  chartConfig: ChartFormConfig,
+): PieSeriesData[] {
+  const labelsColumn = dataSourcesByRole(dataSources, "labels")[0]?.source.columnName;
+  const valuesColumn = dataSourcesByRole(dataSources, "values")[0]?.source.columnName;
+  const aggregateFn = aggregation?.functions?.[0];
+  // The SQL builder projects an aggregate function under its supplied
+  // alias (or `${col || "count"}_${fn}` if absent). The hook only collapses
+  // groupBy aliases back; function aliases stay verbatim, so recompute
+  // here. Falls back to the raw column name when no aggregation is set.
+  const valueRowKey = aggregateFn ? rowKeyForFunction(aggregateFn) : valuesColumn;
+  if (!labelsColumn || !valueRowKey) {
+    return [];
+  }
+
+  const labels: string[] = [];
+  const values: number[] = [];
+  for (const row of rows) {
+    const value = Number(row[valueRowKey]);
+    if (!Number.isFinite(value)) {
+      continue;
+    }
+    labels.push(toBucketKey(row[labelsColumn]));
+    values.push(value);
+  }
+
+  if (labels.length === 0) {
+    return [];
+  }
+
+  // Per-slice colours from the same palette as scatter's categorical-color
+  // path, so the same category reads consistently across chart types.
+  const colors = labels.map((label, i) => getCategoryColor(i, chartConfig.colorMap, label));
+
+  return [
+    {
+      labels,
+      values,
+      marker: { colors },
+      hole: chartConfig.hole,
+      textinfo: chartConfig.textinfo ?? "percent",
+      textposition: chartConfig.pieTextPosition ?? "auto",
+      sort: chartConfig.sortSlices !== false,
+    },
+  ];
+}

--- a/apps/web/components/experiment-visualizations/charts/basic/scatter/panels/style-panel.test.tsx
+++ b/apps/web/components/experiment-visualizations/charts/basic/scatter/panels/style-panel.test.tsx
@@ -50,7 +50,7 @@ describe("ScatterStylePanel", () => {
     expect(screen.getByText("workspace.style.markerSize")).toBeInTheDocument();
     expandSection("workspace.style.lineOptions");
     expect(screen.getByText("workspace.style.markerOpacity")).toBeInTheDocument();
-    // markerShape lives inside MarkerStyleSection (Markers / scatter) — the
+    // markerShape lives inside MarkerStyleSection (Markers / scatter); the
     // trigger above already opened it.
     expect(screen.getByText("workspace.style.markerShape")).toBeInTheDocument();
   });

--- a/apps/web/components/experiment-visualizations/charts/chart-config.ts
+++ b/apps/web/components/experiment-visualizations/charts/chart-config.ts
@@ -8,6 +8,10 @@ import type { LineSeriesData } from "@repo/ui/components/charts/line-chart";
 import type { ScatterSeriesData } from "@repo/ui/components/charts/scatter-chart";
 import type { PlotlyChartConfig } from "@repo/ui/components/charts/types";
 
+import type { AreaChartOptions } from "./basic/area/options";
+import type { BubbleChartOptions } from "./basic/bubble/options";
+import type { LollipopChartOptions } from "./basic/lollipop/options";
+import type { PieChartOptions } from "./basic/pie/options";
 import type {
   BarChartOptions,
   ColorEncodingOptions,
@@ -17,27 +21,15 @@ import type {
   SecondaryAxisOptions,
 } from "./chart-options";
 
-// Options for chart families not yet packaged as their own modules; kept
-// inline so the shared cartesian renderer/transform can reference them
-// without forcing the chart-family barrels to land first.
-interface BubbleChartOptions {
-  sizemode?: "diameter" | "area";
-  bubbleMaxSize?: number;
-  bubbleMinSize?: number;
-}
-
-interface AreaChartOptions {
-  stackMode?: "none" | "stacked" | "percent";
-  fillOpacity?: number;
-}
-
 export type ChartFormConfig = PlotlyChartConfig &
   Partial<Omit<LineSeriesData, "x" | "y">> &
   Partial<Omit<ScatterSeriesData, "x" | "y">> &
   ColorEncodingOptions &
   BarChartOptions &
   AreaChartOptions &
+  LollipopChartOptions &
   BubbleChartOptions &
+  PieChartOptions &
   FacetOptions &
   ReferenceLinesOptions &
   ErrorBarChartOptions &

--- a/apps/web/components/experiment-visualizations/charts/chart-registry.test.ts
+++ b/apps/web/components/experiment-visualizations/charts/chart-registry.test.ts
@@ -22,21 +22,52 @@ describe("chart-type registry", () => {
     expect(def?.family).toBe("basic");
   });
 
-  it("returns undefined for an unregistered chart type", () => {
-    expect(getChartTypeDef("alluvial")).toBeUndefined();
+  it.each([
+    ["bar", "basic"],
+    ["area", "basic"],
+    ["dot-plot", "basic"],
+    ["lollipop", "basic"],
+    ["bubble", "basic"],
+    ["pie", "basic"],
+  ] as const)("returns the %s definition under the %s family", (type, family) => {
+    const def = getChartTypeDef(type);
+    expect(def?.type).toBe(type);
+    expect(def?.family).toBe(family);
+  });
+
+  it("returns true from isSupportedChartType for registered types", () => {
     expect(isSupportedChartType("line")).toBe(true);
-    expect(isSupportedChartType("alluvial")).toBe(false);
+    expect(isSupportedChartType("bar")).toBe(true);
   });
 
   it("listChartTypes returns only registered types", () => {
     const all = listChartTypes();
     const types = all.map((d) => d.type).sort();
-    expect(types).toEqual(["line", "scatter"]);
+    expect(types).toEqual([
+      "area",
+      "bar",
+      "bubble",
+      "dot-plot",
+      "line",
+      "lollipop",
+      "pie",
+      "scatter",
+    ]);
   });
 
   it("listChartTypesByFamily groups registered types under their family", () => {
     const grouped = listChartTypesByFamily();
-    expect(grouped.basic.map((d) => d.type).sort()).toEqual(["line", "scatter"]);
+    expect(grouped.basic.map((d) => d.type).sort()).toEqual([
+      "area",
+      "bar",
+      "bubble",
+      "dot-plot",
+      "line",
+      "lollipop",
+      "pie",
+      "scatter",
+    ]);
+    expect(grouped.statistical).toEqual([]);
     expect(grouped.scientific).toEqual([]);
     expect(grouped["3d"]).toEqual([]);
   });

--- a/apps/web/components/experiment-visualizations/charts/chart-registry.ts
+++ b/apps/web/components/experiment-visualizations/charts/chart-registry.ts
@@ -1,12 +1,24 @@
 import type { ChartFamily, ChartType } from "@repo/api/schemas/experiment.schema";
 
+import { areaChartType } from "./basic/area";
+import { barChartType } from "./basic/bar";
+import { bubbleChartType } from "./basic/bubble";
+import { dotPlotChartType } from "./basic/dot-plot";
 import { lineChartType } from "./basic/line";
+import { lollipopChartType } from "./basic/lollipop";
+import { pieChartType } from "./basic/pie";
 import { scatterChartType } from "./basic/scatter";
 import type { ChartTypeDef } from "./types";
 
 const REGISTRY: Partial<Record<ChartType, ChartTypeDef>> = {
   line: lineChartType,
   scatter: scatterChartType,
+  bar: barChartType,
+  area: areaChartType,
+  "dot-plot": dotPlotChartType,
+  lollipop: lollipopChartType,
+  bubble: bubbleChartType,
+  pie: pieChartType,
 };
 
 export function getChartTypeDef(type: ChartType): ChartTypeDef | undefined {

--- a/apps/web/components/experiment-visualizations/list/visualization-table-row.test.tsx
+++ b/apps/web/components/experiment-visualizations/list/visualization-table-row.test.tsx
@@ -68,6 +68,16 @@ describe("VisualizationTableRow", () => {
     expect(pill).toHaveClass("bg-badge-published");
   });
 
+  it.each(["bar", "area", "dot-plot", "lollipop", "bubble", "pie"] as const)(
+    "renders the basic-family badge for chartType=%s",
+    (chartType) => {
+      renderRow({ visualization: viz({ chartType }) });
+      // Labels use camelCased keys for hyphenated types (workspace.charts.types.dot-plot).
+      const key = `workspace.charts.types.${chartType}`;
+      expect(screen.getByText(key)).toHaveClass("bg-badge-published");
+    },
+  );
+
   it("opens the confirm dialog when the delete menu item is selected", async () => {
     const user = userEvent.setup();
     renderRow();

--- a/apps/web/components/experiment-visualizations/workspace/chart-type-picker.test.tsx
+++ b/apps/web/components/experiment-visualizations/workspace/chart-type-picker.test.tsx
@@ -52,7 +52,7 @@ describe("ChartTypePicker", () => {
   });
 
   it("hides families that have no registered chart types", async () => {
-    // Currently only the basic family registers types (line + scatter); the
+    // Only the basic family registers chart types in this branch; the
     // statistical/scientific/3D tabs land with their respective family PRs.
     const user = userEvent.setup();
     render(<ChartTypePicker value="line" onChange={vi.fn()} />);
@@ -66,5 +66,26 @@ describe("ChartTypePicker", () => {
     expect(
       screen.queryByRole("tab", { name: "workspace.families.scientific" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("renders a tile for every registered basic chart type", async () => {
+    const user = userEvent.setup();
+    render(<ChartTypePicker value="line" onChange={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: /workspace\.charts\.pickerLabel/ }));
+
+    for (const type of [
+      "line",
+      "scatter",
+      "bar",
+      "area",
+      "dot-plot",
+      "lollipop",
+      "bubble",
+      "pie",
+    ]) {
+      expect(
+        screen.getByRole("button", { name: new RegExp(`workspace\\.charts\\.types\\.${type}`) }),
+      ).toBeInTheDocument();
+    }
   });
 });


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Adds six new chart types to the `basic` family: area, bar, bubble, dot-plot, lollipop, and pie. Each plugs into the existing chart-type registry alongside line and scatter, picking up the shared data shelves, aggregation pipeline, grouping/faceting, color encoding, reference lines, and error bars.

Most of the new types reuse `CartesianRenderer`:
- `area` delegates with `defaultTraceType="area"` and introduces a `stackMode` option (`none` / `stacked` / `percent`) plus `fillOpacity`, which the renderer maps to Plotly's `stackgroup` + `groupnorm`.
- `bar` delegates with `defaultTraceType="bar"` and swaps axis title/type in horizontal orientation so the form's "X axis" label follows the category axis.
- `bubble` delegates with `defaultTraceType="scatter"`, `supportsContinuousColor`, and `supportsSize`, and ships a dedicated size shelf that pairs a measure column with an aggregate dropdown. When aggregation is active elsewhere, the size column auto-seeds an `avg` aggregate to avoid being dropped from the SQL projection.

Three types need their own renderer:
- `dot-plot` builds one trace per Y series, or per `(Y series × color category)` when group-by is set, with optional per-row error bars.
- `lollipop` is strictly single-series and feeds the shared `LollipopChart` wrapper with categories/values/errors.
- `pie` uses a dedicated `transformPieData` (one row per label, reads aggregate aliases via `rowKeyForFunction`), with labels and values shelves; the values shelf supports `count` with no column (`COUNT(*)`) and exposes `hole`, `textinfo`, `textposition`, and `sortSlices`.

Each new chart type is registered in `chart-registry.ts` and contributes a `defaults.ts`, `index.ts`, data and style panels, data and style shelves, a renderer, and unit tests covering panel composition, shelf wiring, and renderer output. `chart-config.ts` extends `ChartFormConfig` with the new option interfaces (`AreaChartOptions`, `BubbleChartOptions`, `LollipopChartOptions`, `PieChartOptions`).
