### PR TITLE
fix(mobile): refresh experiment picker on focus + pull-to-refresh (OJD-1631)

### DIFF
--- a/apps/mobile/src/features/experiments/hooks/use-experiments.ts
+++ b/apps/mobile/src/features/experiments/hooks/use-experiments.ts
@@ -3,17 +3,25 @@ import { ellipsize } from "~/shared/utils/ellipsize";
 import { extractTextFromHTML } from "~/shared/utils/extract-text-from-html";
 
 export function useExperiments() {
-  const { data, isLoading, error } = tsr.experiments.listExperiments.useQuery({
-    queryKey: ["experiments"],
-    queryData: {
-      query: {
-        filter: "member",
+  const { data, isLoading, error, refetch, isRefetching } =
+    tsr.experiments.listExperiments.useQuery({
+      queryKey: ["experiments"],
+      queryData: {
+        query: {
+          filter: "member",
+        },
       },
-    },
-    // Explicit: prefer the persisted cache when offline so the picker
-    // doesn't render an empty list while the network is unreachable.
-    networkMode: "offlineFirst",
-  });
+      // Explicit: prefer the persisted cache when offline so the picker
+      // doesn't render an empty list while the network is unreachable.
+      networkMode: "offlineFirst",
+      // The list is cached/persisted across launches, so without this it only
+      // refreshed on a sign-out/in. Refresh it when the picker mounts and when
+      // the app returns to the foreground (focusManager → AppState) so new or
+      // changed experiments show up without forcing re-auth. Cache still
+      // renders instantly first thanks to offlineFirst.
+      refetchOnMount: true,
+      refetchOnWindowFocus: true,
+    });
   const experiments = data?.body;
 
   const options =
@@ -26,5 +34,5 @@ export function useExperiments() {
       fullDescription: item.description,
     })) ?? [];
 
-  return { experiments: options, isLoading, error };
+  return { experiments: options, isLoading, error, refetch, isRefetching };
 }

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/experiment-selection-step.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/experiment-selection-step.tsx
@@ -1,6 +1,13 @@
 import { Search, X } from "lucide-react-native";
 import React, { useMemo } from "react";
-import { ActivityIndicator, FlatList, Text, TouchableOpacity, View } from "react-native";
+import {
+  ActivityIndicator,
+  FlatList,
+  RefreshControl,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useConnectedDevice } from "~/features/connection/hooks/use-device-connection";
 import { useDeviceSheetStore } from "~/features/connection/stores/use-device-sheet-store";
@@ -27,7 +34,7 @@ export function ExperimentSelectionStep() {
   const colors = useThemeColors();
   const insets = useSafeAreaInsets();
   const { t } = useTranslation("measurementFlow");
-  const { experiments, isLoading, error } = useExperiments();
+  const { experiments, isLoading, error, refetch, isRefetching } = useExperiments();
   const { selectedExperimentId, setSelectedExperimentId } = useExperimentSelectionStore();
   const setExperimentId = useMeasurementFlowStore((s) => s.setExperimentId);
   const { isReady: experimentFlowReady } = useLoadExperimentFlow(selectedExperimentId);
@@ -129,6 +136,14 @@ export function ExperimentSelectionStep() {
             data={filtered}
             keyExtractor={(item) => item.value}
             contentContainerStyle={{ paddingHorizontal: 16, gap: 0 }}
+            refreshControl={
+              <RefreshControl
+                refreshing={isRefetching}
+                onRefresh={() => void refetch()}
+                tintColor={colors.brand}
+                colors={[colors.brand]}
+              />
+            }
             renderItem={({ item }) => {
               const meta = flowMeta[item.value];
               return (

--- a/apps/mobile/src/features/recent-measurements/hooks/use-all-measurements.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-all-measurements.ts
@@ -38,10 +38,6 @@ export function useAllMeasurements(filter: MeasurementFilter = "all") {
     },
     networkMode: "always",
     refetchOnMount: true,
-    // Re-read SQLite when the app returns to the foreground (RN's equivalent
-    // of window focus, wired via focusManager → AppState). Keeps the cached
-    // list instant on resume but refreshes it without a sign-out/in. OJD.
-    refetchOnWindowFocus: true,
   });
 
   // Memoize the flattened page list so referentially-stable consumers
@@ -71,7 +67,6 @@ export function useMeasurementCounts() {
     queryFn: countMeasurementsByStatus,
     networkMode: "always",
     refetchOnMount: true,
-    refetchOnWindowFocus: true,
   });
   return {
     counts,
@@ -92,7 +87,6 @@ export function useHasAnyMeasurements(): boolean {
       select: (c) => c.pending + c.failed + c.successful > 0,
       networkMode: "always",
       refetchOnMount: true,
-      refetchOnWindowFocus: true,
     }).data ?? false
   );
 }
@@ -113,7 +107,6 @@ export function useTopMeasurements(n: number) {
     },
     networkMode: "always",
     refetchOnMount: true,
-    refetchOnWindowFocus: true,
   });
 
   return { measurements: query.data ?? [] };

--- a/apps/mobile/src/features/recent-measurements/hooks/use-all-measurements.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-all-measurements.ts
@@ -38,6 +38,10 @@ export function useAllMeasurements(filter: MeasurementFilter = "all") {
     },
     networkMode: "always",
     refetchOnMount: true,
+    // Re-read SQLite when the app returns to the foreground (RN's equivalent
+    // of window focus, wired via focusManager → AppState). Keeps the cached
+    // list instant on resume but refreshes it without a sign-out/in. OJD.
+    refetchOnWindowFocus: true,
   });
 
   // Memoize the flattened page list so referentially-stable consumers
@@ -67,6 +71,7 @@ export function useMeasurementCounts() {
     queryFn: countMeasurementsByStatus,
     networkMode: "always",
     refetchOnMount: true,
+    refetchOnWindowFocus: true,
   });
   return {
     counts,
@@ -87,6 +92,7 @@ export function useHasAnyMeasurements(): boolean {
       select: (c) => c.pending + c.failed + c.successful > 0,
       networkMode: "always",
       refetchOnMount: true,
+      refetchOnWindowFocus: true,
     }).data ?? false
   );
 }
@@ -107,6 +113,7 @@ export function useTopMeasurements(n: number) {
     },
     networkMode: "always",
     refetchOnMount: true,
+    refetchOnWindowFocus: true,
   });
 
   return { measurements: query.data ?? [] };

--- a/apps/mobile/src/shared/ui/configured-query-client-provider.tsx
+++ b/apps/mobile/src/shared/ui/configured-query-client-provider.tsx
@@ -1,8 +1,9 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister";
-import { QueryClient, QueryCache, onlineManager } from "@tanstack/react-query";
+import { QueryClient, QueryCache, onlineManager, focusManager } from "@tanstack/react-query";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
 import React, { useEffect, useRef } from "react";
+import { AppState } from "react-native";
 import { toast } from "sonner-native";
 import { isOnline } from "~/shared/device/is-online";
 import { createLogger } from "~/shared/observability/logger";
@@ -15,6 +16,18 @@ const CHECK_INTERVAL = 10 * 1000;
 // Must run at module level (before any render) so the session guard in
 // the tabs layout doesn't assume online on cold start.
 onlineManager.setOnline(false);
+
+// RN has no window focus events, so React Query's `refetchOnWindowFocus`
+// never fires on its own. Point focusManager at AppState — now "focus" means
+// the app returning to the foreground. setFocused is edge-triggered (only a
+// real false→true flip refetches), so boot-time active→inactive→active flaps
+// don't trigger refetch storms. Symmetric with onlineManager above.
+focusManager.setEventListener((handleFocus) => {
+  const sub = AppState.addEventListener("change", (state) => {
+    handleFocus(state === "active");
+  });
+  return () => sub.remove();
+});
 
 function startConnectivityWatcher() {
   let lastOnline = false;


### PR DESCRIPTION
## Problem

On mobile, the **"Choose an experiment"** picker only refreshed after a **sign-out / sign-in** cycle. New or changed experiments wouldn't appear otherwise.

## Root cause

- The picker uses `tsr.experiments.listExperiments` (key `["experiments"]`), which is **persisted across launches** and `networkMode: "offlineFirst"`.
- Global query defaults are `refetchOnMount: false` + `refetchOnWindowFocus: false`, and React Query's `focusManager` had **no event source** on React Native — so the persisted list was never refreshed.
- The only thing clearing the cache was logout (`resetQueries()`), making it look like it "only refreshes on sign-out/in."

## Fix

1. **`configured-query-client-provider.tsx`** — wire `focusManager` → `AppState` at module level (symmetric with the existing `onlineManager`). This is what makes RN treat "app returned to foreground" as a focus event. `setFocused` is edge-triggered, so boot-time `active→inactive→active` flaps don't storm.
2. **`use-experiments.ts`** — `refetchOnMount: true` + `refetchOnWindowFocus: true` on the experiments query, so the picker refreshes when opened and when the app foregrounds. `offlineFirst` still renders the cached list instantly first. Exposes `refetch` / `isRefetching`.
3. **`experiment-selection-step.tsx`** — `RefreshControl` on the `FlatList` for manual **pull-to-refresh**.

## Result

Cached picker renders instantly, then refreshes on open, on app foreground, or on pull-down — no sign-out/in needed.

## How to verify

Open the measurement flow → "Choose an experiment". Add/change an experiment server-side, then: pull down to refresh, or background+foreground the app → the list updates without re-login.

## Notes

- Scoped `refetchOnWindowFocus` to the experiments query rather than flipping the global default, so unrelated network queries don't refire on every foreground.
- Pre-existing tsc errors in `shared/api/{refresh.api,fetcher}.ts` (`AbortSignal`) are unrelated to this change.

Closes OJD-1631

🤖 Generated with [Claude Code](https://claude.com/claude-code)