### PR TITLE
fix(data): correct volume read paths so generalized uploads parse files

### DIFF
--- a/apps/data/src/tasks/data_upload_task.py
+++ b/apps/data/src/tasks/data_upload_task.py
@@ -103,7 +103,9 @@ def _process_tabular_upload(label: str, extensions: tuple[str, ...], parser) -> 
 
     for path in matched_files:
         try:
-            local_path = path.replace("dbfs:", "/dbfs") if path.startswith("dbfs:") else path
+            # pandas reads UC volumes via the /Volumes FUSE path; strip the dbfs:
+            # scheme dbutils.fs.ls prepends. /dbfs only mounts DBFS, not volumes.
+            local_path = path[len("dbfs:") :] if path.startswith("dbfs:") else path
             df = parser(local_path)
             df = df.where(pd.notnull(df), None)
             rows = df.to_dict(orient="records")

--- a/apps/data/src/tasks/data_upload_task.py
+++ b/apps/data/src/tasks/data_upload_task.py
@@ -235,8 +235,10 @@ def process_ambyte_upload() -> dict:
     if not UPLOAD_ID:
         raise Exception("UPLOAD_ID is required for source_kind=ambyte")
 
+    # Ambyte files land under the shared "uploads" volume dir (the backend uses
+    # volumeSourceType="uploads" for every kind), not a dedicated ambyte dir.
     ambyte_base_path = (
-        f"/Volumes/{CATALOG_NAME}/centrum/data-imports/{EXPERIMENT_ID}/ambyte/{UPLOAD_DIRECTORY}"
+        f"/Volumes/{CATALOG_NAME}/centrum/data-imports/{EXPERIMENT_ID}/uploads/{UPLOAD_DIRECTORY}"
     )
     processed_output_path = (
         f"/Volumes/{CATALOG_NAME}/centrum/data-imports/{EXPERIMENT_ID}/processed-uploads"


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

OJD-1490

## Description

Generalized data uploads were failing on dev with `No rows parsed from 0 files
(1 errors)` for every tabular kind (csv, tsv, parquet, xlsx, json, ndjson). The
files landed in the volume fine; the processing task just couldn't read them
back. Two path bugs in `data_upload_task.py`, both about how the task addresses
files in the data-imports volume.

### 1. Tabular: `/dbfs` instead of `/Volumes`

`dbutils.fs.ls` returns `dbfs:/Volumes/.../file.csv`. The task rewrote that to
`/dbfs/Volumes/...`, but the `/dbfs` FUSE mount only exists for legacy DBFS, not
Unity Catalog volumes (and not on serverless). pandas got a nonexistent path,
threw, and the row was counted as a parse error, so every upload finished with
zero rows. Fixed by stripping the `dbfs:` scheme to get the plain `/Volumes/...`
FUSE path, matching `_strip_dbfs_prefix` in `data_export_task.py`.

### 2. Ambyte: wrong base directory

The backend writes every kind (ambyte included) under
`.../data-imports/{experimentId}/uploads/{dir}` because all kinds share
`volumeSourceType="uploads"`. The ambyte processor read from a dedicated
`.../ambyte/{dir}` dir that nothing writes to, so every ambyte upload failed with
"Ambyte directory not found". Pointed it at the shared `uploads/` dir.