### PR TITLE
fix(dashboards): stop table widget render loop from unstable data ref & react-table autoReset

### DIFF
--- a/apps/web/components/experiment-dashboards/widgets/table/loaded-table-view.test.tsx
+++ b/apps/web/components/experiment-dashboards/widgets/table/loaded-table-view.test.tsx
@@ -142,4 +142,39 @@ describe("LoadedTableView", () => {
     // The column is projected into the rendered table head.
     expect(screen.getByRole("columnheader", { name: /value/i })).toBeInTheDocument();
   });
+
+  it("survives a re-render while data is still loading (no autoReset loop)", async () => {
+    server.mount(contract.experiments.getExperimentTables, {
+      body: [createExperimentTable({ identifier: "raw_data" })],
+    });
+    // Hold the data in a loading state briefly so the re-render lands while
+    // `tableRows` is undefined — the window where an unstable `[]` data ref
+    // used to send react-table's autoReset into an infinite microtask loop.
+    server.mount(contract.experiments.getExperimentData, {
+      delay: 50,
+      body: [
+        createExperimentDataTable({
+          name: "raw_data",
+          page: 1,
+          pageSize: 25,
+          totalPages: 1,
+          totalRows: 1,
+          data: {
+            columns: [{ name: "value", type_name: "DOUBLE", type_text: "DOUBLE" }],
+            rows: [{ value: 9 }],
+            totalRows: 1,
+            truncated: false,
+          },
+        }),
+      ],
+    });
+
+    const { rerender } = render(
+      <LoadedTableView tableName="raw_data" pageSize={25} experimentId="exp-1" />,
+    );
+    rerender(<LoadedTableView tableName="raw_data" pageSize={25} experimentId="exp-1" />);
+
+    // Reaching the loaded row (not timing out) is the regression assertion.
+    await waitFor(() => expect(screen.getByText("9")).toBeInTheDocument());
+  });
 });

--- a/apps/web/components/experiment-dashboards/widgets/table/loaded-table-view.tsx
+++ b/apps/web/components/experiment-dashboards/widgets/table/loaded-table-view.tsx
@@ -74,7 +74,9 @@ export function LoadedTableView({
     filters: mergedFilters,
   });
 
-  const rows = tableRows ?? [];
+  // Stable ref: while loading `tableRows` is undefined, and a fresh `[]` each
+  // render makes react-table's autoReset re-fire forever (microtask loop).
+  const rows = useMemo(() => tableRows ?? [], [tableRows]);
   const totalPages = tableMetadata?.totalPages ?? 1;
   const columns = useMemo(
     () => projectAndOrderColumns(tableMetadata?.columns, selectedColumns),
@@ -85,6 +87,9 @@ export function LoadedTableView({
     data: rows,
     columns,
     getCoreRowModel: getCoreRowModel(),
+    // Pagination is server-side (`page` state + query), so react-table's
+    // page auto-reset is both redundant and the trigger for the loop above.
+    autoResetPageIndex: false,
   });
 
   if (error) {


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)