### PR TITLE
fix(mobile): harden three crashes surfaced in PostHog error tracking

### DIFF
--- a/apps/mobile/src/features/connection/hooks/use-device-connection.ts
+++ b/apps/mobile/src/features/connection/hooks/use-device-connection.ts
@@ -13,6 +13,7 @@ import {
 import { getConnectedDevice } from "../services/device-connection-manager/device-queries";
 import { mergeDevice } from "../services/device-connection-manager/device-sort";
 import {
+  bluetoothDeviceToDevice,
   discoveredEventToDevice,
   serialDeviceToDevice,
 } from "../services/device-connection-manager/device-utils";
@@ -142,13 +143,13 @@ export function useAllDevices() {
     if (!mountedRef.current) return;
     const seed = [
       ...(serial.status === "fulfilled" ? serial.value.map(serialDeviceToDevice) : []),
-      // Use the address-guarded mapper: bonded/connected entries can be truthy
-      // yet lack a usable `address`, which crashed bluetoothDeviceToDevice.
+      // bluetoothDeviceToDevice is address-guarded and returns null for entries
+      // without a usable address, so drop those rather than seeding bad rows.
       ...(bonded.status === "fulfilled"
-        ? bonded.value.map(discoveredEventToDevice).filter((d): d is Device => d !== null)
+        ? bonded.value.map(bluetoothDeviceToDevice).filter((d): d is Device => d !== null)
         : []),
       ...(connected.status === "fulfilled"
-        ? connected.value.map(discoveredEventToDevice).filter((d): d is Device => d !== null)
+        ? connected.value.map(bluetoothDeviceToDevice).filter((d): d is Device => d !== null)
         : []),
     ].reduce<Device[]>(mergeDevice, []);
     setData(seed);

--- a/apps/mobile/src/features/connection/hooks/use-device-connection.ts
+++ b/apps/mobile/src/features/connection/hooks/use-device-connection.ts
@@ -13,7 +13,6 @@ import {
 import { getConnectedDevice } from "../services/device-connection-manager/device-queries";
 import { mergeDevice } from "../services/device-connection-manager/device-sort";
 import {
-  bluetoothDeviceToDevice,
   discoveredEventToDevice,
   serialDeviceToDevice,
 } from "../services/device-connection-manager/device-utils";
@@ -143,11 +142,13 @@ export function useAllDevices() {
     if (!mountedRef.current) return;
     const seed = [
       ...(serial.status === "fulfilled" ? serial.value.map(serialDeviceToDevice) : []),
+      // Use the address-guarded mapper: bonded/connected entries can be truthy
+      // yet lack a usable `address`, which crashed bluetoothDeviceToDevice.
       ...(bonded.status === "fulfilled"
-        ? bonded.value.filter(Boolean).map(bluetoothDeviceToDevice)
+        ? bonded.value.map(discoveredEventToDevice).filter((d): d is Device => d !== null)
         : []),
       ...(connected.status === "fulfilled"
-        ? connected.value.filter(Boolean).map(bluetoothDeviceToDevice)
+        ? connected.value.map(discoveredEventToDevice).filter((d): d is Device => d !== null)
         : []),
     ].reduce<Device[]>(mergeDevice, []);
     setData(seed);

--- a/apps/mobile/src/features/connection/services/device-connection-manager/device-utils.test.ts
+++ b/apps/mobile/src/features/connection/services/device-connection-manager/device-utils.test.ts
@@ -1,6 +1,32 @@
+import type { BluetoothNativeDevice } from "react-native-bluetooth-classic";
 import { describe, expect, it } from "vitest";
 
-import { discoveredEventToDevice } from "./device-utils";
+import { bluetoothDeviceToDevice, discoveredEventToDevice } from "./device-utils";
+
+describe("bluetoothDeviceToDevice", () => {
+  it("maps a device with a usable address", () => {
+    const native = {
+      address: "AA:BB:CC",
+      name: "MultispeQ",
+      rssi: -50,
+    } as unknown as BluetoothNativeDevice;
+    expect(bluetoothDeviceToDevice(native)).toEqual({
+      id: "AA:BB:CC",
+      type: "bluetooth-classic",
+      name: "MultispeQ",
+      rssi: -50,
+    });
+  });
+
+  it("returns null for nullish or address-less entries instead of crashing", () => {
+    expect(bluetoothDeviceToDevice(undefined)).toBeNull();
+    expect(bluetoothDeviceToDevice(null)).toBeNull();
+    // @ts-expect-error - exercising the runtime guard against malformed payloads
+    expect(bluetoothDeviceToDevice({})).toBeNull();
+    // @ts-expect-error - exercising the runtime guard against an empty address
+    expect(bluetoothDeviceToDevice({ address: "" })).toBeNull();
+  });
+});
 
 describe("discoveredEventToDevice", () => {
   it("reads the device from a well-formed { device } event", () => {

--- a/apps/mobile/src/features/connection/services/device-connection-manager/device-utils.ts
+++ b/apps/mobile/src/features/connection/services/device-connection-manager/device-utils.ts
@@ -4,9 +4,16 @@ import type { Device } from "~/shared/types/device";
 const MULTISPEQ_VENDOR_ID = 5824;
 const MULTISPEQ_PRODUCT_ID = 1155;
 
-// Accepts both a bonded/connected BluetoothDevice and a discovered
-// BluetoothNativeDevice (the onDeviceDiscovered payload); both carry these fields.
-export function bluetoothDeviceToDevice(d: BluetoothNativeDevice): Device {
+// Accepts a bonded/connected BluetoothDevice or a discovered BluetoothNativeDevice
+// (the onDeviceDiscovered payload); both carry these fields. The payloads are
+// unreliable, though: an entry can be present yet missing a usable address, so
+// this guards and returns null rather than letting callers deref undefined.
+export function bluetoothDeviceToDevice(
+  d: BluetoothNativeDevice | null | undefined,
+): Device | null {
+  if (!d || typeof d.address !== "string" || d.address.length === 0) {
+    return null;
+  }
   // Keep the raw name even when it's just the MAC: many MultispeQs have no
   // friendly name, and the row still surfaces the bracketed sticker ID below it.
   return {
@@ -19,14 +26,11 @@ export function bluetoothDeviceToDevice(d: BluetoothNativeDevice): Device {
 
 // The onDeviceDiscovered payload from react-native-bluetooth-classic is
 // unreliable: the device may sit on `event.device`, be the event object itself,
-// or be absent (a discovery-finished tick). Returns null for anything without a
-// usable address so callers never deref undefined.
+// or be absent (a discovery-finished tick). Delegates to bluetoothDeviceToDevice,
+// which returns null for anything without a usable address.
 export function discoveredEventToDevice(event: unknown): Device | null {
   const e = event as { device?: BluetoothNativeDevice } | undefined;
   const native = (e?.device ?? e) as BluetoothNativeDevice | undefined;
-  if (!native || typeof native.address !== "string" || native.address.length === 0) {
-    return null;
-  }
   return bluetoothDeviceToDevice(native);
 }
 

--- a/apps/mobile/src/shared/db/prefetch-offline-data.ts
+++ b/apps/mobile/src/shared/db/prefetch-offline-data.ts
@@ -67,7 +67,12 @@ async function _prefetchOfflineData(
     meta: { suppressToast: true },
   });
 
-  const experiments = (experimentsResponse?.body ?? []) as {
+  // The contract response shape can vary (paginated envelope, error body, or a
+  // bare array); only an actual array is iterable, so guard before `.map` to
+  // avoid "experiments.map is not a function" crashes seen in production.
+  const experiments = (
+    Array.isArray(experimentsResponse?.body) ? experimentsResponse.body : []
+  ) as {
     id: string;
     workbookId: string | null;
     workbookVersionId: string | null;

--- a/apps/mobile/src/shared/ui/ctf-rich-text.test.tsx
+++ b/apps/mobile/src/shared/ui/ctf-rich-text.test.tsx
@@ -3,9 +3,13 @@ import type { Document } from "@contentful/rich-text-types";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 import React from "react";
 import { Linking } from "react-native";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getEnvVar } from "~/shared/stores/environment-store";
 
 import { CtfRichText } from "./ctf-rich-text";
+
+vi.mock("~/shared/stores/environment-store", () => ({ getEnvVar: vi.fn() }));
+const mockedGetEnvVar = vi.mocked(getEnvVar);
 
 // Minimal builders for Contentful rich-text nodes — enough to exercise the
 // renderers without pulling in the full type machinery.
@@ -30,6 +34,10 @@ const doc = (...content: RtNode[]): Document =>
   ({ nodeType: BLOCKS.DOCUMENT, data: {}, content }) as unknown as Document;
 
 describe("CtfRichText", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders paragraph text", () => {
     render(<CtfRichText json={doc(block(BLOCKS.PARAGRAPH, text("Hello world")))} />);
 
@@ -185,5 +193,44 @@ describe("CtfRichText", () => {
     expect(screen.getByText("Heading 6")).toBeTruthy();
     expect(screen.getByText("Header cell")).toBeTruthy();
     expect(screen.getByText("Body cell")).toBeTruthy();
+  });
+
+  it("resolves a site-relative hyperlink against the web base url", () => {
+    mockedGetEnvVar.mockReturnValue("https://app.openjii.org");
+    const openURL = vi.spyOn(Linking, "openURL").mockResolvedValue(true);
+
+    render(<CtfRichText json={doc(block(BLOCKS.PARAGRAPH, hyperlink("/about", text("About"))))} />);
+    fireEvent.press(screen.getByText("About"));
+
+    expect(mockedGetEnvVar).toHaveBeenCalledWith("NEXT_AUTH_URI", false);
+    expect(openURL).toHaveBeenCalledWith("https://app.openjii.org/about");
+  });
+
+  it("drops a site-relative hyperlink without crashing when the base url is unavailable", () => {
+    mockedGetEnvVar.mockImplementation(() => {
+      throw new Error("Env variable NEXT_AUTH_URI is required");
+    });
+    const openURL = vi.spyOn(Linking, "openURL").mockResolvedValue(true);
+
+    render(<CtfRichText json={doc(block(BLOCKS.PARAGRAPH, hyperlink("/about", text("About"))))} />);
+
+    expect(() => fireEvent.press(screen.getByText("About"))).not.toThrow();
+    expect(openURL).not.toHaveBeenCalled();
+  });
+
+  it("handles a rejected openURL without throwing", async () => {
+    const openURL = vi.spyOn(Linking, "openURL").mockRejectedValue(new Error("No Activity found"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    render(
+      <CtfRichText
+        json={doc(block(BLOCKS.PARAGRAPH, hyperlink("https://example.com", text("Read more"))))}
+      />,
+    );
+
+    expect(() => fireEvent.press(screen.getByText("Read more"))).not.toThrow();
+    expect(openURL).toHaveBeenCalledWith("https://example.com");
+    await vi.waitFor(() => expect(warn).toHaveBeenCalled());
+    warn.mockRestore();
   });
 });

--- a/apps/mobile/src/shared/ui/ctf-rich-text.tsx
+++ b/apps/mobile/src/shared/ui/ctf-rich-text.tsx
@@ -4,11 +4,25 @@ import type { Block, Document, Node } from "@contentful/rich-text-types";
 import { BLOCKS, INLINES, MARKS } from "@contentful/rich-text-types";
 import React from "react";
 import { Linking, Text, View } from "react-native";
+import { getEnvVar } from "~/shared/stores/environment-store";
 
 export interface CtfRichTextProps {
   json: Document;
   textClass?: string;
   inline?: boolean;
+}
+
+// Contentful hyperlinks can be relative (e.g. "/about"). Passing those straight
+// to Linking.openURL throws on Android ("No Activity found to handle Intent"),
+// so resolve site-relative paths against the web base URL and swallow failures.
+function openHyperlink(uri: string): void {
+  let target = uri;
+  if (uri.startsWith("/")) {
+    const base = getEnvVar("NEXT_AUTH_URI");
+    if (!base) return;
+    target = `${base.replace(/\/$/, "")}${uri}`;
+  }
+  void Linking.openURL(target).catch((e) => console.warn("[ctf] failed to open url", e));
 }
 
 const makeInlineOptions = (textClass: string): Options => ({
@@ -60,7 +74,7 @@ const makeInlineOptions = (textClass: string): Options => ({
       const uri = (node.data as { uri?: string }).uri;
       if (!uri) return null;
       return (
-        <Text className={`${textClass} underline`} onPress={() => void Linking.openURL(uri)}>
+        <Text className={`${textClass} underline`} onPress={() => openHyperlink(uri)}>
           {children}
         </Text>
       );
@@ -159,9 +173,7 @@ const makeOptions = (textClass: string): Options => ({
       return (
         <Text
           className="text-primary text-sm font-medium leading-5"
-          onPress={() =>
-            Linking.openURL(uri).catch((e) => console.warn("[ctf] failed to open url", e))
-          }
+          onPress={() => openHyperlink(uri)}
         >
           {children}
         </Text>

--- a/apps/mobile/src/shared/ui/ctf-rich-text.tsx
+++ b/apps/mobile/src/shared/ui/ctf-rich-text.tsx
@@ -18,7 +18,15 @@ export interface CtfRichTextProps {
 function openHyperlink(uri: string): void {
   let target = uri;
   if (uri.startsWith("/")) {
-    const base = getEnvVar("NEXT_AUTH_URI");
+    // Defensive path: getEnvVar throws when the var is unset or storage hasn't
+    // rehydrated yet, so treat the base as optional and never let resolving a
+    // relative link crash the tap. Drop the link if we can't build a full URL.
+    let base: string | undefined;
+    try {
+      base = getEnvVar("NEXT_AUTH_URI", false);
+    } catch {
+      base = undefined;
+    }
     if (!base) return;
     target = `${base.replace(/\/$/, "")}${uri}`;
   }


### PR DESCRIPTION
## What

Triaged active PostHog error-tracking issues for openJII (last 30d) and fixed the three that are real, in-code, production crashes (not SDK noise, browser noise, hardware timeouts, or dev-environment artifacts).

| Bug | ~Occurrences | Root cause | Fix |
|---|---|---|---|
| `prefetch: undefined is not a function` / `experiments.map is not a function` | ~115+ (≈10 grouped issues) | `experimentsResponse.body` is not guaranteed to be an array; `?? []` only guards null/undefined, so a non-array body crashes on `.map` | Guard with `Array.isArray` before mapping |
| `Could not open URL '/about'` (Android `JSApplicationIllegalArgumentException`) | 42 | Contentful rich-text hyperlinks can be site-relative (`/about`); passing them straight to `Linking.openURL` has no activity to handle the intent | Resolve relative hrefs against the web base URL (`NEXT_AUTH_URI`) and catch open failures; shared `openHyperlink` helper used by both link renderers |
| `Cannot read property 'address' of undefined` (BLE seed) | ~10 | bonded/connected device entries can be truthy yet lack a usable `address`; `bluetoothDeviceToDevice` dereferenced it | Route bonded/connected through the existing address-guarded `discoveredEventToDevice` mapper |

## Verification
- `tsc --noEmit`: no new errors (one pre-existing unrelated `AbortSignal` error remains on main)
- `eslint`: clean on all touched files
- `vitest`: 12 related tests pass (ctf-rich-text, device-utils)

## Triage notes (not addressed here)
- **Suppress (noise):** `PostHogFetchNetworkError` (SDK network drops), web `Script error.`, `ResizeObserver loop`.
- **Operational (MultispeQ device comms):** `command timeout`, `scan error`, `CredentialError` — expected BLE/serial/auth timeouts, not crashes. Suggest downgrading these from `error` to `warn` so they stop polluting error tracking (happy to add in a follow-up).
- **Dev-environment only (ignore):** `path.split is not a function` (NativeWind), `ExpoAsset.downloadAsync rejected`, smoke-test entries — all from `localhost`/`192.168.x` bundle sources.
- **Deferred (needs repro):** web `ZodError: message Required`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes OJD-1651
