### PR TITLE
fix(mobile): refine the experiment picker (OJD-1546)

### DIFF
--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/experiment-card.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/experiment-card.tsx
@@ -1,8 +1,7 @@
 import { FlaskConical, MessageSquare } from "lucide-react-native";
-import React from "react";
+import React, { useEffect } from "react";
 import { Pressable, Text, View } from "react-native";
 import Animated, {
-  cancelAnimation,
   useAnimatedStyle,
   useSharedValue,
   withSequence,
@@ -58,24 +57,22 @@ export function ExperimentCard({
   const { t } = useTranslation("measurementFlow");
   const tag = pickTag(requiresSensor, questionsOnly);
 
-  // Bounce the card on every tap so selecting always animates.
+  // Subtle pop when this card becomes the selected one. Driven off `selected`
+  // so it fires once when a card is first chosen, not on every re-tap. The peak
+  // is kept small so the full-width card never scales past the screen edges.
   const scale = useSharedValue(1);
   const animatedStyle = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
-  const handlePress = () => {
-    // Cancel any in-flight bounce so a fresh tap always restarts it (reanimated
-    // won't replay an identical assignment otherwise).
-    cancelAnimation(scale);
-    scale.value = 1;
+  useEffect(() => {
+    if (!selected) return;
     scale.value = withSequence(
-      withSpring(1.05, { damping: 11, stiffness: 360 }),
-      withSpring(1, { damping: 13, stiffness: 220 }),
+      withSpring(1.03, { damping: 18, stiffness: 320 }),
+      withSpring(1, { damping: 15, stiffness: 240 }),
     );
-    onPress(id);
-  };
+  }, [selected, scale]);
 
   return (
     <Animated.View style={animatedStyle}>
-      <Pressable onPress={handlePress} accessibilityRole="button">
+      <Pressable onPress={() => onPress(id)} accessibilityRole="button">
         <Card tone={selected ? "mint" : "white"} padded style={{ marginVertical: 0, padding: 14 }}>
           <View className="flex-row items-start gap-3">
             <View

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/experiment-card.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/experiment-card.tsx
@@ -52,8 +52,13 @@ export function ExperimentCard({
   const tag = pickTag(requiresSensor, questionsOnly);
 
   return (
-    <Pressable onPress={() => onPress(id)} accessibilityRole="button">
-      <Card tone={selected ? "mint" : "white"} padded style={{ marginVertical: 0, padding: 14 }}>
+    <Pressable onPress={() => onPress(id)} accessibilityRole="button" className="active:opacity-60">
+      <Card
+        tone={selected ? "mint" : "white"}
+        padded
+        className="border-0"
+        style={{ marginVertical: 0, padding: 14 }}
+      >
         <View className="flex-row items-start gap-3">
           <View
             className="h-11 w-11 items-center justify-center rounded-xl"

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/experiment-card.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/experiment-card.tsx
@@ -1,12 +1,6 @@
 import { FlaskConical, MessageSquare } from "lucide-react-native";
-import React, { useEffect } from "react";
+import React from "react";
 import { Pressable, Text, View } from "react-native";
-import Animated, {
-  useAnimatedStyle,
-  useSharedValue,
-  withSequence,
-  withSpring,
-} from "react-native-reanimated";
 import { colors } from "~/shared/constants/colors";
 import { useTranslation } from "~/shared/i18n";
 import { Card } from "~/shared/ui/Card";
@@ -57,69 +51,54 @@ export function ExperimentCard({
   const { t } = useTranslation("measurementFlow");
   const tag = pickTag(requiresSensor, questionsOnly);
 
-  // Subtle pop when this card becomes the selected one. Driven off `selected`
-  // so it fires once when a card is first chosen, not on every re-tap. The peak
-  // is kept small so the full-width card never scales past the screen edges.
-  const scale = useSharedValue(1);
-  const animatedStyle = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
-  useEffect(() => {
-    if (!selected) return;
-    scale.value = withSequence(
-      withSpring(1.03, { damping: 18, stiffness: 320 }),
-      withSpring(1, { damping: 15, stiffness: 240 }),
-    );
-  }, [selected, scale]);
-
   return (
-    <Animated.View style={animatedStyle}>
-      <Pressable onPress={() => onPress(id)} accessibilityRole="button">
-        <Card tone={selected ? "mint" : "white"} padded style={{ marginVertical: 0, padding: 14 }}>
-          <View className="flex-row items-start gap-3">
-            <View
-              className="h-11 w-11 items-center justify-center rounded-xl"
-              style={{ backgroundColor: questionsOnly ? colors.badge.published : colors.jii.mint }}
+    <Pressable onPress={() => onPress(id)} accessibilityRole="button">
+      <Card tone={selected ? "mint" : "white"} padded style={{ marginVertical: 0, padding: 14 }}>
+        <View className="flex-row items-start gap-3">
+          <View
+            className="h-11 w-11 items-center justify-center rounded-xl"
+            style={{ backgroundColor: questionsOnly ? colors.badge.published : colors.jii.mint }}
+          >
+            {questionsOnly ? (
+              <MessageSquare size={20} color={colors.jii.darkGreen} />
+            ) : (
+              <FlaskConical size={20} color={colors.jii.darkGreen} />
+            )}
+          </View>
+          <View className="min-w-0 flex-1">
+            <Text
+              className="text-on-surface"
+              style={{ fontFamily: "Poppins-Bold", fontSize: 15, lineHeight: 19 }}
+              numberOfLines={2}
             >
-              {questionsOnly ? (
-                <MessageSquare size={20} color={colors.jii.darkGreen} />
-              ) : (
-                <FlaskConical size={20} color={colors.jii.darkGreen} />
-              )}
-            </View>
-            <View className="min-w-0 flex-1">
-              <Text
-                className="text-on-surface"
-                style={{ fontFamily: "Poppins-Bold", fontSize: 15, lineHeight: 19 }}
-                numberOfLines={2}
-              >
-                {title}
+              {title}
+            </Text>
+            {description ? (
+              <Text className="text-muted-body mt-1 text-[12.5px]" numberOfLines={2}>
+                {description}
               </Text>
-              {description ? (
-                <Text className="text-muted-body mt-1 text-[12.5px]" numberOfLines={2}>
-                  {description}
+            ) : null}
+            <View className="mt-2 flex-row flex-wrap items-center gap-2">
+              {recentCount > 0 ? (
+                <Tag variant="synced">
+                  {t("experimentSelection.recentThisWeek", { n: recentCount })}
+                </Tag>
+              ) : null}
+              {tag ? (
+                <Tag variant={tag.variant}>{t(`experimentSelection.tag.${tag.key}`)}</Tag>
+              ) : null}
+              {nodeCount > 0 ? (
+                <Text className="text-muted-body text-[11.5px]">
+                  {t("experimentSelection.meta.nodesAndDuration", {
+                    nodes: nodeCount,
+                    minutes: durationMin,
+                  })}
                 </Text>
               ) : null}
-              <View className="mt-2 flex-row flex-wrap items-center gap-2">
-                {recentCount > 0 ? (
-                  <Tag variant="synced">
-                    {t("experimentSelection.recentThisWeek", { n: recentCount })}
-                  </Tag>
-                ) : null}
-                {tag ? (
-                  <Tag variant={tag.variant}>{t(`experimentSelection.tag.${tag.key}`)}</Tag>
-                ) : null}
-                {nodeCount > 0 ? (
-                  <Text className="text-muted-body text-[11.5px]">
-                    {t("experimentSelection.meta.nodesAndDuration", {
-                      nodes: nodeCount,
-                      minutes: durationMin,
-                    })}
-                  </Text>
-                ) : null}
-              </View>
             </View>
           </View>
-        </Card>
-      </Pressable>
-    </Animated.View>
+        </View>
+      </Card>
+    </Pressable>
   );
 }

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/experiment-selection-step.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/experiment-selection-step.tsx
@@ -82,9 +82,6 @@ export function ExperimentSelectionStep() {
               >
                 {t("experimentSelection.heroTitle")}
               </Text>
-              <Text className="text-muted-body mt-1 text-[13px]">
-                {t("experimentSelection.heroSubtitle")}
-              </Text>
             </View>
             <OfflineModeIndicator isVisible={!!precachedData} />
           </View>
@@ -97,25 +94,21 @@ export function ExperimentSelectionStep() {
               placeholder={t("experimentSelection.searchPlaceholder")}
               leftIcon={<Search size={18} color={colors.inactive} />}
               rightElement={
-                search.length > 0 ? (
-                  <TouchableOpacity
-                    className="bg-gray-background mr-2 rounded-md p-1"
-                    onPress={() => setSearch("")}
-                  >
-                    <X size={20} color={colors.onSurface} />
-                  </TouchableOpacity>
-                ) : undefined
+                <View className="mr-2 flex-row items-center gap-1.5">
+                  {search.length > 0 ? (
+                    <TouchableOpacity
+                      className="bg-gray-background rounded-md p-1"
+                      onPress={() => setSearch("")}
+                    >
+                      <X size={18} color={colors.onSurface} />
+                    </TouchableOpacity>
+                  ) : null}
+                  <Tag>{`${filtered.length}`}</Tag>
+                </View>
               }
               autoCapitalize="none"
               autoCorrect={false}
             />
-          </View>
-
-          <View className="mt-4 flex-row items-center justify-between">
-            <Text className="text-on-surface" style={{ fontFamily: "Poppins-Bold", fontSize: 14 }}>
-              {t("experimentSelection.assignedToYou")}
-            </Text>
-            {experiments.length > 0 ? <Tag>{`${experiments.length}`}</Tag> : null}
           </View>
         </View>
 
@@ -134,7 +127,7 @@ export function ExperimentSelectionStep() {
           <FlatList
             data={filtered}
             keyExtractor={(item) => item.value}
-            contentContainerStyle={{ paddingHorizontal: 16, gap: 4 }}
+            contentContainerStyle={{ paddingHorizontal: 16, gap: 0 }}
             renderItem={({ item }) => {
               const meta = flowMeta[item.value];
               return (


### PR DESCRIPTION
## Type of PR

- [x] Bug Fix
- [x] Other: small UI refinement

## Description

Follow-up to #1516 (OJD-1546), refining the measurement-flow experiment picker after testing the new design on device. Started as "fix the selection animation" and, through on-device iteration, settled into a small picker cleanup.

## Related Issues

- Related to #1516 (OJD-1546 — UX fixes new app design)

## Changes Made

- **Remove the experiment-card selection animation.** The reanimated pop introduced in #1516 re-bounced jarringly on every tap and could scale a full-width card past the screen edge; a NativeWind `animate-pulse` alternative didn't render on this reanimated/new-arch stack. Selection is already clear from the card's mint background, so the animation is dropped (no reanimated left in the component).
- **Restyle the cards:** keep the rounded corners and soft shadow, drop the border, and tighten the list to no gap between items. Add an active-press dim so rows clearly read as tappable.
- **Declutter the header:** keep the "Choose an experiment" title; remove the subtitle and the "Assigned to you" label.
- **Move the experiment counter into the search field** as a badge that reflects the live filtered count (updates as you type), alongside the existing clear button.

## Testing Instructions

- [ ] Open the experiment picker. Cards are rounded, borderless, tight together; tapping a row dims it; the selected row is mint.
- [ ] The header shows only the "Choose an experiment" title.
- [ ] The search field shows a count badge at the end; typing filters the list and the badge updates to the match count.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have tested these changes locally
- [x] My changes generate no new warnings
- [x] I have reviewed my own code

## Additional Notes

Verified locally: typecheck and lint clean throughout. Confirmed on a physical device across iterations (cold relaunch, clean bundle each time).