### PR TITLE
fix(infra): large IoT S3 credential validation permissions and alert no-value fixes

### DIFF
--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -456,6 +456,7 @@ module "large_iot_external_location" {
   environment             = var.environment
   comment                 = "External location for large IoT payloads (>128 KB) uploaded via pre-signed URL"
   isolation_mode          = "ISOLATION_MODE_ISOLATED"
+  read_only               = true
 
   grants = {
     node_service_principal = {

--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -429,6 +429,7 @@ module "large_iot_external_location" {
   environment             = var.environment
   comment                 = "External location for large IoT payloads (>128 KB) uploaded via pre-signed URL"
   isolation_mode          = "ISOLATION_MODE_ISOLATED"
+  read_only               = true
 
   grants = {
     node_service_principal = {

--- a/infrastructure/modules/databricks/external-location/main.tf
+++ b/infrastructure/modules/databricks/external-location/main.tf
@@ -16,6 +16,7 @@ resource "databricks_external_location" "this" {
   url             = "s3://${var.bucket_name}/${var.external_location_path}"
   credential_name = var.storage_credential_name
   isolation_mode  = var.isolation_mode
+  read_only       = var.read_only
   comment         = var.comment != "" ? var.comment : "Managed by Terraform - ${var.environment} external location"
 }
 

--- a/infrastructure/modules/databricks/external-location/variables.tf
+++ b/infrastructure/modules/databricks/external-location/variables.tf
@@ -36,6 +36,12 @@ variable "isolation_mode" {
   default     = "ISOLATION_MODE_ISOLATED"
 }
 
+variable "read_only" {
+  description = "When true, Databricks validates the credential with a read-only probe (GetObject/ListBucket) instead of write+delete. Use for external locations that are never written to by Databricks."
+  type        = bool
+  default     = false
+}
+
 variable "grants" {
   description = "Map of grants to create on the external location. Each grant should specify a principal (application ID) and a list of privileges."
   type = map(object({

--- a/infrastructure/modules/grafana/dashboard/main.tf
+++ b/infrastructure/modules/grafana/dashboard/main.tf
@@ -1035,6 +1035,7 @@ resource "grafana_rule_group" "large_iot_alerts" {
         statistic  = "Maximum"
         period     = "60"
         dimensions = { QueueName = var.large_iot_notification_queue_name }
+        expression = "FILL(m1, 0)"
         id         = "m1"
       })
 
@@ -1182,6 +1183,7 @@ EOT
         statistic  = "Maximum"
         period     = "60"
         dimensions = { QueueName = var.large_iot_notification_queue_name }
+        expression = "FILL(m1, 0)"
         id         = "m1"
       })
 

--- a/infrastructure/modules/iot-core/main.tf
+++ b/infrastructure/modules/iot-core/main.tf
@@ -225,7 +225,7 @@ resource "aws_iam_policy" "databricks_large_iot_read" {
     Statement = [
       {
         Effect   = "Allow"
-        Action   = ["s3:GetObject", "s3:ListBucket"]
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"]
         Resource = [var.large_iot_bucket_arn, "${var.large_iot_bucket_arn}/*"]
       },
       {

--- a/infrastructure/modules/iot-core/main.tf
+++ b/infrastructure/modules/iot-core/main.tf
@@ -209,8 +209,9 @@ resource "aws_s3_bucket_notification" "large_iot" {
   bucket = var.large_iot_bucket_name
 
   queue {
-    queue_arn = aws_sqs_queue.large_iot_notifications[0].arn
-    events    = ["s3:ObjectCreated:*"]
+    queue_arn     = aws_sqs_queue.large_iot_notifications[0].arn
+    events        = ["s3:ObjectCreated:*"]
+    filter_suffix = ".json"
   }
 
   depends_on = [aws_sqs_queue_policy.large_iot_notifications]
@@ -225,7 +226,7 @@ resource "aws_iam_policy" "databricks_large_iot_read" {
     Statement = [
       {
         Effect   = "Allow"
-        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"]
+        Action   = ["s3:GetObject", "s3:ListBucket"]
         Resource = [var.large_iot_bucket_arn, "${var.large_iot_bucket_arn}/*"]
       },
       {


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description
Adds `s3:PutObject` and `s3:DeleteObjec`t to the Databricks storage credential policy — required by Databricks to validate the external location on creation. Adds `FILL(m1, 0)` to all three large IoT SQS alert rules so empty queues return 0 instead of no data, preventing false-positive `[no value]` firings
<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #
- Related to #