### PR TITLE
fix(mobile): prevent OTP login crash from NativeWind 5 class combo (OJD-1644)

### DIFF
--- a/apps/mobile/src/shared/ui/OTPInput.tsx
+++ b/apps/mobile/src/shared/ui/OTPInput.tsx
@@ -99,7 +99,9 @@ export function OTPInput({
                 ref={(ref) => {
                   inputRefs.current[index] = ref;
                 }}
-                className="text-on-surface h-full w-full text-center text-2xl font-semibold"
+                // textAlign stays inline: NativeWind 5 crashes when text-center + font-semibold are both classes here.
+                className="text-on-surface h-full w-full text-2xl font-semibold"
+                style={{ textAlign: "center" }}
                 value={digit}
                 onChangeText={(text) => handleChange(text, index)}
                 onKeyPress={(e) => handleKeyPress(e, index)}


### PR DESCRIPTION
## Problem

Logging in via email OTP crashed the mobile app (v2.1.2) the moment the OTP screen mounted: a red box reading *"Something broke — undefined is not a function"*. Underlying error: `TypeError: path.split is not a function` inside NativeWind 5's style→prop mapping.

Fixes Jan-IngenHousz-Institute/open-jii#1692.

## Root cause

NativeWind 5 (preview) miscompiles a specific class **combination** on a `TextInput`. On-device bisection nailed it down:

<!-- linear:table-colwidths:266,266,266 -->
| `text-center` | `font-semibold` | Result |
| -- | -- | -- |
| ✗ | ✗ | fine |
| ✓ | ✗ | fine |
| ✗ | ✓ | fine |
| ✓ | ✓ | **crash** (`path.split`) |

Only `OTPInput` carried both classes, which is why other `TextInput`s (login email field, dropdown search, etc.) were unaffected. The crash reproduces deterministically from a cold cache (i.e. production builds), and is masked intermittently under dev HMR. Separately, NativeWind 5 silently drops `text-center` on this `TextInput`, so centering never actually applied through the class anyway.

## Fix

Break up the offending combination: keep `font-semibold` as a class (safe on its own) and move centering to an inline `textAlign` — which is the only form that actually renders here. Color/size/dimensions stay on Tailwind, so dark mode still resolves through NativeWind. Same visual result (bold, centered digits), no crash.

```tsx
className="text-on-surface h-full w-full text-2xl font-semibold"
style={{ textAlign: "center" }}
```

## Testing

* Reproduced the original crash on a physical Android device (dev client over USB) with the `main` class set, cold cache.
* Verified the fix renders bold, centered digits with no red box; OTP login flow proceeds.