### PR TITLE
chore(macro-sandbox): suppress openssl-fips ASN.1 CVE in base image (CVE-2026-34180)

### DIFF
--- a/apps/macro-sandbox/functions/javascript/.trivyignore.yaml
+++ b/apps/macro-sandbox/functions/javascript/.trivyignore.yaml
@@ -92,6 +92,13 @@ vulnerabilities:
   - id: CVE-2026-31790
     statement: "RSASVE info disclosure. No RSA key encapsulation."
 
+  - id: CVE-2026-34180
+    statement: >-
+      Heap buffer over-read in ASN.1 decoding. Sandbox parses no
+      certificates and has no TLS. Fixed in amzn2023.0.5; awaiting
+      AWS base image republish.
+    expired_at: 2026-11-05
+
   # libcap RPM bundles a Go binary compiled with a vulnerable Go toolchain.
   # CVE is in Go's html/template package. Sandbox does not render HTML.
   - id: CVE-2026-27142

--- a/apps/macro-sandbox/functions/python/.trivyignore.yaml
+++ b/apps/macro-sandbox/functions/python/.trivyignore.yaml
@@ -33,6 +33,13 @@ vulnerabilities:
   - id: CVE-2026-31790
     statement: "RSASVE info disclosure. No RSA key encapsulation."
 
+  - id: CVE-2026-34180
+    statement: >-
+      Heap buffer over-read in ASN.1 decoding. Sandbox parses no
+      certificates and has no TLS. Fixed in amzn2023.0.5; awaiting
+      AWS base image republish.
+    expired_at: 2026-11-05
+
   # libcap RPM bundles a Go binary compiled with a vulnerable Go toolchain.
   # CVE is in Go's html/template package. Sandbox does not render HTML.
   - id: CVE-2026-27142


### PR DESCRIPTION
## What

Adds **CVE-2026-34180** (HIGH) to the macro-sandbox JavaScript and Python `.trivyignore.yaml` files with a justification and expiry.

| Field | Value |
|---|---|
| Package | `openssl-fips-provider` (Amazon Linux 2023 base layer) |
| Installed | `1:3.5.5-1.amzn2023.0.4` |
| Fixed in | `1:3.5.5-1.amzn2023.0.5` |
| Severity | HIGH |
| Title | OpenSSL: Heap buffer over-read in ASN.1 decoding |

## Why suppress rather than patch

The fix exists in the AL2023 repos but has **not yet shipped** in the upstream `public.ecr.aws/lambda/nodejs:24` and `python:3.12` base images. Since `docker-build-check` runs Trivy with `ignore-unfixed: true` and fails on `CRITICAL,HIGH`, this fixable CVE breaks the Docker Build Check until either AWS republishes or we suppress it.

The Dockerfiles deliberately strip package managers and never run `dnf update`, so the established remediation in this repo for "OS package fixed upstream in AL2023 but not yet in the AWS base image" is a justified `.trivyignore.yaml` entry with `expired_at` — see the existing `glibc` (amzn2023.0.4) and `libsolv` (amzn2023.0.4) blocks. This change follows that exact pattern.

## Reachability

The CVE is a heap buffer over-read in OpenSSL's **ASN.1 decoder**, reachable only when the decoder parses attacker-controlled DER (X.509 certificates, CMS). The sandbox Lambdas are VPC-isolated with no inbound/outbound TLS and parse no certificates, so the decoder never receives untrusted input — consistent with the other OpenSSL entries already in these files.

Expiry set to `2026-11-05` (matching the sibling base-image entries) so the suppression auto-revisits once AWS is expected to have republished.

## Scope

- Affects only the **JavaScript** and **Python** images (both AL2023-based).
- The **R** image is `debian:bookworm-slim` and has no `openssl-fips-provider` package, so its `.trivyignore.yaml` is untouched.