### PR TITLE
fix(mobile): post-analysis advance and profile-sourced name (OJD-1546)

### DIFF
--- a/apps/mobile/src/features/auth/hooks/use-login.ts
+++ b/apps/mobile/src/features/auth/hooks/use-login.ts
@@ -5,6 +5,7 @@ import {
   signInWithOrcid,
   verifyEmailLoginOtp,
 } from "~/features/auth/api/login.api";
+import { getAuthClient } from "~/features/auth/services/auth";
 import { prefetchOfflineData } from "~/shared/db/prefetch-offline-data";
 import { createLogger } from "~/shared/utils/logger";
 
@@ -13,8 +14,13 @@ const log = createLogger("auth");
 export function useLoginFlow() {
   const queryClient = useQueryClient();
 
-  const prefetch = () => {
-    void prefetchOfflineData(queryClient);
+  const prefetch = async () => {
+    // Resolve the freshly-signed-in userId so the profile prefetch has a target.
+    const session = await getAuthClient()
+      .getSession()
+      .catch(() => null);
+    const userId = session?.data?.user?.id;
+    void prefetchOfflineData(queryClient, userId);
   };
 
   const github = useMutation({

--- a/apps/mobile/src/features/home/components/home-greeting.tsx
+++ b/apps/mobile/src/features/home/components/home-greeting.tsx
@@ -2,16 +2,22 @@ import React from "react";
 import { Text, View } from "react-native";
 import { useSession } from "~/features/auth/hooks/use-session";
 import { useGreeting } from "~/features/home/hooks/use-greeting";
+import { useGetUserProfile } from "~/features/profile/hooks/use-get-user-profile";
 import { useTranslation } from "~/shared/i18n";
 
 export function HomeGreeting() {
   const { t } = useTranslation("home");
   const { user } = useSession();
+  const { userProfile } = useGetUserProfile(user?.id);
   const { greeting, weekdayAndDate } = useGreeting();
 
   const fallback = t("greeting.fallbackName");
-  const trimmed = (user?.name?.split(" ")[0] ?? "").trim();
-  const firstName = trimmed.length > 0 ? trimmed : fallback;
+  // Profile firstName is the authoritative source; fall back to the session
+  // name (set by OAuth providers) and finally to the localized "there".
+  const profileFirst = userProfile?.firstName?.trim() ?? "";
+  const sessionFirst = user?.name?.split(" ")[0]?.trim() ?? "";
+  const firstName =
+    profileFirst.length > 0 ? profileFirst : sessionFirst.length > 0 ? sessionFirst : fallback;
 
   return (
     <View className="pb-3 pt-1">

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.tsx
@@ -4,7 +4,6 @@ import React, { useMemo, useState } from "react";
 import { View, Text, ScrollView } from "react-native";
 import { useSession } from "~/features/auth/hooks/use-session";
 import { useExperiments } from "~/features/experiments/hooks/use-experiments";
-import { useFinishFlow } from "~/features/measurement-flow/hooks/use-finish-flow";
 import { useMacro } from "~/features/measurement-flow/hooks/use-macro";
 import { useProtocol } from "~/features/measurement-flow/hooks/use-protocol";
 import { useFlowAnswersStore } from "~/features/measurement-flow/stores/use-flow-answers-store";
@@ -36,9 +35,15 @@ export function AnalysisNode({ content }: AnalysisNodeProps) {
   const { classes } = useTheme();
   const { t } = useTranslation("measurementFlow");
   const { macro, isLoading } = useMacro(content.macroId);
-  const { scanResult, previousStep, experimentId, protocolId, iterationCount, flowNodes } =
-    useMeasurementFlowStore();
-  const finishAndExit = useFinishFlow();
+  const {
+    scanResult,
+    previousStep,
+    nextStep,
+    experimentId,
+    protocolId,
+    iterationCount,
+    flowNodes,
+  } = useMeasurementFlowStore();
   const { experiments } = useExperiments();
   const { session } = useSession();
 
@@ -124,7 +129,7 @@ export function AnalysisNode({ content }: AnalysisNodeProps) {
       commentText: measurementComment.trim() || undefined,
       protocolName: protocol?.name ?? protocolId,
     });
-    finishAndExit();
+    nextStep();
   };
 
   const handleRetry = () => {

--- a/apps/mobile/src/features/profile/hooks/use-get-user-profile.ts
+++ b/apps/mobile/src/features/profile/hooks/use-get-user-profile.ts
@@ -1,0 +1,18 @@
+import { tsr } from "~/shared/api/tsr";
+
+export function useGetUserProfile(userId: string | undefined, enabled = true) {
+  const { data, isLoading, error } = tsr.users.getUserProfile.useQuery({
+    queryKey: ["userProfile", userId],
+    queryData: { params: { id: userId ?? "" } },
+    enabled: enabled && !!userId,
+    // A brand-new account hasn't created a profile yet; don't retry on 404.
+    retry: (failureCount, err) => {
+      if (typeof err === "object" && err !== null && "status" in err && err.status === 404) {
+        return false;
+      }
+      return failureCount < 3;
+    },
+  });
+
+  return { userProfile: data?.body, isLoading, error };
+}

--- a/apps/mobile/src/features/profile/screens/profile-screen/profile-screen.tsx
+++ b/apps/mobile/src/features/profile/screens/profile-screen/profile-screen.tsx
@@ -10,6 +10,7 @@ import { ProfileAccountCard } from "~/features/profile/components/profile-accoun
 import { ProfileHardwareCard } from "~/features/profile/components/profile-hardware-card";
 import { ProfileIdentity } from "~/features/profile/components/profile-identity";
 import { ProfileSignoutCard } from "~/features/profile/components/profile-signout-card";
+import { useGetUserProfile } from "~/features/profile/hooks/use-get-user-profile";
 import { useIsDevelopment } from "~/features/profile/hooks/use-is-development";
 import { DevSeedMeasurementsDialog } from "~/features/recent-measurements/components/dev-seed-measurements-dialog";
 import { colors } from "~/shared/constants/colors";
@@ -19,6 +20,7 @@ import { RowItem } from "~/shared/ui/RowItem";
 
 export function ProfileScreen() {
   const { session } = useSession();
+  const { userProfile } = useGetUserProfile(session?.data.user.id);
   const { t } = useTranslation("profile");
   const sheetRef = useRef<BottomSheetModal>(null);
   // Dev tooling only appears when the app points at a non-prod environment.
@@ -28,13 +30,15 @@ export function ProfileScreen() {
   if (!session) return null;
 
   const { user } = session.data;
+  const profileName = userProfile ? `${userProfile.firstName} ${userProfile.lastName}`.trim() : "";
+  const displayName = profileName.length > 0 ? profileName : user.name;
 
   return (
     <ScrollView
       className="bg-background flex-1"
       contentContainerStyle={{ padding: 16, paddingBottom: 32 }}
     >
-      <ProfileIdentity name={user.name} email={user.email} imageUri={user.image} />
+      <ProfileIdentity name={displayName} email={user.email} imageUri={user.image} />
       <ProfileHardwareCard />
       <ProfileAccountCard onOpenAppSettings={() => sheetRef.current?.present()} />
 

--- a/apps/mobile/src/shared/db/prefetch-offline-data.ts
+++ b/apps/mobile/src/shared/db/prefetch-offline-data.ts
@@ -10,9 +10,12 @@ const log = createLogger("prefetch");
  * Prefetches all experiment data needed for offline use.
  * Called after login to ensure measurements can run without network.
  */
-export async function prefetchOfflineData(queryClient: QueryClient): Promise<void> {
+export async function prefetchOfflineData(
+  queryClient: QueryClient,
+  userId?: string,
+): Promise<void> {
   try {
-    await _prefetchOfflineData(queryClient);
+    await _prefetchOfflineData(queryClient, userId);
   } catch (err) {
     log.error("Failed to prefetch offline data", {
       err: err instanceof Error ? err.message : String(err),
@@ -20,7 +23,23 @@ export async function prefetchOfflineData(queryClient: QueryClient): Promise<voi
   }
 }
 
-async function _prefetchOfflineData(queryClient: QueryClient): Promise<void> {
+async function _prefetchOfflineData(queryClient: QueryClient, userId?: string): Promise<void> {
+  // Kick off the profile prefetch in parallel — it's independent of experiments.
+  // 404 is expected for accounts that haven't completed registration on web yet.
+  const profilePromise = userId
+    ? queryClient
+        .prefetchQuery({
+          queryKey: ["userProfile", userId],
+          queryFn: () => tsr.users.getUserProfile.query({ params: { id: userId } }),
+          staleTime: 0,
+        })
+        .catch((err) => {
+          log.warn("user profile prefetch failed", {
+            err: err instanceof Error ? err.message : String(err),
+          });
+        })
+    : Promise.resolve();
+
   // 1. Fetch all user experiments
   const experimentsResponse = await queryClient.fetchQuery({
     queryKey: ["experiments"],
@@ -122,6 +141,9 @@ async function _prefetchOfflineData(queryClient: QueryClient): Promise<void> {
       total: uniqueProtocolIds.length + uniqueMacroIds.length,
     });
   }
+
+  // Make sure the parallel profile prefetch has settled before returning.
+  await profilePromise;
 
   const flowsCached = experiments.length - flowFailures.length;
   const assetsCached = uniqueProtocolIds.length + uniqueMacroIds.length - assetFailures.length;


### PR DESCRIPTION
## Summary

Two mobile UX bugs caught while testing the new app design:

- **Analysis cell ended the whole flow on "Accept Data".** `AnalysisNode` unconditionally called `finishAndExit()` after a successful upload, tearing down `experimentId`/`scanResult` and routing the user back to Recent Measurements. It now calls `nextStep()`; the store already wraps back to step 0 (or shows the questions-only submit screen) when the analysis cell is the last node, so users can keep iterating and finish explicitly via the existing exit UI.
- **"Good morning there." greeting for email-OTP users.** `HomeGreeting` and `ProfileScreen` read the name out of the Better Auth session (`users.name`), but the email-OTP sign-in path leaves that field empty — only OAuth providers populate it. The actual user-entered name lives in the `profiles` table (`firstName` / `lastName`), populated via the web registration form. Both screens now query `GET /api/v1/users/:id/profile` (mirroring the web `useGetUserProfile` hook, including don't-retry-on-404 for fresh accounts) and prefer `profile.firstName` / `lastName`. Session name remains the fallback for OAuth users until the profile resolves, then the localized "there".
- **Prefetch.** The profile is now prefetched in parallel with experiments inside `prefetchOfflineData`, so it's warm by the time the home screen mounts after sign-in. `useLoginFlow` resolves the freshly-signed-in `userId` via `getAuthClient().getSession()` and passes it through.

## Test plan

- [ ] Sign in with an email-OTP user whose profile was created on web → home greeting shows the user's first name; profile screen shows full name + email.
- [ ] Sign in with an email-OTP user that hasn't completed the web profile → falls back gracefully ("there" / `user.name`), no retry storm against the 404.
- [ ] Sign in with GitHub / ORCID → still shows the OAuth name without regression.
- [ ] Run an experiment flow that ends with an analysis cell → "Accept Data" advances to a new iteration instead of dropping you back on Recent Measurements; the explicit exit button still finishes the flow.
- [ ] Run an experiment flow where the analysis cell is intermediate → "Accept Data" advances to the next cell.
- [ ] Retry from the analysis cell still works.