### PR TITLE
feat(iot): isolate device script delivery into its own IoT policy, attach all policies per identity

### DIFF
--- a/apps/backend/.env.test
+++ b/apps/backend/.env.test
@@ -32,7 +32,7 @@ AWS_REGION=moon-base-1
 AWS_LOCATION_PLACE_INDEX_NAME=open-jii-places-test
 AWS_COGNITO_IDENTITY_POOL_ID=moon-base-1:test-pool-id
 AWS_COGNITO_DEVELOPER_PROVIDER_NAME=login.openjii.com
-AWS_IOT_POLICY_NAME=test-iot-policy
+AWS_IOT_POLICY_NAMES=test-iot-policy,test-iot-script-policy
 
 # AWS Lambda - Macro Sandbox
 AWS_LAMBDA_MACRO_SANDBOX_PYTHON_FUNCTION_NAME=test-macro-sandbox-python

--- a/apps/backend/src/common/config/aws.config.ts
+++ b/apps/backend/src/common/config/aws.config.ts
@@ -13,7 +13,7 @@ export default registerAs("aws", () => ({
     developerProviderName: process.env.AWS_COGNITO_DEVELOPER_PROVIDER_NAME,
   },
   iot: {
-    policyName: process.env.AWS_IOT_POLICY_NAME,
+    policyNames: process.env.AWS_IOT_POLICY_NAMES,
   },
   lambda: {
     macroSandboxPythonFunctionName: process.env.AWS_LAMBDA_MACRO_SANDBOX_PYTHON_FUNCTION_NAME,

--- a/apps/backend/src/common/modules/aws/services/cognito/cognito.service.spec.ts
+++ b/apps/backend/src/common/modules/aws/services/cognito/cognito.service.spec.ts
@@ -222,8 +222,9 @@ describe("CognitoService", () => {
   });
 
   describe("attachIotPolicy", () => {
-    it("should attach the IoT policy to the given identity", async () => {
+    it("should attach every configured IoT policy to the given identity", async () => {
       const identityId = "eu-central-1:identity-id-123";
+      const policyNames = process.env.AWS_IOT_POLICY_NAMES?.split(",") ?? [];
 
       iotMock.on(AttachPolicyCommand).resolves({});
 
@@ -231,11 +232,10 @@ describe("CognitoService", () => {
 
       assertSuccess(result);
       const calls = iotMock.commandCalls(AttachPolicyCommand);
-      expect(calls).toHaveLength(1);
-      expect(calls[0].args[0].input).toMatchObject({
-        policyName: process.env.AWS_IOT_POLICY_NAME,
-        target: identityId,
-      });
+      expect(calls).toHaveLength(policyNames.length);
+      expect(calls.map((call) => call.args[0].input)).toEqual(
+        policyNames.map((policyName) => ({ policyName, target: identityId })),
+      );
     });
 
     it("should return failure when IoT API call fails", async () => {

--- a/apps/backend/src/common/modules/aws/services/cognito/cognito.service.spec.ts
+++ b/apps/backend/src/common/modules/aws/services/cognito/cognito.service.spec.ts
@@ -224,7 +224,10 @@ describe("CognitoService", () => {
   describe("attachIotPolicy", () => {
     it("should attach every configured IoT policy to the given identity", async () => {
       const identityId = "eu-central-1:identity-id-123";
-      const policyNames = process.env.AWS_IOT_POLICY_NAMES?.split(",") ?? [];
+      const policyNames =
+        process.env.AWS_IOT_POLICY_NAMES?.split(",")
+          .map((name) => name.trim())
+          .filter(Boolean) ?? [];
 
       iotMock.on(AttachPolicyCommand).resolves({});
 

--- a/apps/backend/src/common/modules/aws/services/cognito/cognito.service.ts
+++ b/apps/backend/src/common/modules/aws/services/cognito/cognito.service.ts
@@ -26,12 +26,14 @@ export class CognitoService {
   async attachIotPolicy(identityId: string): Promise<Result<void>> {
     return tryCatch(
       async () => {
-        await this.iotClient.send(
-          new AttachPolicyCommand({
-            policyName: this.awsConfig.iotPolicyName,
-            target: identityId,
-          }),
-        );
+        for (const policyName of this.awsConfig.iotPolicyNames) {
+          await this.iotClient.send(
+            new AttachPolicyCommand({
+              policyName,
+              target: identityId,
+            }),
+          );
+        }
       },
       (error) => {
         if (error instanceof AppError) {

--- a/apps/backend/src/common/modules/aws/services/config/config.service.spec.ts
+++ b/apps/backend/src/common/modules/aws/services/config/config.service.spec.ts
@@ -43,8 +43,8 @@ describe("AwsConfigService", () => {
       );
     });
 
-    it("should return the correct iotPolicyName", () => {
-      expect(service.iotPolicyName).toBe(process.env.AWS_IOT_POLICY_NAME);
+    it("should return the correct iotPolicyNames", () => {
+      expect(service.iotPolicyNames).toEqual(process.env.AWS_IOT_POLICY_NAMES?.split(","));
     });
   });
 

--- a/apps/backend/src/common/modules/aws/services/config/config.service.spec.ts
+++ b/apps/backend/src/common/modules/aws/services/config/config.service.spec.ts
@@ -44,7 +44,11 @@ describe("AwsConfigService", () => {
     });
 
     it("should return the correct iotPolicyNames", () => {
-      expect(service.iotPolicyNames).toEqual(process.env.AWS_IOT_POLICY_NAMES?.split(","));
+      expect(service.iotPolicyNames).toEqual(
+        process.env.AWS_IOT_POLICY_NAMES?.split(",")
+          .map((name) => name.trim())
+          .filter(Boolean),
+      );
     });
   });
 

--- a/apps/backend/src/common/modules/aws/services/config/config.service.ts
+++ b/apps/backend/src/common/modules/aws/services/config/config.service.ts
@@ -29,8 +29,7 @@ export class AwsConfigService {
       cognitoDeveloperProviderName: this.configService.getOrThrow<string>(
         "aws.cognito.developerProviderName",
       ),
-      iotPolicyNames: this.configService
-        .getOrThrow<string>("aws.iot.policyNames")
+      iotPolicyNames: (this.configService.getOrThrow<string>("aws.iot.policyNames") ?? "")
         .split(",")
         .map((name) => name.trim())
         .filter(Boolean),

--- a/apps/backend/src/common/modules/aws/services/config/config.service.ts
+++ b/apps/backend/src/common/modules/aws/services/config/config.service.ts
@@ -29,7 +29,8 @@ export class AwsConfigService {
       cognitoDeveloperProviderName: this.configService.getOrThrow<string>(
         "aws.cognito.developerProviderName",
       ),
-      iotPolicyNames: (this.configService.getOrThrow<string>("aws.iot.policyNames") ?? "")
+      // get() (not getOrThrow): a missing value parses to [] and is rejected by the schema below.
+      iotPolicyNames: (this.configService.get<string>("aws.iot.policyNames") ?? "")
         .split(",")
         .map((name) => name.trim())
         .filter(Boolean),

--- a/apps/backend/src/common/modules/aws/services/config/config.service.ts
+++ b/apps/backend/src/common/modules/aws/services/config/config.service.ts
@@ -29,7 +29,11 @@ export class AwsConfigService {
       cognitoDeveloperProviderName: this.configService.getOrThrow<string>(
         "aws.cognito.developerProviderName",
       ),
-      iotPolicyName: this.configService.getOrThrow<string>("aws.iot.policyName"),
+      iotPolicyNames: this.configService
+        .getOrThrow<string>("aws.iot.policyNames")
+        .split(",")
+        .map((name) => name.trim())
+        .filter(Boolean),
       lambda: {
         macroSandboxPythonFunctionName: this.configService.getOrThrow<string>(
           "aws.lambda.macroSandboxPythonFunctionName",
@@ -100,8 +104,8 @@ export class AwsConfigService {
     return this.config.cognitoDeveloperProviderName;
   }
 
-  get iotPolicyName(): string {
-    return this.config.iotPolicyName;
+  get iotPolicyNames(): string[] {
+    return this.config.iotPolicyNames;
   }
 
   /**

--- a/apps/backend/src/common/modules/aws/services/config/config.types.ts
+++ b/apps/backend/src/common/modules/aws/services/config/config.types.ts
@@ -5,7 +5,7 @@ export interface AwsConfig {
   placeIndexName: string;
   cognitoIdentityPoolId: string;
   cognitoDeveloperProviderName: string;
-  iotPolicyName: string;
+  iotPolicyNames: string[];
   lambda: {
     macroSandboxPythonFunctionName: string;
     macroSandboxJavascriptFunctionName: string;
@@ -22,7 +22,7 @@ export const awsConfigSchema = z.object({
   placeIndexName: z.string().min(1),
   cognitoIdentityPoolId: z.string().min(1),
   cognitoDeveloperProviderName: z.string().min(1),
-  iotPolicyName: z.string().min(1),
+  iotPolicyNames: z.array(z.string().min(1)).min(1),
   lambda: z.object({
     macroSandboxPythonFunctionName: z.string().min(1),
     macroSandboxJavascriptFunctionName: z.string().min(1),

--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -1793,8 +1793,8 @@ module "backend_ecs" {
       value = module.cognito.developer_provider_name
     },
     {
-      name  = "AWS_IOT_POLICY_NAME"
-      value = module.iot_core.iot_policy_name
+      name  = "AWS_IOT_POLICY_NAMES"
+      value = join(",", module.iot_core.iot_policy_names)
     },
     {
       name  = "EMAIL_BASE_URL"

--- a/infrastructure/env/dr/main.tf
+++ b/infrastructure/env/dr/main.tf
@@ -536,7 +536,7 @@ module "backend_ecs" {
     { name = "AWS_REGION", value = var.aws_region },
     { name = "AWS_COGNITO_IDENTITY_POOL_ID", value = module.cognito.identity_pool_id },
     { name = "AWS_COGNITO_DEVELOPER_PROVIDER_NAME", value = module.cognito.developer_provider_name },
-    { name = "AWS_IOT_POLICY_NAME", value = module.iot_core.iot_policy_name },
+    { name = "AWS_IOT_POLICY_NAMES", value = join(",", module.iot_core.iot_policy_names) },
     { name = "POSTHOG_KEY", value = var.posthog_key },
     { name = "POSTHOG_HOST", value = var.posthog_host },
     { name = "NEXT_PUBLIC_BASE_URL", value = "https://${module.route53.environment_domain}" },

--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -1755,8 +1755,8 @@ module "backend_ecs" {
       value = module.cognito.developer_provider_name
     },
     {
-      name  = "AWS_IOT_POLICY_NAME"
-      value = module.iot_core.iot_policy_name
+      name  = "AWS_IOT_POLICY_NAMES"
+      value = join(",", module.iot_core.iot_policy_names)
     },
     {
       name  = "POSTHOG_KEY"

--- a/infrastructure/modules/iot-core/main.tf
+++ b/infrastructure/modules/iot-core/main.tf
@@ -7,22 +7,6 @@ locals {
   # Get all channel keys.
   all_channels = keys(local.asyncapi.channels)
 
-  # Compute, for each channel, a mapping of parameter name to its topic index.
-  # Inline computation without "let":  
-  # For each channel, we first filter out the parameter segments and remove the braces.
-  # Then, the topic index for each parameter is: static_count + its index in the filtered list + 1.
-  iot_parameter_to_topic_index = {
-    for channel in local.all_channels : channel =>
-    { for idx, name in [
-      for seg in split("/", channel) :
-      substr(seg, 1, length(seg) - 2) if startswith(seg, "{") && endswith(seg, "}")
-      ] : name => (length([
-        for seg in split("/", channel) : seg
-        if !(startswith(seg, "{") && endswith(seg, "}"))
-      ]) + idx + 1)
-    }
-  }
-
   # Channel parameters bound to the connecting Cognito identity. In the policy
   # these render as the ${cognito-identity.amazonaws.com:sub} variable so a device
   # can only subscribe to / receive on its own topic, never another device's.

--- a/infrastructure/modules/iot-core/main.tf
+++ b/infrastructure/modules/iot-core/main.tf
@@ -81,30 +81,7 @@ locals {
     if contains(keys(details), "subscribe")
   }
 
-  # Statements for the single env-wide IoT policy: every channel's permissions,
-  # split by the resource ARN type each action requires.
-  iot_policy_statements = flatten([
-    for channel in local.all_channels : concat(
-      length(local.topic_actions_by_channel[channel]) > 0 ? [
-        {
-          Effect   = "Allow",
-          Action   = local.topic_actions_by_channel[channel],
-          Resource = "arn:aws:iot:${var.aws_region}:${data.aws_caller_identity.current.account_id}:topic/${local.iot_policy_topics[channel]}"
-        }
-      ] : [],
-      length(local.topicfilter_actions_by_channel[channel]) > 0 ? [
-        {
-          Effect   = "Allow",
-          Action   = local.topicfilter_actions_by_channel[channel],
-          Resource = "arn:aws:iot:${var.aws_region}:${data.aws_caller_identity.current.account_id}:topicfilter/${local.iot_policy_topics[channel]}"
-        }
-      ] : []
-    )
-  ])
-
-  # Friendly name per channel. The policy is keyed by the ingest channel and keeps
-  # this derived name so the existing live policy is updated in place rather than
-  # renamed/replaced (a rename would break MQTT auth for connected devices).
+  # Friendly name per channel, derived from the channel's static prefix.
   iot_policy_names = {
     for channel in local.all_channels : channel =>
     "open_jii_${var.environment}_iot_policy_${replace(trim(split("/{", channel)[0], "/"), "/", "_")}"
@@ -120,12 +97,11 @@ resource "aws_iot_logging_options" "iot_core_logging" {
 # -----------------
 # AWS IoT Policies
 # -----------------
-# One IoT policy, keyed by the ingest channel so it keeps its existing resource
-# address and name (no replace of the live, attached policy). Its document grants
-# every channel's permissions, so the single policy the backend attaches to each
-# Cognito identity covers both ingest and script delivery.
+# One IoT policy per channel. The backend attaches every policy to each
+# authenticated Cognito identity, so adding a channel is additive: existing
+# policies keep their name and address and are never replaced.
 resource "aws_iot_policy" "iot_policy" {
-  for_each = local.ingest_channels
+  for_each = local.asyncapi.channels
 
   name = local.iot_policy_names[each.key]
   policy = jsonencode({
@@ -138,7 +114,20 @@ resource "aws_iot_policy" "iot_policy" {
           Resource = "arn:aws:iot:${var.aws_region}:${data.aws_caller_identity.current.account_id}:client/$${iot:ClientId}"
         }
       ],
-      local.iot_policy_statements
+      length(local.topic_actions_by_channel[each.key]) > 0 ? [
+        {
+          Effect   = "Allow",
+          Action   = local.topic_actions_by_channel[each.key],
+          Resource = "arn:aws:iot:${var.aws_region}:${data.aws_caller_identity.current.account_id}:topic/${local.iot_policy_topics[each.key]}"
+        }
+      ] : [],
+      length(local.topicfilter_actions_by_channel[each.key]) > 0 ? [
+        {
+          Effect   = "Allow",
+          Action   = local.topicfilter_actions_by_channel[each.key],
+          Resource = "arn:aws:iot:${var.aws_region}:${data.aws_caller_identity.current.account_id}:topicfilter/${local.iot_policy_topics[each.key]}"
+        }
+      ] : []
     )
   })
 }

--- a/infrastructure/modules/iot-core/outputs.tf
+++ b/infrastructure/modules/iot-core/outputs.tf
@@ -1,11 +1,6 @@
 output "iot_policy_names" {
-  description = "Names of the IoT policies"
+  description = "Names of the IoT policies attached to each authenticated Cognito identity (one per channel)"
   value       = [for policy in aws_iot_policy.iot_policy : policy.name]
-}
-
-output "iot_policy_name" {
-  description = "Name of the IoT policy attached to authenticated Cognito identities"
-  value       = one([for policy in aws_iot_policy.iot_policy : policy.name])
 }
 
 


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Splits IoT permissions into one policy **per channel** and has the backend attach
**every** policy to each authenticated Cognito identity, instead of folding all
topics into a single policy.

- **Ingest policy** (`open_jii_<env>_iot_policy_experiment_data_ingest_v1`):
  back to ingest-only (`Connect` + `iot:Publish` on the data-ingest topic).
- **New script policy** (`open_jii_<env>_iot_policy_device_scripts_v1`):
  `Connect` + `iot:Subscribe`/`iot:Receive` on
  `device/scripts/v1/*/*/${cognito-identity.amazonaws.com:sub}`, so a device can
  only receive its own scripts.
- **Backend** now reads `AWS_IOT_POLICY_NAMES` (comma-separated) and attaches
  each policy to the identity in `attachIotPolicy`.