### PR TITLE
fix(dashboards): stop thumbnail resize loop by damping sub-scrollbar width wobble

### DIFF
--- a/apps/web/components/experiment-dashboards/list/thumbnail/dashboard-thumbnail.test.tsx
+++ b/apps/web/components/experiment-dashboards/list/thumbnail/dashboard-thumbnail.test.tsx
@@ -1,9 +1,9 @@
 import { createExperimentDashboard, createRichTextWidget } from "@/test/factories";
-import { render, screen } from "@/test/test-utils";
+import { render, renderHook, screen } from "@/test/test-utils";
 import React from "react";
 import { describe, expect, it, vi } from "vitest";
 
-import { DashboardThumbnail } from "./dashboard-thumbnail";
+import { DashboardThumbnail, useStableWidth } from "./dashboard-thumbnail";
 
 vi.mock("@repo/ui/hooks/use-element-size", () => ({
   useElementSize: () => {
@@ -65,5 +65,31 @@ describe("DashboardThumbnail", () => {
     const dashboard = createExperimentDashboard({ widgets: [] });
     render(<DashboardThumbnail dashboard={dashboard} experimentId="exp-1" />);
     expect(screen.getByText("widget.emptyDashboardDescription")).toBeInTheDocument();
+  });
+});
+
+describe("useStableWidth", () => {
+  const mount = (w: number | null) =>
+    renderHook(({ width }: { width: number | null }) => useStableWidth(width), {
+      initialProps: { width: w },
+    });
+
+  it("stays null until a width is measured, then latches it", () => {
+    const { result, rerender } = mount(null);
+    expect(result.current).toBeNull();
+    rerender({ width: 640 });
+    expect(result.current).toBe(640);
+  });
+
+  it("ignores sub-scrollbar width wobble (the resize-loop guard)", () => {
+    const { result, rerender } = mount(640);
+    rerender({ width: 624 }); // 16px shrink, within a scrollbar's width
+    expect(result.current).toBe(640);
+  });
+
+  it("follows a resize beyond the scrollbar tolerance", () => {
+    const { result, rerender } = mount(640);
+    rerender({ width: 500 });
+    expect(result.current).toBe(500);
   });
 });

--- a/apps/web/components/experiment-dashboards/list/thumbnail/dashboard-thumbnail.tsx
+++ b/apps/web/components/experiment-dashboards/list/thumbnail/dashboard-thumbnail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 
 import type { ExperimentDashboard } from "@repo/api/schemas/experiment.schema";
 import { useElementSize } from "@repo/ui/hooks/use-element-size";
@@ -22,6 +22,21 @@ interface DashboardThumbnailProps {
 const INNER_WIDTH_PX = 1280;
 const FALLBACK_ROW_COUNT = 4;
 
+const SCROLLBAR_TOLERANCE_PX = 24;
+
+// Height is derived from width, so a scrollbar toggling on a width change
+// would feed back into an infinite resize loop. Ignore sub-scrollbar wobble.
+export function useStableWidth(measured: number | null): number | null {
+  const ref = useRef<number | null>(null);
+  if (
+    measured !== null &&
+    (ref.current === null || Math.abs(measured - ref.current) > SCROLLBAR_TOLERANCE_PX)
+  ) {
+    ref.current = measured;
+  }
+  return ref.current;
+}
+
 export function DashboardThumbnail({
   dashboard,
   experimentId,
@@ -29,7 +44,7 @@ export function DashboardThumbnail({
 }: DashboardThumbnailProps) {
   const [widthRef, size] = useElementSize<HTMLDivElement>();
   const [inViewRef, mounted] = useInView<HTMLDivElement>({ rootMargin: "200px" });
-  const width = size?.width ?? null;
+  const width = useStableWidth(size?.width ?? null);
   const everLoaded = useEverLoaded(experimentId, mounted);
 
   const setRefs = (node: HTMLDivElement | null) => {


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)