### PR TITLE
chore(macro-sandbox): suppress openssl base-image CVE batch (amzn2023.0.5)

### DIFF
--- a/apps/macro-sandbox/functions/javascript/.trivyignore.yaml
+++ b/apps/macro-sandbox/functions/javascript/.trivyignore.yaml
@@ -99,6 +99,51 @@ vulnerabilities:
       AWS base image republish.
     expired_at: 2026-11-05
 
+  # openssl batch fixed in amzn2023.0.5; awaiting AWS base image republish.
+  # Sandbox is VPC-isolated: no TLS, no network, no certificate/CMS processing.
+  - id: CVE-2026-34181
+    statement: "PKCS#12 PBMAC1 short-salt acceptance. Sandbox parses no PKCS#12."
+    expired_at: 2026-11-05
+  - id: CVE-2026-34182
+    statement: "CMS AuthEnvelopedData forgery. No CMS processing."
+    expired_at: 2026-11-05
+  - id: CVE-2026-34183
+    statement: "QUIC PATH_CHALLENGE memory growth. No QUIC; sandbox has no network."
+    expired_at: 2026-11-05
+  - id: CVE-2026-42764
+    statement: "QUIC server NULL deref. No QUIC; sandbox has no network."
+    expired_at: 2026-11-05
+  - id: CVE-2026-42766
+    statement: "Password-based CMS NULL deref. No CMS processing."
+    expired_at: 2026-11-05
+  - id: CVE-2026-42767
+    statement: "CRMF EncryptedValue NULL deref. No CMP/CRMF."
+    expired_at: 2026-11-05
+  - id: CVE-2026-42768
+    statement: "Multi-RecipientInfo Bleichenbacher oracle. No CMS decryption."
+    expired_at: 2026-11-05
+  - id: CVE-2026-42769
+    statement: "Trust-anchor substitution in cert verification. Sandbox verifies no certs."
+    expired_at: 2026-11-05
+  - id: CVE-2026-42770
+    statement: "FFC-DH peer validation flaw. No DH key exchange."
+    expired_at: 2026-11-05
+  - id: CVE-2026-45445
+    statement: "AES-OCB IV ignored on EVP_Cipher path. Sandbox does no OCB encryption."
+    expired_at: 2026-11-05
+  - id: CVE-2026-45446
+    statement: "Empty-message tag mis-processing. Sandbox does no AEAD on untrusted input."
+    expired_at: 2026-11-05
+  - id: CVE-2026-45447
+    statement: "Heap UAF in PKCS7_verify. Sandbox verifies no PKCS7."
+    expired_at: 2026-11-05
+  - id: CVE-2026-7383
+    statement: "Heap overflow via signed integer. No untrusted crypto input in sandbox."
+    expired_at: 2026-11-05
+  - id: CVE-2026-9076
+    statement: "DoS via heap. No untrusted TLS/crypto input in sandbox."
+    expired_at: 2026-11-05
+
   # libcap RPM bundles a Go binary compiled with a vulnerable Go toolchain.
   # CVE is in Go's html/template package. Sandbox does not render HTML.
   - id: CVE-2026-27142

--- a/apps/macro-sandbox/functions/python/.trivyignore.yaml
+++ b/apps/macro-sandbox/functions/python/.trivyignore.yaml
@@ -40,6 +40,51 @@ vulnerabilities:
       AWS base image republish.
     expired_at: 2026-11-05
 
+  # openssl batch fixed in amzn2023.0.5; awaiting AWS base image republish.
+  # Sandbox is VPC-isolated: no TLS, no network, no certificate/CMS processing.
+  - id: CVE-2026-34181
+    statement: "PKCS#12 PBMAC1 short-salt acceptance. Sandbox parses no PKCS#12."
+    expired_at: 2026-11-05
+  - id: CVE-2026-34182
+    statement: "CMS AuthEnvelopedData forgery. No CMS processing."
+    expired_at: 2026-11-05
+  - id: CVE-2026-34183
+    statement: "QUIC PATH_CHALLENGE memory growth. No QUIC; sandbox has no network."
+    expired_at: 2026-11-05
+  - id: CVE-2026-42764
+    statement: "QUIC server NULL deref. No QUIC; sandbox has no network."
+    expired_at: 2026-11-05
+  - id: CVE-2026-42766
+    statement: "Password-based CMS NULL deref. No CMS processing."
+    expired_at: 2026-11-05
+  - id: CVE-2026-42767
+    statement: "CRMF EncryptedValue NULL deref. No CMP/CRMF."
+    expired_at: 2026-11-05
+  - id: CVE-2026-42768
+    statement: "Multi-RecipientInfo Bleichenbacher oracle. No CMS decryption."
+    expired_at: 2026-11-05
+  - id: CVE-2026-42769
+    statement: "Trust-anchor substitution in cert verification. Sandbox verifies no certs."
+    expired_at: 2026-11-05
+  - id: CVE-2026-42770
+    statement: "FFC-DH peer validation flaw. No DH key exchange."
+    expired_at: 2026-11-05
+  - id: CVE-2026-45445
+    statement: "AES-OCB IV ignored on EVP_Cipher path. Sandbox does no OCB encryption."
+    expired_at: 2026-11-05
+  - id: CVE-2026-45446
+    statement: "Empty-message tag mis-processing. Sandbox does no AEAD on untrusted input."
+    expired_at: 2026-11-05
+  - id: CVE-2026-45447
+    statement: "Heap UAF in PKCS7_verify. Sandbox verifies no PKCS7."
+    expired_at: 2026-11-05
+  - id: CVE-2026-7383
+    statement: "Heap overflow via signed integer. No untrusted crypto input in sandbox."
+    expired_at: 2026-11-05
+  - id: CVE-2026-9076
+    statement: "DoS via heap. No untrusted TLS/crypto input in sandbox."
+    expired_at: 2026-11-05
+
   # libcap RPM bundles a Go binary compiled with a vulnerable Go toolchain.
   # CVE is in Go's html/template package. Sandbox does not render HTML.
   - id: CVE-2026-27142


### PR DESCRIPTION
## What

Adds the rest of the newly-disclosed openssl CVE batch to the macro-sandbox **JavaScript** and **Python** `.trivyignore.yaml` files. Follow-up to #1683, which suppressed `CVE-2026-34180` — that was only the **first row** of a 14-CVE batch that Trivy's database surfaced.

Each is reported against two AL2023 base-layer packages (`openssl-fips-provider-latest` + `openssl-snapsafe-libs`) → 28 HIGH findings, tripping the `CRITICAL,HIGH` gate in the Docker Build Check (`ignore-unfixed: true`).

| CVE | Issue |
|---|---|
| CVE-2026-34181 | PKCS#12 PBMAC1 accepted with short salt |
| CVE-2026-34182 | CMS AuthEnvelopedData accepts forged data |
| CVE-2026-34183 | QUIC PATH_CHALLENGE unbounded memory growth |
| CVE-2026-42764 | QUIC server NULL deref |
| CVE-2026-42766 | Password-based CMS NULL deref |
| CVE-2026-42767 | CRMF EncryptedValue NULL deref |
| CVE-2026-42768 | Multi-RecipientInfo Bleichenbacher oracle |
| CVE-2026-42769 | Trust-anchor substitution via cert/issuer typo |
| CVE-2026-42770 | FFC-DH peer validation uses attacker-supplied q |
| CVE-2026-45445 | AES-OCB IV ignored on EVP_Cipher() |
| CVE-2026-45446 | Incorrect tag processing for empty messages |
| CVE-2026-45447 | Heap UAF in PKCS7_verify() |
| CVE-2026-7383 | Heap buffer overflow (signed integer) |
| CVE-2026-9076 | DoS via heap |

All are fixed in **`1:3.5.5-1.amzn2023.0.5`** — the same package bump as `CVE-2026-34180` — but AWS has not yet republished the `public.ecr.aws/lambda` base images with it.

## Why suppress rather than patch

Same rationale as #1683 and the existing `glibc`/`libsolv` base-image entries: the fix exists upstream but not in the AWS base image, and the Dockerfiles deliberately strip package managers rather than run `dnf update`. Suppression with `expired_at: 2026-11-05` auto-revisits once AWS is expected to have republished.

## Reachability

Every CVE requires TLS/QUIC, certificate verification, or CMS/PKCS processing. The sandbox Lambdas are VPC-isolated with no inbound/outbound network and do none of these, so the affected code paths are unreachable — consistent with the existing openssl entries.

## Scope

- **JavaScript** and **Python** images only (both AL2023-based).
- The **R** image (`debian:bookworm-slim`) has no `openssl-fips-provider` package — untouched.
- Once merged, branches like #1351 pick this up by merging `main`.