### PR TITLE
fix(mobile): show experiment name prefix on Measure button (OJD-1551)

### DIFF
--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/experiment-selection-step.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/experiment-selection-step.tsx
@@ -18,6 +18,7 @@ import { Button } from "~/shared/ui/Button";
 import { Input } from "~/shared/ui/Input";
 import { Tag } from "~/shared/ui/Tag";
 import { useThemeColors } from "~/shared/ui/hooks/use-theme-colors";
+import { ellipsize } from "~/shared/utils/ellipsize";
 
 import { ExperimentCard } from "./experiment-card";
 import { OfflineModeIndicator } from "./offline-mode-indicator";
@@ -170,7 +171,7 @@ export function ExperimentSelectionStep() {
           title={
             selectedExperiment
               ? t("experimentSelection.startNamedFlow", {
-                  label: selectedExperiment.label.split(" ")[0].toLowerCase(),
+                  label: ellipsize(selectedExperiment.label.trim(), 21),
                 })
               : t("experimentSelection.startFlow")
           }


### PR DESCRIPTION
## Problem

On the measurement-flow experiment selection step, tapping an experiment card updates the bottom primary button to read **"Measure {{label}}"**. The label was derived with `selectedExperiment.label.split(" ")[0].toLowerCase()` — only the **first space-separated word**.

Most trials are named like `2026 - Tomato Trial`, so every one collapsed to **"Measure 2026"** and it was impossible to tell which experiment was actually selected.

## Fix

Show a short prefix of the full name (first ~20 chars + ellipsis, original casing) instead of just the first word, reusing the existing `ellipsize` util (`apps/mobile/src/shared/utils/ellipsize.ts`).

```diff
- label: selectedExperiment.label.split(" ")[0].toLowerCase(),
+ label: ellipsize(selectedExperiment.label.trim(), 21),
```

Result: `2026 - Tomato Trial` → button reads "Measure 2026 - Tomato Tr…", so distinct `2026 - …` trials are now distinguishable.

No translation changes needed — `startNamedFlow` already interpolates `{{label}}`.

## Verification

- eslint clean on the file; `tsc --noEmit` passes for the mobile app.
- Fallback "Start measurement" still shows when nothing is selected.

Closes OJD-1551.