### PR TITLE
fix(web,viz): coerce null cells to null so numeric axes stay linear

### DIFF
--- a/apps/web/components/experiment-visualizations/charts/series-helpers.test.ts
+++ b/apps/web/components/experiment-visualizations/charts/series-helpers.test.ts
@@ -36,10 +36,16 @@ describe("coerceCell", () => {
     expect(coerceCell("Infinity")).toBe("Infinity");
   });
 
-  it("stringifies non-string, non-number values (booleans, null, objects)", () => {
+  it("returns null for null and undefined so axis detection isn't poisoned", () => {
+    // `String(null)` is `"null"` — a non-numeric string that flips
+    // detectAxisType to "category" and breaks an otherwise-numeric column.
+    expect(coerceCell(null)).toBeNull();
+    expect(coerceCell(undefined)).toBeNull();
+  });
+
+  it("stringifies other non-string, non-number values (booleans, objects)", () => {
     expect(coerceCell(true)).toBe("true");
     expect(coerceCell(false)).toBe("false");
-    expect(coerceCell(null)).toBe("null");
     expect(coerceCell({ a: 1 })).toBe("[object Object]");
   });
 });

--- a/apps/web/components/experiment-visualizations/charts/series-helpers.ts
+++ b/apps/web/components/experiment-visualizations/charts/series-helpers.ts
@@ -13,8 +13,14 @@ import type { IndexedDataSource } from "./form-values";
  * some genuine labels) end up with a mix of numbers and strings, which
  * Plotly treats as categorical — the right call when a column isn't
  * uniformly numeric.
+ *
+ * null/undefined return as `null` (Plotly renders gaps; detectAxisType
+ * skips them) — stringifying them to `"null"` / `"undefined"` would inject
+ * a non-numeric string and poison axis detection for an otherwise-numeric
+ * column, flipping the axis to category.
  */
-export function coerceCell(value: unknown): string | number {
+export function coerceCell(value: unknown): string | number | null {
+  if (value == null) return null;
   if (typeof value === "number") return value;
   if (typeof value === "string") {
     const trimmed = value.trim();
@@ -53,7 +59,7 @@ export function buildXValues(
   rows: Record<string, unknown>[],
   xColumn: string | undefined,
   useIndexForX: boolean,
-): (string | number)[] {
+): (string | number | null)[] {
   if (useIndexForX || !xColumn) return rows.map((_row, i) => i);
   return rows.map((row) => coerceCell(row[xColumn]));
 }

--- a/packages/ui/src/components/charts/line-chart.tsx
+++ b/packages/ui/src/components/charts/line-chart.tsx
@@ -15,8 +15,8 @@ import {
 } from "./utils";
 
 export interface LineSeriesData extends BaseSeries {
-  x: (string | number | Date)[];
-  y: (string | number)[];
+  x: (string | number | Date | null)[];
+  y: (string | number | null)[];
   mode?: "lines" | "markers" | "lines+markers" | "text" | "none";
   line?: LineConfig;
   marker?: MarkerConfig;

--- a/packages/ui/src/components/charts/scatter-chart.tsx
+++ b/packages/ui/src/components/charts/scatter-chart.tsx
@@ -15,8 +15,8 @@ import {
 } from "./utils";
 
 export interface ScatterSeriesData extends BaseSeries {
-  x: (string | number | Date)[];
-  y: (string | number)[];
+  x: (string | number | Date | null)[];
+  y: (string | number | null)[];
   mode?:
     | "markers"
     | "lines"


### PR DESCRIPTION
## Summary

- `coerceCell(null)` was returning the string `"null"`, mixing strings into otherwise-numeric arrays and flipping Plotly's auto-detection to `category`. Numeric axes then sorted ticks lexicographically (e.g. `1.561, 10.386, 1061.066, 11.769`) — visible on the FoPD scatter for users with any null cells in PAR/LEF.
- Returns `null` for `null`/`undefined` instead. `detectAxisType` already skips `v == null` (`packages/ui/src/components/charts/utils.ts:91`) and Plotly renders nulls as gaps, so the axis stays linear and the missing points are simply dropped.
- Widens `ScatterSeriesData.x/y` and `LineSeriesData.x/y` to accept `null`, plus `buildXValues` return type. Test for `coerceCell(null)` updated to `toBeNull()` and `undefined` covered.

Already cherry-picked to `release/18052026` so the FoPD users can unblock immediately.

## Test plan

- [x] `vitest run series-helpers.test.ts` — 16/16 pass
- [ ] Open the FoPD scatter on a column with at least one null cell, confirm both axes render as linear with proper numeric ticks
- [ ] Same column on the line chart — confirm gaps render in place of nulls, no axis flip