### PR TITLE
fix(mobile): run Python macros against the server helper prelude (OJD-1647)

### DIFF
--- a/apps/mobile/src/features/measurement-flow/components/python-macro-provider.tsx
+++ b/apps/mobile/src/features/measurement-flow/components/python-macro-provider.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { View } from "react-native";
 import WebView from "react-native-webview";
-import { pythonMacroSandboxHtml } from "~/features/measurement-flow/services/python/python-macro-sandbox";
+import { getPythonMacroSandboxHtml } from "~/features/measurement-flow/services/python/python-macro-sandbox";
 import type { MacroOutput } from "~/features/measurement-flow/utils/process-scan/process-scan";
 import { registerPythonMacroRunner } from "~/features/measurement-flow/utils/process-scan/python-macro-runner";
 import { createLogger } from "~/shared/observability/logger";
@@ -17,6 +17,20 @@ export function PythonMacroProvider({ children }: { children: React.ReactNode })
   const pendingRef = useRef<Map<string, Pending>>(new Map());
   const requestIdRef = useRef(0);
   const webViewRef = useRef<WebView>(null);
+  // HTML is built once the bundled helper source loads (a local file read).
+  const [html, setHtml] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    getPythonMacroSandboxHtml()
+      .then((h) => {
+        if (alive) setHtml(h);
+      })
+      .catch((err) => log.error("failed to load sandbox html", { err: (err as Error)?.message }));
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   const runPythonMacro = useCallback(async (code: string, json: object): Promise<MacroOutput> => {
     const requestId = `py-${++requestIdRef.current}`;
@@ -30,12 +44,15 @@ export function PythonMacroProvider({ children }: { children: React.ReactNode })
     });
   }, []);
 
+  // Only advertise the runner once the WebView is mounted, so a macro can't be
+  // dispatched at a ref that isn't there yet (its promise would never settle).
   useEffect(() => {
+    if (!html) return;
     registerPythonMacroRunner(runPythonMacro);
     return () => {
       registerPythonMacroRunner(null);
     };
-  }, [runPythonMacro]);
+  }, [html, runPythonMacro]);
 
   const handleMessage = useCallback((event: { nativeEvent: { data: string } }) => {
     try {
@@ -75,13 +92,15 @@ export function PythonMacroProvider({ children }: { children: React.ReactNode })
           pointerEvents: "none",
         }}
       >
-        <WebView
-          ref={webViewRef}
-          originWhitelist={["*"]}
-          source={{ html: pythonMacroSandboxHtml }}
-          onMessage={handleMessage}
-          style={{ width: 1, height: 1 }}
-        />
+        {html ? (
+          <WebView
+            ref={webViewRef}
+            originWhitelist={["*"]}
+            source={{ html }}
+            onMessage={handleMessage}
+            style={{ width: 1, height: 1 }}
+          />
+        ) : null}
       </View>
     </View>
   );

--- a/apps/mobile/src/features/measurement-flow/services/python/macro-helpers.py.txt
+++ b/apps/mobile/src/features/measurement-flow/services/python/macro-helpers.py.txt
@@ -1,0 +1,906 @@
+"""Python helper functions for MultispeQ macro processing."""
+
+import math
+import json
+import statistics
+from typing import List, Dict, Any, Union
+
+# Try to import numpy and scipy, fall back to standard library if not available
+try:
+    import numpy as np
+    NUMPY_AVAILABLE = True
+except ImportError:
+    NUMPY_AVAILABLE = False
+    print("[HELPERS] WARNING: NumPy not available. Some advanced functions may be limited.")
+
+try:
+    from scipy import stats
+    from scipy.optimize import curve_fit
+    SCIPY_AVAILABLE = True
+except ImportError:
+    SCIPY_AVAILABLE = False
+    print("[HELPERS] WARNING: SciPy not available. Some advanced functions may be limited.")
+
+try:
+    from scipy.signal import savgol_filter
+    SCIPY_SIGNAL_AVAILABLE = True
+except ImportError:
+    SCIPY_SIGNAL_AVAILABLE = False
+
+
+def ArrayNth(arr: List[Union[int, float]], size: int = 1, idx: int = 0) -> List[Union[int, float]]:
+    """
+    Extract every n-th element from an array.
+    
+    Args:
+        arr: Input array
+        size: Step size (default: 1)
+        idx: Starting point (default: 0)
+        
+    Returns:
+        Every n-th element
+        
+    Example:
+        ArrayNth([1, 2, 3, 4, 5, 6], 2, 2)
+        # returns [3, 5]
+    """
+    if not isinstance(arr, list):
+        return None
+    
+    if idx < 0:
+        idx = 0
+    
+    if size < 1:
+        size = 1
+    
+    return arr[idx::size]
+
+
+def ArrayRange(start: int = None, stop: int = None, step: int = 1, transform: str = "none") -> List[Union[int, float]]:
+    """
+    Generate an array of arithmetic progressions with optional transformations.
+    
+    Args:
+        start: Start value (default: 0)
+        stop: Stop value (required if start is provided)
+        step: Step size (default: 1)
+        transform: Transformation type ('none', 'log', 'ln', 'x2')
+        
+    Returns:
+        Array of numbers with optional transformation applied
+        
+    Example:
+        ArrayRange(10)  # returns [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        ArrayRange(1, 11)  # returns [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        ArrayRange(0, 10, 3, "x2")  # returns [0, 9, 36, 81]
+    """
+    if start is None:
+        return []
+    
+    if not isinstance(start, (int, float)):
+        return None
+    
+    if stop is None:
+        stop = start
+        start = 0
+    
+    if not isinstance(stop, (int, float)):
+        return None
+    
+    if not isinstance(step, (int, float)) or step == 0:
+        return None
+    
+    if transform not in ['none', 'log', 'ln', 'x2']:
+        return None
+    
+    arr = []
+    current = start
+    
+    while (step > 0 and current < stop) or (step < 0 and current > stop):
+        if transform == 'none':
+            arr.append(current)
+        elif transform == 'log':
+            arr.append(math.log10(current) if current > 0 else None)
+        elif transform == 'ln':
+            arr.append(math.log(current) if current > 0 else None)
+        elif transform == 'x2':
+            arr.append(current ** 2)
+        current += step
+    
+    return [x for x in arr if x is not None]
+
+
+def ArrayUnZip(input_data: List[List[Union[int, float]]]) -> Dict[str, List[Union[int, float]]]:
+    """
+    Transform an array of [x, y] pairs into an object with separate x and y arrays.
+    
+    Args:
+        input_data: Array of [x, y] pairs
+        
+    Returns:
+        Dictionary with 'x' and 'y' arrays
+        
+    Example:
+        ArrayUnZip([[1, 4], [2, 5], [3, 6]])
+        # returns {'x': [1, 2, 3], 'y': [4, 5, 6]}
+    """
+    if not input_data or not isinstance(input_data, list) or not isinstance(input_data[0], list):
+        return None
+    
+    x_vals = []
+    y_vals = []
+    
+    for pair in input_data:
+        if len(pair) >= 2:
+            x_vals.append(pair[0])
+            y_vals.append(pair[1])
+    
+    return {'x': x_vals, 'y': y_vals}
+
+
+def ArrayZip(x: List[Union[int, float]], y: List[Union[int, float]]) -> List[List[Union[int, float]]]:
+    """
+    Transform two arrays into one array of x,y pairs.
+    
+    Args:
+        x: Array of x values
+        y: Array of y values
+        
+    Returns:
+        Array of [x, y] pairs
+        
+    Example:
+        ArrayZip([1, 2, 3], [4, 5, 6])
+        # returns [[1, 4], [2, 5], [3, 6]]
+    """
+    if not isinstance(x, list) or not isinstance(y, list) or len(x) != len(y):
+        return None
+    
+    return [[x[i], y[i]] for i in range(len(x))]
+
+
+def GetIndexByLabel(label: str, json_data: Dict, array: bool = False) -> Union[int, List[int]]:
+    """
+    Find positions for protocols within a protocol set matching the provided label.
+    
+    Args:
+        label: Label from the protocol set
+        json_data: The protocol content
+        array: Always return an array (default: False)
+        
+    Returns:
+        Single index or array of indexes
+    """
+    if label is None:
+        return None
+    
+    if not json_data.get('set'):
+        return None
+    
+    indexes = []
+    for i, protocol in enumerate(json_data['set']):
+        if protocol.get('label') == label:
+            indexes.append(i)
+    
+    if len(indexes) == 0:
+        return None
+    elif len(indexes) == 1 and not array:
+        return indexes[0]
+    else:
+        return indexes
+
+
+def GetLabelLookup(json_data: Dict) -> Dict[str, List[int]]:
+    """
+    Generate a protocol lookup table for a protocol set.
+    
+    Args:
+        json_data: Protocol data
+        
+    Returns:
+        Lookup table mapping labels to index arrays
+    """
+    if not json_data.get('set'):
+        return None
+    
+    lookup = {}
+    for i, protocol in enumerate(json_data['set']):
+        label = protocol.get('label')
+        if label:
+            if label not in lookup:
+                lookup[label] = []
+            lookup[label].append(i)
+    
+    return lookup if lookup else None
+
+
+def GetProtocolByLabel(label: str, json_data: Dict, array: bool = False) -> Union[Dict, List[Dict]]:
+    """
+    Returns protocols from within the protocol set matching the provided label.
+    
+    Args:
+        label: The label from the protocol set
+        json_data: The protocol content
+        array: Always return an array (default: False)
+        
+    Returns:
+        Single protocol or array of protocols
+    """
+    if label is None:
+        return None
+    
+    if not json_data.get('set'):
+        return None
+    
+    protocols = [p for p in json_data['set'] if p.get('label') == label]
+    
+    if len(protocols) == 0:
+        return None
+    elif len(protocols) == 1 and not array:
+        return protocols[0]
+    else:
+        return protocols
+
+
+# Mathematical Functions
+
+def MathLINREG(x: List[float], y: List[float]) -> Dict[str, float]:
+    """
+    Perform simple linear regression (y = mx + b).
+    
+    Args:
+        x: x-values
+        y: y-values
+        
+    Returns:
+        Dictionary with slope (m), y-intercept (b), correlation coefficient (r), and R² (r2)
+    """
+    if len(x) != len(y) or len(x) < 2:
+        return None
+    
+    try:
+        if SCIPY_AVAILABLE:
+            slope, intercept, r_value, p_value, std_err = stats.linregress(x, y)
+            return {
+                'm': slope,
+                'b': intercept,
+                'r': r_value,
+                'r2': r_value ** 2
+            }
+        else:
+            # Fallback calculation without scipy
+            n = len(x)
+            sum_x = sum(x)
+            sum_y = sum(y)
+            sum_xy = sum(x[i] * y[i] for i in range(n))
+            sum_x2 = sum(xi ** 2 for xi in x)
+            sum_y2 = sum(yi ** 2 for yi in y)
+            
+            # Calculate slope and intercept
+            slope = (n * sum_xy - sum_x * sum_y) / (n * sum_x2 - sum_x ** 2)
+            intercept = (sum_y - slope * sum_x) / n
+            
+            # Calculate correlation coefficient
+            numerator = n * sum_xy - sum_x * sum_y
+            denominator = math.sqrt((n * sum_x2 - sum_x ** 2) * (n * sum_y2 - sum_y ** 2))
+            r_value = numerator / denominator if denominator != 0 else 0
+            
+            return {
+                'm': slope,
+                'b': intercept,
+                'r': r_value,
+                'r2': r_value ** 2
+            }
+    except:
+        return None
+
+
+def MathLN(value: Union[int, float]) -> float:
+    """
+    Returns the natural logarithm (base E) of a number.
+    
+    Args:
+        value: Input value
+        
+    Returns:
+        Natural logarithm of the value
+    """
+    if value and value > 0:
+        return math.log(value)
+    return None
+
+
+def MathLOG(value: Union[int, float]) -> float:
+    """
+    Returns the logarithm (base 10) of a number.
+    
+    Args:
+        value: Input value
+        
+    Returns:
+        Base-10 logarithm of the value
+    """
+    if value and value > 0:
+        return math.log10(value)
+    return None
+
+
+def MathMAX(values: List[Union[int, float]]) -> float:
+    """
+    Get the maximum value from an array of numbers.
+    
+    Args:
+        values: Array of numbers
+        
+    Returns:
+        Maximum value
+    """
+    if values and isinstance(values, list) and len(values) > 0:
+        try:
+            return max(values)
+        except:
+            return None
+    return None
+
+
+def MathMEAN(values: List[Union[int, float]]) -> float:
+    """
+    Calculate the mean from an array of numbers.
+    
+    Args:
+        values: Array of numbers
+        
+    Returns:
+        Mean value
+    """
+    if values and isinstance(values, list) and len(values) > 0:
+        try:
+            return statistics.mean(values)
+        except:
+            return None
+    return None
+
+
+def MathMEDIAN(values: List[Union[int, float]]) -> float:
+    """
+    Calculate the median from an array of numbers.
+    
+    Args:
+        values: Array of numbers
+        
+    Returns:
+        Median value
+    """
+    if values and isinstance(values, list) and len(values) > 0:
+        try:
+            return statistics.median(values)
+        except:
+            return None
+    return None
+
+
+def MathMIN(values: List[Union[int, float]]) -> float:
+    """
+    Get the minimum value from an array of numbers.
+    
+    Args:
+        values: Array of numbers
+        
+    Returns:
+        Minimum value
+    """
+    if values and isinstance(values, list) and len(values) > 0:
+        try:
+            return min(values)
+        except:
+            return None
+    return None
+
+
+def MathROUND(value: Union[int, float], digits: int = 2) -> float:
+    """
+    Round a number to specified decimal places.
+    
+    Args:
+        value: Value to round
+        digits: Number of decimal places (default: 2)
+        
+    Returns:
+        Rounded value
+    """
+    if value is None or value == '':
+        return None
+    
+    try:
+        return round(float(value), digits)
+    except:
+        return None
+
+
+def MathSTDERR(values: List[Union[int, float]]) -> float:
+    """
+    Calculate the standard error from an array of numbers.
+    
+    Args:
+        values: Array of numbers
+        
+    Returns:
+        Standard error
+    """
+    if values and isinstance(values, list) and len(values) > 1:
+        try:
+            std_dev = statistics.stdev(values)
+            return std_dev / math.sqrt(len(values))
+        except:
+            return None
+    return None
+
+
+def MathSTDEV(values: List[Union[int, float]]) -> float:
+    """
+    Calculate the population standard deviation from an array of numbers.
+    
+    Args:
+        values: Array of numbers
+        
+    Returns:
+        Population standard deviation
+    """
+    if values and isinstance(values, list) and len(values) > 0:
+        try:
+            return statistics.pstdev(values)
+        except:
+            return None
+    return None
+
+
+def MathSTDEVS(values: List[Union[int, float]]) -> float:
+    """
+    Calculate the sample standard deviation from an array of numbers.
+    
+    Args:
+        values: Array of numbers
+        
+    Returns:
+        Sample standard deviation
+    """
+    if values and isinstance(values, list) and len(values) > 1:
+        try:
+            return statistics.stdev(values)
+        except:
+            return None
+    return None
+
+
+def MathSUM(values: List[Union[int, float]]) -> float:
+    """
+    Calculate the sum from an array of numbers.
+    
+    Args:
+        values: Array of numbers
+        
+    Returns:
+        Sum of values
+    """
+    if values and isinstance(values, list) and len(values) > 0:
+        try:
+            return sum(values)
+        except:
+            return None
+    return None
+
+
+def MathVARIANCE(values: List[Union[int, float]]) -> float:
+    """
+    Calculate the variance from an array of numbers.
+    
+    Args:
+        values: Array of numbers
+        
+    Returns:
+        Variance
+    """
+    if values and isinstance(values, list) and len(values) > 1:
+        try:
+            return statistics.variance(values)
+        except:
+            return None
+    return None
+
+
+# Messaging Functions
+
+def info(msg: str, output: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Add an Info Message for the User.
+    
+    Args:
+        msg: Info message
+        output: Output object that is returned at the end
+        
+    Returns:
+        Modified output object with the message
+    """
+    if 'messages' not in output:
+        output['messages'] = {}
+    if 'info' not in output['messages']:
+        output['messages']['info'] = []
+    output['messages']['info'].append(msg)
+    return output
+
+
+def warning(msg: str, output: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Add a Warning Message for the User.
+    
+    Args:
+        msg: Warning message
+        output: Output object that is returned at the end
+        
+    Returns:
+        Modified output object with the message
+    """
+    if 'messages' not in output:
+        output['messages'] = {}
+    if 'warning' not in output['messages']:
+        output['messages']['warning'] = []
+    output['messages']['warning'].append(msg)
+    return output
+
+
+def danger(msg: str, output: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Add a Danger Message for the User.
+    
+    Args:
+        msg: Danger message
+        output: Output object that is returned at the end
+        
+    Returns:
+        Modified output object with the message
+    """
+    if 'messages' not in output:
+        output['messages'] = {}
+    if 'danger' not in output['messages']:
+        output['messages']['danger'] = []
+    output['messages']['danger'].append(msg)
+    return output
+
+
+# Advanced Mathematical Functions
+
+def MathMULTREG(input_raw: List[List[float]]) -> Dict[str, Any]:
+    """
+    Multiple Linear Regression.
+    
+    Args:
+        input_raw: Array with values [predictor 1, predictor 2, ..., response]
+        
+    Returns:
+        Regression results
+    """
+    if not input_raw or len(input_raw) < 2:
+        return None
+    
+    if not NUMPY_AVAILABLE:
+        print("[HELPERS] WARNING: NumPy required for MathMULTREG")
+        return None
+    
+    try:
+        # Convert to numpy arrays
+        data = np.array(input_raw)
+        X = data[:, :-1]  # All columns except last (predictors)
+        y = data[:, -1]   # Last column (response)
+        
+        # Add intercept column
+        X = np.column_stack([np.ones(len(X)), X])
+        
+        # Calculate coefficients using normal equation
+        coefficients = np.linalg.lstsq(X, y, rcond=None)[0]
+        
+        # Calculate R-squared
+        y_pred = X.dot(coefficients)
+        ss_res = np.sum((y - y_pred) ** 2)
+        ss_tot = np.sum((y - np.mean(y)) ** 2)
+        r_squared = 1 - (ss_res / ss_tot) if ss_tot != 0 else 0
+        
+        return {
+            'coefficients': coefficients.tolist(),
+            'r_squared': r_squared,
+            'intercept': coefficients[0],
+            'slopes': coefficients[1:].tolist()
+        }
+    except:
+        return None
+
+
+def MathEXPINVREG(input_raw: List[List[float]]) -> Dict[str, Any]:
+    """
+    Exponential inverse regression: Fit to Y = Y0 + Ae^(-x/t).
+    
+    Args:
+        input_raw: Array of [predictor, response] pairs
+        
+    Returns:
+        Regression results
+    """
+    if not input_raw or len(input_raw) < 3:
+        return None
+    
+    if not NUMPY_AVAILABLE or not SCIPY_AVAILABLE:
+        print("[HELPERS] WARNING: NumPy and SciPy required for MathEXPINVREG")
+        return None
+    
+    try:
+        data = np.array(input_raw)
+        x = data[:, 0]
+        y = data[:, 1]
+        
+        # Define the exponential decay function
+        def exp_decay(x, y0, a, t):
+            return y0 + a * np.exp(-x / t)
+        
+        # Initial parameter guesses
+        y0_guess = min(y)
+        a_guess = max(y) - min(y)
+        t_guess = (max(x) - min(x)) / 3
+        
+        # Fit the curve
+        popt, pcov = curve_fit(exp_decay, x, y, p0=[y0_guess, a_guess, t_guess])
+        
+        # Calculate R-squared
+        y_pred = exp_decay(x, *popt)
+        ss_res = np.sum((y - y_pred) ** 2)
+        ss_tot = np.sum((y - np.mean(y)) ** 2)
+        r_squared = 1 - (ss_res / ss_tot) if ss_tot != 0 else 0
+        
+        return {
+            'y0': popt[0],
+            'a': popt[1],
+            't': popt[2],
+            'r_squared': r_squared,
+            'parameters': popt.tolist()
+        }
+    except:
+        return None
+
+
+def MathPOLYREG(input_raw: List[List[float]], degree: int) -> Dict[str, Any]:
+    """
+    Polynomial regression: fit to y = a0 + a1*x + a2*x^2 + a3*x^3 + ...
+    
+    Args:
+        input_raw: Array of [predictor, response] pairs
+        degree: Degree of polynomial
+        
+    Returns:
+        Regression results
+    """
+    if not input_raw or len(input_raw) < degree + 1:
+        return None
+    
+    if not NUMPY_AVAILABLE:
+        print("[HELPERS] WARNING: NumPy required for MathPOLYREG")
+        return None
+    
+    try:
+        data = np.array(input_raw)
+        x = data[:, 0]
+        y = data[:, 1]
+        
+        # Fit polynomial
+        coefficients = np.polyfit(x, y, degree)
+        
+        # Calculate R-squared
+        y_pred = np.polyval(coefficients, x)
+        ss_res = np.sum((y - y_pred) ** 2)
+        ss_tot = np.sum((y - np.mean(y)) ** 2)
+        r_squared = 1 - (ss_res / ss_tot) if ss_tot != 0 else 0
+        
+        return {
+            'coefficients': coefficients.tolist(),
+            'r_squared': r_squared,
+            'degree': degree
+        }
+    except:
+        return None
+
+
+def TransformTrace(fn: str, a1: List[float], a2: Union[float, List[float]] = None) -> List[float]:
+    """
+    Transform a given array by providing a second array or a single number.
+    
+    Args:
+        fn: Function name ('add', 'subtract', 'multiply', 'divide', '+', '-', '*', '/', 
+            'normToMin', 'normToMax', 'normToRange', 'normToIdx', 'normToVal', 'ma', 'sgf', 'abs')
+        a1: Input array
+        a2: Second array or single number (optional)
+        
+    Returns:
+        Transformed array
+    """
+    if not isinstance(a1, list) or len(a1) == 0:
+        return None
+    
+    try:
+        if NUMPY_AVAILABLE:
+            arr = np.array(a1)
+        else:
+            arr = a1[:]  # Make a copy
+    
+        if fn in ['add', '+']:
+            if isinstance(a2, (int, float)):
+                if NUMPY_AVAILABLE:
+                    return (arr + a2).tolist()
+                else:
+                    return [x + a2 for x in arr]
+            elif isinstance(a2, list) and len(a2) == len(a1):
+                if NUMPY_AVAILABLE:
+                    return (arr + np.array(a2)).tolist()
+                else:
+                    return [a1[i] + a2[i] for i in range(len(a1))]
+                
+        elif fn in ['subtract', '-']:
+            if isinstance(a2, (int, float)):
+                if NUMPY_AVAILABLE:
+                    return (arr - a2).tolist()
+                else:
+                    return [x - a2 for x in arr]
+            elif isinstance(a2, list) and len(a2) == len(a1):
+                if NUMPY_AVAILABLE:
+                    return (arr - np.array(a2)).tolist()
+                else:
+                    return [a1[i] - a2[i] for i in range(len(a1))]
+                
+        elif fn in ['multiply', '*']:
+            if isinstance(a2, (int, float)):
+                if NUMPY_AVAILABLE:
+                    return (arr * a2).tolist()
+                else:
+                    return [x * a2 for x in arr]
+            elif isinstance(a2, list) and len(a2) == len(a1):
+                if NUMPY_AVAILABLE:
+                    return (arr * np.array(a2)).tolist()
+                else:
+                    return [a1[i] * a2[i] for i in range(len(a1))]
+                
+        elif fn in ['divide', '/']:
+            if isinstance(a2, (int, float)) and a2 != 0:
+                if NUMPY_AVAILABLE:
+                    return (arr / a2).tolist()
+                else:
+                    return [x / a2 for x in arr]
+            elif isinstance(a2, list) and len(a2) == len(a1):
+                if NUMPY_AVAILABLE:
+                    a2_arr = np.array(a2)
+                    return np.divide(arr, a2_arr, out=np.zeros_like(arr), where=a2_arr!=0).tolist()
+                else:
+                    return [a1[i] / a2[i] if a2[i] != 0 else 0 for i in range(len(a1))]
+                
+        elif fn == 'normToMin':
+            if NUMPY_AVAILABLE:
+                min_val = np.min(arr)
+                return (arr / min_val if min_val != 0 else arr).tolist()
+            else:
+                min_val = min(arr)
+                return [x / min_val if min_val != 0 else x for x in arr]
+            
+        elif fn == 'normToMax':
+            if NUMPY_AVAILABLE:
+                max_val = np.max(arr)
+                return (arr / max_val if max_val != 0 else arr).tolist()
+            else:
+                max_val = max(arr)
+                return [x / max_val if max_val != 0 else x for x in arr]
+            
+        elif fn == 'normToRange':
+            if NUMPY_AVAILABLE:
+                min_val, max_val = np.min(arr), np.max(arr)
+                range_val = max_val - min_val
+                return ((arr - min_val) / range_val if range_val != 0 else np.zeros_like(arr)).tolist()
+            else:
+                min_val, max_val = min(arr), max(arr)
+                range_val = max_val - min_val
+                return [(x - min_val) / range_val if range_val != 0 else 0 for x in arr]
+            
+        elif fn == 'normToIdx' and isinstance(a2, int) and 0 <= a2 < len(a1):
+            norm_val = arr[a2] if NUMPY_AVAILABLE else a1[a2]
+            if NUMPY_AVAILABLE:
+                return (arr / norm_val if norm_val != 0 else arr).tolist()
+            else:
+                return [x / norm_val if norm_val != 0 else x for x in arr]
+            
+        elif fn == 'normToVal' and isinstance(a2, (int, float)):
+            if NUMPY_AVAILABLE:
+                return (arr / a2 if a2 != 0 else arr).tolist()
+            else:
+                return [x / a2 if a2 != 0 else x for x in arr]
+            
+        elif fn == 'ma':  # Moving average
+            window = min(3, len(arr))
+            if NUMPY_AVAILABLE:
+                return np.convolve(arr, np.ones(window)/window, mode='same').tolist()
+            else:
+                # Simple moving average implementation
+                result = []
+                for i in range(len(arr)):
+                    start = max(0, i - window//2)
+                    end = min(len(arr), i + window//2 + 1)
+                    result.append(sum(arr[start:end]) / (end - start))
+                return result
+                
+        elif fn == 'sgf':  # Savitzky-Golay filter
+            if SCIPY_SIGNAL_AVAILABLE and NUMPY_AVAILABLE:
+                window_length = min(5, len(arr) if len(arr) % 2 == 1 else len(arr) - 1)
+                if window_length >= 3:
+                    return savgol_filter(arr, window_length, 2).tolist()
+            # Fallback to moving average if scipy not available
+            return TransformTrace('ma', a1, a2)
+                
+        elif fn == 'abs':  # Absorbance: -log(I/I0)
+            i0 = a2 if isinstance(a2, (int, float)) else arr[0]
+            if i0 > 0:
+                if NUMPY_AVAILABLE:
+                    return (-np.log10(arr / i0)).tolist()
+                else:
+                    return [-math.log10(x / i0) if x > 0 else 0 for x in arr]
+                
+    except Exception as e:
+        print(f"Error in TransformTrace: {e}")
+        return None
+    
+    return None
+
+
+def calcSunAngle(roll: float, pitch: float, compass: float, azimuth: float, altitude: float) -> float:
+    """
+    Calculate the angular difference between the device and the sun.
+    
+    Args:
+        roll: Device roll angle
+        pitch: Device pitch angle
+        compass: Device compass heading
+        azimuth: Sun azimuth angle
+        altitude: Sun altitude angle
+        
+    Returns:
+        Angular difference in degrees
+    """
+    try:
+        # Convert to radians
+        roll_rad = math.radians(roll)
+        pitch_rad = math.radians(pitch)
+        compass_rad = math.radians(compass)
+        azimuth_rad = math.radians(azimuth)
+        altitude_rad = math.radians(altitude)
+        
+        # Device normal vector
+        device_x = math.sin(roll_rad) * math.cos(pitch_rad)
+        device_y = -math.sin(pitch_rad)
+        device_z = math.cos(roll_rad) * math.cos(pitch_rad)
+        
+        # Sun vector
+        sun_x = math.cos(altitude_rad) * math.sin(azimuth_rad - compass_rad)
+        sun_y = math.sin(altitude_rad)
+        sun_z = math.cos(altitude_rad) * math.cos(azimuth_rad - compass_rad)
+        
+        # Dot product
+        dot_product = device_x * sun_x + device_y * sun_y + device_z * sun_z
+        
+        # Angle in degrees
+        angle = math.degrees(math.acos(max(-1, min(1, dot_product))))
+        
+        return angle
+    except:
+        return None
+
+
+# Make all functions available for import
+__all__ = [
+    'ArrayNth', 'ArrayRange', 'ArrayUnZip', 'ArrayZip',
+    'GetIndexByLabel', 'GetLabelLookup', 'GetProtocolByLabel',
+    'MathLINREG', 'MathLN', 'MathLOG', 'MathMAX', 'MathMEAN', 'MathMEDIAN',
+    'MathMIN', 'MathROUND', 'MathSTDERR', 'MathSTDEV', 'MathSTDEVS',
+    'MathSUM', 'MathVARIANCE', 'info', 'warning', 'danger',
+    'MathMULTREG', 'MathEXPINVREG', 'MathPOLYREG', 'TransformTrace', 'calcSunAngle'
+]

--- a/apps/mobile/src/features/measurement-flow/services/python/python-macro-sandbox.test.ts
+++ b/apps/mobile/src/features/measurement-flow/services/python/python-macro-sandbox.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  MACRO_HELPER_NAMES,
+  buildMacroProgram,
+  buildPythonMacroSandboxHtml,
+} from "./python-macro-sandbox";
+
+// The raw `.txt` import has no Node loader; stub it (the builders under test
+// take the source as an argument, so the asset value is irrelevant here).
+vi.mock("./macro-helpers.py.txt", () => ({ default: "mock-helpers-asset" }));
+vi.mock("expo-asset", () => ({
+  Asset: { fromModule: vi.fn(() => ({ downloadAsync: vi.fn(() => Promise.resolve()), uri: "x" })) },
+}));
+vi.mock("expo-file-system", () => ({
+  File: class {
+    text() {
+      return Promise.resolve("");
+    }
+  },
+}));
+
+describe("buildMacroProgram", () => {
+  const program = buildMacroProgram("return danger('bad', output)", "eyJhIjoxfQ==");
+
+  it("wraps the macro in execute_macro and indents its body", () => {
+    expect(program).toContain("def execute_macro():");
+    expect(program).toContain("    return danger('bad', output)");
+  });
+
+  it("exposes `json` (the input row) and an empty `output`, matching wrapper.py", () => {
+    expect(program).toContain("json = __json_input__");
+    expect(program).toContain("output = {}");
+  });
+
+  it("merges a dict return into output and serialises output as the result", () => {
+    expect(program).toContain("if isinstance(__macro_result__, dict):");
+    expect(program).toContain("    output.update(__macro_result__)");
+    expect(program).toContain("__result_holder__.result = __jsonmod__.dumps(output)");
+  });
+
+  it("decodes the passed json payload", () => {
+    expect(program).toContain('__b64__.b64decode("eyJhIjoxfQ==")');
+  });
+});
+
+describe("buildPythonMacroSandboxHtml", () => {
+  it("imports the helpers as a module and binds every helper name as a global", () => {
+    const html = buildPythonMacroSandboxHtml("# helpers");
+    expect(html).toContain("pyodide.FS.writeFile('jii_macro_helpers.py', HELPERS_SRC)");
+    expect(html).toContain("import jii_macro_helpers");
+    expect(html).toContain("from jii_macro_helpers import ' + HELPER_NAMES");
+    for (const name of ["danger", "info", "warning", "GetProtocolByLabel", "MathMEAN"]) {
+      expect(MACRO_HELPER_NAMES).toContain(name);
+    }
+  });
+
+  it("escapes `<` in the helper source so a stray </script> can't close the tag", () => {
+    const html = buildPythonMacroSandboxHtml("LT_TEST = '<x>'");
+    expect(html).toContain("LT_TEST = '\\u003cx>'");
+    expect(html).not.toContain("LT_TEST = '<x>'");
+  });
+});

--- a/apps/mobile/src/features/measurement-flow/services/python/python-macro-sandbox.ts
+++ b/apps/mobile/src/features/measurement-flow/services/python/python-macro-sandbox.ts
@@ -1,9 +1,77 @@
+import { Asset } from "expo-asset";
+import { File } from "expo-file-system";
+
+import helpersResource from "./macro-helpers.py.txt";
+
+// Helper names bound as globals for every macro, mirroring the server's
+// wrapper.py. Without them a Python macro NameErrors on-device (e.g. `danger`).
+export const MACRO_HELPER_NAMES = [
+  "ArrayNth",
+  "ArrayRange",
+  "ArrayUnZip",
+  "ArrayZip",
+  "GetIndexByLabel",
+  "GetLabelLookup",
+  "GetProtocolByLabel",
+  "MathLINREG",
+  "MathLN",
+  "MathLOG",
+  "MathMAX",
+  "MathMEAN",
+  "MathMEDIAN",
+  "MathMIN",
+  "MathROUND",
+  "MathSTDERR",
+  "MathSTDEV",
+  "MathSTDEVS",
+  "MathSUM",
+  "MathVARIANCE",
+  "MathMULTREG",
+  "MathEXPINVREG",
+  "MathPOLYREG",
+  "TransformTrace",
+  "calcSunAngle",
+  "info",
+  "warning",
+  "danger",
+] as const;
+
+// JS string literal safe to embed inside an HTML <script>: escaping `<` keeps a
+// stray "</script>" in the helper source from closing the tag early.
+function jsStringLiteral(value: string): string {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}
+
 /**
- * Inline HTML for a hidden WebView that runs Python macros via Pyodide.
- * Listens for postMessage({ requestId, code, json }), wraps code in a function
- * that receives json, runs it, and posts back { requestId, result } or { requestId, error }.
+ * Builds the Pyodide program for one macro run, matching wrapper.py: `json` is
+ * the input row, `output` starts empty, and a dict return is merged into it.
  */
-export const pythonMacroSandboxHtml = `
+export function buildMacroProgram(code: string, jsonB64: string): string {
+  const indented = code
+    .split("\n")
+    .map((line) => `    ${line}`)
+    .join("\n");
+  return [
+    "import json as __jsonmod__, base64 as __b64__",
+    `__json_input__ = __jsonmod__.loads(__b64__.b64decode("${jsonB64}").decode("utf-8"))`,
+    "json = __json_input__",
+    "output = {}",
+    "def execute_macro():",
+    indented,
+    "",
+    "__macro_result__ = execute_macro()",
+    "if isinstance(__macro_result__, dict):",
+    "    output.update(__macro_result__)",
+    "__result_holder__.result = __jsonmod__.dumps(output)",
+    "",
+  ].join("\n");
+}
+
+// HTML for a hidden WebView running macros via Pyodide. Helpers are baked in and
+// imported as an isolated module at init (so their `json`/`math` don't collide
+// with the macro's `json`), then bound as globals.
+export function buildPythonMacroSandboxHtml(helpersSource: string): string {
+  return `
 <!DOCTYPE html>
 <html>
 <head><meta charset="UTF-8"/><title>Python Macro</title></head>
@@ -13,6 +81,8 @@ export const pythonMacroSandboxHtml = `
 (function() {
   var pyodideReady = false;
   var pending = [];
+  var HELPERS_SRC = ${jsStringLiteral(helpersSource)};
+  var HELPER_NAMES = ${jsStringLiteral(MACRO_HELPER_NAMES.join(", "))};
 
   function send(obj) {
     if (window.ReactNativeWebView && ReactNativeWebView.postMessage) {
@@ -30,11 +100,14 @@ export const pythonMacroSandboxHtml = `
       pyodide.globals.set('__result_holder__', resultHolder);
       var jsonB64 = btoa(unescape(encodeURIComponent(JSON.stringify(json))));
       var wrapped =
-        'import base64, json\\n' +
-        '__json_input__ = json.loads(base64.b64decode("' + jsonB64 + '").decode("utf-8"))\\n' +
-        'def __macro__(json):\\n' + indent(code) + '\\n\\n' +
-        '__result__ = __macro__(__json_input__)\\n' +
-        '__result_holder__.result = json.dumps(__result__)\\n';
+        'import json as __jsonmod__, base64 as __b64__\\n' +
+        '__json_input__ = __jsonmod__.loads(__b64__.b64decode("' + jsonB64 + '").decode("utf-8"))\\n' +
+        'json = __json_input__\\n' +
+        'output = {}\\n' +
+        'def execute_macro():\\n' + indent(code) + '\\n\\n' +
+        '__macro_result__ = execute_macro()\\n' +
+        'if isinstance(__macro_result__, dict):\\n    output.update(__macro_result__)\\n' +
+        '__result_holder__.result = __jsonmod__.dumps(output)\\n';
       await pyodide.runPythonAsync(wrapped);
       var raw = resultHolder.result;
       var str = (typeof raw === 'string') ? raw : (raw != null ? String(raw) : '');
@@ -63,8 +136,15 @@ export const pythonMacroSandboxHtml = `
     }
   });
 
-  loadPyodide().then(function(pyodide) {
+  loadPyodide().then(async function(pyodide) {
     window.pyodide = pyodide;
+    // Define helpers as a module so their internal imports stay isolated, then
+    // expose the functions as globals for the macro to call.
+    pyodide.FS.writeFile('jii_macro_helpers.py', HELPERS_SRC);
+    await pyodide.runPythonAsync(
+      'import jii_macro_helpers\\n' +
+      'from jii_macro_helpers import ' + HELPER_NAMES + '\\n'
+    );
     pyodideReady = true;
     send({ type: 'ready' });
     pending.forEach(function(p) { runMacro(p.requestId, p.code, p.json || {}); });
@@ -81,3 +161,19 @@ export const pythonMacroSandboxHtml = `
 </body>
 </html>
 `;
+}
+
+async function loadHelpersSource(): Promise<string> {
+  const asset = Asset.fromModule(helpersResource);
+  await asset.downloadAsync();
+  const path = asset.localUri ?? asset.uri;
+  return await new File(path).text();
+}
+
+let htmlPromise: Promise<string> | null = null;
+
+/** Loads the bundled helper source once and returns the ready-to-render HTML. */
+export function getPythonMacroSandboxHtml(): Promise<string> {
+  htmlPromise ??= loadHelpersSource().then(buildPythonMacroSandboxHtml);
+  return htmlPromise;
+}


### PR DESCRIPTION
## Problem
On-device Python macros fail with a `NameError` ("danger does not exist") even though the same macro runs online. Pre-existing gap, **not** the OJD-1564 flatten (git confirms the macro runtime was untouched there).

## Root cause
The Pyodide macro sandbox gave macros none of the runtime the server's `apps/macro-sandbox/lib/wrappers/wrapper.py` injects: no helpers (`danger`/`info`/`warning`/`GetProtocolByLabel`/`Math*`/`Array*`/`TransformTrace`/`calcSunAngle`) and no `json`/`output` globals macros are written against. The JS macro path prepends `math.lib.js`; the Python path had no equivalent prelude. Online works only because the server supplies them.

## Fix
- Bundle the server's `helpers.py` as `macro-helpers.py.txt`; at Pyodide init write it to the FS and `import` it as an **isolated module** (so the helpers' own `json`/`math` don't collide with the macro's `json` data global), then bind the helper functions as macro globals.
- Run each macro with `json` = the input row and `output` = `{}`, merging a dict return into `output`, mirroring `wrapper.py` so on-device output matches online.
- Pure builders (`buildMacroProgram`, `buildPythonMacroSandboxHtml`) are exported and unit-tested.

## Limitation
numpy is not loaded in Pyodide, so the regression helpers (`MathMULTREG`/`MathEXPINVREG`/`MathPOLYREG`) return `None` (graceful, same as server-without-numpy). All common helpers work. Follow-up: `pyodide.loadPackage("numpy")` if a macro needs the regressions.

## Verification
- tsc clean, 603 tests + 6 new sandbox-builder tests, eslint clean.
- On-device (USB cable): run the Ambit's Python macro; expect no NameError and output matching the dev env.

## Note
`macro-helpers.py.txt` is a copy of the server `helpers.py` (drift risk; could share via a package later).