### PR TITLE
fix(data): harden PhotosynQ project-transfer write path + classify empty sources (OJD-1650)

### DIFF
--- a/apps/data/src/tasks/project_transfer_task.py
+++ b/apps/data/src/tasks/project_transfer_task.py
@@ -26,6 +26,16 @@ ENVIRONMENT = dbutils.widgets.get("ENVIRONMENT").lower()
 VOLUME_BASE = f"/Volumes/{CATALOG_NAME}/centrum/data-imports"
 TRANSFER_TABLE = f"{CATALOG_NAME}.{CENTRUM_SCHEMA}.openjii_project_transfer_requests"
 
+
+def set_request_status(request_id: str, status: str, error: str = None) -> None:
+    """Single place to set a request's terminal status + error detail + timestamp."""
+    err_lit = "NULL" if error is None else "'" + str(error)[:4000].replace("'", "''") + "'"
+    spark.sql(f"""
+        UPDATE {TRANSFER_TABLE}
+        SET status = '{status}', error_message = {err_lit}, updated_at = current_timestamp()
+        WHERE request_id = '{request_id}'
+    """)
+
 # COMMAND ----------
 
 # DBTITLE 1,Parquet Schemas
@@ -137,7 +147,7 @@ if requests.count() == 0:
     dbutils.notebook.exit(json.dumps({"status": "success", "transfers": []}))
 
 # Split: requests whose experiment_id is already populated had their backend call
-# succeed on a previous run — skip the backend for those and re-use stored columns.
+# succeed on a previous run - skip the backend for those and re-use stored columns.
 # Snapshot request_id lists so the mid-notebook MERGE (which writes experiment_id back
 # to the table) doesn't cause the recovery split to pick up newly-updated rows.
 _new_ids = [r["request_id"] for r in requests.filter(F.col("experiment_id").isNull()).select("request_id").collect()]
@@ -257,7 +267,7 @@ def to_json_string(value: str) -> str:
     """Convert a Python repr string (single quotes) to valid JSON (double quotes).
     
     If the parsed result is a single-element list, unwrap it to return just the
-    object — macro output should always be a single JSON object, not an array.
+    object - macro output should always be a single JSON object, not an array.
     """
     if value is None:
         return None
@@ -269,7 +279,7 @@ def to_json_string(value: str) -> str:
             obj = ast.literal_eval(value)
         except Exception:
             return None
-    # Unwrap single-element arrays — macro output is always one object
+    # Unwrap single-element arrays - macro output is always one object
     if isinstance(obj, list) and len(obj) == 1:
         obj = obj[0]
     return json.dumps(obj)
@@ -343,7 +353,7 @@ if new_requests.count() > 0:
 
     transfers = (
         metadata
-        # Only send new transfers to the backend — not recovery ones
+        # Only send new transfers to the backend - not recovery ones
         .filter(
             F.col("transfer_id").isin(
                 [r["request_id"] for r in new_requests.select("request_id").collect()]
@@ -392,16 +402,20 @@ if new_requests.count() > 0:
         """)
         log("Persisted backend response columns")
 
-    # Mark failed ones immediately
+    # Mark failed ones immediately, carrying the backend error for diagnosis
     new_failed = new_results.filter(F.col("success") == False)
     if new_failed.count() > 0:
         new_failed.select(
             F.col("transfer_id").alias("request_id"),
+            F.col("error"),
         ).createOrReplaceTempView("_failed_updates")
         spark.sql(f"""
             MERGE INTO {TRANSFER_TABLE} t
             USING _failed_updates u ON t.request_id = u.request_id
-            WHEN MATCHED THEN UPDATE SET t.status = 'failed'
+            WHEN MATCHED THEN UPDATE SET
+                t.status = 'failed',
+                t.error_message = u.error,
+                t.updated_at = current_timestamp()
         """)
 
     transfer_results = new_results
@@ -458,42 +472,47 @@ enriched = (
     )
 )
 
+# Cache once so the per-experiment filter/write below does not recompute the full
+# measurement join on every loop iteration.
+enriched = enriched.cache()
+enriched.count()
+
 written_experiments = set()
 
 for row in successful.select("experiment_id", "transfer_id").collect():
     experiment_id = row["experiment_id"]
     transfer_id = row["transfer_id"]
-    output_path = f"{VOLUME_BASE}/{experiment_id}/photosynq_transfer"
+    # Write to a run-unique subpath instead of overwriting in place: the continuous
+    # centrum pipeline lists this volume (recursiveFileLookup), so an in-place
+    # mode("overwrite") that deletes files mid-read can fail the write.
+    output_path = f"{VOLUME_BASE}/{experiment_id}/photosynq_transfer/run={transfer_id}"
 
-    # Guard: skip duplicate experiment_id within this run — the downstream Auto Loader
-    # stream will crash if files are overwritten mid-read.
+    # Guard: skip duplicate experiment_id within this run.
     if experiment_id in written_experiments:
         log(f"  {transfer_id}: skipped (already written {experiment_id} this run)")
-        spark.sql(f"""
-            UPDATE {TRANSFER_TABLE}
-            SET status = 'completed'
-            WHERE request_id = '{transfer_id}'
-        """)
+        set_request_status(transfer_id, "completed")
         log(f"  {transfer_id}: completed")
         continue
 
+    exp_df = enriched.filter(F.col("experiment_id") == experiment_id)
+    # Empty source project (no measurements): classify as no_data rather than letting
+    # an empty parquet write throw into partial_failed.
+    if exp_df.limit(1).count() == 0:
+        log(f"  {transfer_id}: no measurements for {experiment_id} - marking no_data")
+        set_request_status(transfer_id, "no_data")
+        continue
+
     try:
-        enriched.filter(F.col("experiment_id") == experiment_id).write.mode("overwrite").parquet(output_path)
+        exp_df.repartition(8).write.mode("overwrite").parquet(output_path)
         written_experiments.add(experiment_id)
         log(f"Wrote import data to {output_path}")
-        spark.sql(f"""
-            UPDATE {TRANSFER_TABLE}
-            SET status = 'completed'
-            WHERE request_id = '{transfer_id}'
-        """)
+        set_request_status(transfer_id, "completed")
         log(f"  {transfer_id}: completed")
     except Exception as e:
         log(f"  {transfer_id}: parquet write failed - {e}")
-        spark.sql(f"""
-            UPDATE {TRANSFER_TABLE}
-            SET status = 'partial_failed'
-            WHERE request_id = '{transfer_id}'
-        """)
+        set_request_status(transfer_id, "partial_failed", error=str(e))
+
+enriched.unpersist()
 
 for row in transfer_results.filter(F.col("success") == False).select("transfer_id", "error").collect():
     error_msg = row["error"] or "Unknown error"

--- a/apps/web/app/[locale]/platform/transfer-request/history/page.tsx
+++ b/apps/web/app/[locale]/platform/transfer-request/history/page.tsx
@@ -20,6 +20,7 @@ const statusBadgeVariants = cva("", {
       completed: "bg-badge-active",
       rejected: "bg-destructive text-destructive-foreground",
       failed: "bg-destructive text-destructive-foreground",
+      no_data: "bg-badge-stale",
     },
   },
   defaultVariants: {

--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -893,6 +893,8 @@ module "openjii_project_transfer_requests_table" {
     { name = "macro_filename", type = "STRING" },
     { name = "macro_name", type = "STRING" },
     { name = "flow_id", type = "STRING" },
+    { name = "error_message", type = "STRING", comment = "Last failure detail from the transfer job" },
+    { name = "updated_at", type = "TIMESTAMP", comment = "Last time the transfer job mutated this row" },
   ]
 
   grants = {

--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -818,6 +818,8 @@ module "openjii_project_transfer_requests_table" {
     { name = "macro_filename", type = "STRING" },
     { name = "macro_name", type = "STRING" },
     { name = "flow_id", type = "STRING" },
+    { name = "error_message", type = "STRING", comment = "Last failure detail from the transfer job" },
+    { name = "updated_at", type = "TIMESTAMP", comment = "Last time the transfer job mutated this row" },
   ]
 
   grants = {

--- a/packages/api/src/schemas/experiment.schema.ts
+++ b/packages/api/src/schemas/experiment.schema.ts
@@ -219,6 +219,7 @@ export const zTransferRequestStatus = z.enum([
   "completed",
   "rejected",
   "failed",
+  "no_data",
 ]);
 
 export const zTransferRequest = z.object({


### PR DESCRIPTION
---
title: "pr_body.md"
date: 2026-06-29
generated_by: skills-for-architects
---

## Context

Investigating OJD-1650 (recurring `partial_failed` PhotosynQ project transfers), the failures fall into two distinct buckets:

1. **Empty-source projects** (e.g. 37825 / 38169 / 38162) — `data_count = 0` on PhotosynQ. The backend creates the experiment shell, then the per-experiment parquet write of **zero rows throws**, marking the request `partial_failed`. There is nothing to import; this should be classified, not treated as a retryable error.
2. **Real-data projects (~31)** — valid data in the dump, but the per-experiment write itself throws in the job. The exact exception was never captured because it is only `log()`'d to **serverless notebook stdout**, which the Jobs API does not return, and the table has no error column.

This PR addresses both, plus the observability gap that made (2) un-diagnosable.

## Changes

**`apps/data/src/tasks/project_transfer_task.py`**
- `set_request_status(...)` helper: every status transition now also writes `error_message` + `updated_at` (single source of truth).
- `failed` MERGE carries the backend `error` into `error_message`.
- Write loop:
  - **Empty-source guard** — if an experiment has 0 measurement rows, mark `no_data` and skip the write (no more empty-write `partial_failed`).
  - **Run-unique subpath** — write to `…/photosynq_transfer/run=<request_id>/` instead of in-place `mode("overwrite")`, so the write never deletes files the always-on continuous centrum pipeline is listing (`recursiveFileLookup` still ingests the nested path).
  - `cache()` the enriched join once + bounded `repartition(8)`.

**Infra** — add `error_message` (STRING) + `updated_at` (TIMESTAMP) columns to `openjii_project_transfer_requests` (`env/dev` + `env/prod`). Trailing nullable columns ⇒ `ALTER TABLE ADD COLUMN` (in-place). **Confirm `terraform plan` shows `~ update in-place`, not replace, before apply** (replace would drop the MANAGED table).

**API / Web** — add `no_data` to `zTransferRequestStatus` + a history-page badge.

## Validation status (read before merging)

- ✅ **Empty-source / `no_data`**: validated. Confirmed 37825/38169/38162 are `data_count = 0` at source; the current code's empty write is what throws.
- ✅ **Error persistence**: low-risk, and it is the mechanism that makes the next item testable.
- ✅ **Run-unique subpath ingestion**: verified out-of-band — a corrected 18703 write to a nested `…/photosynq_transfer/<sub>/` path was ingested by the pipeline via `recursiveFileLookup`. So this change does not break ingestion.
- ⚠️ **Run-unique subpath as the *fix* for the ~31**: NOT yet proven. The write-race is a **hypothesis** — an isolated manual write of 18703 used the same in-place `mode("overwrite")` and succeeded, so in-place is not obviously broken; the failure tracked the job runtime and the real exception was never captured.

### How to validate the write-path fix (do this before relying on it)
1. Deploy the **error-persistence** part of this PR (columns + `set_request_status`).
2. Re-approve **one** of the ~31 real-data projects with the *current* in-place write → read back `error_message`. This reveals the true cause (`FileNotFound`/commit-conflict ⇒ race confirmed; OOM ⇒ memory; else ⇒ rethink).
3. If confirmed, the run-unique-subpath change here should resolve it — verify by re-transferring the same project and confirming it reaches `centrum.experiment_raw_data` (gold).

Dev cannot reliably reproduce the race (it depends on the always-on prod pipeline), so validation is on prod, gated on step 2.

## Notes
- Deploy order: infra (columns) before the job, since `set_request_status` writes them.
- `no_data` semantics: terminal "nothing to import", distinct from `rejected` (invalid request) and `partial_failed` (retryable write failure).
