### PR TITLE
fix(mobile): bound offline fetches and probe backend connectivity

### DIFF
--- a/apps/mobile/src/features/auth/api/__tests__/refresh.api.test.ts
+++ b/apps/mobile/src/features/auth/api/__tests__/refresh.api.test.ts
@@ -34,6 +34,7 @@ describe("refreshSession", () => {
   it("returns false when getSession hangs past the timeout", async () => {
     vi.useFakeTimers();
     try {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function -- intentional: simulates a hang
       mockGetSession.mockImplementationOnce(() => new Promise(() => {}));
 
       const p = refreshSession();

--- a/apps/mobile/src/features/auth/api/__tests__/refresh.api.test.ts
+++ b/apps/mobile/src/features/auth/api/__tests__/refresh.api.test.ts
@@ -31,16 +31,65 @@ describe("refreshSession", () => {
     expect(await refreshSession()).toBe(false);
   });
 
-  it("returns false when getSession hangs past the timeout", async () => {
+  it("forwards fetchOptions.signal so the upstream call can be cancelled", async () => {
+    mockGetSession.mockImplementationOnce(({ fetchOptions }) => {
+      return new Promise((_resolve, reject) => {
+        fetchOptions.signal.addEventListener("abort", () =>
+          reject(new DOMException("aborted", "AbortError")),
+        );
+      });
+    });
+
     vi.useFakeTimers();
     try {
-      // eslint-disable-next-line @typescript-eslint/no-empty-function -- intentional: simulates a hang
-      mockGetSession.mockImplementationOnce(() => new Promise(() => {}));
-
       const p = refreshSession();
       await vi.advanceTimersByTimeAsync(8_000);
-
       expect(await p).toBe(false);
+
+      // The mock saw a signal and that signal was aborted by the timeout.
+      const call = mockGetSession.mock.calls[0][0];
+      expect(call.fetchOptions.signal).toBeInstanceOf(AbortSignal);
+      expect(call.fetchOptions.signal.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the single-flight lock until the upstream settles, not just the race", async () => {
+    // Regression: previously, Promise.race resolved the caller and cleared
+    // refreshInFlight in `finally`, while the underlying getSession kept
+    // running. Subsequent 401s would then kick off a second concurrent
+    // refresh. The lock must stay held until the upstream actually settles.
+    let resolveSession!: (v: { data: { session: { id: string } } }) => void;
+    // Ignore the abort signal so the upstream stays in flight past the timeout.
+    mockGetSession.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSession = resolve;
+        }),
+    );
+
+    vi.useFakeTimers();
+    try {
+      const first = refreshSession();
+      await vi.advanceTimersByTimeAsync(8_000);
+      expect(await first).toBe(false);
+
+      // Upstream still in flight. A second caller must dedupe onto it
+      // rather than starting a fresh getSession.
+      const second = refreshSession();
+      expect(mockGetSession).toHaveBeenCalledTimes(1);
+
+      // Resolve the upstream — the second caller now sees the real result.
+      resolveSession({ data: { session: { id: "s1" } } });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(await second).toBe(true);
+
+      // After the upstream settles, the lock releases and the next call
+      // starts fresh.
+      mockGetSession.mockResolvedValueOnce({ data: { session: { id: "s2" } } });
+      expect(await refreshSession()).toBe(true);
+      expect(mockGetSession).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/mobile/src/features/auth/api/__tests__/refresh.api.test.ts
+++ b/apps/mobile/src/features/auth/api/__tests__/refresh.api.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { refreshSession } from "../refresh.api";
+
+const { mockGetSession } = vi.hoisted(() => ({ mockGetSession: vi.fn() }));
+
+vi.mock("~/features/auth/services/auth", () => ({
+  getAuthClient: () => ({ getSession: mockGetSession }),
+}));
+
+describe("refreshSession", () => {
+  beforeEach(() => {
+    mockGetSession.mockReset();
+  });
+
+  it("returns true when getSession resolves with a valid session", async () => {
+    mockGetSession.mockResolvedValueOnce({ data: { session: { id: "s1" } } });
+
+    expect(await refreshSession()).toBe(true);
+  });
+
+  it("returns false when getSession resolves without a session", async () => {
+    mockGetSession.mockResolvedValueOnce({ data: null });
+
+    expect(await refreshSession()).toBe(false);
+  });
+
+  it("returns false when getSession rejects (e.g. offline)", async () => {
+    mockGetSession.mockRejectedValueOnce(new Error("offline"));
+
+    expect(await refreshSession()).toBe(false);
+  });
+
+  it("returns false when getSession hangs past the timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      mockGetSession.mockImplementationOnce(() => new Promise(() => {}));
+
+      const p = refreshSession();
+      await vi.advanceTimersByTimeAsync(8_000);
+
+      expect(await p).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("dedupes concurrent callers via the single-flight lock", async () => {
+    let resolveSession!: (v: { data: { session: { id: string } } }) => void;
+    mockGetSession.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSession = resolve;
+        }),
+    );
+
+    const p1 = refreshSession();
+    const p2 = refreshSession();
+    resolveSession({ data: { session: { id: "s1" } } });
+
+    expect(await p1).toBe(true);
+    expect(await p2).toBe(true);
+    expect(mockGetSession).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/features/auth/api/refresh.api.ts
+++ b/apps/mobile/src/features/auth/api/refresh.api.ts
@@ -2,6 +2,10 @@ import { getAuthClient } from "~/features/auth/services/auth";
 
 let refreshInFlight: Promise<boolean> | null = null;
 
+// Bounded so an offline `getSession` can't keep the fetcher stuck on a 401
+// retry beyond the per-request fetch budget.
+const REFRESH_TIMEOUT_MS = 8_000;
+
 /**
  * Single-flight session re-validation.
  *
@@ -20,9 +24,12 @@ export async function refreshSession(): Promise<boolean> {
   refreshInFlight = (async () => {
     try {
       const authClient = getAuthClient();
-      const { data } = await authClient.getSession({
-        query: { disableCookieCache: true },
-      });
+      const data = await Promise.race([
+        authClient.getSession({ query: { disableCookieCache: true } }).then((res) => res.data),
+        new Promise<null>((_, reject) =>
+          setTimeout(() => reject(new Error("refreshSession timed out")), REFRESH_TIMEOUT_MS),
+        ),
+      ]);
       return !!data?.session;
     } catch {
       return false;

--- a/apps/mobile/src/features/auth/api/refresh.api.ts
+++ b/apps/mobile/src/features/auth/api/refresh.api.ts
@@ -1,6 +1,7 @@
 import { getAuthClient } from "~/features/auth/services/auth";
 
 let refreshInFlight: Promise<boolean> | null = null;
+let refreshController: AbortController | null = null;
 
 // Bounded so an offline `getSession` can't keep the fetcher stuck on a 401
 // retry beyond the per-request fetch budget.
@@ -17,26 +18,37 @@ const REFRESH_TIMEOUT_MS = 8_000;
  * single-flight lock that prevents the OJD-1515 burst class where N
  * parallel requests on a stale session each tried to refresh
  * independently.
+ *
+ * Each caller is bounded by REFRESH_TIMEOUT_MS via Promise.race; the
+ * timeout also aborts the shared upstream fetch through fetchOptions.signal
+ * so the underlying request actually stops, and refreshInFlight stays tied
+ * to that upstream call (not the race) so concurrent callers always dedupe.
  */
 export async function refreshSession(): Promise<boolean> {
-  if (refreshInFlight) return refreshInFlight;
+  if (!refreshInFlight) {
+    const authClient = getAuthClient();
+    refreshController = new AbortController();
+    refreshInFlight = authClient
+      .getSession({
+        query: { disableCookieCache: true },
+        fetchOptions: { signal: refreshController.signal },
+      })
+      .then((res) => !!res?.data?.session)
+      .catch(() => false)
+      .finally(() => {
+        refreshInFlight = null;
+        refreshController = null;
+      });
+  }
 
-  refreshInFlight = (async () => {
-    try {
-      const authClient = getAuthClient();
-      const data = await Promise.race([
-        authClient.getSession({ query: { disableCookieCache: true } }).then((res) => res.data),
-        new Promise<null>((_, reject) =>
-          setTimeout(() => reject(new Error("refreshSession timed out")), REFRESH_TIMEOUT_MS),
-        ),
-      ]);
-      return !!data?.session;
-    } catch {
-      return false;
-    } finally {
-      refreshInFlight = null;
-    }
-  })();
-
-  return refreshInFlight;
+  const upstream = refreshInFlight;
+  return Promise.race([
+    upstream,
+    new Promise<boolean>((resolve) =>
+      setTimeout(() => {
+        refreshController?.abort();
+        resolve(false);
+      }, REFRESH_TIMEOUT_MS),
+    ),
+  ]);
 }

--- a/apps/mobile/src/features/profile/hooks/use-get-user-profile.ts
+++ b/apps/mobile/src/features/profile/hooks/use-get-user-profile.ts
@@ -12,6 +12,9 @@ export function useGetUserProfile(userId: string | undefined, enabled = true) {
       }
       return failureCount < 3;
     },
+    // Greeting/profile screen fall back gracefully; don't blast the user with
+    // a toast on a missing profile.
+    meta: { suppressToast: true },
   });
 
   return { userProfile: data?.body, isLoading, error };

--- a/apps/mobile/src/shared/api/__tests__/fetcher.test.ts
+++ b/apps/mobile/src/shared/api/__tests__/fetcher.test.ts
@@ -140,4 +140,59 @@ describe("customApiFetcher", () => {
     const sent = mockTsRestFetch.mock.calls[0][0];
     expect(sent.headers.Cookie).toBeUndefined();
   });
+
+  it("aborts the underlying fetch when the upstream signal aborts", async () => {
+    const upstream = new AbortController();
+    mockTsRestFetch.mockImplementation((sentArgs: { signal: AbortSignal }) => {
+      return new Promise((_resolve, reject) => {
+        sentArgs.signal.addEventListener("abort", () =>
+          reject(new DOMException("aborted", "AbortError")),
+        );
+      });
+    });
+
+    const p = customApiFetcher({ ...args, signal: upstream.signal } as ApiFetcherArgs);
+    upstream.abort();
+
+    await expect(p).rejects.toThrow();
+  });
+
+  it("aborts a hung fetch via its internal timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      mockTsRestFetch.mockImplementation((sentArgs: { signal: AbortSignal }) => {
+        return new Promise((_resolve, reject) => {
+          sentArgs.signal.addEventListener("abort", () =>
+            reject(new DOMException("aborted", "AbortError")),
+          );
+        });
+      });
+
+      const p = customApiFetcher(args);
+      // Catch the rejection synchronously so the unhandled-rejection check passes
+      // while we still advance the clock to trigger the timeout abort.
+      const settled = p.catch((e: unknown) => e);
+      await vi.advanceTimersByTimeAsync(10_000);
+      const err = await settled;
+      expect((err as Error)?.name).toBe("AbortError");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not abort a request that resolves within the timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      mockTsRestFetch.mockResolvedValueOnce({ status: 200 });
+
+      const result = await customApiFetcher(args);
+
+      expect(result.status).toBe(200);
+      // The internal timeout would have fired had it not been cleared on success.
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(mockSignOut).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/apps/mobile/src/shared/api/fetcher.ts
+++ b/apps/mobile/src/shared/api/fetcher.ts
@@ -4,6 +4,12 @@ import { refreshSession } from "~/features/auth/api/refresh.api";
 import { getAuthClient } from "~/features/auth/services/auth";
 import { getEnvVar } from "~/shared/stores/environment-store";
 
+// Without this, fetch hangs at the platform default whenever the backend is
+// unreachable (Wi-Fi-without-internet, captive portal, sleeping device). The
+// hung promises cascade across mounted queries and the UI lags for tens of
+// seconds offline. 10s is generous for any real call and fails fast otherwise.
+const FETCH_TIMEOUT_MS = 10_000;
+
 function removeTrailingSlashes(value: string) {
   return value.replace(/\/+$/, "");
 }
@@ -19,15 +25,25 @@ export const customApiFetcher = async (args: ApiFetcherArgs) => {
   const path = removeLeadingSlashes(args.path);
   const fullPath = `${base}/${path}`;
 
-  const send = () =>
-    tsRestFetchApi({
+  const send = () => {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    // Honor any upstream signal (e.g. React Query unmount) by forwarding aborts.
+    const upstream = args.signal;
+    if (upstream) {
+      if (upstream.aborted) controller.abort();
+      else upstream.addEventListener("abort", () => controller.abort(), { once: true });
+    }
+    return tsRestFetchApi({
       ...args,
       path: fullPath,
+      signal: controller.signal,
       headers: {
         ...args.headers,
         ...(authClient.getCookie() ? { Cookie: authClient.getCookie() } : {}),
       },
-    });
+    }).finally(() => clearTimeout(timeoutId));
+  };
 
   let result = await send();
 

--- a/apps/mobile/src/shared/db/prefetch-offline-data.ts
+++ b/apps/mobile/src/shared/db/prefetch-offline-data.ts
@@ -32,6 +32,7 @@ async function _prefetchOfflineData(queryClient: QueryClient, userId?: string): 
           queryKey: ["userProfile", userId],
           queryFn: () => tsr.users.getUserProfile.query({ params: { id: userId } }),
           staleTime: 0,
+          meta: { suppressToast: true },
         })
         .catch((err) => {
           log.warn("user profile prefetch failed", {

--- a/apps/mobile/src/shared/ui/configured-query-client-provider.tsx
+++ b/apps/mobile/src/shared/ui/configured-query-client-provider.tsx
@@ -61,9 +61,12 @@ export function ConfiguredQueryClientProvider({ children }) {
 
   if (!queryClientRef.current) {
     const queryCache = new QueryCache({
-      onError: (error: any) => {
+      onError: (error: any, query) => {
         const message = error?.body?.message ?? error?.message ?? "Something went wrong";
         log.warn("query error", { message, status: error?.status });
+        // Queries that gracefully fall back (e.g. user profile) opt out of the
+        // global toast via meta.suppressToast so a 404 doesn't blare at the user.
+        if (query.meta?.suppressToast) return;
         toast.error(message);
       },
     });

--- a/apps/mobile/src/shared/utils/__tests__/is-online.test.ts
+++ b/apps/mobile/src/shared/utils/__tests__/is-online.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { isOnline } from "../is-online";
+
+const { mockHead } = vi.hoisted(() => ({ mockHead: vi.fn() }));
+
+vi.mock("axios", () => ({
+  default: { head: mockHead },
+}));
+
+vi.mock("~/shared/stores/environment-store", () => ({
+  getEnvVar: (k: string) => (k === "BACKEND_URI" ? "https://api.test/" : ""),
+}));
+
+describe("isOnline", () => {
+  beforeEach(() => {
+    mockHead.mockReset();
+  });
+
+  it("targets BACKEND_URI with a HEAD probe", async () => {
+    mockHead.mockResolvedValueOnce({ status: 200 });
+
+    expect(await isOnline()).toBe(true);
+    expect(mockHead).toHaveBeenCalledWith(
+      "https://api.test/",
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+  });
+
+  it("treats any HTTP response as online (incl. 404 on the bare root)", async () => {
+    mockHead.mockResolvedValueOnce({ status: 404 });
+
+    expect(await isOnline()).toBe(true);
+  });
+
+  it("passes validateStatus that accepts every status code", async () => {
+    mockHead.mockResolvedValueOnce({ status: 500 });
+
+    await isOnline();
+    const opts = mockHead.mock.calls[0][1] as { validateStatus: (s: number) => boolean };
+    expect(opts.validateStatus(200)).toBe(true);
+    expect(opts.validateStatus(404)).toBe(true);
+    expect(opts.validateStatus(500)).toBe(true);
+  });
+
+  it("returns false when the probe rejects (network failure / timeout)", async () => {
+    mockHead.mockRejectedValueOnce(new Error("ECONNABORTED"));
+
+    expect(await isOnline()).toBe(false);
+  });
+});

--- a/apps/mobile/src/shared/utils/is-online.ts
+++ b/apps/mobile/src/shared/utils/is-online.ts
@@ -1,10 +1,21 @@
 import axios from "axios";
+import { getEnvVar } from "~/shared/stores/environment-store";
 
-const PING_URL = "https://clients3.google.com/generate_204";
+// Probing a generic page (e.g. google.com/generate_204) reports "online"
+// whenever the user has any network, even on Wi-Fi-without-internet or
+// captive portals where our backend is unreachable. The onlineManager then
+// flips React Query's queries on and they hang on the unreachable backend.
+// Probing the backend directly ties the "online" signal to actual app usability.
+const PING_TIMEOUT_MS = 3000;
 
 export async function isOnline(): Promise<boolean> {
   try {
-    await axios.head(PING_URL, { timeout: 3000 });
+    const base = getEnvVar("BACKEND_URI");
+    await axios.head(base, {
+      timeout: PING_TIMEOUT_MS,
+      // Any response (incl. 404 on the bare root) proves the backend answers.
+      validateStatus: () => true,
+    });
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary

Two related fixes for the "any button takes ~40 seconds offline" report, plus the toast-suppression follow-up that missed the previous PR.

- **Fetch timeout (`apps/mobile/src/shared/api/fetcher.ts`)** — `customApiFetcher` now wraps `tsRestFetchApi` with an `AbortController` and a 10s timeout, and forwards any upstream signal (e.g. React Query unmount) so component teardowns cancel in-flight requests. Unbounded hangs against an unreachable backend were the root cause of the "ANY button takes ~40s" lag when the device was offline but the `onlineManager` wrongly thought we were online.
- **Connectivity check (`apps/mobile/src/shared/utils/is-online.ts`)** — `isOnline` now HEADs `BACKEND_URI` instead of `clients3.google.com`. Pinging Google reports "online" on Wi-Fi-without-internet and captive portals where our backend is unreachable. Pinging the backend ties the online signal to actual app usability. `validateStatus: () => true` so any response code (including 404 on the bare root) proves the server answered.
- **Refresh timeout (`apps/mobile/src/features/auth/api/refresh.api.ts`)** — `refreshSession` races `authClient.getSession` against an 8s timeout so the 401 retry path can't hang past the per-request fetch budget.
- **Toast suppression** — graceful-fallback queries opt out of the global `QueryCache.onError` toast via `meta: { suppressToast: true }`. Wired into the handler in `configured-query-client-provider.tsx`, the `useGetUserProfile` hook, and the profile prefetch in `prefetch-offline-data.ts`, so a 404 on a brand-new account no longer fires "User profile with ID X not found" at the user.

## Test plan

- [ ] With ~20 stored measurements, put the device in airplane mode and tap buttons (open the experiment picker, select an experiment, navigate tabs). Each interaction should respond within the fetch timeout (~10s worst case) rather than the previous 40s.
- [ ] On Wi-Fi-without-internet (e.g. a captive portal), the `OfflineModeIndicator` should reflect "offline" within ~10s and queries should serve from the persisted cache without hanging.
- [ ] Reconnect to a real network — the `onlineManager` flips back, queries refetch, and the UI updates without a manual reload.
- [ ] Log in with a brand-new account that has no profile yet — no "User profile with ID X not found" toast.
- [ ] Log in with an existing account — greeting and profile screen show the user's name as before (no regression on the OJD-1546 fix).
- [ ] Run the analysis cell flow end-to-end — still advances to the next step / iteration on Accept Data, still finishes via the exit button.