### PR TITLE
fix(infra): scope iot:AttachPolicy IAM resource to * and remove unused iot_policy_arn variable

### DIFF
--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -1629,7 +1629,6 @@ module "backend_ecs" {
 
   enable_cognito_policy     = true
   cognito_identity_pool_arn = module.cognito.identity_pool_arn
-  iot_policy_arn            = module.iot_core.iot_policy_arns[0]
 
   # Secrets configuration
   secrets = [

--- a/infrastructure/env/dr/main.tf
+++ b/infrastructure/env/dr/main.tf
@@ -493,7 +493,6 @@ module "backend_ecs" {
 
   enable_cognito_policy     = true
   cognito_identity_pool_arn = module.cognito.identity_pool_arn
-  iot_policy_arn            = module.iot_core.iot_policy_arns[0]
 
   secrets = [
     { name = "AUTH_GITHUB_ID", valueFrom = "${module.auth_secrets.secret_arn}:AUTH_GITHUB_ID::" },

--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -1587,7 +1587,6 @@ module "backend_ecs" {
 
   enable_cognito_policy     = true
   cognito_identity_pool_arn = module.cognito.identity_pool_arn
-  iot_policy_arn            = module.iot_core.iot_policy_arns[0]
 
   # Secrets configuration
   secrets = [

--- a/infrastructure/modules/ecs/main.tf
+++ b/infrastructure/modules/ecs/main.tf
@@ -124,7 +124,7 @@ resource "aws_iam_role_policy" "ecs_task_cognito_policy" {
       {
         Effect   = "Allow"
         Action   = ["iot:AttachPolicy"]
-        Resource = var.iot_policy_arn != "" ? var.iot_policy_arn : "*"
+        Resource = "*"
       }
     ]
   })

--- a/infrastructure/modules/ecs/variables.tf
+++ b/infrastructure/modules/ecs/variables.tf
@@ -240,8 +240,3 @@ variable "cognito_identity_pool_arn" {
   default     = ""
 }
 
-variable "iot_policy_arn" {
-  description = "IoT policy ARN to scope the iot:AttachPolicy permission"
-  type        = string
-  default     = ""
-}

--- a/infrastructure/modules/iot-core/outputs.tf
+++ b/infrastructure/modules/iot-core/outputs.tf
@@ -8,10 +8,6 @@ output "iot_policy_name" {
   value       = one([for policy in aws_iot_policy.iot_policy : policy.name])
 }
 
-output "iot_policy_arns" {
-  description = "ARNs of the IoT policies"
-  value       = [for policy in aws_iot_policy.iot_policy : policy.arn]
-}
 
 output "iot_topic_rule_names" {
   description = "Names of the IoT Topic Rules"


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description
AWS IAM does not support resource-level scoping for iot:AttachPolicy — the action has no resource type defined, so Resource = "*" is required. The previous attempt to scope it to the IoT policy ARN caused authorization failures at runtime since the resource being evaluated is the Cognito identity ID, not the policy ARN.

Removes the unused iot_policy_arn variable from the ECS module and cleans up references in dev/prod/dr environments.

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #
- Related to #