### PR TITLE
fix(mobile): exclude .cache/tsbuildinfo from EAS upload

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -24,6 +24,8 @@ coverage
 out
 build
 dist
+.cache
+*.tsbuildinfo
 
 # CI/CD
 

--- a/.easignore
+++ b/.easignore
@@ -26,6 +26,23 @@ build
 dist
 .cache
 *.tsbuildinfo
+.asyncapi
+.openapi
+.expo
+
+# Secrets (mirror .gitignore; never ship to the builder)
+
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+*.pem
+
+# AI artifacts (huge: worktrees, sessions)
+
+.claude
+.wolf
 
 # CI/CD
 
@@ -35,5 +52,7 @@ dist
 
 .vscode
 .turbo
+.vercel
+*.zip
 *.md
 !apps/mobile/README.md


### PR DESCRIPTION
## Type of PR

- [x] Bug Fix

## Description

Fixes the EAS mobile build failure introduced with the 2.1.0 release. The `apps/mobile postinstall` step fails while building `@repo/auth`:

```
src/email/otpEmail.ts(3,32): error TS2307: Cannot find module '@repo/transactional/render/otp-email' or its corresponding type declarations.
src/email/verificationEmail.ts(4,43): error TS2307: Cannot find module '@repo/transactional/render/verification-request' or its corresponding type declarations.
```

Failing build: https://expo.dev/accounts/jan-ingenhousz-institute/projects/openjii/builds/26620822-1b84-4a97-b369-8398bc40e83e

### Root cause

PR #1351 (2.1.0) added a root `.easignore`. **Once `.easignore` exists, EAS ignores `.gitignore` when deciding what to upload.** The file excluded `dist` but **not** `.cache`, which is where the `tsc --build` incremental state lives (`tsBuildInfoFile: ${configDir}/.cache/tsbuildinfo.json`).

So a developer's local `packages/transactional/.cache/tsbuildinfo.json` (and `packages/cms`'s) gets uploaded to the builder while `dist/` does not. On the builder, `mobile postinstall` runs the package builds in order (`api → transactional → auth → iot → cms`):

- `api` has no `tsBuildInfoFile`, so it always emits. ✅
- `transactional`'s `tsc --build` finds the stale `tsbuildinfo.json`, reports **"up to date"**, and emits nothing — but `dist/` was never uploaded. ❌
- `auth` resolves `@repo/transactional/render/otp-email` to `./dist/render/otp-email.d.ts`, which doesn't exist → `TS2307`. 💥

This matches the log exactly: both `cms` and `transactional` report "up to date" (both ship a `.cache/tsbuildinfo.json`), `api` builds fine, only `auth` fails. The `render/*` sources are old and unchanged — the source is fine.

### Fix

Re-list `.cache` and `*.tsbuildinfo` in `.easignore` (both already in `.gitignore`). With no incremental state uploaded, the builder starts clean, `tsc --build` does a full build and emits `dist/`, and `auth` resolves.

---

## Additional hardening (same root cause)

Because `.easignore` *replaces* `.gitignore` for the EAS archive, every gitignored item not re-listed here is uploaded to the builder. Audited the upload scope (root + `apps/mobile` + `packages/*`, since other apps and `infrastructure` are already excluded) and re-added the gitignored items that were present:

- **`.claude` / `.wolf`** — AI artifacts, multi-GB on dev machines (worktrees, sessions). Large, irrelevant upload.
- **`.env` + `*.local` + `*.pem`** — secrets that were being shipped to the cloud builder. Not needed there (mobile build env comes from EAS env/secrets; #1351 dropped `babel-plugin-inline-dotenv`). Mirrors `.gitignore`'s exact patterns, so the tracked `.env.default` / `.env.test` are still uploaded.
- **`.expo`, `.asyncapi`, `.openapi`, `.vercel`, `*.zip`** — local state, generated output, and stray archives.