### PR TITLE
fix(mobile): default to English with opt-in language switcher

### DIFF
--- a/apps/mobile/src/features/profile/components/app-settings-sheet.tsx
+++ b/apps/mobile/src/features/profile/components/app-settings-sheet.tsx
@@ -1,10 +1,11 @@
 import { BottomSheetBackdrop, BottomSheetModal, BottomSheetView } from "@gorhom/bottom-sheet";
-import { Moon, Sun, X } from "lucide-react-native";
+import { cva } from "class-variance-authority";
+import { Check, Moon, Sun, X } from "lucide-react-native";
 import React, { forwardRef, useCallback } from "react";
 import { Pressable, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useTranslation } from "~/shared/i18n";
-import { cn } from "~/shared/ui/cn";
+import type { SupportedLocale } from "~/shared/i18n";
+import { setLanguage, useTranslation } from "~/shared/i18n";
 import type { ThemePreference } from "~/shared/ui/context/ThemeContext";
 import { useThemeColors } from "~/shared/ui/hooks/use-theme-colors";
 import { useThemePreference } from "~/shared/ui/hooks/use-theme-preference";
@@ -18,10 +19,42 @@ const THEME_OPTIONS: {
   { key: "dark", labelKey: "themeDark", Icon: Moon },
 ];
 
+// Language names are shown as autonyms (each in its own language), so they are
+// intentionally not translated.
+const LANGUAGE_OPTIONS: { key: SupportedLocale; name: string }[] = [
+  { key: "en-US", name: "English" },
+  { key: "nl-NL", name: "Nederlands" },
+];
+
+// Shared selected/unselected styling for the theme and language option rows.
+// The theme row lays out as equal-width pills; the language row is a full-width
+// list item, so the layout is a variant rather than tacked on per call site.
+const optionRowVariants = cva("flex-row items-center rounded-lg border px-3 py-2.5", {
+  variants: {
+    active: {
+      true: "border-primary bg-primary/10",
+      false: "border-border bg-transparent",
+    },
+    layout: {
+      pill: "flex-1 justify-center gap-2",
+      row: "justify-between",
+    },
+  },
+});
+
+const optionLabelVariants = cva("text-sm font-semibold", {
+  variants: {
+    active: {
+      true: "text-primary",
+      false: "text-on-surface",
+    },
+  },
+});
+
 export const AppSettingsSheet = forwardRef<BottomSheetModal>(
   function AppSettingsSheet(_props, ref) {
     const themeColors = useThemeColors();
-    const { t } = useTranslation("profile");
+    const { t, i18n } = useTranslation("profile");
     const { themePreference, changeTheme } = useThemePreference();
     const insets = useSafeAreaInsets();
 
@@ -68,24 +101,42 @@ export const AppSettingsSheet = forwardRef<BottomSheetModal>(
                 return (
                   // Force remount on every render so RN's native style cache
                   // (Expo SDK 54) re-applies the theme's resolved colors after
-                  // a theme switch — same workaround used by Back/Next.
+                  // a theme switch (same workaround used by Back/Next).
                   <Pressable
                     key={`${key}-${themeColors.scheme}-${isActive ? "1" : "0"}`}
                     onPress={() => void changeTheme(key)}
-                    className={cn(
-                      "flex-1 flex-row items-center justify-center gap-2 rounded-lg border px-3 py-2.5",
-                      isActive ? "border-primary bg-primary/10" : "border-border bg-transparent",
-                    )}
+                    className={optionRowVariants({ active: isActive, layout: "pill" })}
                   >
                     <Icon size={16} color={isActive ? themeColors.brand : themeColors.onSurface} />
-                    <Text
-                      className={cn(
-                        "text-sm font-semibold",
-                        isActive ? "text-primary" : "text-on-surface",
-                      )}
-                    >
-                      {t(labelKey)}
-                    </Text>
+                    <Text className={optionLabelVariants({ active: isActive })}>{t(labelKey)}</Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+          </View>
+
+          <View>
+            <Text className="text-muted-body mb-2 text-[12px] font-bold uppercase tracking-wider">
+              {t("appSettingsSheet.languageLabel")}
+            </Text>
+            <View className="gap-2">
+              {LANGUAGE_OPTIONS.map(({ key, name }) => {
+                const isActive = i18n.language === key;
+                return (
+                  <Pressable
+                    key={`${key}-${themeColors.scheme}-${isActive ? "1" : "0"}`}
+                    onPress={() => void setLanguage(key)}
+                    className={optionRowVariants({ active: isActive, layout: "row" })}
+                  >
+                    <View className="flex-1">
+                      <Text className={optionLabelVariants({ active: isActive })}>{name}</Text>
+                      {key === "nl-NL" ? (
+                        <Text className="text-muted-body mt-0.5 text-[12px]">
+                          {t("appSettingsSheet.dutchTranslationNote")}
+                        </Text>
+                      ) : null}
+                    </View>
+                    {isActive ? <Check size={18} color={themeColors.brand} /> : null}
                   </Pressable>
                 );
               })}

--- a/apps/mobile/src/shared/i18n/index.ts
+++ b/apps/mobile/src/shared/i18n/index.ts
@@ -1,5 +1,4 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import * as Localization from "expo-localization";
 import i18next from "i18next";
 import { useEffect, useState } from "react";
 import { initReactI18next } from "react-i18next";
@@ -58,23 +57,10 @@ const bundledResources = {
   },
 } as const;
 
-function pickDeviceLocale(): SupportedLocale {
-  const deviceLocales = Localization.getLocales();
-  for (const { languageTag } of deviceLocales) {
-    if ((SUPPORTED_LOCALES as readonly string[]).includes(languageTag)) {
-      return languageTag as SupportedLocale;
-    }
-    // Match language code only (e.g. "nl" -> "nl-NL").
-    const langOnly = languageTag.split("-")[0];
-    const match = (SUPPORTED_LOCALES as readonly string[]).find((l) => l.startsWith(langOnly));
-    if (match) return match as SupportedLocale;
-  }
-  return FALLBACK_LOCALE;
-}
-
 /**
- * Resolves the active locale at boot:
- *   user preference (AsyncStorage) > device locale > fallback.
+ * Resolves the active locale at boot: a saved user preference if present,
+ * otherwise English. Device locale is deliberately ignored so the app
+ * defaults to English everywhere; Dutch is opt-in via app settings.
  */
 async function resolveInitialLocale(): Promise<SupportedLocale> {
   try {
@@ -83,9 +69,9 @@ async function resolveInitialLocale(): Promise<SupportedLocale> {
       return saved as SupportedLocale;
     }
   } catch {
-    /* ignore — fall through to device locale */
+    /* ignore and fall back to the default locale */
   }
-  return pickDeviceLocale();
+  return FALLBACK_LOCALE;
 }
 
 let initPromise: Promise<typeof i18next> | null = null;

--- a/apps/mobile/src/shared/i18n/locales/en-US/profile.json
+++ b/apps/mobile/src/shared/i18n/locales/en-US/profile.json
@@ -34,6 +34,8 @@
   "footer": "openJII Mobile · v{{version}} ({{build}})",
   "appSettingsSheet": {
     "title": "App settings",
-    "themeLabel": "Theme"
+    "themeLabel": "Theme",
+    "languageLabel": "Language",
+    "dutchTranslationNote": "Dutch translations are still being refined and may contain errors."
   }
 }

--- a/apps/mobile/src/shared/i18n/locales/nl-NL/profile.json
+++ b/apps/mobile/src/shared/i18n/locales/nl-NL/profile.json
@@ -34,6 +34,8 @@
   "footer": "openJII Mobile · v{{version}} ({{build}})",
   "appSettingsSheet": {
     "title": "App-instellingen",
-    "themeLabel": "Thema"
+    "themeLabel": "Thema",
+    "languageLabel": "Taal",
+    "dutchTranslationNote": "De Nederlandse vertalingen worden nog verfijnd en kunnen fouten bevatten."
   }
 }


### PR DESCRIPTION
## Problem

On first launch the mobile app auto-selected the **device** language, so a phone set to Dutch booted the app into Dutch (`nl-NL`). English should be the default for everyone, with Dutch as a deliberate, opt-in choice. The Dutch translations are also still rough, so opting in should come with a warning.

The i18n plumbing already existed in `apps/mobile/src/shared/i18n/index.ts` (`setLanguage()` + AsyncStorage persistence under `openjii_language`, `SUPPORTED_LOCALES = ["en-US", "nl-NL"]`, full `nl-NL` bundles) — it was just (1) defaulting to the device locale and (2) never wired to any UI.

## Changes

- **Default to English** — `resolveInitialLocale()` now returns the English fallback when there is no saved preference; device-locale detection (`pickDeviceLocale` + the `expo-localization` import) is removed. Resolution order is now: saved preference → English.
- **Language switcher** — the App Settings sheet (`app-settings-sheet.tsx`) gains a Language section mirroring the existing theme selector: English / Nederlands as full-width rows with a check on the active option. A small caption under the **Nederlands** option warns that Dutch translations may contain errors. Selecting a language calls the existing `setLanguage()`, which persists the choice.
- **Copy** — new `appSettingsSheet.languageLabel` and `appSettingsSheet.dutchTranslationNote` keys in `en-US/profile.json` and `nl-NL/profile.json`.

## Testing

- `tsc --noEmit` clean for the mobile package.
- `eslint` clean for the changed files.
- Manual (to verify on device): fresh install on a Dutch device boots in English; Profile → App settings → Language switches to Nederlands and shows the caption; the choice survives a full app restart; switching back to English persists.

Closes OJD-1649.