### PR TITLE
fix(mobile): surface protocol-unavailable distinctly and make precache recoverable (OJD-1564)

### DIFF
--- a/apps/mobile/src/features/experiments/hooks/__tests__/use-precached-experiment-data.test.ts
+++ b/apps/mobile/src/features/experiments/hooks/__tests__/use-precached-experiment-data.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { usePrecachedExperimentData } from "../use-precached-experiment-data";
+
+const { mockGetFlow, mockGetProtocol, mockGetMacro } = vi.hoisted(() => ({
+  mockGetFlow: vi.fn(),
+  mockGetProtocol: vi.fn(),
+  mockGetMacro: vi.fn(),
+}));
+
+vi.mock("~/shared/api/tsr", () => ({
+  tsr: {
+    experiments: { getFlow: { query: (...a: unknown[]) => mockGetFlow(...a) } },
+    protocols: { getProtocol: { query: (...a: unknown[]) => mockGetProtocol(...a) } },
+    macros: { getMacro: { query: (...a: unknown[]) => mockGetMacro(...a) } },
+  },
+}));
+
+function flowWith(protocolIds: string[], macroIds: string[] = []) {
+  return {
+    body: {
+      graph: {
+        nodes: [
+          ...protocolIds.map((id) => ({ type: "measurement", content: { protocolId: id } })),
+          ...macroIds.map((id) => ({ type: "analysis", content: { macroId: id } })),
+        ],
+      },
+    },
+  };
+}
+
+let queryClient: QueryClient;
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  mockGetProtocol.mockImplementation(({ params }: any) =>
+    Promise.resolve({ body: { id: params.id, name: `protocol ${params.id}` } }),
+  );
+  mockGetMacro.mockImplementation(({ params }: any) =>
+    Promise.resolve({ body: { id: params.id } }),
+  );
+});
+
+afterEach(() => {
+  queryClient.clear();
+});
+
+describe("usePrecachedExperimentData", () => {
+  it("succeeds and caches every protocol when all fetches resolve", async () => {
+    mockGetFlow.mockResolvedValue(flowWith(["proto-1", "proto-2"], ["macro-1"]));
+
+    const { result } = renderHook(() => usePrecachedExperimentData("exp-1"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.protocolIds).toEqual(["proto-1", "proto-2"]);
+    expect(queryClient.getQueryData(["protocol", "proto-1"])).toEqual({
+      body: { id: "proto-1", name: "protocol proto-1" },
+    });
+    expect(queryClient.getQueryData(["protocol", "proto-2"])).toBeDefined();
+  });
+
+  it("ends in an error state when any protocol fetch fails", async () => {
+    mockGetFlow.mockResolvedValue(flowWith(["proto-1", "proto-2"]));
+    mockGetProtocol.mockImplementation(({ params }: any) =>
+      params.id === "proto-2"
+        ? Promise.reject(new Error("offline"))
+        : Promise.resolve({ body: { id: params.id } }),
+    );
+
+    const { result } = renderHook(() => usePrecachedExperimentData("exp-1"), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData(["precache-experiment-data", "exp-1"])).toBeUndefined();
+  });
+
+  it("recovers on refetch once the failing fetch succeeds (reconnect path)", async () => {
+    mockGetFlow.mockResolvedValue(flowWith(["proto-1", "proto-2"]));
+    mockGetProtocol.mockImplementation(({ params }: any) =>
+      params.id === "proto-2"
+        ? Promise.reject(new Error("offline"))
+        : Promise.resolve({ body: { id: params.id } }),
+    );
+
+    const { result } = renderHook(() => usePrecachedExperimentData("exp-1"), { wrapper });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    // Simulate connectivity returning: the previously-failing fetch now resolves.
+    mockGetProtocol.mockImplementation(({ params }: any) =>
+      Promise.resolve({ body: { id: params.id } }),
+    );
+    await result.current.refetch();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queryClient.getQueryData(["protocol", "proto-2"])).toBeDefined();
+  });
+
+  it("deduplicates repeated protocol ids before fetching", async () => {
+    mockGetFlow.mockResolvedValue(flowWith(["proto-1", "proto-1", "proto-1"]));
+
+    const { result } = renderHook(() => usePrecachedExperimentData("exp-1"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.protocolIds).toEqual(["proto-1"]);
+    expect(mockGetProtocol).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/features/experiments/hooks/use-precached-experiment-data.ts
+++ b/apps/mobile/src/features/experiments/hooks/use-precached-experiment-data.ts
@@ -3,6 +3,45 @@ import type { FlowNode } from "~/features/measurement-flow/screens/measurement-f
 import { tsr } from "~/shared/api/tsr";
 import { uniq } from "~/shared/utils/uniq";
 
+// Refetch eligibility window. A successful precache won't churn on every
+// reconnect, but a stale/failed one becomes eligible to retry once the device
+// is online again (paired with the global refetchOnReconnect default).
+const PRECACHE_STALE_TIME = 5 * 60 * 1000;
+
+/**
+ * Fetches `assets` into the query cache, one query per id. Uses fetchQuery (not
+ * prefetchQuery) so a failed fetch rejects rather than being swallowed: if any
+ * asset fails we throw, marking the precache incomplete so it retries on
+ * reconnect instead of falsely reporting success and leaving a hole that blocks
+ * offline measurement.
+ */
+async function cacheAssets<T>(
+  ids: string[],
+  queryKeyPrefix: string,
+  queryFn: (id: string) => Promise<{ body: T }>,
+  queryClient: ReturnType<typeof useQueryClient>,
+): Promise<void> {
+  const results = await Promise.allSettled(
+    ids.map((id) =>
+      queryClient.fetchQuery({
+        queryKey: [queryKeyPrefix, id],
+        queryFn: () => queryFn(id),
+        // Background cache-warming: a failed asset is retried on reconnect and,
+        // for protocols, surfaced precisely at the measurement step. Don't blare
+        // a generic global-onError toast here.
+        meta: { suppressToast: true },
+      }),
+    ),
+  );
+
+  const failed = ids.filter((_, i) => results[i].status === "rejected");
+  if (failed.length > 0) {
+    throw new Error(
+      `Failed to cache ${failed.length}/${ids.length} ${queryKeyPrefix}(s): ${failed.join(", ")}`,
+    );
+  }
+}
+
 async function precacheExperimentMacrosFn(
   experimentId: string,
   queryClient: ReturnType<typeof useQueryClient>,
@@ -23,19 +62,14 @@ async function precacheExperimentMacrosFn(
   // Remove duplicates
   const uniqueMacroIds = uniq<string>(macroIds);
 
-  // Prefetch each macro
-  await Promise.all(
-    uniqueMacroIds.map((macroId: string) =>
-      queryClient.prefetchQuery({
-        queryKey: ["macro", macroId],
-        queryFn: async () => {
-          const response = await tsr.macros.getMacro.query({
-            params: { id: macroId },
-          });
-          return { body: response.body };
-        },
-      }),
-    ),
+  await cacheAssets(
+    uniqueMacroIds,
+    "macro",
+    async (macroId) => {
+      const response = await tsr.macros.getMacro.query({ params: { id: macroId } });
+      return { body: response.body };
+    },
+    queryClient,
   );
 
   return uniqueMacroIds;
@@ -61,19 +95,14 @@ async function precacheExperimentProtocolsFn(
   // Remove duplicates
   const uniqueProtocolIds = uniq<string>(protocolIds);
 
-  // Prefetch each protocol
-  await Promise.all(
-    uniqueProtocolIds.map((protocolId: string) =>
-      queryClient.prefetchQuery({
-        queryKey: ["protocol", protocolId],
-        queryFn: async () => {
-          const response = await tsr.protocols.getProtocol.query({
-            params: { id: protocolId },
-          });
-          return { body: response.body };
-        },
-      }),
-    ),
+  await cacheAssets(
+    uniqueProtocolIds,
+    "protocol",
+    async (protocolId) => {
+      const response = await tsr.protocols.getProtocol.query({ params: { id: protocolId } });
+      return { body: response.body };
+    },
+    queryClient,
   );
 
   return uniqueProtocolIds;
@@ -98,7 +127,12 @@ export function usePrecachedExperimentData(experimentId: string | undefined) {
     queryKey: ["precache-experiment-data", experimentId],
     queryFn: () => precacheExperimentDataFn(experimentId ?? "", queryClient),
     enabled: !!experimentId,
-    staleTime: Infinity,
+    // Incomplete precache (offline / failed assets) is expected and handled via
+    // retry-on-reconnect; don't surface a technical toast for it.
+    meta: { suppressToast: true },
+    // Finite staleTime (not Infinity) so an incomplete/errored precache becomes
+    // eligible to refetch when connectivity returns and fill the missing assets.
+    staleTime: PRECACHE_STALE_TIME,
     gcTime: Infinity,
   });
 }

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/measurement-node/measurement-node.test.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/measurement-node/measurement-node.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react-native";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MeasurementNode } from "./measurement-node";
+
+// Only the network / native boundaries and the deep state children are mocked;
+// MeasurementNode's own logic (the start-scan guards) runs unmocked.
+const {
+  useProtocol,
+  executeScan,
+  resetScan,
+  cancelCommand,
+  useConnectedDevice,
+  nextStep,
+  setScanResult,
+  setProtocolId,
+  navigateToQuestionFromOverview,
+  openDeviceSheet,
+  toastError,
+  playSound,
+} = vi.hoisted(() => ({
+  useProtocol: vi.fn(),
+  executeScan: vi.fn(),
+  resetScan: vi.fn(),
+  cancelCommand: vi.fn(),
+  useConnectedDevice: vi.fn(),
+  nextStep: vi.fn(),
+  setScanResult: vi.fn(),
+  setProtocolId: vi.fn(),
+  navigateToQuestionFromOverview: vi.fn(),
+  openDeviceSheet: vi.fn(),
+  toastError: vi.fn(),
+  playSound: vi.fn(),
+}));
+
+vi.mock("~/features/measurement-flow/hooks/use-protocol", () => ({
+  useProtocol: (id: string | undefined) => useProtocol(id),
+}));
+
+vi.mock("~/features/connection/hooks/use-scan-manager", () => ({
+  useScanner: () => ({
+    executeScan,
+    isScanning: false,
+    reset: resetScan,
+    result: undefined,
+    error: undefined,
+    cancelCommand,
+  }),
+}));
+
+vi.mock("~/features/connection/hooks/use-device-connection", () => ({
+  useConnectedDevice: () => useConnectedDevice(),
+}));
+
+vi.mock("~/features/connection/stores/use-device-sheet-store", () => ({
+  useDeviceSheetStore: (selector: (s: { open: () => void }) => unknown) =>
+    selector({ open: openDeviceSheet }),
+}));
+
+vi.mock("~/features/measurement-flow/stores/use-measurement-flow-store", () => ({
+  useMeasurementFlowStore: () => ({
+    nextStep,
+    setScanResult,
+    setProtocolId,
+    navigateToQuestionFromOverview,
+  }),
+}));
+
+vi.mock("sonner-native", () => ({
+  toast: { error: (...args: unknown[]) => toastError(...args) },
+}));
+
+vi.mock("~/features/measurement-flow/utils/play-sound", () => ({
+  playSound: () => playSound(),
+}));
+
+vi.mock("~/shared/ui/hooks/use-theme", () => ({
+  useTheme: () => ({
+    classes: { textMuted: "" },
+    colors: { brand: "#000", onPrimary: "#fff", primary: { dark: "#000" } },
+  }),
+}));
+
+// i18n: echo the key so assertions are unambiguous about which toast fired.
+vi.mock("~/shared/i18n", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// The render-state children touch other stores; stub them so the tests focus on
+// the Start button + start-scan guards that live in MeasurementNode itself.
+vi.mock("./components/ready-state", () => ({ ReadyState: () => null }));
+vi.mock("./components/error-state", () => ({ ErrorState: () => null }));
+vi.mock("./components/scanning-state", () => ({ ScanningState: () => null }));
+vi.mock("./components/no-device-state", () => ({ NoDeviceState: () => null }));
+
+const PROTOCOL = { name: "Photosynthesis", code: [{ foo: 1 }] };
+const START_KEY = "measurementFlow:measurementNode.startMeasurement";
+const PROTOCOL_UNAVAILABLE_KEY = "measurementFlow:measurementNode.toast.protocolUnavailable";
+const SCAN_ERROR_KEY = "measurementFlow:measurementNode.toast.scanError";
+
+const content = { params: {}, protocolId: "proto-1" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useConnectedDevice.mockReturnValue({ data: { id: "dev-1" } });
+  useProtocol.mockReturnValue({ protocol: PROTOCOL, isLoading: false });
+});
+
+describe("MeasurementNode start-scan guards", () => {
+  it("shows the protocol-unavailable toast (not scan error) when the protocol is uncached", () => {
+    useProtocol.mockReturnValue({ protocol: undefined, isLoading: false });
+
+    render(<MeasurementNode content={content} />);
+    fireEvent.press(screen.getByText(START_KEY));
+
+    expect(toastError).toHaveBeenCalledWith(PROTOCOL_UNAVAILABLE_KEY);
+    expect(toastError).not.toHaveBeenCalledWith(SCAN_ERROR_KEY);
+    expect(executeScan).not.toHaveBeenCalled();
+  });
+
+  it("disables the Start button while the protocol is still loading", () => {
+    useProtocol.mockReturnValue({ protocol: undefined, isLoading: true });
+
+    render(<MeasurementNode content={content} />);
+
+    expect(screen.getByText(START_KEY)).toBeDisabled();
+  });
+
+  it("runs the scan and advances when the protocol is available", async () => {
+    executeScan.mockResolvedValue({ result: 42 });
+
+    render(<MeasurementNode content={content} />);
+    fireEvent.press(screen.getByText(START_KEY));
+
+    await waitFor(() => expect(executeScan).toHaveBeenCalledWith(PROTOCOL));
+    expect(setScanResult).toHaveBeenCalledWith({ result: 42 });
+    expect(nextStep).toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("shows the generic scan-error toast when the scan itself fails", async () => {
+    executeScan.mockRejectedValue(new Error("device timeout"));
+
+    render(<MeasurementNode content={content} />);
+    fireEvent.press(screen.getByText(START_KEY));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledWith(SCAN_ERROR_KEY));
+    expect(nextStep).not.toHaveBeenCalled();
+  });
+
+  it("hides the Start button entirely when no device is connected", () => {
+    useConnectedDevice.mockReturnValue({ data: undefined });
+
+    render(<MeasurementNode content={content} />);
+
+    expect(screen.queryByText(START_KEY)).toBeNull();
+    expect(executeScan).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/measurement-node/measurement-node.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/measurement-node/measurement-node.tsx
@@ -31,7 +31,7 @@ interface MeasurementNodeProps {
 export function MeasurementNode({ content }: MeasurementNodeProps) {
   const { classes, colors } = useTheme();
   const { t } = useTranslation("measurementFlow");
-  const { protocol } = useProtocol(content.protocolId);
+  const { protocol, isLoading: protocolLoading } = useProtocol(content.protocolId);
   const {
     executeScan,
     isScanning,
@@ -80,13 +80,21 @@ export function MeasurementNode({ content }: MeasurementNodeProps) {
       toast.error(t("measurementFlow:measurementNode.toast.noProtocol"));
       return;
     }
+    // The protocol is fetched offline-first; if it never made it into the cache
+    // (offline + not previously downloaded) it's undefined here. Surface that
+    // distinctly instead of the generic scan error so the user — and telemetry —
+    // see the real cause.
+    if (!protocol) {
+      log.warn("protocol unavailable", {
+        protocolId: content.protocolId,
+        loading: protocolLoading,
+      });
+      toast.error(t("measurementFlow:measurementNode.toast.protocolUnavailable"));
+      return;
+    }
 
     resetScan();
     try {
-      if (!protocol) {
-        throw new Error("No protocol");
-      }
-
       const result = await executeScan(protocol);
       setScanResult(result);
       // Play system notification sound when measurement completes
@@ -157,6 +165,7 @@ export function MeasurementNode({ content }: MeasurementNodeProps) {
           <Button
             title={t("measurementFlow:measurementNode.startMeasurement")}
             onPress={handleStartScan}
+            isDisabled={protocolLoading}
             style={{ height: 44 }}
           />
         </View>

--- a/apps/mobile/src/shared/i18n/locales/en-US/measurement-flow.json
+++ b/apps/mobile/src/shared/i18n/locales/en-US/measurement-flow.json
@@ -145,6 +145,7 @@
     "toast": {
       "notConnected": "Not connected to sensor",
       "noProtocol": "No protocol selected",
+      "protocolUnavailable": "Protocol not available offline. Reconnect to download it.",
       "scanError": "Scan error"
     },
     "privacyNote": "Your (gps)location and full name will be stored amongst other measurements data. Note that these are publicly available.",

--- a/apps/mobile/src/shared/i18n/locales/nl-NL/measurement-flow.json
+++ b/apps/mobile/src/shared/i18n/locales/nl-NL/measurement-flow.json
@@ -145,6 +145,7 @@
     "toast": {
       "notConnected": "Geen verbinding met sensor",
       "noProtocol": "Geen protocol geselecteerd",
+      "protocolUnavailable": "Protocol niet offline beschikbaar. Maak verbinding om het te downloaden.",
       "scanError": "Scanfout"
     },
     "privacyNote": "Je (gps-)locatie en volledige naam worden samen met de meetgegevens opgeslagen. Houd er rekening mee dat deze openbaar zijn.",


### PR DESCRIPTION
## Why

Closes [OJD-1564](https://linear.app/openjii/issue/OJD-1564/intermittent-scan-error-blocks-offline-measurement-flow). Some users intermittently saw a generic **"Scan error"** that blocked the offline measurement flow; the only known workaround was going back online.

Root cause: a measurement node's protocol is fetched offline-first via `useProtocol(content.protocolId)`. When that protocol isn't in cache and the device is offline, `protocol` is `undefined`, and `measurement-node` threw `"No protocol"` which was caught and surfaced as the **generic** `scanError` toast — masking the real cause from both the user and telemetry. Reconnecting refetches the protocol, which is exactly why "go online" worked.

The cache is already persisted to disk, so the real gap is **coverage**: the per-experiment precache (`usePrecachedExperimentData`) used `prefetchQuery`, which **swallows per-asset errors**, so a partially-failed precache reported *success* and — with `staleTime: Infinity` — never retried for the session, leaving the protocol uncached until the next login.

## What

- **`measurement-node.tsx`** — replace the `"No protocol"` throw-into-generic-toast with an explicit guard that shows a specific `protocolUnavailable` message and logs the `protocolId`; disable the **Start** button while the protocol query is still loading so users can't tap into a guaranteed failure. The `try/catch` now wraps only `executeScan`, so `scanError` is reserved for genuine scan failures.
- **i18n** — add `measurementNode.toast.protocolUnavailable` to `en-US` and `nl-NL`.
- **`use-precached-experiment-data.ts`** — switch `prefetchQuery` → `fetchQuery` + `Promise.allSettled`, throwing if any asset fails (so the precache reports `error` instead of false success); drop `staleTime: Infinity` to a finite 5-min window so an incomplete precache becomes eligible to refetch on reconnect (via the global `refetchOnReconnect`) and fill the missing protocol without re-login; add `meta: { suppressToast: true }` so the now-possible offline error doesn't blare a technical toast.

## Tests

- `measurement-node.test.tsx` — protocol-unavailable shows the specific toast (not scan error) and skips `executeScan`; Start disabled while loading; scan success advances; genuine scan error preserved; no-device hides Start. 
- `use-precached-experiment-data.test.ts` — all-succeed caches protocols; a failed fetch → `isError` (the key new behavior); recovery via `refetch` (reconnect path); dedup of repeated protocol ids.

All 15 new tests pass; the changed files typecheck and lint clean. (Two unrelated pre-existing `main` failures — `ctf-rich-text.tsx` typecheck, `fetch-active-alerts.ts` lint — are untouched here.)

## Reviewer note

`OfflineModeIndicator` keys off `precachedData` truthiness, so it now appears only once **all** assets are cached (precache success) rather than after a partially-failed run — more accurate, but a visible behavior change.

## Out of scope (deferred follow-up)

Re-running the login prefetch on app foreground/reconnect (not just at login), per the ticket's noted follow-up.