### PR TITLE
fix(cms): improve CMS image and video captions 

### DIFF
--- a/packages/cms/src/features/article/article-image.tsx
+++ b/packages/cms/src/features/article/article-image.tsx
@@ -7,6 +7,7 @@ import { cn, cva } from "@repo/ui/lib/utils";
 
 import type { ComponentRichImage } from "../../lib/__generated/sdk";
 import { CtfImage } from "../contentful/ctf-image";
+import { ArticleMediaCaption } from "./article-media-caption";
 
 interface ArticleImageProps {
   image: ComponentRichImage;
@@ -58,7 +59,9 @@ export const ArticleImage = ({ image, imageClassName }: ArticleImageProps): Reac
         />
       </div>
       {image.caption && (
-        <figcaption {...inspectorProps({ fieldId: "caption" })}>{image.caption}</figcaption>
+        <ArticleMediaCaption {...inspectorProps({ fieldId: "caption" })}>
+          {image.caption}
+        </ArticleMediaCaption>
       )}
     </figure>
   );

--- a/packages/cms/src/features/article/article-media-caption.tsx
+++ b/packages/cms/src/features/article/article-media-caption.tsx
@@ -9,7 +9,10 @@ export const ArticleMediaCaption = ({
   className,
   ...props
 }: ArticleMediaCaptionProps) => (
-  <figcaption {...props} className={cn("text-muted-foreground -mt-1 text-sm italic", className)}>
+  <figcaption
+    {...props}
+    className={cn("text-muted-foreground -mt-1 text-center text-sm italic", className)}
+  >
     {children}
   </figcaption>
 );

--- a/packages/cms/src/features/article/article-media-caption.tsx
+++ b/packages/cms/src/features/article/article-media-caption.tsx
@@ -1,0 +1,15 @@
+import type { ComponentPropsWithoutRef } from "react";
+
+import { cn } from "@repo/ui/lib/utils";
+
+type ArticleMediaCaptionProps = ComponentPropsWithoutRef<"figcaption">;
+
+export const ArticleMediaCaption = ({
+  children,
+  className,
+  ...props
+}: ArticleMediaCaptionProps) => (
+  <figcaption {...props} className={cn("-mt-1 text-sm italic text-gray-500", className)}>
+    {children}
+  </figcaption>
+);

--- a/packages/cms/src/features/article/article-media-caption.tsx
+++ b/packages/cms/src/features/article/article-media-caption.tsx
@@ -9,7 +9,7 @@ export const ArticleMediaCaption = ({
   className,
   ...props
 }: ArticleMediaCaptionProps) => (
-  <figcaption {...props} className={cn("-mt-1 text-sm italic text-gray-500", className)}>
+  <figcaption {...props} className={cn("text-muted-foreground -mt-1 text-sm italic", className)}>
     {children}
   </figcaption>
 );

--- a/packages/cms/src/features/article/article-video.tsx
+++ b/packages/cms/src/features/article/article-video.tsx
@@ -7,6 +7,7 @@ import { cn, cva } from "@repo/ui/lib/utils";
 
 import type { ComponentRichImage } from "../../lib/__generated/sdk";
 import { CtfVideo } from "../contentful/ctf-video";
+import { ArticleMediaCaption } from "./article-media-caption";
 
 interface ArticleVideoProps {
   video: ComponentRichImage;
@@ -56,7 +57,9 @@ export const ArticleVideo = ({ video, videoClassName }: ArticleVideoProps): Reac
         />
       </div>
       {video.caption && (
-        <figcaption {...inspectorProps({ fieldId: "caption" })}>{video.caption}</figcaption>
+        <ArticleMediaCaption {...inspectorProps({ fieldId: "caption" })}>
+          {video.caption}
+        </ArticleMediaCaption>
       )}
     </figure>
   );


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description
Adds a shared ArticleMediaCaption component and uses it for both CMS image and video captions. Captions now render with smaller italic muted text.