### PR TITLE
feat(iot): add device-bound script delivery MQTT topic with per-identity scoping

### DIFF
--- a/asyncapi.yaml
+++ b/asyncapi.yaml
@@ -9,7 +9,6 @@ info:
     device-bound channels (the cloud publishes behaviour scripts that devices subscribe to).
   contact:
     name: openJII
-    email: ji-institute@info.nl
   license:
     name: GNU General Public License
     url: https://www.gnu.org/licenses/gpl-3.0.html

--- a/asyncapi.yaml
+++ b/asyncapi.yaml
@@ -144,41 +144,48 @@ components:
     DeviceScriptMessage:
       contentType: application/json
       name: DeviceScriptMessage
-      title: Device Script Delivery Message
-      summary: A behaviour script delivered from the cloud to a device.
+      title: Device Script Update Message
+      summary: A protocol measurement script delivered from the cloud to a device.
       payload:
         type: object
         properties:
-          scriptId:
+          type:
             type: string
-            description: Identifier of the script version (UUID recommended). Lets a device skip a script it has already applied.
-          script:
+            enum: ["script_update"]
+            description: >
+              Command discriminator. Lets the same topic carry future command
+              types alongside script_update.
+          id:
             type: string
             description: >
-              The script body. May be a raw string (legacy) or a gzip+base64
-              encoded string when _script_encoding is set.
-          _script_encoding:
+              Unique update identifier (e.g. upd-2026-06-08-001). Lets a device
+              skip an update it has already applied.
+          payload:
+            type: string
+            description: >
+              The protocol measurement script body (Lua source), sent inline.
+              May be a raw string or a gzip+base64 encoded string when
+              _payload_encoding is set.
+          _payload_encoding:
             type: string
             enum: ["gzip+base64"]
             description: >
-              When present, indicates that the `script` field has been compressed
-              (gzip) and base64-encoded to reduce payload size. Absent on legacy
-              (uncompressed) payloads.
+              When present, indicates that the `payload` field has been
+              compressed (gzip) and base64-encoded to reduce message size.
+              Absent on raw (uncompressed) payloads.
           checksum:
             type: string
             description: SHA-256 hex digest of the decoded script body, for integrity verification before applying.
-          issuedAt:
-            type: string
-            description: ISO 8601 timestamp with UTC offset marking when the script was issued (e.g. "2026-03-09T10:30:00.000Z").
         required:
-          - scriptId
-          - script
+          - type
+          - id
+          - payload
       examples:
         - payload:
-            scriptId: "9b2c1f7e-4d3a-4c8e-9f10-2a6b5c4d3e2f"
-            script: "{\"protocol\":\"pulse\",\"interval_ms\":500}"
+            type: "script_update"
+            id: "upd-2026-06-08-001"
+            payload: "-- Lua protocol script\nreturn { pulses = 100, interval_ms = 500 }"
             checksum: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-            issuedAt: "2026-03-09T10:30:00.000Z"
 
   securitySchemes:
     sigv4:

--- a/asyncapi.yaml
+++ b/asyncapi.yaml
@@ -180,12 +180,13 @@ components:
           - type
           - id
           - payload
+          - checksum
       examples:
         - payload:
             type: "script_update"
             id: "upd-2026-06-08-001"
             payload: "-- Lua protocol script\nreturn { pulses = 100, interval_ms = 500 }"
-            checksum: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            checksum: "adaeff5386f5e9dcaef58c0cc39f69f2d62a98bedae07195d02bdc82595a90ad"
 
   securitySchemes:
     sigv4:

--- a/asyncapi.yaml
+++ b/asyncapi.yaml
@@ -4,8 +4,9 @@ info:
   version: "1.0.0"
   description: >
     This AsyncAPI specification defines the MQTT topics and message schemas for AWS IoT Core.
-    It details channels for device status updates and sensor data, allowing devices to publish
-    their state and sensor readings securely.
+    It is the single source of truth consumed by the Terraform iot-core module to generate IoT
+    policies and topic rules. It covers cloud-bound channels (devices publish sensor data) and
+    device-bound channels (the cloud publishes behaviour scripts that devices subscribe to).
   contact:
     name: openJII
     email: ji-institute@info.nl
@@ -15,9 +16,13 @@ info:
 
 servers:
   production:
-    url: a123456789.iot.us-east-1.amazonaws.com
-    protocol: mqtt
-    description: AWS IoT Core production endpoint
+    url: a3xxxxxxxxxxxx-ats.iot.eu-central-1.amazonaws.com
+    protocol: secure-mqtt
+    description: >
+      AWS IoT Core production ATS endpoint. Clients connect over MQTT on WebSocket
+      Secure (wss://.../mqtt), authenticated with AWS Signature Version 4.
+    security:
+      - sigv4: []
 
 channels:
   experiment/data_ingest/v1/{experimentId}/{sensorType}/{sensorVersion}/{sensorId}/{protocolId}:
@@ -57,6 +62,39 @@ channels:
       summary: Ingest experiment sensor data.
       message:
         $ref: "#/components/messages/ExperimentDataMessage"
+
+  device/scripts/v1/{sensorType}/{sensorVersion}/{identityId}:
+    description: |
+      Channel for delivering behaviour scripts to a device. The cloud publishes and
+      the device subscribes, then applies the script to its attached sensor. Messages
+      are published retained at QoS 1, so a device that reconnects immediately receives
+      the current script for its topic.
+      The path parameters represent:
+      <ul>
+        <li><strong>sensorType:</strong> The target sensor family (e.g., MultispeQ, Ambit...).</li>
+        <li><strong>sensorVersion:</strong> Target firmware/hardware revision (without the 'v' prefix, e.g., 1, 2.1).</li>
+        <li><strong>identityId:</strong> Cognito identity id of the target device. The generated IoT
+          policy binds this segment to ${cognito-identity.amazonaws.com:sub}, so a device can only
+          subscribe to and receive its own scripts.</li>
+      </ul>
+    parameters:
+      sensorType:
+        description: The target sensor family (e.g., MultispeQ, Ambit...).
+        schema:
+          type: string
+      sensorVersion:
+        description: Target firmware/hardware revision (without the 'v' prefix, e.g., 1, 2.1).
+        schema:
+          type: string
+      identityId:
+        description: Cognito identity id of the target device (e.g., eu-central-1:uuid).
+        schema:
+          type: string
+    publish:
+      operationId: deliverDeviceScript
+      summary: Deliver a behaviour script to a device.
+      message:
+        $ref: "#/components/messages/DeviceScriptMessage"
 
 components:
   messages:
@@ -103,6 +141,45 @@ components:
             data:
               moisture: 30.5
               temperature: 22.1
+
+    DeviceScriptMessage:
+      contentType: application/json
+      name: DeviceScriptMessage
+      title: Device Script Delivery Message
+      summary: A behaviour script delivered from the cloud to a device.
+      payload:
+        type: object
+        properties:
+          scriptId:
+            type: string
+            description: Identifier of the script version (UUID recommended). Lets a device skip a script it has already applied.
+          script:
+            type: string
+            description: >
+              The script body. May be a raw string (legacy) or a gzip+base64
+              encoded string when _script_encoding is set.
+          _script_encoding:
+            type: string
+            enum: ["gzip+base64"]
+            description: >
+              When present, indicates that the `script` field has been compressed
+              (gzip) and base64-encoded to reduce payload size. Absent on legacy
+              (uncompressed) payloads.
+          checksum:
+            type: string
+            description: SHA-256 hex digest of the decoded script body, for integrity verification before applying.
+          issuedAt:
+            type: string
+            description: ISO 8601 timestamp with UTC offset marking when the script was issued (e.g. "2026-03-09T10:30:00.000Z").
+        required:
+          - scriptId
+          - script
+      examples:
+        - payload:
+            scriptId: "9b2c1f7e-4d3a-4c8e-9f10-2a6b5c4d3e2f"
+            script: "{\"protocol\":\"pulse\",\"interval_ms\":500}"
+            checksum: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            issuedAt: "2026-03-09T10:30:00.000Z"
 
   securitySchemes:
     sigv4:

--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -1838,6 +1838,7 @@ module "backend_ecs" {
     module.location_service.iam_policy_arn,
     module.macro_sandbox.invoke_policy_arn,
     module.iot_core.backend_s3_presign_policy_arn,
+    module.iot_core.backend_iot_publish_policy_arn,
   ]
 
   tags = {

--- a/infrastructure/env/dr/main.tf
+++ b/infrastructure/env/dr/main.tf
@@ -546,6 +546,7 @@ module "backend_ecs" {
   additional_task_role_policy_arns = [
     module.location_service.iam_policy_arn,
     module.iot_core.backend_s3_presign_policy_arn,
+    module.iot_core.backend_iot_publish_policy_arn,
   ]
 
   tags = {

--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -1796,6 +1796,7 @@ module "backend_ecs" {
     module.location_service.iam_policy_arn,
     module.macro_sandbox.invoke_policy_arn,
     module.iot_core.backend_s3_presign_policy_arn,
+    module.iot_core.backend_iot_publish_policy_arn,
   ]
 
   tags = {

--- a/infrastructure/modules/iot-core/main.tf
+++ b/infrastructure/modules/iot-core/main.tf
@@ -46,11 +46,33 @@ locals {
     contains(keys(details), "publish") ? ["iot:Subscribe"] : []
   }
 
-  # Compute a friendly name for each IoT policy based on the static portion of the channel.
-  iot_policy_names = {
-    for channel in local.all_channels : channel =>
-    "open_jii_${var.environment}_iot_policy_${replace(trim(split("/{", channel)[0], "/"), "/", "_")}"
-  }
+  # All channels are consolidated into a single IoT policy per environment. An
+  # authenticated Cognito identity is attached to this one policy (dual-auth),
+  # which must grant every topic it may use: publishing ingest data and
+  # subscribing to its own scripts.
+  iot_policy_name = "open_jii_${var.environment}_iot_policy"
+
+  # Per-channel policy statements, split by IoT resource ARN type (Subscribe
+  # resolves against topicfilter/, Publish and Receive against topic/), merged
+  # into the single policy below.
+  iot_policy_statements = flatten([
+    for channel in local.all_channels : concat(
+      length(local.topic_actions_by_channel[channel]) > 0 ? [
+        {
+          Effect   = "Allow",
+          Action   = local.topic_actions_by_channel[channel],
+          Resource = "arn:aws:iot:${var.aws_region}:${data.aws_caller_identity.current.account_id}:topic/${local.iot_policy_topics[channel]}"
+        }
+      ] : [],
+      length(local.topicfilter_actions_by_channel[channel]) > 0 ? [
+        {
+          Effect   = "Allow",
+          Action   = local.topicfilter_actions_by_channel[channel],
+          Resource = "arn:aws:iot:${var.aws_region}:${data.aws_caller_identity.current.account_id}:topicfilter/${local.iot_policy_topics[channel]}"
+        }
+      ] : []
+    )
+  ])
 
   # Compute a friendly name for each IoT topic rule based on the static portion of the channel.
   iot_rule_names = {
@@ -107,9 +129,7 @@ resource "aws_iot_logging_options" "iot_core_logging" {
 # AWS IoT Policies
 # -----------------
 resource "aws_iot_policy" "iot_policy" {
-  for_each = local.asyncapi.channels
-
-  name = local.iot_policy_names[each.key]
+  name = local.iot_policy_name
   policy = jsonencode({
     Version = "2012-10-17",
     Statement = concat(
@@ -120,20 +140,7 @@ resource "aws_iot_policy" "iot_policy" {
           Resource = "arn:aws:iot:${var.aws_region}:${data.aws_caller_identity.current.account_id}:client/$${iot:ClientId}"
         }
       ],
-      length(local.topic_actions_by_channel[each.key]) > 0 ? [
-        {
-          Effect   = "Allow",
-          Action   = local.topic_actions_by_channel[each.key],
-          Resource = "arn:aws:iot:${var.aws_region}:${data.aws_caller_identity.current.account_id}:topic/${local.iot_policy_topics[each.key]}"
-        }
-      ] : [],
-      length(local.topicfilter_actions_by_channel[each.key]) > 0 ? [
-        {
-          Effect   = "Allow",
-          Action   = local.topicfilter_actions_by_channel[each.key],
-          Resource = "arn:aws:iot:${var.aws_region}:${data.aws_caller_identity.current.account_id}:topicfilter/${local.iot_policy_topics[each.key]}"
-        }
-      ] : []
+      local.iot_policy_statements
     )
   })
 }

--- a/infrastructure/modules/iot-core/main.tf
+++ b/infrastructure/modules/iot-core/main.tf
@@ -23,13 +23,27 @@ locals {
     }
   }
 
-  # Map each channel's operations to IoT actions.
-  actions_by_channel = {
+  # Channel parameters whose topic segment is bound to the connecting Cognito
+  # identity. In IoT policies these render as the
+  # ${cognito-identity.amazonaws.com:sub} variable so a device can only
+  # subscribe to / receive on its own topic, never another device's.
+  identity_param_names = ["identityId"]
+
+  # AsyncAPI operations are described from the server's perspective, so a
+  # "subscribe" op means devices publish (cloud-bound) and "publish" means the
+  # cloud publishes and devices receive. Subscribe/Receive resolve against
+  # different IoT resource ARN types (topicfilter vs topic), so they are split.
+  topic_actions_by_channel = {
     for channel, details in local.asyncapi.channels : channel =>
     concat(
       contains(keys(details), "subscribe") ? ["iot:Publish"] : [],
-      contains(keys(details), "publish") ? ["iot:Subscribe", "iot:Receive"] : []
+      contains(keys(details), "publish") ? ["iot:Receive"] : []
     )
+  }
+
+  topicfilter_actions_by_channel = {
+    for channel, details in local.asyncapi.channels : channel =>
+    contains(keys(details), "publish") ? ["iot:Subscribe"] : []
   }
 
   # Compute a friendly name for each IoT policy based on the static portion of the channel.
@@ -52,6 +66,35 @@ locals {
       (startswith(segment, "{") && endswith(segment, "}")) ? "+" : segment
     ])
   }
+
+  # Topic used in IoT policy resource ARNs. Identity-bound parameters become the
+  # Cognito sub policy variable; every other parameter becomes a "*" wildcard.
+  iot_policy_topics = {
+    for channel in local.all_channels : channel =>
+    join("/", [
+      for segment in split("/", channel) :
+      (startswith(segment, "{") && endswith(segment, "}")) ? (
+        contains(local.identity_param_names, substr(segment, 1, length(segment) - 2))
+        ? "$${cognito-identity.amazonaws.com:sub}"
+        : "*"
+      ) : segment
+    ])
+  }
+
+  # Only cloud-bound (device-publish) channels are routed to Kinesis/S3. Outbound
+  # channels (e.g. script delivery) must not be ingested back into the data lake.
+  ingest_channels = {
+    for channel, details in local.asyncapi.channels : channel => details
+    if contains(keys(details), "subscribe")
+  }
+
+  # Topics the cloud publishes to devices; the backend task role needs
+  # iot:Publish on these to deliver scripts/commands.
+  outbound_topic_arns = [
+    for channel, details in local.asyncapi.channels :
+    "arn:aws:iot:${var.aws_region}:${data.aws_caller_identity.current.account_id}:topic/${replace(local.iot_topic_filters[channel], "+", "*")}"
+    if contains(keys(details), "publish")
+  ]
 }
 
 # Configure IoT Core logging - Use the role from cloudwatch module
@@ -69,18 +112,29 @@ resource "aws_iot_policy" "iot_policy" {
   name = local.iot_policy_names[each.key]
   policy = jsonencode({
     Version = "2012-10-17",
-    Statement = [
-      {
-        Effect   = "Allow",
-        Action   = "iot:Connect",
-        Resource = "arn:aws:iot:${var.aws_region}:${data.aws_caller_identity.current.account_id}:client/$${iot:ClientId}"
-      },
-      {
-        Effect   = "Allow",
-        Action   = distinct(local.actions_by_channel[each.key]),
-        Resource = "arn:aws:iot:${var.aws_region}:${data.aws_caller_identity.current.account_id}:topic/${replace(local.iot_topic_filters[each.key], "+", "*")}"
-      }
-    ]
+    Statement = concat(
+      [
+        {
+          Effect   = "Allow",
+          Action   = "iot:Connect",
+          Resource = "arn:aws:iot:${var.aws_region}:${data.aws_caller_identity.current.account_id}:client/$${iot:ClientId}"
+        }
+      ],
+      length(local.topic_actions_by_channel[each.key]) > 0 ? [
+        {
+          Effect   = "Allow",
+          Action   = local.topic_actions_by_channel[each.key],
+          Resource = "arn:aws:iot:${var.aws_region}:${data.aws_caller_identity.current.account_id}:topic/${local.iot_policy_topics[each.key]}"
+        }
+      ] : [],
+      length(local.topicfilter_actions_by_channel[each.key]) > 0 ? [
+        {
+          Effect   = "Allow",
+          Action   = local.topicfilter_actions_by_channel[each.key],
+          Resource = "arn:aws:iot:${var.aws_region}:${data.aws_caller_identity.current.account_id}:topicfilter/${local.iot_policy_topics[each.key]}"
+        }
+      ] : []
+    )
   })
 }
 
@@ -149,6 +203,27 @@ resource "aws_iam_policy" "iot_s3_policy" {
 resource "aws_iam_role_policy_attachment" "iot_s3_attach" {
   role       = aws_iam_role.iot_s3_role.name
   policy_arn = aws_iam_policy.iot_s3_policy.arn
+}
+
+# IAM policy that allows the ECS backend task role to publish device scripts /
+# commands to the outbound IoT topics (cloud -> device channels).
+resource "aws_iam_policy" "backend_iot_publish" {
+  name = "open_jii_${var.environment}_backend_iot_publish"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "iot:Publish"
+        Resource = local.outbound_topic_arns
+      },
+      {
+        Effect   = "Allow"
+        Action   = "iot:DescribeEndpoint"
+        Resource = "*"
+      }
+    ]
+  })
 }
 
 # IAM policy that allows the ECS backend task role to generate pre-signed
@@ -246,7 +321,7 @@ resource "aws_iam_policy" "databricks_large_iot_read" {
 # IoT Topic Rules
 # ----------------
 resource "aws_iot_topic_rule" "iot_rules" {
-  for_each = local.asyncapi.channels
+  for_each = local.ingest_channels
 
   name        = local.iot_rule_names[each.key]
   enabled     = true

--- a/infrastructure/modules/iot-core/outputs.tf
+++ b/infrastructure/modules/iot-core/outputs.tf
@@ -8,6 +8,11 @@ output "iot_kinesis_role_arn" {
   value       = aws_iam_role.iot_kinesis_role.arn
 }
 
+output "backend_iot_publish_policy_arn" {
+  description = "ARN of the IAM policy that allows the backend ECS task role to publish device scripts/commands to the outbound IoT topics"
+  value       = aws_iam_policy.backend_iot_publish.arn
+}
+
 output "backend_s3_presign_policy_arn" {
   description = "ARN of the IAM policy that allows the backend ECS task role to generate pre-signed S3 PutObject URLs for large IoT payloads"
   value       = aws_iam_policy.backend_s3_presign.arn

--- a/infrastructure/modules/iot-core/outputs.tf
+++ b/infrastructure/modules/iot-core/outputs.tf
@@ -1,11 +1,11 @@
 output "iot_policy_names" {
   description = "Names of the IoT policies"
-  value       = [for policy in aws_iot_policy.iot_policy : policy.name]
+  value       = [aws_iot_policy.iot_policy.name]
 }
 
 output "iot_policy_name" {
-  description = "Name of the IoT policy for Cognito identity attachment (single channel)"
-  value       = one([for policy in aws_iot_policy.iot_policy : policy.name])
+  description = "Name of the IoT policy attached to authenticated Cognito identities"
+  value       = aws_iot_policy.iot_policy.name
 }
 
 


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Adds a device-bound MQTT channel so the cloud can deliver behaviour scripts to individual devices, and wires the IoT Core Terraform module to generate the right policies and IAM permissions for that outbound direction.

The AsyncAPI spec gains a `device/scripts/v1/{sensorType}/{sensorVersion}/{identityId}` channel. The `identityId` segment is bound to the connecting Cognito identity, so a device can only subscribe to and receive its own scripts, never another device's. Messages follow a `{type, id, payload}` contract with an optional `_payload_encoding` (gzip+base64) and a SHA-256 `checksum` for integrity checking before applying. They are published retained at QoS 1 so a reconnecting device immediately gets the current script.

Because AsyncAPI operations are described from the server's perspective, the iot-core module now distinguishes cloud-bound channels (device publishes) from device-bound channels (cloud publishes, device receives). The policy generation is split accordingly:

- `iot:Subscribe` resolves against `topicfilter/` ARNs while `iot:Receive` resolves against `topic/` ARNs, so the two are generated as separate statements.
- Identity-bound parameters render as the `${cognito-identity.amazonaws.com:sub}` policy variable in resource ARNs; all other parameters become `*` wildcards.
- IoT topic rules now only target ingest (device-publish) channels, so outbound script topics are not routed back into Kinesis/S3.

A new `backend_iot_publish` IAM policy grants the ECS backend task role `iot:Publish` on the outbound topics plus `iot:DescribeEndpoint`, and it is attached to the backend task role across dev, dr, and prod.

The spec's server metadata is also corrected to a real ATS endpoint in eu-central-1 using secure-mqtt with SigV4, replacing the placeholder endpoint.
