### PR TITLE
feat(workbooks): show version number on workbook detail page (OJD-1632)

### DIFF
--- a/apps/web/components/workbook-overview/workbook-layout-content.test.tsx
+++ b/apps/web/components/workbook-overview/workbook-layout-content.test.tsx
@@ -95,4 +95,14 @@ describe("WorkbookLayoutContent", () => {
     renderContent();
     expect(await screen.findByText("workbooks.draftVersion")).toBeInTheDocument();
   });
+
+  it("falls back to a dash (not 'Draft') when the versions fetch fails", async () => {
+    server.mount(contract.workbooks.listWorkbookVersions, { status: 500 });
+
+    renderContent({ createdByName: "Test User" });
+
+    // The version cell shows "-" rather than wrongly claiming the workbook is a draft.
+    expect(await screen.findByText("-")).toBeInTheDocument();
+    expect(screen.queryByText("workbooks.draftVersion")).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/components/workbook-overview/workbook-layout-content.test.tsx
+++ b/apps/web/components/workbook-overview/workbook-layout-content.test.tsx
@@ -1,5 +1,5 @@
 import { AutosaveStatusProvider } from "@/components/shared/autosave/autosave-status-context";
-import { createWorkbook } from "@/test/factories";
+import { createWorkbook, createWorkbookVersionSummary } from "@/test/factories";
 import { server } from "@/test/msw/server";
 import { render, screen, userEvent, waitFor } from "@/test/test-utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -23,6 +23,9 @@ describe("WorkbookLayoutContent", () => {
       data: { user: { id: "user-1", name: "Test User", email: "test@test.com" } },
       isPending: false,
     } as ReturnType<typeof useSession>);
+    // Default: an unpublished workbook (no versions). Tests that need a
+    // published version re-mount the handler.
+    server.mount(contract.workbooks.listWorkbookVersions, { body: [] });
   });
 
   function renderContent(overrides: Partial<typeof workbook> = {}) {
@@ -73,5 +76,23 @@ describe("WorkbookLayoutContent", () => {
   it("shows a dash when createdByName is null", () => {
     renderContent({ createdByName: undefined });
     expect(screen.getByText("-")).toBeInTheDocument();
+  });
+
+  it("shows the latest published version number", async () => {
+    server.mount(contract.workbooks.listWorkbookVersions, {
+      body: [
+        createWorkbookVersionSummary({ workbookId: "wb-1", version: 3 }),
+        createWorkbookVersionSummary({ workbookId: "wb-1", version: 2 }),
+      ],
+    });
+
+    renderContent();
+
+    expect(await screen.findByText("v3")).toBeInTheDocument();
+  });
+
+  it("shows a draft label when the workbook has no published versions", async () => {
+    renderContent();
+    expect(await screen.findByText("workbooks.draftVersion")).toBeInTheDocument();
   });
 });

--- a/apps/web/components/workbook-overview/workbook-layout-content.tsx
+++ b/apps/web/components/workbook-overview/workbook-layout-content.tsx
@@ -26,7 +26,11 @@ export function WorkbookLayoutContent({ id, workbook, children }: WorkbookLayout
   const { t: tCommon } = useTranslation("common");
   const { data: session } = useSession();
   const { mutateAsync: updateWorkbook, isPending: isUpdating } = useWorkbookUpdate(id);
-  const { data: versionsData, isLoading: isLoadingVersions } = useWorkbookVersions(id);
+  const {
+    data: versionsData,
+    isLoading: isLoadingVersions,
+    isError: isVersionsError,
+  } = useWorkbookVersions(id);
   const autosave = useAutosaveStatus();
 
   // Versions are returned newest-first; the live page is the draft, so the
@@ -94,6 +98,9 @@ export function WorkbookLayoutContent({ id, workbook, children }: WorkbookLayout
             </span>
             {isLoadingVersions ? (
               <Skeleton className="h-[21px] w-10" />
+            ) : isVersionsError ? (
+              // Don't claim "Draft" when the version state is simply unknown.
+              <span className="text-sm leading-[21px] text-[#68737B]">-</span>
             ) : latestVersion != null ? (
               <WorkbookVersionBadge currentVersion={latestVersion} showUpgrade={false} />
             ) : (

--- a/apps/web/components/workbook-overview/workbook-layout-content.tsx
+++ b/apps/web/components/workbook-overview/workbook-layout-content.tsx
@@ -3,13 +3,16 @@
 import { AutosaveIndicator } from "@/components/shared/autosave/autosave-indicator";
 import { useAutosaveStatus } from "@/components/shared/autosave/autosave-status-context";
 import { InlineEditableTitle } from "@/components/shared/inline-editable-title";
+import { WorkbookVersionBadge } from "@/components/workbook/workbook-version-badge";
 import { useWorkbookUpdate } from "@/hooks/workbook/useWorkbookUpdate/useWorkbookUpdate";
+import { useWorkbookVersions } from "@/hooks/workbook/useWorkbookVersions/useWorkbookVersions";
 import { formatDate } from "@/util/date";
 import { parseApiError } from "~/util/apiError";
 
 import type { Workbook } from "@repo/api/schemas/workbook.schema";
 import { useSession } from "@repo/auth/client";
 import { useTranslation } from "@repo/i18n";
+import { Skeleton } from "@repo/ui/components/skeleton";
 import { toast } from "@repo/ui/hooks/use-toast";
 
 interface WorkbookLayoutContentProps {
@@ -23,8 +26,12 @@ export function WorkbookLayoutContent({ id, workbook, children }: WorkbookLayout
   const { t: tCommon } = useTranslation("common");
   const { data: session } = useSession();
   const { mutateAsync: updateWorkbook, isPending: isUpdating } = useWorkbookUpdate(id);
+  const { data: versionsData, isLoading: isLoadingVersions } = useWorkbookVersions(id);
   const autosave = useAutosaveStatus();
 
+  // Versions are returned newest-first; the live page is the draft, so the
+  // latest published version is the meaningful number to surface here.
+  const latestVersion = versionsData?.body[0]?.version;
   const isCreator = session?.user.id === workbook.createdBy;
   const indicatorStatus = isUpdating ? "saving" : (autosave?.status ?? "idle");
 
@@ -80,6 +87,20 @@ export function WorkbookLayoutContent({ id, workbook, children }: WorkbookLayout
             <span className="text-sm leading-[21px] text-[#68737B]">
               {workbook.createdByName ?? "-"}
             </span>
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-sm font-medium leading-[18px] tracking-[0.02em] text-[#011111]">
+              {t("workbooks.version")}
+            </span>
+            {isLoadingVersions ? (
+              <Skeleton className="h-[21px] w-10" />
+            ) : latestVersion != null ? (
+              <WorkbookVersionBadge currentVersion={latestVersion} showUpgrade={false} />
+            ) : (
+              <span className="text-sm leading-[21px] text-[#68737B]">
+                {t("workbooks.draftVersion")}
+              </span>
+            )}
           </div>
         </div>
       </div>

--- a/packages/i18n/locales/de-DE/workbook.json
+++ b/packages/i18n/locales/de-DE/workbook.json
@@ -17,6 +17,8 @@
     "filterWorkbooks": "Arbeitsmappen filtern",
     "clearSearch": "Suche loschen",
     "lastUpdate": "Letzte Aktualisierung",
+    "version": "Version",
+    "draftVersion": "Entwurf",
     "noCells": "Noch keine Zellen. Offnen Sie die Arbeitsmappe, um Ihr Notebook zu erstellen.",
     "saving": "Speichern...",
     "allChangesSaved": "Alle Änderungen gespeichert",

--- a/packages/i18n/locales/en-US/workbook.json
+++ b/packages/i18n/locales/en-US/workbook.json
@@ -22,6 +22,8 @@
     "filterWorkbooks": "Filter workbooks",
     "clearSearch": "Clear search",
     "lastUpdate": "Last update",
+    "version": "Version",
+    "draftVersion": "Draft",
     "noCells": "No cells yet. Open the workbook to start building your notebook.",
     "saving": "Saving...",
     "allChangesSaved": "All changes saved",

--- a/packages/i18n/locales/nl-NL/workbook.json
+++ b/packages/i18n/locales/nl-NL/workbook.json
@@ -17,6 +17,8 @@
     "filterWorkbooks": "Werkboeken filteren",
     "clearSearch": "Zoekopdracht wissen",
     "lastUpdate": "Laatste update",
+    "version": "Versie",
+    "draftVersion": "Concept",
     "noCells": "Nog geen cellen. Open het werkboek om uw notebook te bouwen.",
     "saving": "Opslaan...",
     "allChangesSaved": "Alle wijzigingen opgeslagen",


### PR DESCRIPTION
## What

Adds a **Version** field to the workbook detail page header metadata row (next to Created / Updated / Created by).

Closes OJD-1632.

## How versioning works here

A workbook is a live, editable **draft**; published snapshots live in a separate `workbookVersions` table with a monotonically increasing integer `version` (`listWorkbookVersions` returns them newest-first). So the meaningful number to surface on the draft page is the **latest published version**.

## Behavior

- Shows the latest published version using the existing `WorkbookVersionBadge` (e.g. `v3`, with `showUpgrade={false}` since this page *is* the draft).
- Shows **Draft** when the workbook has no published versions yet.
- Shows a small skeleton while versions load (avoids a Draft→v3 flash).

## Screenshots

Captured against the local stack via the `apps/web/e2e` harness, with the versions API stubbed to drive each state.

**Latest published version (`v5`)**

![Workbook header showing version v5](https://raw.githubusercontent.com/Jan-IngenHousz-Institute/open-jii/pr-assets-ojd-1632/01_v5.png)

**Single published version (`v1`)**

![Workbook header showing version v1](https://raw.githubusercontent.com/Jan-IngenHousz-Institute/open-jii/pr-assets-ojd-1632/02_v1.png)

**No published versions (`Draft`)**

![Workbook header showing Draft](https://raw.githubusercontent.com/Jan-IngenHousz-Institute/open-jii/pr-assets-ojd-1632/03_draft.png)

## Changes

- `apps/web/components/workbook-overview/workbook-layout-content.tsx` — version field + `useWorkbookVersions` fetch.
- `packages/i18n/locales/{en-US,de-DE,nl-NL}/workbook.json` — `version` / `draftVersion` keys.
- `apps/web/components/workbook-overview/workbook-layout-content.test.tsx` — mounts the versions handler; adds coverage for the version and draft cases.

## Verification

- `workbook-layout-content.test.tsx` 6/6 pass; workbook `[id]` layout test 5/5 pass.
- `eslint` clean on changed files; `tsc --noEmit` reports no errors for any changed file (the one pre-existing error in `terms-and-conditions-dialog.tsx` is an unrelated CMS `dist`/`src` type mismatch).

