### PR TITLE
fix(ci): make Codecov PR upload non-blocking

### DIFF
--- a/.github/actions/test-packages/action.yml
+++ b/.github/actions/test-packages/action.yml
@@ -108,7 +108,8 @@ runs:
         token: ${{ inputs.codecov-token }}
         files: apps/*/coverage.json,tooling/*/coverage.json,packages/*/coverage.json
         flags: affected
-        fail_ci_if_error: true
+        # Non-blocking: a Codecov-side upload/verification hiccup must not fail PR CI
+        fail_ci_if_error: false
         verbose: true
         override_branch: ${{ github.head_ref }}
         override_commit: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## What

Set `fail_ci_if_error: false` on the Codecov **PR** upload step in `.github/actions/test-packages/action.yml`.

## Why

Recent PRs (e.g. #1563, #1556, #1549) have been showing the "Build, Lint, & Test" job red with no Codecov status check posted. The root cause is **not** our tests or coverage thresholds — it's the Codecov uploader CLI's GPG signature self-verification failing during install:

```
gpg: no valid OpenPGP data found.
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
##[error]Process completed with exit code 1.
```

This is a known, intermittent `codecov-action` issue ([codecov-action#1876](https://github.com/codecov/codecov-action/issues/1876)) where importing Codecov's verification key flakes (keyserver/network), likely aggravated by the ongoing Codecov→Harness infra migration. Because the PR upload step used `fail_ci_if_error: true`, a Codecov-side hiccup became a hard PR blocker and suppressed the coverage status check.

Setting it to `false` means coverage still uploads when Codecov is healthy, but a Codecov outage no longer red-lines PRs. This matches `main-coverage.yml`, which already uses `fail_ci_if_error: false`.

## Scope

- One-line change (plus a comment). Minimal, intended to unblock the open PRs now.
- Follow-up option if flakiness persists: add `skip_validation: true` to skip the GPG integrity check entirely.

cc @petar-INFO
