### PR TITLE
feat(mobile): prioritize MultispeQ devices in scan list and show MAC ID

### DIFF
--- a/apps/mobile/src/features/connection/components/device-sheet/device-sheet.tsx
+++ b/apps/mobile/src/features/connection/components/device-sheet/device-sheet.tsx
@@ -1,6 +1,6 @@
 import { BottomSheetBackdrop, BottomSheetModal, BottomSheetView } from "@gorhom/bottom-sheet";
-import { Bluetooth, X } from "lucide-react-native";
-import React, { useCallback, useEffect, useRef } from "react";
+import { Bluetooth, ChevronDown, X } from "lucide-react-native";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Pressable, Text, View } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -11,6 +11,7 @@ import {
   useConnectedDevice,
 } from "~/features/connection/hooks/use-device-connection";
 import { useDeviceConnectionStore } from "~/features/connection/hooks/use-device-connection-store";
+import { partitionDevices } from "~/features/connection/services/device-connection-manager/device-sort";
 import { useDeviceSheetStore } from "~/features/connection/stores/use-device-sheet-store";
 import { colors } from "~/shared/constants/colors";
 import { useTranslation } from "~/shared/i18n";
@@ -34,6 +35,14 @@ export function DeviceSheet() {
   const batteryLevel = useDeviceConnectionStore((s) => s.batteryLevel);
   const { data: nearbyDevices = [], refetch: refreshDevices, isFetching } = useAllDevices();
   const { connectToDevice, disconnectFromDevice, connectingDeviceId } = useConnectToDevice();
+
+  const [showAllDevices, setShowAllDevices] = useState(false);
+  const { named, unnamed } = useMemo(() => partitionDevices(nearbyDevices), [nearbyDevices]);
+  const visibleDevices = showAllDevices ? [...named, ...unnamed] : named;
+
+  useEffect(() => {
+    if (!isOpen) setShowAllDevices(false);
+  }, [isOpen]);
 
   useEffect(() => {
     if (isOpen) sheetRef.current?.present();
@@ -191,16 +200,29 @@ export function DeviceSheet() {
           {nearbyDevices.length === 0 ? (
             <Text className="text-muted-body py-3 text-[13px]">{t("deviceList.empty")}</Text>
           ) : (
-            <ScrollView style={{ maxHeight: 240 }}>
-              {nearbyDevices.map((d, i) => (
+            <ScrollView style={{ maxHeight: 280 }}>
+              {visibleDevices.map((d, i) => (
                 <NearbyDeviceRow
                   key={d.id}
                   device={d}
                   isPairing={connectingDeviceId === d.id}
                   onPair={(dev) => void handleConnect(dev)}
-                  isLast={i === nearbyDevices.length - 1}
+                  isLast={
+                    i === visibleDevices.length - 1 && !(!showAllDevices && unnamed.length > 0)
+                  }
                 />
               ))}
+              {!showAllDevices && unnamed.length > 0 ? (
+                <Pressable
+                  onPress={() => setShowAllDevices(true)}
+                  className="flex-row items-center justify-center gap-1.5 py-3"
+                >
+                  <ChevronDown size={16} color={themeColors.inactive} />
+                  <Text className="text-muted-body text-[13px] font-semibold">
+                    {t("deviceSheet.seeMoreDevices", { count: unnamed.length })}
+                  </Text>
+                </Pressable>
+              ) : null}
             </ScrollView>
           )}
         </View>

--- a/apps/mobile/src/features/connection/components/device-sheet/device-sheet.tsx
+++ b/apps/mobile/src/features/connection/components/device-sheet/device-sheet.tsx
@@ -38,7 +38,10 @@ export function DeviceSheet() {
 
   const [showAllDevices, setShowAllDevices] = useState(false);
   const { named, unnamed } = useMemo(() => partitionDevices(nearbyDevices), [nearbyDevices]);
-  const visibleDevices = showAllDevices ? [...named, ...unnamed] : named;
+  // When nothing has a friendly name (common: MultispeQs advertise as a MAC),
+  // show every device directly instead of an empty list above "See more".
+  const collapseUnnamed = named.length > 0 && !showAllDevices;
+  const visibleDevices = collapseUnnamed ? named : [...named, ...unnamed];
 
   useEffect(() => {
     if (!isOpen) setShowAllDevices(false);
@@ -207,12 +210,10 @@ export function DeviceSheet() {
                   device={d}
                   isPairing={connectingDeviceId === d.id}
                   onPair={(dev) => void handleConnect(dev)}
-                  isLast={
-                    i === visibleDevices.length - 1 && !(!showAllDevices && unnamed.length > 0)
-                  }
+                  isLast={i === visibleDevices.length - 1 && !collapseUnnamed}
                 />
               ))}
-              {!showAllDevices && unnamed.length > 0 ? (
+              {collapseUnnamed && unnamed.length > 0 ? (
                 <Pressable
                   onPress={() => setShowAllDevices(true)}
                   className="flex-row items-center justify-center gap-1.5 py-3"

--- a/apps/mobile/src/features/connection/components/device-sheet/nearby-device-row.tsx
+++ b/apps/mobile/src/features/connection/components/device-sheet/nearby-device-row.tsx
@@ -22,6 +22,11 @@ function signalKey(
   return "signalWeak";
 }
 
+// MultispeQ stickers show the last 4 octets of the MAC, so match that.
+function shortMac(id: string): string {
+  return id.split(/[:-]/).slice(-4).join(":");
+}
+
 interface NearbyDeviceRowProps {
   device: Device;
   isPairing: boolean;
@@ -35,7 +40,8 @@ export function NearbyDeviceRow({ device, isPairing, onPair, isLast }: NearbyDev
 
   const sigKey = signalKey(device.rssi);
 
-  const macId = device.type === "bluetooth-classic" || device.type === "ble" ? device.id : null;
+  const macId =
+    device.type === "bluetooth-classic" || device.type === "ble" ? shortMac(device.id) : null;
   const hasName = device.name.trim().length > 0;
   const title = hasName ? device.name : (macId ?? t("deviceList.fallbackName"));
   const subParts: string[] = [];

--- a/apps/mobile/src/features/connection/components/device-sheet/nearby-device-row.tsx
+++ b/apps/mobile/src/features/connection/components/device-sheet/nearby-device-row.tsx
@@ -35,6 +35,14 @@ export function NearbyDeviceRow({ device, isPairing, onPair, isLast }: NearbyDev
 
   const sigKey = signalKey(device.rssi);
 
+  const macId = device.type === "bluetooth-classic" || device.type === "ble" ? device.id : null;
+  const hasName = device.name.trim().length > 0;
+  const title = hasName ? device.name : (macId ?? t("deviceList.fallbackName"));
+  const subParts: string[] = [];
+  if (hasName && macId) subParts.push(`(${macId})`);
+  if (sigKey) subParts.push(t("deviceList.signal", { strength: t(`deviceList.${sigKey}`) }));
+  const subtitle = subParts.join("  ·  ");
+
   return (
     <View
       className={[
@@ -47,11 +55,11 @@ export function NearbyDeviceRow({ device, isPairing, onPair, isLast }: NearbyDev
       </View>
       <View className="min-w-0 flex-1">
         <Text className="text-on-surface text-[15px] font-semibold" numberOfLines={1}>
-          {device.name || t("deviceList.fallbackName")}
+          {title}
         </Text>
-        {sigKey ? (
-          <Text className="text-muted-body mt-0.5 text-[12px]">
-            {t("deviceList.signal", { strength: t(`deviceList.${sigKey}`) })}
+        {subtitle ? (
+          <Text className="text-muted-body mt-0.5 text-[12px]" numberOfLines={1}>
+            {subtitle}
           </Text>
         ) : null}
       </View>

--- a/apps/mobile/src/features/connection/services/device-connection-manager/device-sort.test.ts
+++ b/apps/mobile/src/features/connection/services/device-connection-manager/device-sort.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { Device } from "~/shared/types/device";
+
+import { isNamedDevice, looksLikeMac, partitionDevices, sortDevices } from "./device-sort";
+
+const ble = (name: string, id: string, rssi?: number): Device => ({
+  type: "bluetooth-classic",
+  name,
+  id,
+  rssi,
+});
+
+describe("looksLikeMac", () => {
+  it("matches colon- and dash-separated addresses", () => {
+    expect(looksLikeMac("AA:BB:CC:DD:EE:FF")).toBe(true);
+    expect(looksLikeMac("aa-bb-cc-dd-ee-ff")).toBe(true);
+  });
+
+  it("rejects human and numeric names", () => {
+    expect(looksLikeMac("MultispeQ")).toBe(false);
+    expect(looksLikeMac("1520")).toBe(false);
+  });
+});
+
+describe("isNamedDevice", () => {
+  it("treats empty and MAC-looking names as unnamed", () => {
+    expect(isNamedDevice(ble("", "AA:BB:CC:DD:EE:FF"))).toBe(false);
+    expect(isNamedDevice(ble("AA:BB:CC:DD:EE:FF", "AA:BB:CC:DD:EE:FF"))).toBe(false);
+  });
+
+  it("treats numeric MultispeQ serials as named", () => {
+    expect(isNamedDevice(ble("1520", "AA:BB:CC:DD:EE:01"))).toBe(true);
+  });
+});
+
+describe("sortDevices", () => {
+  it("orders MultispeQ first, then other named, then unnamed", () => {
+    const devices = [
+      ble("", "AA:00:00:00:00:01"),
+      ble("Headphones", "AA:00:00:00:00:02"),
+      ble("MultispeQ-X", "AA:00:00:00:00:03"),
+    ];
+
+    expect(sortDevices(devices).map((d) => d.id)).toEqual([
+      "AA:00:00:00:00:03",
+      "AA:00:00:00:00:02",
+      "AA:00:00:00:00:01",
+    ]);
+  });
+
+  it("breaks ties within a rank by stronger signal", () => {
+    const devices = [ble("Speaker", "AA:01", -80), ble("Watch", "AA:02", -50)];
+    expect(sortDevices(devices).map((d) => d.id)).toEqual(["AA:02", "AA:01"]);
+  });
+});
+
+describe("partitionDevices", () => {
+  it("splits named (incl. MultispeQ) from unnamed/MAC-only", () => {
+    const devices = [
+      ble("MultispeQ", "AA:01"),
+      ble("", "AA:02"),
+      ble("Keyboard", "AA:03"),
+      ble("BB:CC:DD:EE:FF:00", "BB:CC:DD:EE:FF:00"),
+    ];
+
+    const { named, unnamed } = partitionDevices(devices);
+    expect(named.map((d) => d.id)).toEqual(["AA:01", "AA:03"]);
+    expect(unnamed.map((d) => d.id)).toEqual(["AA:02", "BB:CC:DD:EE:FF:00"]);
+  });
+});

--- a/apps/mobile/src/features/connection/services/device-connection-manager/device-sort.ts
+++ b/apps/mobile/src/features/connection/services/device-connection-manager/device-sort.ts
@@ -1,0 +1,38 @@
+import type { Device } from "~/shared/types/device";
+
+const MAC_LIKE = /^([0-9a-f]{2}[:-]){2,}[0-9a-f]{2}$/i;
+
+export function looksLikeMac(value: string): boolean {
+  return MAC_LIKE.test(value.trim());
+}
+
+export function isNamedDevice(device: Device): boolean {
+  const name = device.name.trim();
+  return name.length > 0 && !looksLikeMac(name);
+}
+
+export function isMultispeqDevice(device: Device): boolean {
+  return /multispeq/i.test(device.name);
+}
+
+function rank(device: Device): number {
+  if (isMultispeqDevice(device)) return 0;
+  if (isNamedDevice(device)) return 1;
+  return 2;
+}
+
+export function sortDevices(devices: Device[]): Device[] {
+  return [...devices].sort((a, b) => {
+    const byRank = rank(a) - rank(b);
+    if (byRank !== 0) return byRank;
+    return (b.rssi ?? -Infinity) - (a.rssi ?? -Infinity);
+  });
+}
+
+export function partitionDevices(devices: Device[]): { named: Device[]; unnamed: Device[] } {
+  const sorted = sortDevices(devices);
+  return {
+    named: sorted.filter((d) => rank(d) < 2),
+    unnamed: sorted.filter((d) => rank(d) === 2),
+  };
+}

--- a/apps/mobile/src/features/connection/services/device-connection-manager/device-utils.ts
+++ b/apps/mobile/src/features/connection/services/device-connection-manager/device-utils.ts
@@ -2,9 +2,11 @@ import { BluetoothDevice } from "react-native-bluetooth-classic";
 import type { Device } from "~/shared/types/device";
 
 export function bluetoothDeviceToDevice(d: BluetoothDevice): Device {
+  const hasName = !!d.name && d.name !== d.address;
   return {
     id: d.address,
     type: "bluetooth-classic",
-    name: d.name + " (" + d.id.slice(-11) + ")",
+    name: hasName ? d.name : "",
+    rssi: d.rssi?.valueOf(),
   };
 }

--- a/apps/mobile/src/features/connection/services/device-connection-manager/device-utils.ts
+++ b/apps/mobile/src/features/connection/services/device-connection-manager/device-utils.ts
@@ -2,11 +2,12 @@ import { BluetoothDevice } from "react-native-bluetooth-classic";
 import type { Device } from "~/shared/types/device";
 
 export function bluetoothDeviceToDevice(d: BluetoothDevice): Device {
-  const hasName = !!d.name && d.name !== d.address;
+  // Keep the raw name even when it's just the MAC: many MultispeQs have no
+  // friendly name, and the row still surfaces the bracketed sticker ID below it.
   return {
     id: d.address,
     type: "bluetooth-classic",
-    name: hasName ? d.name : "",
+    name: d.name ?? "",
     rssi: d.rssi?.valueOf(),
   };
 }

--- a/apps/mobile/src/shared/i18n/locales/en-US/connection.json
+++ b/apps/mobile/src/shared/i18n/locales/en-US/connection.json
@@ -37,6 +37,7 @@
     "scanning": "Scanning…",
     "pair": "Pair",
     "pairing": "Pairing…",
+    "seeMoreDevices": "See more devices ({{count}})",
     "helperText": "Can't find your device? Hold the button on the MultispeQ for 3 seconds."
   },
   "chip": {

--- a/apps/mobile/src/shared/i18n/locales/nl-NL/connection.json
+++ b/apps/mobile/src/shared/i18n/locales/nl-NL/connection.json
@@ -37,6 +37,7 @@
     "scanning": "Zoeken…",
     "pair": "Koppelen",
     "pairing": "Koppelen…",
+    "seeMoreDevices": "Meer apparaten tonen ({{count}})",
     "helperText": "Vind je je apparaat niet? Houd de knop op de MultispeQ 3 seconden ingedrukt."
   },
   "chip": {


### PR DESCRIPTION
Closes OJD-1552 — https://linear.app/openjii/issue/OJD-1552

## Context
Reported by Tom: in the mobile device sheet, MultispeQ units get lost in a long list of nearby Bluetooth devices, and the MAC ID — printed on the MultispeQ sticker, shown in brackets after the name — was truncated and only partly visible. Many MultispeQs have **no friendly name and advertise as a bare MAC address**, so the bracketed 4-part sticker ID is the only way a user recognizes their unit.

## Changes
- **Sorting** (`device-sort.ts`): ranks scanned devices — friendly-named devices first, MAC-only devices after; stronger RSSI breaks ties within a rank.
- **Bracketed sticker ID always visible**: the name is no longer concatenated with the address into one truncated line. The row shows the device name (or full MAC if it has none) on line 1 and the **4-part** MAC `(11:16:70:80)` on its own line below, alongside signal strength — so it can never be truncated. This matches the last 4 octets printed on the MultispeQ sticker.
- **MAC-named devices stay recognizable**: the raw name is kept even when it equals the MAC, so nameless MultispeQs still render the bracketed sticker ID.
- **See more devices**: friendly-named devices render immediately; MAC-only devices collapse behind a `See more devices (N)` expander (resets when the sheet closes). When *no* device has a friendly name, all devices show directly instead of an empty list above the expander.
- `device-utils.ts` carries `rssi` for signal display and tie-breaking.
- Added `seeMoreDevices` string (en-US + nl-NL) and `device-sort.test.ts` (7 cases).

## Testing
- `vitest` connection suite: 63 passed. `device-sort` test: 7 passed.
- tsc + eslint clean on touched files.
- Built and ran on a physical device; confirmed with the reporter that a nameless MultispeQ now shows its `(xx:xx:xx:xx)` sticker ID.

## Follow-up (not in this PR)
- The sheet scans via `startDiscovery` (only actively-advertising devices). A richer `getBluetoothClassicDevices` (bonded + connected + discovered, deduped) exists but isn't wired into this sheet.
- Pinning MultispeQs to the very top isn't done: a nameless MultispeQ is indistinguishable from any other MAC-only device without a known MAC OUI prefix.