### PR TITLE
fix(mobile): trim happy-path toasts; inline UI for QR mismatch

### DIFF
--- a/apps/mobile/src/features/calibration/screens/calibration/components/CalibrationFlow.tsx
+++ b/apps/mobile/src/features/calibration/screens/calibration/components/CalibrationFlow.tsx
@@ -42,7 +42,6 @@ export function CalibrationFlow({ protocol }: CalibrationFlowProps) {
     setMeasurements([]);
     setCurrentMeasurementIndex(0);
     setProcessedOutput(null);
-    toast.info(t("calibration:flow.toastStarted"));
   };
 
   const handleGainCalibration = async () => {
@@ -62,7 +61,6 @@ export function CalibrationFlow({ protocol }: CalibrationFlowProps) {
 
     console.log("Gain calibration completed");
     setCurrentStep("measurements");
-    toast.success(t("calibration:flow.toastGainComplete"));
   };
 
   const handleMeasurement = async (panelNumber: number) => {
@@ -103,14 +101,6 @@ export function CalibrationFlow({ protocol }: CalibrationFlowProps) {
 
     if (currentMeasurementIndex < measurementSteps.length - 1) {
       setCurrentMeasurementIndex((prev) => prev + 1);
-      const nextPanelNumber =
-        measurementSteps[currentMeasurementIndex + 1]?.prompt?.match(/#(\d+)/)?.[1];
-      toast.info(
-        t("calibration:flow.toastPanelMeasured", {
-          panel: panelNumber,
-          next: nextPanelNumber,
-        }),
-      );
     } else {
       setCurrentStep("processing");
       handleDataProcessing();

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/question-node/question-node.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/question-node/question-node.tsx
@@ -1,7 +1,6 @@
-import { Repeat2, Search, X, Bookmark, ScanQrCode } from "lucide-react-native";
+import { CircleAlert, Repeat2, Search, X, Bookmark, ScanQrCode } from "lucide-react-native";
 import React, { useState } from "react";
 import { View, Text, ScrollView, TextInput, TouchableOpacity, Keyboard } from "react-native";
-import { toast } from "sonner-native";
 import { useFlowAnswersStore } from "~/features/measurement-flow/stores/use-flow-answers-store";
 import { useMeasurementFlowStore } from "~/features/measurement-flow/stores/use-measurement-flow-store";
 import { colors } from "~/shared/constants/colors";
@@ -40,6 +39,12 @@ export function QuestionNode({ node }: QuestionNodeProps) {
   const content = node.content;
   const [searchTerm, setSearchTerm] = useState("");
   const [qrScannerVisible, setQrScannerVisible] = useState(false);
+  const [qrMismatch, setQrMismatch] = useState<string | null>(null);
+
+  const openQrScanner = () => {
+    setQrMismatch(null);
+    setQrScannerVisible(true);
+  };
 
   const answerValue = getAnswer(iterationCount, node.id) ?? "";
 
@@ -60,20 +65,18 @@ export function QuestionNode({ node }: QuestionNodeProps) {
           (opt) => opt.trim().toLowerCase() === data.trim().toLowerCase(),
         );
         if (!match) {
-          toast.error(t("measurementFlow:questionNode.qrNotMatch", { data }));
+          setQrMismatch(data);
           return;
         }
+        setQrMismatch(null);
         handleAnswerChangeAndAdvance(match);
-        toast.success(t("measurementFlow:questionNode.qrSelected", { match }));
         break;
       }
       case "open_ended":
         handleAnswerChange(data);
-        toast.success(t("measurementFlow:questionNode.qrApplied"));
         break;
       default:
         handleAnswerChange(data);
-        toast.success(t("measurementFlow:questionNode.qrApplied"));
     }
   };
 
@@ -116,7 +119,7 @@ export function QuestionNode({ node }: QuestionNodeProps) {
             content={content}
             value={answerValue}
             onChange={handleAnswerChange}
-            onQRPress={() => setQrScannerVisible(true)}
+            onQRPress={openQrScanner}
           />
         );
       default:
@@ -200,13 +203,30 @@ export function QuestionNode({ node }: QuestionNodeProps) {
               <X size={20} color={colors.neutral.black} />
             </TouchableOpacity>
           ) : (
-            <TouchableOpacity
-              className="bg-gray-background rounded-md p-1"
-              onPress={() => setQrScannerVisible(true)}
-            >
+            <TouchableOpacity className="bg-gray-background rounded-md p-1" onPress={openQrScanner}>
               <ScanQrCode size={20} color={colors.neutral.black} />
             </TouchableOpacity>
           )}
+        </View>
+      )}
+
+      {content.kind === "multi_choice" && qrMismatch !== null && (
+        <View
+          className="border-destructive/40 bg-destructive/10 flex-row items-start gap-2 rounded-xl border px-3 py-2"
+          accessibilityRole="alert"
+          accessibilityLiveRegion="polite"
+        >
+          <CircleAlert size={16} color="hsl(0, 84%, 60%)" style={{ marginTop: 1 }} />
+          <Text className="text-destructive flex-1 text-sm">
+            {t("measurementFlow:questionNode.qrNotMatch", { data: qrMismatch })}
+          </Text>
+          <TouchableOpacity
+            onPress={() => setQrMismatch(null)}
+            hitSlop={8}
+            accessibilityLabel={t("measurementFlow:questionNode.qrDismissLabel")}
+          >
+            <X size={16} color={themeColors.inactive} />
+          </TouchableOpacity>
         </View>
       )}
       <ScrollView

--- a/apps/mobile/src/features/recent-measurements/hooks/__tests__/use-auto-upload.test.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/__tests__/use-auto-upload.test.ts
@@ -211,25 +211,13 @@ describe("useAutoUpload", () => {
   // ---------------------------------------------------------------------------
 
   describe("toast messages", () => {
-    it("shows info toast and success toast for 1 measurement", async () => {
+    it("does not show start/success toasts for the happy path", async () => {
       mockFailedUploads = [{ key: "k1", data: {} }];
       renderHook(() => useAutoUpload());
 
-      await waitFor(() => expect(mockToastSuccess).toHaveBeenCalled());
-      expect(mockToastInfo).toHaveBeenCalledWith("Uploading 1 unsynced measurement…");
-      expect(mockToastSuccess).toHaveBeenCalledWith("1 measurement synced");
-    });
-
-    it("uses plural form for multiple measurements", async () => {
-      mockFailedUploads = [
-        { key: "k1", data: {} },
-        { key: "k2", data: {} },
-      ];
-      renderHook(() => useAutoUpload());
-
-      await waitFor(() => expect(mockToastSuccess).toHaveBeenCalled());
-      expect(mockToastInfo).toHaveBeenCalledWith("Uploading 2 unsynced measurements…");
-      expect(mockToastSuccess).toHaveBeenCalledWith("2 measurements synced");
+      await waitFor(() => expect(mockUploadAll).toHaveBeenCalled());
+      expect(mockToastInfo).not.toHaveBeenCalled();
+      expect(mockToastSuccess).not.toHaveBeenCalled();
     });
 
     it("shows error toast when upload fails", async () => {
@@ -240,6 +228,7 @@ describe("useAutoUpload", () => {
       await waitFor(() => expect(mockToastError).toHaveBeenCalled());
       expect(mockToastError).toHaveBeenCalledWith("Upload failed. Please try again.");
       expect(mockToastSuccess).not.toHaveBeenCalled();
+      expect(mockToastInfo).not.toHaveBeenCalled();
     });
   });
 
@@ -421,7 +410,7 @@ describe("useAutoUpload", () => {
       expect(mockUploadAll).toHaveBeenCalledOnce();
 
       resolveUpload();
-      await waitFor(() => expect(mockToastSuccess).toHaveBeenCalled());
+      await act(() => Promise.resolve());
     });
 
     it("resets inFlight ref after success so next call can proceed", async () => {

--- a/apps/mobile/src/features/recent-measurements/hooks/__tests__/use-measurement-upload.test.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/__tests__/use-measurement-upload.test.ts
@@ -139,7 +139,7 @@ describe("useMeasurementUpload", () => {
     expect(mockSendMqttEvent).toHaveBeenCalled();
     expect(mockMarkUploaded).toHaveBeenCalledWith("row-1");
     expect(mockMarkFailed).not.toHaveBeenCalled();
-    expect(mockToastSuccess).toHaveBeenCalledWith("Measurement uploaded!");
+    expect(mockToastSuccess).not.toHaveBeenCalled();
     expect(mockSaveMeasurement).toHaveBeenCalledTimes(1);
   });
 
@@ -160,9 +160,7 @@ describe("useMeasurementUpload", () => {
     expect(mockSendMqttEvent).not.toHaveBeenCalled();
     expect(mockMarkFailed).not.toHaveBeenCalled();
     expect(mockMarkUploaded).not.toHaveBeenCalled();
-    expect(mockToastInfo).toHaveBeenCalledWith(
-      "Saved offline — will upload when you're back online",
-    );
+    expect(mockToastInfo).not.toHaveBeenCalled();
     expect(mockToastError).not.toHaveBeenCalled();
   });
 
@@ -280,9 +278,9 @@ describe("useMeasurementUpload", () => {
   });
 
   // Once the MQTT publish has succeeded the data is on the cloud, so a
-  // later local-state write failure must surface as an info toast (and
-  // leave the row's status alone) rather than the "upload failed" path.
-  it("shows an info toast and does not touch status when markUploaded errors after a successful publish", async () => {
+  // later local-state write failure must NOT flip the row to "failed".
+  // Logging is enough; the next refetch reconciles the local row to "synced".
+  it("does not touch status when markUploaded errors after a successful publish", async () => {
     mockSaveMeasurement.mockResolvedValueOnce("row-1");
     mockSendMqttEvent.mockResolvedValueOnce(undefined);
     mockMarkUploaded.mockRejectedValueOnce(new Error("disk full"));
@@ -293,7 +291,7 @@ describe("useMeasurementUpload", () => {
     expect(mockMarkFailed).not.toHaveBeenCalled();
     expect(mockToastError).not.toHaveBeenCalled();
     expect(mockToastSuccess).not.toHaveBeenCalled();
-    expect(mockToastInfo).toHaveBeenCalledWith("Uploaded — local status will refresh on next sync");
+    expect(mockToastInfo).not.toHaveBeenCalled();
     expect(consoleSpy).toHaveBeenCalledWith(
       "Local status update failed after successful publish:",
       expect.any(Error),

--- a/apps/mobile/src/features/recent-measurements/hooks/__tests__/use-measurements.test.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/__tests__/use-measurements.test.ts
@@ -353,7 +353,7 @@ describe("useMeasurements", () => {
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["measurements"] });
     });
 
-    it("shows toast, calls markAsFailed, and still prunes when MQTT send fails", async () => {
+    it("calls markAsFailed and still prunes when MQTT send fails", async () => {
       const { result } = renderMeasurements([{ key: "upload-key-1", data: mockMeasurement }]);
       await waitFor(() => expect(result.current.failedUploads).toHaveLength(1));
       mockSendMqttEvent.mockRejectedValueOnce(new Error("timeout"));
@@ -363,7 +363,7 @@ describe("useMeasurements", () => {
 
       expect(mockMarkAsSuccessful).not.toHaveBeenCalled();
       expect(mockMarkAsFailed).toHaveBeenCalledWith("upload-key-1");
-      expect(mockToastInfo).toHaveBeenCalledWith("Failed to upload, try again later");
+      expect(mockToastInfo).not.toHaveBeenCalled();
       expect(mockPruneExpiredMeasurements).toHaveBeenCalledOnce();
 
       consoleSpy.mockRestore();

--- a/apps/mobile/src/features/recent-measurements/hooks/__tests__/use-questions-upload.test.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/__tests__/use-questions-upload.test.ts
@@ -120,7 +120,7 @@ describe("useQuestionsUpload", () => {
     );
     expect(mockMarkUploaded).toHaveBeenCalledWith("row-1");
     expect(mockMarkFailed).not.toHaveBeenCalled();
-    expect(mockToastSuccess).toHaveBeenCalledWith("Answers uploaded!");
+    expect(mockToastSuccess).not.toHaveBeenCalled();
     expect(mockSaveMeasurement).toHaveBeenCalledTimes(1);
   });
 
@@ -140,9 +140,7 @@ describe("useQuestionsUpload", () => {
     expect(mockSendMqttEvent).not.toHaveBeenCalled();
     expect(mockMarkFailed).not.toHaveBeenCalled();
     expect(mockMarkUploaded).not.toHaveBeenCalled();
-    expect(mockToastInfo).toHaveBeenCalledWith(
-      "Saved offline — will upload when you're back online",
-    );
+    expect(mockToastInfo).not.toHaveBeenCalled();
     expect(mockToastError).not.toHaveBeenCalled();
   });
 
@@ -197,9 +195,9 @@ describe("useQuestionsUpload", () => {
   });
 
   // Once the MQTT publish has succeeded the answers are on the cloud, so a
-  // later local-state write failure must surface as an info toast (and
-  // leave the row's status alone) rather than the "upload failed" path.
-  it("shows an info toast and does not touch status when markUploaded errors after a successful publish", async () => {
+  // later local-state write failure must NOT flip the row to "failed".
+  // Logging is enough; the next refetch reconciles the local row to "synced".
+  it("does not touch status when markUploaded errors after a successful publish", async () => {
     mockSaveMeasurement.mockResolvedValueOnce("row-1");
     mockSendMqttEvent.mockResolvedValueOnce(undefined);
     mockMarkUploaded.mockRejectedValueOnce(new Error("disk full"));
@@ -210,7 +208,7 @@ describe("useQuestionsUpload", () => {
     expect(mockMarkFailed).not.toHaveBeenCalled();
     expect(mockToastError).not.toHaveBeenCalled();
     expect(mockToastSuccess).not.toHaveBeenCalled();
-    expect(mockToastInfo).toHaveBeenCalledWith("Uploaded — local status will refresh on next sync");
+    expect(mockToastInfo).not.toHaveBeenCalled();
     expect(consoleSpy).toHaveBeenCalledWith(
       "Local status update failed after successful publish:",
       expect.any(Error),

--- a/apps/mobile/src/features/recent-measurements/hooks/__tests__/use-recent-measurements-actions.test.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/__tests__/use-recent-measurements-actions.test.ts
@@ -222,7 +222,7 @@ describe("useRecentMeasurementsActions", () => {
       );
     });
 
-    it("calls uploadAll, toasts success, and invalidates on confirm", async () => {
+    it("calls uploadAll and invalidates on confirm (no success toast)", async () => {
       const { result } = renderHook(() => useRecentMeasurementsActions("all"));
 
       act(() => result.current.confirmSyncAll());
@@ -230,7 +230,7 @@ describe("useRecentMeasurementsActions", () => {
       await act(() => confirmBtn.onPress());
 
       expect(mockUploadAll).toHaveBeenCalled();
-      expect(mockToastSuccess).toHaveBeenCalledWith("All measurements synced successfully");
+      expect(mockToastSuccess).not.toHaveBeenCalled();
       expect(mockInvalidate).toHaveBeenCalled();
     });
   });

--- a/apps/mobile/src/features/recent-measurements/hooks/use-auto-upload.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-auto-upload.ts
@@ -44,12 +44,8 @@ export function useAutoUpload() {
     }
 
     autoUploadInFlight.current = true;
-    const count = failedUploads.length;
-
-    toast.info(t("recentMeasurements:toasts.uploadingMeasurements", { count }));
     try {
       await uploadAll();
-      toast.success(t("recentMeasurements:toasts.measurementsSynced", { count }));
     } catch {
       toast.error(t("recentMeasurements:toasts.uploadFailed"));
     } finally {

--- a/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.ts
@@ -182,7 +182,6 @@ export function useMeasurementUpload() {
       // exposes around connectivity transitions — otherwise we'd fall through
       // to MQTT and freeze the UI on the full connect timeout.
       if (networkState.isInternetReachable !== true) {
-        toast.info(t("recentMeasurements:toasts.savedOffline"));
         return;
       }
 
@@ -209,10 +208,8 @@ export function useMeasurementUpload() {
 
       try {
         await markUploaded(savedId);
-        toast.success(t("recentMeasurements:toasts.measurementUploaded"));
       } catch (localError) {
         console.error("Local status update failed after successful publish:", localError);
-        toast.info(t("recentMeasurements:toasts.uploadedLocalStatusRefresh"));
       }
     },
   });

--- a/apps/mobile/src/features/recent-measurements/hooks/use-measurements.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-measurements.ts
@@ -1,6 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRef, useState } from "react";
-import { toast } from "sonner-native";
 import { sendMqttEvent } from "~/features/connection/services/mqtt/send-mqtt-event";
 import {
   clearMeasurements,
@@ -14,7 +13,6 @@ import {
   pruneExpiredMeasurements,
 } from "~/shared/db/measurements-storage";
 import type { Measurement, MeasurementStatus } from "~/shared/db/measurements-storage";
-import { useTranslation } from "~/shared/i18n";
 import {
   buildAnnotations,
   getFlagTypeFromMeasurementResult,
@@ -22,7 +20,6 @@ import {
 
 export function useMeasurements() {
   const queryClient = useQueryClient();
-  const { t } = useTranslation(["common", "recentMeasurements"]);
   const [uploadProgress, setUploadProgress] = useState<{ done: number; total: number } | null>(
     null,
   );
@@ -133,7 +130,6 @@ export function useMeasurements() {
         } catch (error) {
           console.warn(`Failed to upload item with key ${key}:`, error);
           await markAsFailed(key);
-          toast.info(t("recentMeasurements:toasts.uploadOneFailed"));
           return;
         }
 

--- a/apps/mobile/src/features/recent-measurements/hooks/use-questions-upload.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-questions-upload.ts
@@ -92,7 +92,6 @@ export function useQuestionsUpload() {
         // "Uploading…" for the full connect timeout while paho fails to connect.
         // useAutoUpload's network-restore listener picks the row up on reconnect.
         if (networkState.isInternetReachable !== true) {
-          toast.info(t("recentMeasurements:toasts.savedOffline"));
           return;
         }
 
@@ -123,10 +122,8 @@ export function useQuestionsUpload() {
           console.log("[questions-upload] markUploaded: start");
           await markUploaded(savedId);
           console.log("[questions-upload] markUploaded: done");
-          toast.success(t("recentMeasurements:toasts.answersUploaded"));
         } catch (localError) {
           console.error("Local status update failed after successful publish:", localError);
-          toast.info(t("recentMeasurements:toasts.uploadedLocalStatusRefresh"));
         }
       } finally {
         console.log("[questions-upload] mutationFn: exit");

--- a/apps/mobile/src/features/recent-measurements/hooks/use-recent-measurements-actions.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-recent-measurements-actions.ts
@@ -97,7 +97,6 @@ export function useRecentMeasurementsActions(filter: MeasurementFilter) {
       errorMessage: t("recentMeasurements:alerts.uploadAllError"),
       run: async () => {
         await uploadAll();
-        toast.success(t("recentMeasurements:alerts.uploadAllSuccess"));
         invalidate();
       },
     });

--- a/apps/mobile/src/shared/i18n/locales/en-US/calibration.json
+++ b/apps/mobile/src/shared/i18n/locales/en-US/calibration.json
@@ -4,9 +4,6 @@
     "body": "This calibration flow is currently running in demonstration mode. All measurements and calculations are simulated for testing purposes only."
   },
   "flow": {
-    "toastStarted": "Calibration started. Please follow the instructions.",
-    "toastGainComplete": "Gain calibration completed. Proceeding to measurements.",
-    "toastPanelMeasured": "Panel #{{panel}} measured. Next: Panel #{{next}}",
     "toastComplete": "Calibration completed successfully!",
     "toastProcessingError": "Error processing calibration data. Please try again."
   },

--- a/apps/mobile/src/shared/i18n/locales/en-US/measurement-flow.json
+++ b/apps/mobile/src/shared/i18n/locales/en-US/measurement-flow.json
@@ -161,8 +161,7 @@
     "searchPlaceholder": "Search options...",
     "unsupportedKind": "Unsupported question kind: {{kind}}",
     "qrNotMatch": "\"{{data}}\" does not exist.",
-    "qrSelected": "\"{{match}}\" selected successfully!",
-    "qrApplied": "QR applied successfully!"
+    "qrDismissLabel": "Dismiss"
   },
   "questionTypes": {
     "multipleChoice": {

--- a/apps/mobile/src/shared/i18n/locales/en-US/recent-measurements.json
+++ b/apps/mobile/src/shared/i18n/locales/en-US/recent-measurements.json
@@ -71,7 +71,6 @@
     "uploadAllMessage_other": "Are you sure you want to sync {{count}} unsynced measurements?",
     "uploadAllButton": "Upload All",
     "uploadAllError": "Sync failed. Please try again.",
-    "uploadAllSuccess": "All measurements synced successfully",
     "deleteAllSyncedTitle": "Delete all synced measurements",
     "deleteAllSyncedMessage": "Are you sure you want to delete all {{count}} synced measurements from local storage?",
     "deleteAllSyncedError": "Failed to delete synced measurements",
@@ -82,17 +81,8 @@
     "saveToFileError": "Could not save measurement. Please try again."
   },
   "toasts": {
-    "uploadingMeasurements_one": "Uploading {{count}} unsynced measurement…",
-    "uploadingMeasurements_other": "Uploading {{count}} unsynced measurements…",
-    "measurementsSynced_one": "{{count}} measurement synced",
-    "measurementsSynced_other": "{{count}} measurements synced",
     "uploadFailed": "Upload failed. Please try again.",
-    "uploadOneFailed": "Failed to upload, try again later",
     "uploadNotAvailable": "Upload not available, upload it later from Recent",
-    "measurementUploaded": "Measurement uploaded!",
-    "answersUploaded": "Answers uploaded!",
-    "answersSaveFailed": "Answers could not be saved on this device. Please export your data now to avoid losing it.",
-    "uploadedLocalStatusRefresh": "Uploaded — local status will refresh on next sync",
-    "savedOffline": "Saved offline — will upload when you're back online"
+    "answersSaveFailed": "Answers could not be saved on this device. Please export your data now to avoid losing it."
   }
 }

--- a/apps/mobile/src/shared/i18n/locales/nl-NL/calibration.json
+++ b/apps/mobile/src/shared/i18n/locales/nl-NL/calibration.json
@@ -4,9 +4,6 @@
     "body": "Deze kalibratiestroom draait momenteel in demonstratiemodus. Alle metingen en berekeningen zijn gesimuleerd en uitsluitend bedoeld om te testen."
   },
   "flow": {
-    "toastStarted": "Kalibratie gestart. Volg de instructies.",
-    "toastGainComplete": "Versterkingskalibratie voltooid. Doorgaan naar metingen.",
-    "toastPanelMeasured": "Paneel #{{panel}} gemeten. Volgende: paneel #{{next}}",
     "toastComplete": "Kalibratie succesvol voltooid!",
     "toastProcessingError": "Fout bij het verwerken van kalibratiegegevens. Probeer het opnieuw."
   },

--- a/apps/mobile/src/shared/i18n/locales/nl-NL/measurement-flow.json
+++ b/apps/mobile/src/shared/i18n/locales/nl-NL/measurement-flow.json
@@ -161,8 +161,7 @@
     "searchPlaceholder": "Zoek opties...",
     "unsupportedKind": "Niet-ondersteund vraagtype: {{kind}}",
     "qrNotMatch": "\"{{data}}\" bestaat niet.",
-    "qrSelected": "\"{{match}}\" succesvol geselecteerd!",
-    "qrApplied": "QR succesvol toegepast!"
+    "qrDismissLabel": "Sluiten"
   },
   "questionTypes": {
     "multipleChoice": {

--- a/apps/mobile/src/shared/i18n/locales/nl-NL/recent-measurements.json
+++ b/apps/mobile/src/shared/i18n/locales/nl-NL/recent-measurements.json
@@ -71,7 +71,6 @@
     "uploadAllMessage_other": "Weet je zeker dat je {{count}} niet-gesynchroniseerde metingen wilt synchroniseren?",
     "uploadAllButton": "Alles uploaden",
     "uploadAllError": "Synchronisatie mislukt. Probeer het opnieuw.",
-    "uploadAllSuccess": "Alle metingen succesvol gesynchroniseerd",
     "deleteAllSyncedTitle": "Alle gesynchroniseerde metingen verwijderen",
     "deleteAllSyncedMessage": "Weet je zeker dat je alle {{count}} gesynchroniseerde metingen uit lokale opslag wilt verwijderen?",
     "deleteAllSyncedError": "Kon gesynchroniseerde metingen niet verwijderen",
@@ -82,17 +81,8 @@
     "saveToFileError": "Kon meting niet opslaan. Probeer het opnieuw."
   },
   "toasts": {
-    "uploadingMeasurements_one": "{{count}} niet-gesynchroniseerde meting wordt geüpload…",
-    "uploadingMeasurements_other": "{{count}} niet-gesynchroniseerde metingen worden geüpload…",
-    "measurementsSynced_one": "{{count}} meting gesynchroniseerd",
-    "measurementsSynced_other": "{{count}} metingen gesynchroniseerd",
     "uploadFailed": "Upload mislukt. Probeer het opnieuw.",
-    "uploadOneFailed": "Uploaden mislukt, probeer later opnieuw",
     "uploadNotAvailable": "Upload niet beschikbaar, upload later vanuit Recent",
-    "measurementUploaded": "Meting geüpload!",
-    "answersUploaded": "Antwoorden geüpload!",
-    "answersSaveFailed": "Antwoorden konden niet op dit apparaat worden opgeslagen. Exporteer je gegevens nu om verlies te voorkomen.",
-    "uploadedLocalStatusRefresh": "Geüpload — lokale status wordt bij volgende synchronisatie bijgewerkt",
-    "savedOffline": "Offline opgeslagen — wordt geüpload zodra je weer online bent"
+    "answersSaveFailed": "Antwoorden konden niet op dit apparaat worden opgeslagen. Exporteer je gegevens nu om verlies te voorkomen."
   }
 }

--- a/apps/mobile/src/shared/utils/time-sync.test.ts
+++ b/apps/mobile/src/shared/utils/time-sync.test.ts
@@ -290,16 +290,14 @@ describe("time-sync", () => {
       spy.mockRestore();
     });
 
-    it("should show toast.warning when missedPings reaches threshold (3)", async () => {
+    it("does not toast on repeated sync failures (warnings were too noisy in the field)", async () => {
       const { startTimeSync, getTimeSyncState } = await import("./time-sync");
       const { toast } = await import("sonner-native");
 
-      // Successful initial sync
       mockServerUtcMs = Date.now();
       startTimeSync();
       await vi.advanceTimersByTimeAsync(50);
 
-      // Make server fail
       const clientModule = await import("~/shared/api/client");
       const spy = vi.spyOn(clientModule, "getApiClient").mockReturnValue({
         health: {
@@ -309,7 +307,6 @@ describe("time-sync", () => {
 
       (toast.warning as ReturnType<typeof vi.fn>).mockClear();
 
-      // Trigger 3 failed syncs via foreground events (each needs debounce window to pass)
       for (let i = 0; i < 3; i++) {
         await advancePastDebounce();
         capturedAppStateHandler?.("active");
@@ -317,15 +314,12 @@ describe("time-sync", () => {
       }
 
       expect(getTimeSyncState().missedPings).toBe(3);
-      expect(toast.warning).toHaveBeenCalledWith(
-        "Time sync lost. Please check your phone's date and time settings.",
-      );
+      expect(toast.warning).not.toHaveBeenCalled();
 
       spy.mockRestore();
     });
 
-    it("should show toast.warning on initial sync failure", async () => {
-      // Make server fail from the start
+    it("does not toast on initial sync failure", async () => {
       const clientModule = await import("~/shared/api/client");
       const spy = vi.spyOn(clientModule, "getApiClient").mockReturnValue({
         health: {
@@ -340,7 +334,7 @@ describe("time-sync", () => {
       startTimeSync();
       await vi.advanceTimersByTimeAsync(50);
 
-      expect(toast.warning).toHaveBeenCalledWith("Unable to synchronize time.");
+      expect(toast.warning).not.toHaveBeenCalled();
 
       spy.mockRestore();
     });

--- a/apps/mobile/src/shared/utils/time-sync.ts
+++ b/apps/mobile/src/shared/utils/time-sync.ts
@@ -22,7 +22,6 @@ export interface TimeSyncState {
   lastSyncedAt: number;
 }
 
-const MISSED_PING_WARN_THRESHOLD = 3;
 const STORAGE_KEY = "TIME_SYNC_STATE";
 
 let state: TimeSyncState = {
@@ -167,12 +166,6 @@ async function performSync(isInitial = false): Promise<void> {
       missedPings: state.missedPings,
       lastSyncedAt: state.lastSyncedAt ? new Date(state.lastSyncedAt).toISOString() : "never",
     });
-
-    if (isInitial) {
-      toast.warning("Unable to synchronize time.");
-    } else if (state.missedPings >= MISSED_PING_WARN_THRESHOLD) {
-      toast.warning("Time sync lost. Please check your phone's date and time settings.");
-    }
   }
 }
 


### PR DESCRIPTION
Closes [OJD-1545](https://linear.app/openjii/issue/OJD-1545/mobile-trim-happy-path-toasts-replace-qr-mismatch-toast-with-inline-ui).

## Summary

- Removes 15 toasts that fired on the happy path. Each had a UI affordance already conveying the same state (row status tag, toolbar counts, calibration progress screen), so the toast was visual noise that crowded out the cases where a toast actually signals something.
- Drops both time-sync `warning` toasts (too noisy in the field). Failures still surface via the upload-error path.
- Replaces the QR-mismatch toast with an inline dismissible banner under the multi-choice search bar (\`accessibilityRole=\"alert\"\`, polite live region). The toast disappeared before users could react; the banner sticks until dismissed or a successful scan replaces it.

## What's removed

| Toast | Why |
|---|---|
| \`savedOffline\` (×2) | Row appears with a \"pending\" tag |
| \`answersUploaded\` / \`measurementUploaded\` | Row's status tag flips to \"synced\" |
| \`uploadedLocalStatusRefresh\` (×2) | Meta-toast about a local refresh users don't care about |
| \`uploadingMeasurements\` + \`measurementsSynced\` | Background auto-upload; user didn't trigger it, tags convey state |
| \`qrSelected\` + \`qrApplied\` (×2) | The scanned answer is already visible in the field |
| Calibration \`toastStarted\` + \`toastGainComplete\` + \`toastPanelMeasured\` | Calibration screen has its own progress UI |
| \`uploadAllSuccess\` | Toolbar counts + per-row tags already reflect success |
| \`uploadOneFailed\` (info) | Row flips to \"failed\" tag; toast was redundant |
| Time-sync \`toast.warning\` (×2) | Too noisy in the field; upload-error path still toasts |

## What's kept

Every error toast: \`uploadNotAvailable\`, \`uploadFailed\`, \`answersSaveFailed\`, \`saveToFileError\`, \`exportError\`, \`notConnected\`, \`noProtocol\`, \`scanError\`, \`errorConnect\`, \`errorDisconnect\`, \`toastProcessingError\`, time-sync \`unavailable\`, the global query-error fallback in \`configured-query-client-provider\`, and OTA update toasts.

## i18n

Removed the now-unused keys from \`en-US\` and \`nl-NL\` (\`recent-measurements.json\`, \`calibration.json\`, \`measurement-flow.json\`). Added \`questionNode.qrDismissLabel\` for the new banner's dismiss button.

## Tests

- Flipped the relevant \`expect(toast).toHaveBeenCalledWith(...)\` assertions to \`expect(toast).not.toHaveBeenCalled()\` and renamed test descriptions.
- 413 / 413 mobile tests pass, lint + typecheck clean.

## Test plan

- [ ] Record a measurement online → row appears as \"synced\" without a toast.
- [ ] Record a measurement offline → row appears with a \"pending\" tag, no toast.
- [ ] Trigger sync-all from the toolbar → counts update silently; only failures toast.
- [ ] Scan an invalid QR for a multi-choice question → inline red banner under the search bar shows the bad value; dismiss via X or re-scan.
- [ ] Scan a valid QR → answer applied silently.
- [ ] Calibration flow → screen progresses without toast clutter.