### PR TITLE
fix(mobile): make selected experiment visible in dark mode

### DIFF
--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/experiment-card.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/experiment-card.tsx
@@ -1,3 +1,4 @@
+import { cva } from "class-variance-authority";
 import { FlaskConical, MessageSquare } from "lucide-react-native";
 import React from "react";
 import { Pressable, Text, View } from "react-native";
@@ -19,6 +20,15 @@ export interface ExperimentCardProps {
   durationMin: number;
   recentCount?: number;
 }
+
+const cardSelection = cva("border-2", {
+  variants: {
+    selected: {
+      true: "border-primary",
+      false: "border-transparent",
+    },
+  },
+});
 
 function pickTag(
   requiresSensor: boolean,
@@ -56,7 +66,7 @@ export function ExperimentCard({
       <Card
         tone={selected ? "mint" : "white"}
         padded
-        className="border-0"
+        className={cardSelection({ selected })}
         style={{ marginVertical: 0, padding: 14 }}
       >
         <View className="flex-row items-start gap-3">


### PR DESCRIPTION
## Problem

On the mobile "start experiment" screen, the experiment picker signaled selection **only** by switching the card's background to the `mint` tone. In dark mode that tone is `bg-jii-mint/40` — a `180 14% 16%` color at 40% opacity sitting on a `0 0% 15%` card. The selected and unselected states are nearly identical, so it's very hard to tell which experiment is selected. In light mode it's fine.

## Fix

Add a `primary`-colored 2px border to the selected card, driven by a `cva` variant (matching the pattern in `Card.tsx`). `border-primary` resolves to `#005e5e` (dark teal) in light mode and `#49e06d` (bright green) in dark mode — clearly visible against both backgrounds. The unselected state keeps a transparent 2px border so toggling selection doesn't shift layout.

```tsx
const cardSelection = cva("border-2", {
  variants: {
    selected: {
      true: "border-primary",
      false: "border-transparent",
    },
  },
});
```

## Testing

Not yet verified in a running build — visual change only. Happy to bring up the mobile app and screenshot the picker in both themes if wanted.