### PR TITLE
fix(cicd): gate every deploy with required approval, even when tofu is skipped

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,9 +76,34 @@ jobs:
         id: apps
         uses: ./.github/actions/detect-affected-packages
 
+  # Required manual approval before anything is applied or deployed. Runs on
+  # every deploy that would change something, even when no infrastructure
+  # changed (tofu plan/apply skipped), so app-only deploys are gated too.
+  approval-gate:
+    name: Approval Gate
+    needs: [detect]
+    if: >-
+      inputs.deploy_all ||
+      inputs.deploy_app != '' ||
+      inputs.deploy_infrastructure ||
+      needs.detect.outputs.infra_changed == 'true' ||
+      contains(fromJSON(needs.detect.outputs.affected_apps), 'web') ||
+      contains(fromJSON(needs.detect.outputs.affected_apps), 'backend') ||
+      contains(fromJSON(needs.detect.outputs.affected_apps), '@repo/database') ||
+      contains(fromJSON(needs.detect.outputs.affected_apps), 'docs') ||
+      contains(fromJSON(needs.detect.outputs.affected_apps), 'data') ||
+      contains(fromJSON(needs.detect.outputs.affected_apps), 'macro-sandbox')
+    runs-on: ubuntu-latest
+    environment: approval-gate
+    permissions:
+      contents: read
+    steps:
+      - name: Await Approval for Deployment
+        run: echo "Approved deployment for ${{ inputs.environment }} environment."
+
   deploy-infrastructure:
     name: Deploy Infrastructure
-    needs: [detect]
+    needs: [detect, approval-gate]
     if: inputs.deploy_infrastructure || needs.detect.outputs.infra_changed == 'true'
     permissions:
       id-token: write
@@ -88,14 +113,16 @@ jobs:
       environment: ${{ inputs.environment }}
       ref: ${{ inputs.ref || github.sha }}
       tofu_version: "1.9.0"
+      skip_approval_gate: true
     secrets: inherit
 
   database-migrations:
     name: Database Migrations
-    needs: [deploy-infrastructure, detect]
+    needs: [deploy-infrastructure, detect, approval-gate]
     if: >-
       always() &&
       needs.detect.result == 'success' &&
+      needs.approval-gate.result == 'success' &&
       contains('success,skipped', needs.deploy-infrastructure.result) &&
       (inputs.deploy_all || contains(inputs.deploy_app, 'migration') || (inputs.deploy_app == '' && contains(fromJSON(needs.detect.outputs.affected_apps), '@repo/database')))
     permissions:
@@ -110,10 +137,11 @@ jobs:
 
   deploy-backend:
     name: Deploy Backend
-    needs: [deploy-infrastructure, database-migrations, detect]
+    needs: [deploy-infrastructure, database-migrations, detect, approval-gate]
     if: >-
       always() &&
       needs.detect.result == 'success' &&
+      needs.approval-gate.result == 'success' &&
       contains('success,skipped', needs.deploy-infrastructure.result) &&
       contains('success,skipped', needs.database-migrations.result) &&
       (inputs.deploy_all || contains(inputs.deploy_app, 'backend') || (inputs.deploy_app == '' && contains(fromJSON(needs.detect.outputs.affected_apps), 'backend')))
@@ -128,10 +156,11 @@ jobs:
 
   deploy-frontend:
     name: Deploy Frontend
-    needs: [deploy-infrastructure, deploy-backend, detect]
+    needs: [deploy-infrastructure, deploy-backend, detect, approval-gate]
     if: >-
       always() &&
       needs.detect.result == 'success' &&
+      needs.approval-gate.result == 'success' &&
       contains('success,skipped', needs.deploy-infrastructure.result) &&
       contains('success,skipped', needs.deploy-backend.result) &&
       (inputs.deploy_all || contains(inputs.deploy_app, 'web') || (inputs.deploy_app == '' && contains(fromJSON(needs.detect.outputs.affected_apps), 'web')))
@@ -146,10 +175,11 @@ jobs:
 
   deploy-docs:
     name: Deploy Documentation
-    needs: [deploy-infrastructure, detect]
+    needs: [deploy-infrastructure, detect, approval-gate]
     if: >-
       always() &&
       needs.detect.result == 'success' &&
+      needs.approval-gate.result == 'success' &&
       contains('success,skipped', needs.deploy-infrastructure.result) &&
       (inputs.deploy_all || contains(inputs.deploy_app, 'docs') || (inputs.deploy_app == '' && contains(fromJSON(needs.detect.outputs.affected_apps), 'docs')))
     permissions:
@@ -163,10 +193,11 @@ jobs:
 
   deploy-databricks:
     name: Deploy Databricks
-    needs: [deploy-infrastructure, detect]
+    needs: [deploy-infrastructure, detect, approval-gate]
     if: >-
       always() &&
       needs.detect.result == 'success' &&
+      needs.approval-gate.result == 'success' &&
       contains('success,skipped', needs.deploy-infrastructure.result) &&
       (inputs.deploy_all || contains(inputs.deploy_app, 'databricks') || (inputs.deploy_app == '' && contains(fromJSON(needs.detect.outputs.affected_apps), 'data')))
     permissions:
@@ -179,10 +210,11 @@ jobs:
 
   deploy-macro-sandbox:
     name: Deploy Macro Sandbox
-    needs: [deploy-infrastructure, detect]
+    needs: [deploy-infrastructure, detect, approval-gate]
     if: >-
       always() &&
       needs.detect.result == 'success' &&
+      needs.approval-gate.result == 'success' &&
       contains('success,skipped', needs.deploy-infrastructure.result) &&
       (inputs.deploy_all || contains(inputs.deploy_app, 'macro-sandbox') || (inputs.deploy_app == '' && contains(fromJSON(needs.detect.outputs.affected_apps), 'macro-sandbox') && needs.detect.outputs.macro_sandbox_languages != '[]'))
     permissions:

--- a/.github/workflows/tofu.yml
+++ b/.github/workflows/tofu.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: string
         default: "1.9.0"
+      skip_approval_gate:
+        description: "Skip the internal approval gate (set by callers that gate the whole deployment themselves)"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: opentofu-${{ inputs.environment }}
@@ -100,6 +105,7 @@ jobs:
   approval_gate:
     name: Approval Gate
     needs: plan
+    if: ${{ !inputs.skip_approval_gate }}
     runs-on: ubuntu-latest
     environment: approval-gate
     permissions:
@@ -113,6 +119,10 @@ jobs:
   apply:
     name: OpenTofu Apply
     needs: [plan, approval_gate]
+    if: >-
+      always() &&
+      needs.plan.result == 'success' &&
+      (needs.approval_gate.result == 'success' || needs.approval_gate.result == 'skipped')
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }} # This environment should have required reviewers for approval
     permissions:


### PR DESCRIPTION
## Type of PR

- [x] Bug Fix

## Description

[Run 26445169102](https://github.com/Jan-IngenHousz-Institute/open-jii/actions/runs/26445169102) deployed app code to dev with **no approval gate**.

Root cause: #1509 made the `deploy-infrastructure` (tofu) job conditional on infra changes, but the approval gate lived *inside* `tofu.yml` (`plan -> approval_gate -> apply`). Skipping the whole tofu job on app-only deploys skipped the gate along with it.

### Changes

- **`deploy.yml`**: new top-level `approval-gate` job (uses the existing `approval-gate` environment) that all deploy jobs now depend on. It gates the **whole deployment** (infra + apps) on both dev and prod, including app-only deploys where tofu plan/apply is skipped. Its `if` mirrors the real deploy triggers, so no-op / mobile-only / `@repo/*`-only pushes do not pause for a pointless approval.
- **`tofu.yml`**: new `skip_approval_gate` input. `deploy.yml` passes `true` so the orchestrated path is gated once (no double prompt); `apply` runs when the internal gate is approved or intentionally skipped. **Standalone `tofu.yml` dispatch keeps its own gate** (input defaults to `false`).

Fail-closed by design: if a reviewer rejects, or the gate condition is ever too narrow, jobs skip rather than deploy ungated. Validated with `actionlint`.

### Behavior change

Every dev push to main that deploys something now pauses for manual approval (matches the desired "gate dev and prod" behavior). No repo settings change needed; the `approval-gate` environment already exists with reviewers.