### PR TITLE
feat(web, mobile): In-app "What's New" feed + public /releases changelog

### DIFF
--- a/apps/backend/src/users/application/use-cases/get-whats-new-seen/get-whats-new-seen.spec.ts
+++ b/apps/backend/src/users/application/use-cases/get-whats-new-seen/get-whats-new-seen.spec.ts
@@ -1,0 +1,84 @@
+import { profiles, eq } from "@repo/database";
+
+import { assertFailure, assertSuccess } from "../../../../common/utils/fp-utils";
+import { TestHarness } from "../../../../test/test-harness";
+import { GetWhatsNewSeenUseCase } from "./get-whats-new-seen";
+
+describe("GetWhatsNewSeenUseCase", () => {
+  const testApp = TestHarness.App;
+  let testUserId: string;
+  let getWhatsNewSeenUseCase: GetWhatsNewSeenUseCase;
+
+  beforeAll(async () => {
+    await testApp.setup();
+  });
+
+  beforeEach(async () => {
+    await testApp.beforeEach();
+    testUserId = await testApp.createTestUser({});
+    getWhatsNewSeenUseCase = testApp.module.get(GetWhatsNewSeenUseCase);
+  });
+
+  afterEach(() => {
+    testApp.afterEach();
+  });
+
+  afterAll(async () => {
+    await testApp.teardown();
+  });
+
+  it("should return null when the user has never opened the What's new panel", async () => {
+    // Act
+    const result = await getWhatsNewSeenUseCase.execute(testUserId);
+
+    // Assert
+    expect(result.isSuccess()).toBe(true);
+    assertSuccess(result);
+    expect(result.value).toBeNull();
+  });
+
+  it("should return the last-seen timestamp when the user has opened the panel before", async () => {
+    // Arrange: stamp a last-seen timestamp directly in the database
+    const lastSeenAt = new Date("2026-01-15T10:30:00.000Z");
+    await testApp.database
+      .update(profiles)
+      .set({ whatsNewLastSeenAt: lastSeenAt })
+      .where(eq(profiles.userId, testUserId));
+
+    // Act
+    const result = await getWhatsNewSeenUseCase.execute(testUserId);
+
+    // Assert
+    expect(result.isSuccess()).toBe(true);
+    assertSuccess(result);
+    expect(result.value).toBeInstanceOf(Date);
+    expect(result.value?.getTime()).toBe(lastSeenAt.getTime());
+  });
+
+  it("should return NOT_FOUND when no profile exists for the user", async () => {
+    // Arrange: create a user without a profile row
+    const userWithoutProfileId = await testApp.createTestUser({
+      createProfile: false,
+    });
+
+    // Act
+    const result = await getWhatsNewSeenUseCase.execute(userWithoutProfileId);
+
+    // Assert
+    expect(result.isSuccess()).toBe(false);
+    expect(result._tag).toBe("failure");
+    assertFailure(result);
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should return NOT_FOUND for a non-existent user id", async () => {
+    const nonExistentId = "00000000-0000-0000-0000-000000000000";
+
+    const result = await getWhatsNewSeenUseCase.execute(nonExistentId);
+
+    expect(result.isSuccess()).toBe(false);
+    expect(result._tag).toBe("failure");
+    assertFailure(result);
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/apps/backend/src/users/application/use-cases/get-whats-new-seen/get-whats-new-seen.ts
+++ b/apps/backend/src/users/application/use-cases/get-whats-new-seen/get-whats-new-seen.ts
@@ -1,0 +1,43 @@
+import { Injectable, Logger } from "@nestjs/common";
+
+import { ErrorCodes } from "../../../../common/utils/error-codes";
+import { Result, failure, AppError } from "../../../../common/utils/fp-utils";
+import { UserProfileDto } from "../../../core/models/user.model";
+import { UserRepository } from "../../../core/repositories/user.repository";
+
+/**
+ * Returns the timestamp the user last opened the "What's new" panel.
+ * null = never opened, so the client treats every release note as unread. A missing
+ * profile row is an anomaly (not a valid "never seen"), so it surfaces as not-found —
+ * matching how the other profile-table use cases guard existence.
+ */
+@Injectable()
+export class GetWhatsNewSeenUseCase {
+  private readonly logger = new Logger(GetWhatsNewSeenUseCase.name);
+
+  constructor(private readonly userRepository: UserRepository) {}
+
+  async execute(userId: string): Promise<Result<Date | null>> {
+    this.logger.log({
+      msg: "Getting What's new last-seen timestamp",
+      operation: "getWhatsNewSeen",
+      userId,
+    });
+
+    const profileResult = await this.userRepository.findUserProfile(userId);
+
+    return profileResult.chain(async (profile: UserProfileDto | null) => {
+      if (!profile) {
+        this.logger.warn({
+          msg: "User profile not found",
+          errorCode: ErrorCodes.USER_PROFILE_NOT_FOUND,
+          operation: "getWhatsNewSeen",
+          userId,
+        });
+        return failure(AppError.notFound(`User profile with ID ${userId} not found`));
+      }
+
+      return this.userRepository.findWhatsNewLastSeen(userId);
+    });
+  }
+}

--- a/apps/backend/src/users/application/use-cases/mark-whats-new-seen/mark-whats-new-seen.spec.ts
+++ b/apps/backend/src/users/application/use-cases/mark-whats-new-seen/mark-whats-new-seen.spec.ts
@@ -1,0 +1,93 @@
+import { profiles, eq } from "@repo/database";
+
+import { assertFailure, assertSuccess } from "../../../../common/utils/fp-utils";
+import { TestHarness } from "../../../../test/test-harness";
+import { MarkWhatsNewSeenUseCase } from "./mark-whats-new-seen";
+
+describe("MarkWhatsNewSeenUseCase", () => {
+  const testApp = TestHarness.App;
+  let testUserId: string;
+  let markWhatsNewSeenUseCase: MarkWhatsNewSeenUseCase;
+
+  beforeAll(async () => {
+    await testApp.setup();
+  });
+
+  beforeEach(async () => {
+    await testApp.beforeEach();
+    testUserId = await testApp.createTestUser({});
+    markWhatsNewSeenUseCase = testApp.module.get(MarkWhatsNewSeenUseCase);
+  });
+
+  afterEach(() => {
+    testApp.afterEach();
+  });
+
+  afterAll(async () => {
+    await testApp.teardown();
+  });
+
+  it("should stamp the last-seen timestamp and return it", async () => {
+    // Act
+    const result = await markWhatsNewSeenUseCase.execute(testUserId);
+
+    // Assert
+    expect(result.isSuccess()).toBe(true);
+    assertSuccess(result);
+    expect(result.value).toBeInstanceOf(Date);
+
+    // Verify the timestamp was persisted in the database
+    const profs = await testApp.database
+      .select()
+      .from(profiles)
+      .where(eq(profiles.userId, testUserId));
+    expect(profs.length).toBe(1);
+    expect(profs[0].whatsNewLastSeenAt).not.toBeNull();
+    expect(profs[0].whatsNewLastSeenAt?.getTime()).toBe(result.value?.getTime());
+  });
+
+  it("should update an existing last-seen timestamp to a newer one", async () => {
+    // Arrange: stamp an old last-seen timestamp directly in the database
+    const previousSeenAt = new Date("2020-01-01T00:00:00.000Z");
+    await testApp.database
+      .update(profiles)
+      .set({ whatsNewLastSeenAt: previousSeenAt })
+      .where(eq(profiles.userId, testUserId));
+
+    // Act
+    const result = await markWhatsNewSeenUseCase.execute(testUserId);
+
+    // Assert
+    expect(result.isSuccess()).toBe(true);
+    assertSuccess(result);
+    expect(result.value).toBeInstanceOf(Date);
+    expect(result.value?.getTime()).toBeGreaterThan(previousSeenAt.getTime());
+  });
+
+  it("should return NOT_FOUND when no profile exists for the user", async () => {
+    // Arrange: create a user without a profile row
+    const userWithoutProfileId = await testApp.createTestUser({
+      createProfile: false,
+    });
+
+    // Act
+    const result = await markWhatsNewSeenUseCase.execute(userWithoutProfileId);
+
+    // Assert
+    expect(result.isSuccess()).toBe(false);
+    expect(result._tag).toBe("failure");
+    assertFailure(result);
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+
+  it("should return NOT_FOUND for a non-existent user id", async () => {
+    const nonExistentId = "00000000-0000-0000-0000-000000000000";
+
+    const result = await markWhatsNewSeenUseCase.execute(nonExistentId);
+
+    expect(result.isSuccess()).toBe(false);
+    expect(result._tag).toBe("failure");
+    assertFailure(result);
+    expect(result.error.code).toBe("NOT_FOUND");
+  });
+});

--- a/apps/backend/src/users/application/use-cases/mark-whats-new-seen/mark-whats-new-seen.ts
+++ b/apps/backend/src/users/application/use-cases/mark-whats-new-seen/mark-whats-new-seen.ts
@@ -1,0 +1,43 @@
+import { Injectable, Logger } from "@nestjs/common";
+
+import { ErrorCodes } from "../../../../common/utils/error-codes";
+import { Result, failure, AppError } from "../../../../common/utils/fp-utils";
+import { UserProfileDto } from "../../../core/models/user.model";
+import { UserRepository } from "../../../core/repositories/user.repository";
+
+/**
+ * Stamps the user's "What's new" last-seen timestamp to now, clearing the
+ * unread indicator across all of their devices. Returns the new timestamp. Guards that the
+ * profile row exists first, so a write that would match no rows surfaces as not-found instead
+ * of silently succeeding — matching how the other profile-table use cases guard existence.
+ */
+@Injectable()
+export class MarkWhatsNewSeenUseCase {
+  private readonly logger = new Logger(MarkWhatsNewSeenUseCase.name);
+
+  constructor(private readonly userRepository: UserRepository) {}
+
+  async execute(userId: string): Promise<Result<Date | null>> {
+    this.logger.log({
+      msg: "Marking What's new as seen",
+      operation: "markWhatsNewSeen",
+      userId,
+    });
+
+    const profileResult = await this.userRepository.findUserProfile(userId);
+
+    return profileResult.chain(async (profile: UserProfileDto | null) => {
+      if (!profile) {
+        this.logger.warn({
+          msg: "User profile not found",
+          errorCode: ErrorCodes.USER_PROFILE_NOT_FOUND,
+          operation: "markWhatsNewSeen",
+          userId,
+        });
+        return failure(AppError.notFound(`User profile with ID ${userId} not found`));
+      }
+
+      return this.userRepository.markWhatsNewSeen(userId);
+    });
+  }
+}

--- a/apps/backend/src/users/core/models/user.model.ts
+++ b/apps/backend/src/users/core/models/user.model.ts
@@ -21,6 +21,7 @@ export const createUserProfileSchema = createInsertSchema(profiles)
     userId: true,
     organizationId: true,
     createdAt: true,
+    whatsNewLastSeenAt: true,
   })
   .extend({
     organization: z.string().optional(),
@@ -30,6 +31,7 @@ export const selectUserProfileSchema = createSelectSchema(profiles)
   .omit({
     id: true,
     organizationId: true,
+    whatsNewLastSeenAt: true,
   })
   .extend({
     organization: z.string().optional(),

--- a/apps/backend/src/users/core/repositories/user.repository.spec.ts
+++ b/apps/backend/src/users/core/repositories/user.repository.spec.ts
@@ -845,4 +845,103 @@ describe("UserRepository", () => {
       expect(userIds.filter((id) => id === testUser2Id)).toHaveLength(1);
     });
   });
+
+  describe("findWhatsNewLastSeen", () => {
+    it("should return null when the user has never opened the What's new panel", async () => {
+      // Act
+      const result = await repository.findWhatsNewLastSeen(testUserId);
+
+      // Assert
+      expect(result.isSuccess()).toBe(true);
+      assertSuccess(result);
+      expect(result.value).toBeNull();
+    });
+
+    it("should return the stored timestamp when the user has opened the panel before", async () => {
+      // Arrange: stamp a last-seen timestamp directly in the database
+      const lastSeenAt = new Date("2026-01-15T10:30:00.000Z");
+      await testApp.database
+        .update(profiles)
+        .set({ whatsNewLastSeenAt: lastSeenAt })
+        .where(eq(profiles.userId, testUserId));
+
+      // Act
+      const result = await repository.findWhatsNewLastSeen(testUserId);
+
+      // Assert
+      expect(result.isSuccess()).toBe(true);
+      assertSuccess(result);
+      expect(result.value).toBeInstanceOf(Date);
+      expect(result.value?.getTime()).toBe(lastSeenAt.getTime());
+    });
+
+    it("should return null when the user has no profile row", async () => {
+      // Arrange
+      const userWithoutProfileId = await testApp.createTestUser({
+        createProfile: false,
+      });
+
+      // Act
+      const result = await repository.findWhatsNewLastSeen(userWithoutProfileId);
+
+      // Assert
+      expect(result.isSuccess()).toBe(true);
+      assertSuccess(result);
+      expect(result.value).toBeNull();
+    });
+  });
+
+  describe("markWhatsNewSeen", () => {
+    it("should stamp the last-seen timestamp and return it", async () => {
+      // Act
+      const result = await repository.markWhatsNewSeen(testUserId);
+
+      // Assert
+      expect(result.isSuccess()).toBe(true);
+      assertSuccess(result);
+      expect(result.value).toBeInstanceOf(Date);
+
+      // Verify the timestamp was persisted in the database
+      const profs = await testApp.database
+        .select()
+        .from(profiles)
+        .where(eq(profiles.userId, testUserId));
+      expect(profs.length).toBe(1);
+      expect(profs[0].whatsNewLastSeenAt).not.toBeNull();
+      expect(profs[0].whatsNewLastSeenAt?.getTime()).toBe(result.value?.getTime());
+    });
+
+    it("should overwrite an existing last-seen timestamp with a newer one", async () => {
+      // Arrange: stamp an old last-seen timestamp directly in the database
+      const previousSeenAt = new Date("2020-01-01T00:00:00.000Z");
+      await testApp.database
+        .update(profiles)
+        .set({ whatsNewLastSeenAt: previousSeenAt })
+        .where(eq(profiles.userId, testUserId));
+
+      // Act
+      const result = await repository.markWhatsNewSeen(testUserId);
+
+      // Assert
+      expect(result.isSuccess()).toBe(true);
+      assertSuccess(result);
+      expect(result.value).toBeInstanceOf(Date);
+      expect(result.value?.getTime()).toBeGreaterThan(previousSeenAt.getTime());
+    });
+
+    it("should return null when the user has no profile row", async () => {
+      // Arrange
+      const userWithoutProfileId = await testApp.createTestUser({
+        createProfile: false,
+      });
+
+      // Act
+      const result = await repository.markWhatsNewSeen(userWithoutProfileId);
+
+      // Assert
+      expect(result.isSuccess()).toBe(true);
+      assertSuccess(result);
+      expect(result.value).toBeNull();
+    });
+  });
 });

--- a/apps/backend/src/users/core/repositories/user.repository.ts
+++ b/apps/backend/src/users/core/repositories/user.repository.ts
@@ -342,4 +342,36 @@ export class UserRepository {
       } as UserProfileDto;
     });
   }
+
+  /**
+   * Returns when the user last opened the "What's new" panel, or null if they
+   * never have (or have no profile yet) — null means everything is unread.
+   */
+  async findWhatsNewLastSeen(userId: string): Promise<Result<Date | null>> {
+    return tryCatch(async () => {
+      const result = await this.database
+        .select({ whatsNewLastSeenAt: profiles.whatsNewLastSeenAt })
+        .from(profiles)
+        .where(eq(profiles.userId, userId))
+        .limit(1);
+
+      return result.length > 0 ? result[0].whatsNewLastSeenAt : null;
+    });
+  }
+
+  /**
+   * Stamps the user's "What's new" last-seen timestamp to now, clearing the unread indicator
+   * across their devices. Returns the new timestamp (null if the user has no profile row).
+   */
+  async markWhatsNewSeen(userId: string): Promise<Result<Date | null>> {
+    return tryCatch(async () => {
+      const result = await this.database
+        .update(profiles)
+        .set({ whatsNewLastSeenAt: sql`now() AT TIME ZONE 'UTC'` })
+        .where(eq(profiles.userId, userId))
+        .returning({ whatsNewLastSeenAt: profiles.whatsNewLastSeenAt });
+
+      return result.length > 0 ? result[0].whatsNewLastSeenAt : null;
+    });
+  }
 }

--- a/apps/backend/src/users/presentation/whats-new.controller.spec.ts
+++ b/apps/backend/src/users/presentation/whats-new.controller.spec.ts
@@ -1,0 +1,164 @@
+import { StatusCodes } from "http-status-codes";
+
+import { contract } from "@repo/api/contract";
+import type { WhatsNewSeenResponse } from "@repo/api/schemas/user.schema";
+import { profiles, eq } from "@repo/database";
+
+import { failure, AppError } from "../../common/utils/fp-utils";
+import type { SuperTestResponse } from "../../test/test-harness";
+import { TestHarness } from "../../test/test-harness";
+import { GetWhatsNewSeenUseCase } from "../application/use-cases/get-whats-new-seen/get-whats-new-seen";
+import { MarkWhatsNewSeenUseCase } from "../application/use-cases/mark-whats-new-seen/mark-whats-new-seen";
+
+describe("WhatsNewController", () => {
+  const testApp = TestHarness.App;
+  let testUserId: string;
+  let getWhatsNewSeenUseCase: GetWhatsNewSeenUseCase;
+  let markWhatsNewSeenUseCase: MarkWhatsNewSeenUseCase;
+
+  beforeAll(async () => {
+    await testApp.setup();
+  });
+
+  beforeEach(async () => {
+    await testApp.beforeEach();
+    testUserId = await testApp.createTestUser({});
+    getWhatsNewSeenUseCase = testApp.module.get(GetWhatsNewSeenUseCase);
+    markWhatsNewSeenUseCase = testApp.module.get(MarkWhatsNewSeenUseCase);
+  });
+
+  afterEach(() => {
+    testApp.afterEach();
+  });
+
+  afterAll(async () => {
+    await testApp.teardown();
+  });
+
+  describe("getWhatsNewSeen", () => {
+    it("should return null when the user has never opened the What's new panel", async () => {
+      const response: SuperTestResponse<WhatsNewSeenResponse> = await testApp
+        .get(contract.users.getWhatsNewSeen.path)
+        .withAuth(testUserId)
+        .expect(StatusCodes.OK);
+
+      expect(response.body).toEqual({ lastSeenAt: null });
+    });
+
+    it("should return the last-seen timestamp as an ISO string when set", async () => {
+      // Arrange: stamp a last-seen timestamp directly in the database
+      const lastSeenAt = new Date("2026-01-15T10:30:00.000Z");
+      await testApp.database
+        .update(profiles)
+        .set({ whatsNewLastSeenAt: lastSeenAt })
+        .where(eq(profiles.userId, testUserId));
+
+      const response: SuperTestResponse<WhatsNewSeenResponse> = await testApp
+        .get(contract.users.getWhatsNewSeen.path)
+        .withAuth(testUserId)
+        .expect(StatusCodes.OK);
+
+      expect(response.body.lastSeenAt).toBe(lastSeenAt.toISOString());
+    });
+
+    it("should return 401 if not authenticated", async () => {
+      await testApp
+        .get(contract.users.getWhatsNewSeen.path)
+        .withoutAuth()
+        .expect(StatusCodes.UNAUTHORIZED);
+    });
+
+    it("should return 404 when the user has no profile", async () => {
+      const userWithoutProfileId = await testApp.createTestUser({
+        createProfile: false,
+      });
+
+      await testApp
+        .get(contract.users.getWhatsNewSeen.path)
+        .withAuth(userWithoutProfileId)
+        .expect(StatusCodes.NOT_FOUND);
+    });
+
+    it("should return 500 when use case returns failure", async () => {
+      vi.spyOn(getWhatsNewSeenUseCase, "execute").mockResolvedValue(
+        failure(AppError.internal("Database error")),
+      );
+
+      await testApp
+        .get(contract.users.getWhatsNewSeen.path)
+        .withAuth(testUserId)
+        .expect(StatusCodes.INTERNAL_SERVER_ERROR);
+    });
+  });
+
+  describe("markWhatsNewSeen", () => {
+    it("should stamp the last-seen timestamp and return it", async () => {
+      const response: SuperTestResponse<WhatsNewSeenResponse> = await testApp
+        .post(contract.users.markWhatsNewSeen.path)
+        .withAuth(testUserId)
+        .send({})
+        .expect(StatusCodes.OK);
+
+      expect(response.body.lastSeenAt).toEqual(expect.any(String));
+
+      // Verify the timestamp was persisted in the database
+      const profs = await testApp.database
+        .select()
+        .from(profiles)
+        .where(eq(profiles.userId, testUserId));
+      expect(profs.length).toBe(1);
+      expect(profs[0].whatsNewLastSeenAt).not.toBeNull();
+      expect(profs[0].whatsNewLastSeenAt?.toISOString()).toBe(response.body.lastSeenAt);
+    });
+
+    it("should return the new timestamp on subsequent getWhatsNewSeen calls", async () => {
+      // Arrange: mark as seen first
+      const markResponse: SuperTestResponse<WhatsNewSeenResponse> = await testApp
+        .post(contract.users.markWhatsNewSeen.path)
+        .withAuth(testUserId)
+        .send({})
+        .expect(StatusCodes.OK);
+
+      // Act
+      const getResponse: SuperTestResponse<WhatsNewSeenResponse> = await testApp
+        .get(contract.users.getWhatsNewSeen.path)
+        .withAuth(testUserId)
+        .expect(StatusCodes.OK);
+
+      // Assert
+      expect(getResponse.body.lastSeenAt).toBe(markResponse.body.lastSeenAt);
+    });
+
+    it("should return 401 if not authenticated", async () => {
+      await testApp
+        .post(contract.users.markWhatsNewSeen.path)
+        .withoutAuth()
+        .send({})
+        .expect(StatusCodes.UNAUTHORIZED);
+    });
+
+    it("should return 404 when the user has no profile", async () => {
+      const userWithoutProfileId = await testApp.createTestUser({
+        createProfile: false,
+      });
+
+      await testApp
+        .post(contract.users.markWhatsNewSeen.path)
+        .withAuth(userWithoutProfileId)
+        .send({})
+        .expect(StatusCodes.NOT_FOUND);
+    });
+
+    it("should return 500 when use case returns failure", async () => {
+      vi.spyOn(markWhatsNewSeenUseCase, "execute").mockResolvedValue(
+        failure(AppError.internal("Database error")),
+      );
+
+      await testApp
+        .post(contract.users.markWhatsNewSeen.path)
+        .withAuth(testUserId)
+        .send({})
+        .expect(StatusCodes.INTERNAL_SERVER_ERROR);
+    });
+  });
+});

--- a/apps/backend/src/users/presentation/whats-new.controller.ts
+++ b/apps/backend/src/users/presentation/whats-new.controller.ts
@@ -1,0 +1,64 @@
+import { Controller, Logger } from "@nestjs/common";
+import { Session } from "@thallesp/nestjs-better-auth";
+import type { UserSession } from "@thallesp/nestjs-better-auth";
+import { TsRestHandler, tsRestHandler } from "@ts-rest/nest";
+import { StatusCodes } from "http-status-codes";
+
+import { contract } from "@repo/api/contract";
+
+import { handleFailure } from "../../common/utils/fp-utils";
+import { GetWhatsNewSeenUseCase } from "../application/use-cases/get-whats-new-seen/get-whats-new-seen";
+import { MarkWhatsNewSeenUseCase } from "../application/use-cases/mark-whats-new-seen/mark-whats-new-seen";
+
+/**
+ * "What's new" read-state endpoints. The backend only tracks when the caller last
+ * opened the panel so the unread indicator can sync across devices — release-note content is
+ * fetched directly from Contentful by the web/mobile clients.
+ */
+@Controller()
+export class WhatsNewController {
+  private readonly logger = new Logger(WhatsNewController.name);
+
+  constructor(
+    private readonly getWhatsNewSeenUseCase: GetWhatsNewSeenUseCase,
+    private readonly markWhatsNewSeenUseCase: MarkWhatsNewSeenUseCase,
+  ) {}
+
+  @TsRestHandler(contract.users.getWhatsNewSeen)
+  getLastSeen(@Session() session: UserSession) {
+    return tsRestHandler(contract.users.getWhatsNewSeen, async () => {
+      const result = await this.getWhatsNewSeenUseCase.execute(session.user.id);
+
+      if (result.isSuccess()) {
+        return {
+          status: StatusCodes.OK,
+          body: { lastSeenAt: result.value ? result.value.toISOString() : null },
+        };
+      }
+
+      return handleFailure(result, this.logger);
+    });
+  }
+
+  @TsRestHandler(contract.users.markWhatsNewSeen)
+  markSeen(@Session() session: UserSession) {
+    return tsRestHandler(contract.users.markWhatsNewSeen, async () => {
+      const result = await this.markWhatsNewSeenUseCase.execute(session.user.id);
+
+      if (result.isSuccess()) {
+        this.logger.log({
+          msg: "What's new marked as seen",
+          operation: "markWhatsNewSeen",
+          userId: session.user.id,
+          status: "success",
+        });
+        return {
+          status: StatusCodes.OK,
+          body: { lastSeenAt: result.value ? result.value.toISOString() : null },
+        };
+      }
+
+      return handleFailure(result, this.logger);
+    });
+  }
+}

--- a/apps/backend/src/users/user.module.ts
+++ b/apps/backend/src/users/user.module.ts
@@ -14,6 +14,8 @@ import { GetInvitationsUseCase } from "./application/use-cases/get-invitations/g
 import { GetUserProfileUseCase } from "./application/use-cases/get-user-profile/get-user-profile";
 import { GetUserUseCase } from "./application/use-cases/get-user/get-user";
 import { GetUsersMetadataUseCase } from "./application/use-cases/get-users-metadata/get-users-metadata";
+import { GetWhatsNewSeenUseCase } from "./application/use-cases/get-whats-new-seen/get-whats-new-seen";
+import { MarkWhatsNewSeenUseCase } from "./application/use-cases/mark-whats-new-seen/mark-whats-new-seen";
 import { RevokeInvitationUseCase } from "./application/use-cases/revoke-invitation/revoke-invitation";
 import { SearchUsersUseCase } from "./application/use-cases/search-users/search-users";
 import { UpdateInvitationRoleUseCase } from "./application/use-cases/update-invitation-role/update-invitation-role";
@@ -26,10 +28,11 @@ import { InvitationController } from "./presentation/user-invitation.controller"
 import { UserWebhookController } from "./presentation/user-webhook.controller";
 // Controllers
 import { UserController } from "./presentation/user.controller";
+import { WhatsNewController } from "./presentation/whats-new.controller";
 
 @Module({
   imports: [DatabricksModule, EmailModule, forwardRef(() => ExperimentModule)],
-  controllers: [UserController, UserWebhookController, InvitationController],
+  controllers: [UserController, UserWebhookController, InvitationController, WhatsNewController],
   providers: [
     // Repositories
     UserRepository,
@@ -53,6 +56,8 @@ import { UserController } from "./presentation/user.controller";
     CreateUserProfileUseCase,
     GetUserProfileUseCase,
     GetUsersMetadataUseCase,
+    GetWhatsNewSeenUseCase,
+    MarkWhatsNewSeenUseCase,
     AcceptPendingInvitationsUseCase,
     CreateInvitationUseCase,
     GetInvitationsUseCase,

--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -7,6 +7,7 @@ import { useAutoReconnect } from "~/features/connection/hooks/use-auto-reconnect
 import { useDeviceChip } from "~/features/connection/hooks/use-device-chip";
 import { RecentTabIcon } from "~/features/recent-measurements/components/recent-tab-icon";
 import { usePruneExpiredMeasurements } from "~/features/recent-measurements/hooks/use-prune-expired-measurements";
+import { WhatsNewSheet } from "~/features/release-notes/components/whats-new-sheet";
 import { useTranslation } from "~/shared/i18n";
 import { AnimatedTabBar } from "~/shared/ui/animated-tab-bar";
 import { useThemeColors } from "~/shared/ui/hooks/use-theme-colors";
@@ -120,6 +121,7 @@ export default function TabLayout() {
       </Tabs>
 
       <DeviceSheet />
+      <WhatsNewSheet />
     </View>
   );
 }

--- a/apps/mobile/src/features/alerts/components/alert-banner.test.tsx
+++ b/apps/mobile/src/features/alerts/components/alert-banner.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react-native";
 import React from "react";
-import { Text } from "react-native";
+import { Linking, Text } from "react-native";
 import { describe, it, expect, vi } from "vitest";
 
 import type { ComponentAlertFieldsFragment } from "@repo/cms/lib/__generated/sdk";
@@ -66,5 +66,33 @@ describe("AlertBanner", () => {
     const json = { nodeType: "document", content: [] };
     render(<AlertBanner alert={makeAlert({ body: { json } })} onDismiss={vi.fn()} />);
     expect(screen.getByText(JSON.stringify(json))).toBeTruthy();
+  });
+
+  it("opens an absolute link URL as-is when the CTA is pressed", () => {
+    const openURL = vi.spyOn(Linking, "openURL").mockImplementation(() => Promise.resolve());
+    render(
+      <AlertBanner
+        alert={makeAlert({ link: { url: "https://example.com/x", label: "Learn more" } })}
+        onDismiss={vi.fn()}
+        baseUrl="https://app.openjii.org"
+      />,
+    );
+    fireEvent.press(screen.getByText("Learn more"));
+    expect(openURL).toHaveBeenCalledWith("https://example.com/x");
+    openURL.mockRestore();
+  });
+
+  it("resolves a relative link URL against baseUrl before opening", () => {
+    const openURL = vi.spyOn(Linking, "openURL").mockImplementation(() => Promise.resolve());
+    render(
+      <AlertBanner
+        alert={makeAlert({ link: { url: "/releases", label: "See releases" } })}
+        onDismiss={vi.fn()}
+        baseUrl="https://app.openjii.org"
+      />,
+    );
+    fireEvent.press(screen.getByText("See releases"));
+    expect(openURL).toHaveBeenCalledWith("https://app.openjii.org/releases");
+    openURL.mockRestore();
   });
 });

--- a/apps/mobile/src/features/alerts/components/alert-banner.tsx
+++ b/apps/mobile/src/features/alerts/components/alert-banner.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { Linking, Pressable, Text, View } from "react-native";
 import { CtfRichText } from "~/shared/ui/ctf-rich-text";
 import { useThemeColors } from "~/shared/ui/hooks/use-theme-colors";
+import { resolveExternalUrl } from "~/shared/utils/resolve-external-url";
 
 import type { ComponentAlertFieldsFragment } from "@repo/cms";
 import { getSeverity } from "@repo/cms/alert";
@@ -55,13 +56,16 @@ export interface AlertBannerProps {
   alert: ComponentAlertFieldsFragment;
   onDismiss: () => void;
   topPadding?: number;
+  /** App origin used to resolve a relative link url; full urls are opened as-is. */
+  baseUrl?: string;
 }
 
-export function AlertBanner({ alert, onDismiss, topPadding = 0 }: AlertBannerProps) {
+export function AlertBanner({ alert, onDismiss, topPadding = 0, baseUrl }: AlertBannerProps) {
   const severity = getSeverity(alert);
   const themeColors = useThemeColors();
 
   const Icon = typeIcons[alert.type ?? ""] ?? null;
+  const linkHref = alert.link?.url ? resolveExternalUrl(alert.link.url, baseUrl) : undefined;
 
   return (
     <View className={bannerVariants({ severity })}>
@@ -89,14 +93,10 @@ export function AlertBanner({ alert, onDismiss, topPadding = 0 }: AlertBannerPro
           )}
         </Text>
 
-        {alert.link?.url && alert.link?.label && (
+        {linkHref && alert.link?.label && (
           <Pressable
             className={actionButtonVariants({ severity })}
-            onPress={() => {
-              if (alert.link?.url) {
-                void Linking.openURL(alert.link.url);
-              }
-            }}
+            onPress={() => void Linking.openURL(linkHref)}
           >
             <Text className="text-sm font-medium text-white">{alert.link.label}</Text>
             <ArrowRight size={14} color="white" />

--- a/apps/mobile/src/features/alerts/components/alerts-container.tsx
+++ b/apps/mobile/src/features/alerts/components/alerts-container.tsx
@@ -2,6 +2,7 @@ import { View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useActiveAlerts } from "~/features/alerts/hooks/use-active-alerts";
 import { useDismissedAlertsStore } from "~/features/alerts/stores/dismissed-alerts-store";
+import { useEnvVar } from "~/shared/stores/environment-store";
 
 import type { ComponentAlertFieldsFragment } from "@repo/cms/lib/__generated/sdk";
 
@@ -11,6 +12,7 @@ export function AlertsBar() {
   const insets = useSafeAreaInsets();
   const visible = useActiveAlerts();
   const dismiss = useDismissedAlertsStore((s) => s.dismiss);
+  const baseUrl = useEnvVar("NEXT_AUTH_URI");
 
   if (visible.length === 0) return null;
 
@@ -22,6 +24,7 @@ export function AlertsBar() {
           alert={alert}
           onDismiss={() => dismiss(alert.internalName ?? alert.sys.id)}
           topPadding={index === 0 ? insets.top : 0}
+          baseUrl={baseUrl}
         />
       ))}
     </View>

--- a/apps/mobile/src/features/home/components/home-device-card.tsx
+++ b/apps/mobile/src/features/home/components/home-device-card.tsx
@@ -7,6 +7,7 @@ import { useDeviceConnectionStore } from "~/features/connection/hooks/use-device
 import { useDeviceSheetStore } from "~/features/connection/stores/use-device-sheet-store";
 import { colors } from "~/shared/constants/colors";
 import { useTranslation } from "~/shared/i18n";
+import { cn } from "~/shared/ui/cn";
 import { useThemeColors } from "~/shared/ui/hooks/use-theme-colors";
 
 const MAC_PATTERN = /^(?:[0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$/;
@@ -55,30 +56,14 @@ export function HomeDeviceCard() {
       <View className="bg-card shadow-xs rounded-2xl p-3.5 shadow-black/10">
         <View className="flex-row items-center">
           <View
-            className="mr-3 items-center justify-center"
-            style={{
-              width: 46,
-              height: 46,
-              borderRadius: 14,
-              backgroundColor: isConnected ? colors.jii.mint : "#fff4d6",
-              position: "relative",
-            }}
+            className={cn(
+              "h-13 w-13 relative mr-3 items-center justify-center rounded-[14px]",
+              isConnected ? "bg-jii-mint" : "bg-[#fff4d6]",
+            )}
           >
             <Bluetooth size={22} color={isConnected ? colors.jii.darkGreen : "#8a6800"} />
             {isConnected ? (
-              <View
-                style={{
-                  position: "absolute",
-                  right: -2,
-                  bottom: -2,
-                  width: 14,
-                  height: 14,
-                  borderRadius: 7,
-                  backgroundColor: colors.semantic.success,
-                  borderWidth: 2,
-                  borderColor: "#FFFFFF",
-                }}
-              />
+              <View className="absolute -bottom-0.5 -right-0.5 h-3.5 w-3.5 rounded-full border-2 border-white bg-[#09b732]" />
             ) : null}
           </View>
 

--- a/apps/mobile/src/features/home/components/home-whats-new-card.tsx
+++ b/apps/mobile/src/features/home/components/home-whats-new-card.tsx
@@ -1,0 +1,55 @@
+import { ChevronRight, Sparkles } from "lucide-react-native";
+import React from "react";
+import { Pressable, Text, View } from "react-native";
+import { useWhatsNew } from "~/features/release-notes/hooks/use-whats-new";
+import { useWhatsNewSheetStore } from "~/features/release-notes/stores/use-whats-new-sheet-store";
+import { useTranslation } from "~/shared/i18n";
+import { useThemeColors } from "~/shared/ui/hooks/use-theme-colors";
+
+/**
+ * Home-screen entry point for the What's new drawer: a card that communicates whether
+ * there are unread release notes (brand-green dot + count) and opens the shared sheet on tap.
+ * Mirrors HomeDeviceCard's layout/store pattern.
+ */
+export function HomeWhatsNewCard() {
+  const { t } = useTranslation("whatsNew");
+  const themeColors = useThemeColors();
+  const { unreadCount } = useWhatsNew();
+  const hasUnread = unreadCount > 0;
+
+  const onPress = () => useWhatsNewSheetStore.getState().open();
+
+  const subtitle = hasUnread
+    ? t("card.subtitleUnread", { count: unreadCount })
+    : t("card.subtitleCaughtUp");
+
+  return (
+    <Pressable onPress={onPress} className="mb-1 mt-3" accessibilityRole="button">
+      <View className="bg-card shadow-xs rounded-2xl p-3.5 shadow-black/10">
+        <View className="flex-row items-center">
+          <View className="bg-jii-mint h-13 w-13 relative mr-3 items-center justify-center rounded-[14px]">
+            <Sparkles size={26} color={themeColors.brand} />
+            {hasUnread ? (
+              <View className="bg-jii-primary-bright absolute -right-0.5 -top-0.5 h-3.5 w-3.5 rounded-full border-2 border-white" />
+            ) : null}
+          </View>
+
+          <View className="min-w-0 flex-1">
+            <Text
+              className="text-on-surface text-[15px]"
+              style={{ fontFamily: "Poppins-Bold" }}
+              numberOfLines={1}
+            >
+              {t("card.title")}
+            </Text>
+            <Text className="text-muted-body mt-0.5 text-[12px]" numberOfLines={1}>
+              {subtitle}
+            </Text>
+          </View>
+
+          <ChevronRight size={20} color={themeColors.inactive} />
+        </View>
+      </View>
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/features/home/screens/home-screen/home-screen.tsx
+++ b/apps/mobile/src/features/home/screens/home-screen/home-screen.tsx
@@ -5,6 +5,7 @@ import { HomeDeviceCard } from "~/features/home/components/home-device-card";
 import { HomeGreeting } from "~/features/home/components/home-greeting";
 import { HomePrimaryCta } from "~/features/home/components/home-primary-cta";
 import { HomeRecentMeasurements } from "~/features/home/components/home-recent-measurements";
+import { HomeWhatsNewCard } from "~/features/home/components/home-whats-new-card";
 
 export function HomeScreen() {
   return (
@@ -17,6 +18,7 @@ export function HomeScreen() {
       <HomeContinueCard />
       <HomePrimaryCta />
       <HomeDeviceCard />
+      <HomeWhatsNewCard />
       <HomeRecentMeasurements />
       <View style={{ height: 24 }} />
     </ScrollView>

--- a/apps/mobile/src/features/release-notes/category.ts
+++ b/apps/mobile/src/features/release-notes/category.ts
@@ -1,0 +1,32 @@
+import type { TagVariant } from "~/shared/ui/Tag";
+
+/** Release-note categories, mapped to the shared Tag variants for badge colors. */
+export const RELEASE_CATEGORIES = [
+  "new_feature",
+  "improvement",
+  "bug_fix",
+  "announcement",
+] as const;
+
+export type ReleaseCategory = (typeof RELEASE_CATEGORIES)[number];
+
+interface CategoryMeta {
+  /** i18n key under the `whatsNew` namespace. */
+  labelKey: `category.${ReleaseCategory}`;
+  tagVariant: TagVariant;
+}
+
+const CATEGORY_META: Record<ReleaseCategory, CategoryMeta> = {
+  new_feature: { labelKey: "category.new_feature", tagVariant: "sensor" },
+  improvement: { labelKey: "category.improvement", tagVariant: "questions" },
+  bug_fix: { labelKey: "category.bug_fix", tagVariant: "default" },
+  announcement: { labelKey: "category.announcement", tagVariant: "queued" },
+};
+
+/** Normalizes the free-text `category` field to known {@link CategoryMeta}; unknown → announcement. */
+export function getCategoryMeta(category?: string | null): CategoryMeta {
+  if (category && category in CATEGORY_META) {
+    return CATEGORY_META[category as ReleaseCategory];
+  }
+  return CATEGORY_META.announcement;
+}

--- a/apps/mobile/src/features/release-notes/components/release-note-entry.tsx
+++ b/apps/mobile/src/features/release-notes/components/release-note-entry.tsx
@@ -1,0 +1,129 @@
+import type { Document } from "@contentful/rich-text-types";
+import { ChevronRight } from "lucide-react-native";
+import React, { useState } from "react";
+import { Image, Linking, Pressable, Text, View } from "react-native";
+import { getCategoryMeta } from "~/features/release-notes/category";
+import { useTranslation } from "~/shared/i18n";
+import { Tag } from "~/shared/ui/Tag";
+import { CtfRichText } from "~/shared/ui/ctf-rich-text";
+import { useThemeColors } from "~/shared/ui/hooks/use-theme-colors";
+import { resolveExternalUrl } from "~/shared/utils/resolve-external-url";
+
+import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "@repo/cms/lib/__generated/sdk";
+
+interface ReleaseNoteEntryProps {
+  entry: ReleaseNoteFields;
+  /** Base URL for the public release detail page; entries link to `${linkBaseHref}/${slug}`. */
+  linkBaseHref?: string;
+}
+
+/** Relative-time label ("3 days ago"); falls back to a plain date if Intl is unavailable. */
+function formatRelativeTime(iso: string, locale: string): string | null {
+  const ms = new Date(iso).getTime();
+  if (Number.isNaN(ms)) return null;
+  try {
+    const diffSec = Math.round((ms - Date.now()) / 1000);
+    const abs = Math.abs(diffSec);
+    const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+    if (abs < 60) return rtf.format(diffSec, "second");
+    if (abs < 3600) return rtf.format(Math.round(diffSec / 60), "minute");
+    if (abs < 86400) return rtf.format(Math.round(diffSec / 3600), "hour");
+    if (abs < 2592000) return rtf.format(Math.round(diffSec / 86400), "day");
+    if (abs < 31536000) return rtf.format(Math.round(diffSec / 2592000), "month");
+    return rtf.format(Math.round(diffSec / 31536000), "year");
+  } catch {
+    return new Date(ms).toDateString();
+  }
+}
+
+export function ReleaseNoteEntry({ entry, linkBaseHref }: ReleaseNoteEntryProps) {
+  const { t, i18n } = useTranslation("whatsNew");
+  const themeColors = useThemeColors();
+  const [expanded, setExpanded] = useState(false);
+
+  const category = getCategoryMeta(entry.category);
+  const media = entry.media;
+  // RN renders image/gif heroes directly; video heroes need expo-av, so they're skipped on mobile.
+  const showImage = !!media?.url && !media.contentType?.startsWith("video/");
+  const relativeTime = entry.publishedAt
+    ? formatRelativeTime(entry.publishedAt as string, i18n.language)
+    : null;
+  const ctaLabel = entry.cta?.label;
+  const ctaHref = entry.cta?.url ? resolveExternalUrl(entry.cta.url, linkBaseHref) : undefined;
+  const releaseHref = linkBaseHref && entry.slug ? `${linkBaseHref}/${entry.slug}` : undefined;
+
+  return (
+    <View className="border-border bg-card shadow-xs overflow-hidden rounded-xl border shadow-black/10">
+      {showImage && media?.url && (
+        <Image
+          source={{ uri: `${media.url}?w=960&fm=webp&fit=fill` }}
+          className="aspect-video w-full"
+          resizeMode="cover"
+        />
+      )}
+
+      <View className="gap-3 p-4">
+        <View className="flex-row items-center justify-between gap-3">
+          <Tag variant={category.tagVariant} size="sm">
+            {t(category.labelKey)}
+          </Tag>
+          {relativeTime ? (
+            <Text className="text-muted-body shrink text-right text-xs">{relativeTime}</Text>
+          ) : null}
+        </View>
+
+        <Text
+          className="text-on-surface"
+          style={{ fontFamily: "Poppins-SemiBold", fontSize: 17, lineHeight: 23 }}
+        >
+          {entry.title}
+        </Text>
+
+        {entry.summary ? (
+          <Text className="text-muted-body text-sm leading-5">{entry.summary}</Text>
+        ) : null}
+
+        <View className="flex-row flex-wrap items-center gap-2 pt-1">
+          {releaseHref ? (
+            <Pressable
+              onPress={() => void Linking.openURL(releaseHref)}
+              hitSlop={6}
+              className="bg-primary flex-row items-center gap-1 rounded-lg px-3 py-1.5"
+            >
+              <Text className="text-primary-foreground text-sm font-semibold">{t("showMore")}</Text>
+              <ChevronRight size={14} color={themeColors.onPrimary} />
+            </Pressable>
+          ) : entry.body?.json ? (
+            <Pressable
+              onPress={() => setExpanded((prev) => !prev)}
+              hitSlop={6}
+              className="bg-primary/10 flex-row items-center gap-1 rounded-lg px-3 py-1.5"
+            >
+              <Text className="text-primary text-sm font-semibold">
+                {expanded ? t("showLess") : t("showMore")}
+              </Text>
+              <ChevronRight size={14} color={themeColors.brand} />
+            </Pressable>
+          ) : null}
+
+          {ctaHref && ctaLabel ? (
+            <Pressable
+              onPress={() => void Linking.openURL(ctaHref)}
+              hitSlop={6}
+              className="border-border bg-surface flex-row items-center gap-1 rounded-lg border px-3 py-1.5"
+            >
+              <Text className="text-on-surface text-sm font-semibold">{ctaLabel}</Text>
+              <ChevronRight size={14} color={themeColors.onSurface} />
+            </Pressable>
+          ) : null}
+        </View>
+
+        {expanded && entry.body?.json ? (
+          <View className="border-border border-t pt-3">
+            <CtfRichText json={entry.body.json as Document} textClass="text-on-surface" />
+          </View>
+        ) : null}
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/src/features/release-notes/components/whats-new-feed.tsx
+++ b/apps/mobile/src/features/release-notes/components/whats-new-feed.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { Text, View } from "react-native";
+import { ReleaseNoteEntry } from "~/features/release-notes/components/release-note-entry";
+import { useTranslation } from "~/shared/i18n";
+
+import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "@repo/cms/lib/__generated/sdk";
+
+interface MonthGroup {
+  key: string;
+  label: string;
+  entries: ReleaseNoteFields[];
+}
+
+function monthLabel(date: Date, locale: string): string {
+  try {
+    return new Intl.DateTimeFormat(locale, { month: "long", year: "numeric" }).format(date);
+  } catch {
+    return String(date.getFullYear());
+  }
+}
+
+/** Groups entries by month, preserving the incoming newest-first order. */
+function groupByMonth(entries: ReleaseNoteFields[], locale: string): MonthGroup[] {
+  const order: MonthGroup[] = [];
+  const byKey = new Map<string, MonthGroup>();
+
+  for (const entry of entries) {
+    const date = entry.publishedAt ? new Date(entry.publishedAt as string) : null;
+    const valid = date !== null && !Number.isNaN(date.getTime());
+    const key = valid ? `${date.getFullYear()}-${date.getMonth()}` : "undated";
+
+    let group = byKey.get(key);
+    if (!group) {
+      group = { key, label: valid && date ? monthLabel(date, locale) : "", entries: [] };
+      byKey.set(key, group);
+      order.push(group);
+    }
+    group.entries.push(entry);
+  }
+
+  return order;
+}
+
+export function WhatsNewFeed({
+  entries,
+  linkBaseHref,
+}: {
+  entries: ReleaseNoteFields[];
+  linkBaseHref?: string;
+}) {
+  const { t, i18n } = useTranslation("whatsNew");
+
+  if (entries.length === 0) {
+    return <Text className="text-muted-body text-sm">{t("empty")}</Text>;
+  }
+
+  const groups = groupByMonth(entries, i18n.language);
+
+  return (
+    <View className="gap-6">
+      {groups.map((group) => (
+        <View key={group.key} className="gap-4">
+          {group.label ? (
+            <Text className="text-muted-body text-xs font-semibold uppercase">{group.label}</Text>
+          ) : null}
+          {group.entries.map((entry) => (
+            <ReleaseNoteEntry key={entry.sys.id} entry={entry} linkBaseHref={linkBaseHref} />
+          ))}
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/apps/mobile/src/features/release-notes/components/whats-new-feed.tsx
+++ b/apps/mobile/src/features/release-notes/components/whats-new-feed.tsx
@@ -48,10 +48,10 @@ export function WhatsNewFeed({
   entries: ReleaseNoteFields[];
   linkBaseHref?: string;
 }) {
-  const { t, i18n } = useTranslation("whatsNew");
+  const { i18n } = useTranslation("whatsNew");
 
   if (entries.length === 0) {
-    return <Text className="text-muted-body text-sm">{t("empty")}</Text>;
+    return null;
   }
 
   const groups = groupByMonth(entries, i18n.language);

--- a/apps/mobile/src/features/release-notes/components/whats-new-sheet.tsx
+++ b/apps/mobile/src/features/release-notes/components/whats-new-sheet.tsx
@@ -1,0 +1,97 @@
+import { BottomSheetBackdrop, BottomSheetModal, BottomSheetScrollView } from "@gorhom/bottom-sheet";
+import { ExternalLink, X } from "lucide-react-native";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import { Linking, Pressable, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useWhatsNew } from "~/features/release-notes/hooks/use-whats-new";
+import { useWhatsNewSheetStore } from "~/features/release-notes/stores/use-whats-new-sheet-store";
+import { useTranslation } from "~/shared/i18n";
+import { useEnvVar } from "~/shared/stores/environment-store";
+import { useThemeColors } from "~/shared/ui/hooks/use-theme-colors";
+import { resolveExternalUrl } from "~/shared/utils/resolve-external-url";
+
+import { WhatsNewFeed } from "./whats-new-feed";
+
+const RELEASES_PATH = "/releases";
+const SHEET_TOP_GAP = 4;
+
+/** Full-screen What's new drawer; mirrors the device sheet's store/ref pattern. */
+export function WhatsNewSheet() {
+  const isOpen = useWhatsNewSheetStore((s) => s.isOpen);
+  const close = useWhatsNewSheetStore((s) => s.close);
+  const insets = useSafeAreaInsets();
+  const themeColors = useThemeColors();
+  const { t } = useTranslation("whatsNew");
+  const sheetRef = useRef<BottomSheetModal>(null);
+  const { entries, markSeen } = useWhatsNew();
+  const webBaseUrl = useEnvVar("NEXT_AUTH_URI");
+  const releaseNotesBaseUrl = useMemo(
+    () => resolveExternalUrl(RELEASES_PATH, webBaseUrl),
+    [webBaseUrl],
+  );
+  const snapPoints = useMemo(() => ["100%"], []);
+
+  useEffect(() => {
+    if (isOpen) sheetRef.current?.present();
+    else sheetRef.current?.dismiss();
+  }, [isOpen]);
+
+  const renderBackdrop = useCallback(
+    (props: React.ComponentProps<typeof BottomSheetBackdrop>) => (
+      <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} />
+    ),
+    [],
+  );
+
+  // Closing the panel stamps "seen" so the unread dot clears across devices.
+  const handleDismiss = useCallback(() => {
+    close();
+    markSeen();
+  }, [close, markSeen]);
+
+  return (
+    <BottomSheetModal
+      ref={sheetRef}
+      snapPoints={snapPoints}
+      backdropComponent={renderBackdrop}
+      onDismiss={handleDismiss}
+      handleIndicatorStyle={{ backgroundColor: themeColors.inactive }}
+      backgroundStyle={{ backgroundColor: themeColors.background }}
+      topInset={insets.top + SHEET_TOP_GAP}
+    >
+      <View className="border-border flex-row items-center justify-between border-b px-4 pb-3 pt-1">
+        <Text className="text-on-surface" style={{ fontFamily: "Poppins-Bold", fontSize: 20 }}>
+          {t("title")}
+        </Text>
+        <Pressable onPress={() => sheetRef.current?.dismiss()} hitSlop={8} className="p-1">
+          <X size={22} color={themeColors.onSurface} />
+        </Pressable>
+      </View>
+
+      <BottomSheetScrollView
+        contentContainerStyle={{
+          paddingHorizontal: 16,
+          paddingTop: 16,
+          paddingBottom: 24,
+          gap: 16,
+        }}
+      >
+        <WhatsNewFeed entries={entries} linkBaseHref={releaseNotesBaseUrl} />
+      </BottomSheetScrollView>
+
+      <View
+        className="border-border bg-card border-t px-4 py-3"
+        style={{ paddingBottom: insets.bottom, minHeight: insets.bottom + 64 }}
+      >
+        <Pressable
+          onPress={() => void Linking.openURL(releaseNotesBaseUrl)}
+          hitSlop={6}
+          className="flex-row items-center gap-1.5 self-start"
+        >
+          <Text className="text-primary text-sm font-semibold">{t("fullChangelog")}</Text>
+          <ExternalLink size={14} color={themeColors.brand} />
+        </Pressable>
+      </View>
+    </BottomSheetModal>
+  );
+}

--- a/apps/mobile/src/features/release-notes/components/whats-new-sheet.tsx
+++ b/apps/mobile/src/features/release-notes/components/whats-new-sheet.tsx
@@ -1,5 +1,5 @@
 import { BottomSheetBackdrop, BottomSheetModal, BottomSheetScrollView } from "@gorhom/bottom-sheet";
-import { ExternalLink, X } from "lucide-react-native";
+import { ExternalLink, WifiOff, X } from "lucide-react-native";
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { Linking, Pressable, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -7,6 +7,7 @@ import { useWhatsNew } from "~/features/release-notes/hooks/use-whats-new";
 import { useWhatsNewSheetStore } from "~/features/release-notes/stores/use-whats-new-sheet-store";
 import { useTranslation } from "~/shared/i18n";
 import { useEnvVar } from "~/shared/stores/environment-store";
+import { useIsOnline } from "~/shared/ui/hooks/use-is-online";
 import { useThemeColors } from "~/shared/ui/hooks/use-theme-colors";
 import { resolveExternalUrl } from "~/shared/utils/resolve-external-url";
 
@@ -14,6 +15,26 @@ import { WhatsNewFeed } from "./whats-new-feed";
 
 const RELEASES_PATH = "/releases";
 const SHEET_TOP_GAP = 4;
+
+/** Shown when release notes can't be fetched because the device is offline (and none are cached). */
+function WhatsNewOfflineState() {
+  const { t } = useTranslation("whatsNew");
+  const themeColors = useThemeColors();
+  return (
+    <View className="items-center gap-3 px-6 py-16">
+      <View className="border-border h-16 w-16 items-center justify-center rounded-full border">
+        <WifiOff size={28} color={themeColors.inactive} />
+      </View>
+      <Text
+        className="text-on-surface text-center"
+        style={{ fontFamily: "Poppins-SemiBold", fontSize: 16 }}
+      >
+        {t("offline.title")}
+      </Text>
+      <Text className="text-muted-body text-center text-sm leading-5">{t("offline.subtitle")}</Text>
+    </View>
+  );
+}
 
 /** Full-screen What's new drawer; mirrors the device sheet's store/ref pattern. */
 export function WhatsNewSheet() {
@@ -24,6 +45,10 @@ export function WhatsNewSheet() {
   const { t } = useTranslation("whatsNew");
   const sheetRef = useRef<BottomSheetModal>(null);
   const { entries, markSeen } = useWhatsNew();
+  // Offline is read from the shared connectivity hook, not useWhatsNew — the feed hook is untouched.
+  // Undefined (first probe) is treated as online so we never flash the offline state on open.
+  const { data: online } = useIsOnline();
+  const isOffline = online === false;
   const webBaseUrl = useEnvVar("NEXT_AUTH_URI");
   const releaseNotesBaseUrl = useMemo(
     () => resolveExternalUrl(RELEASES_PATH, webBaseUrl),
@@ -76,7 +101,11 @@ export function WhatsNewSheet() {
           gap: 16,
         }}
       >
-        <WhatsNewFeed entries={entries} linkBaseHref={releaseNotesBaseUrl} />
+        {isOffline && entries.length === 0 ? (
+          <WhatsNewOfflineState />
+        ) : (
+          <WhatsNewFeed entries={entries} linkBaseHref={releaseNotesBaseUrl} />
+        )}
       </BottomSheetScrollView>
 
       <View

--- a/apps/mobile/src/features/release-notes/components/whats-new-sheet.tsx
+++ b/apps/mobile/src/features/release-notes/components/whats-new-sheet.tsx
@@ -1,4 +1,10 @@
-import { BottomSheetBackdrop, BottomSheetModal, BottomSheetScrollView } from "@gorhom/bottom-sheet";
+import {
+  BottomSheetBackdrop,
+  BottomSheetFooter,
+  BottomSheetModal,
+  BottomSheetScrollView,
+} from "@gorhom/bottom-sheet";
+import type { BottomSheetFooterProps } from "@gorhom/bottom-sheet";
 import { ExternalLink, WifiOff, X } from "lucide-react-native";
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { Linking, Pressable, Text, View } from "react-native";
@@ -36,7 +42,7 @@ function WhatsNewOfflineState() {
   );
 }
 
-/** Full-screen What's new drawer; mirrors the device sheet's store/ref pattern. */
+/** Content-sized What's new drawer; mirrors the device sheet's store/ref pattern. */
 export function WhatsNewSheet() {
   const isOpen = useWhatsNewSheetStore((s) => s.isOpen);
   const close = useWhatsNewSheetStore((s) => s.close);
@@ -54,8 +60,6 @@ export function WhatsNewSheet() {
     () => resolveExternalUrl(RELEASES_PATH, webBaseUrl),
     [webBaseUrl],
   );
-  const snapPoints = useMemo(() => ["100%"], []);
-
   useEffect(() => {
     if (isOpen) sheetRef.current?.present();
     else sheetRef.current?.dismiss();
@@ -74,26 +78,64 @@ export function WhatsNewSheet() {
     markSeen();
   }, [close, markSeen]);
 
+  // Header lives in the handle so dynamic sizing counts its height (only the
+  // handle and the scrollable's content are measured; sibling views are not).
+  const renderHandle = useCallback(
+    () => (
+      <View>
+        <View className="items-center pb-1 pt-2.5">
+          <View
+            style={{ width: 40, height: 4, borderRadius: 4, backgroundColor: themeColors.inactive }}
+          />
+        </View>
+        <View className="border-border flex-row items-center justify-between border-b px-4 pb-3 pt-1">
+          <Text className="text-on-surface" style={{ fontFamily: "Poppins-Bold", fontSize: 20 }}>
+            {t("title")}
+          </Text>
+          <Pressable onPress={() => sheetRef.current?.dismiss()} hitSlop={8} className="p-1">
+            <X size={22} color={themeColors.onSurface} />
+          </Pressable>
+        </View>
+      </View>
+    ),
+    [t, themeColors],
+  );
+
+  // Rendered via footerComponent (with enableFooterMarginAdjustment on the
+  // scroll view) so its height is padded into the content and measured too.
+  const renderFooter = useCallback(
+    (props: BottomSheetFooterProps) => (
+      <BottomSheetFooter {...props}>
+        <View
+          className="border-border bg-card border-t px-6 py-4"
+          style={{ paddingBottom: Math.max(insets.bottom, 16) }}
+        >
+          <Pressable
+            onPress={() => void Linking.openURL(releaseNotesBaseUrl)}
+            hitSlop={6}
+            className="flex-row items-center gap-1.5 self-start"
+          >
+            <Text className="text-primary text-sm font-semibold">{t("fullChangelog")}</Text>
+            <ExternalLink size={14} color={themeColors.brand} />
+          </Pressable>
+        </View>
+      </BottomSheetFooter>
+    ),
+    [insets.bottom, releaseNotesBaseUrl, t, themeColors],
+  );
+
   return (
     <BottomSheetModal
       ref={sheetRef}
-      snapPoints={snapPoints}
       backdropComponent={renderBackdrop}
       onDismiss={handleDismiss}
-      handleIndicatorStyle={{ backgroundColor: themeColors.inactive }}
+      handleComponent={renderHandle}
+      footerComponent={renderFooter}
       backgroundStyle={{ backgroundColor: themeColors.background }}
       topInset={insets.top + SHEET_TOP_GAP}
     >
-      <View className="border-border flex-row items-center justify-between border-b px-4 pb-3 pt-1">
-        <Text className="text-on-surface" style={{ fontFamily: "Poppins-Bold", fontSize: 20 }}>
-          {t("title")}
-        </Text>
-        <Pressable onPress={() => sheetRef.current?.dismiss()} hitSlop={8} className="p-1">
-          <X size={22} color={themeColors.onSurface} />
-        </Pressable>
-      </View>
-
       <BottomSheetScrollView
+        enableFooterMarginAdjustment
         contentContainerStyle={{
           paddingHorizontal: 16,
           paddingTop: 16,
@@ -107,20 +149,6 @@ export function WhatsNewSheet() {
           <WhatsNewFeed entries={entries} linkBaseHref={releaseNotesBaseUrl} />
         )}
       </BottomSheetScrollView>
-
-      <View
-        className="border-border bg-card border-t px-4 py-3"
-        style={{ paddingBottom: insets.bottom, minHeight: insets.bottom + 64 }}
-      >
-        <Pressable
-          onPress={() => void Linking.openURL(releaseNotesBaseUrl)}
-          hitSlop={6}
-          className="flex-row items-center gap-1.5 self-start"
-        >
-          <Text className="text-primary text-sm font-semibold">{t("fullChangelog")}</Text>
-          <ExternalLink size={14} color={themeColors.brand} />
-        </Pressable>
-      </View>
     </BottomSheetModal>
   );
 }

--- a/apps/mobile/src/features/release-notes/components/whats-new-sheet.tsx
+++ b/apps/mobile/src/features/release-notes/components/whats-new-sheet.tsx
@@ -5,7 +5,7 @@ import {
   BottomSheetScrollView,
 } from "@gorhom/bottom-sheet";
 import type { BottomSheetFooterProps } from "@gorhom/bottom-sheet";
-import { ExternalLink, WifiOff, X } from "lucide-react-native";
+import { ExternalLink, FileText, WifiOff, X } from "lucide-react-native";
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { Linking, Pressable, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -42,6 +42,26 @@ function WhatsNewOfflineState() {
   );
 }
 
+/** Shown when there are no release notes available yet. */
+function WhatsNewEmptyState() {
+  const { t } = useTranslation("whatsNew");
+  const themeColors = useThemeColors();
+  return (
+    <View className="items-center gap-3 px-6 py-16">
+      <View className="border-border h-16 w-16 items-center justify-center rounded-full border">
+        <FileText size={28} color={themeColors.inactive} />
+      </View>
+      <Text
+        className="text-on-surface text-center"
+        style={{ fontFamily: "Poppins-SemiBold", fontSize: 16 }}
+      >
+        {t("empty")}
+      </Text>
+      <Text className="text-muted-body text-center text-sm leading-5">{t("emptySubtitle")}</Text>
+    </View>
+  );
+}
+
 /** Content-sized What's new drawer; mirrors the device sheet's store/ref pattern. */
 export function WhatsNewSheet() {
   const isOpen = useWhatsNewSheetStore((s) => s.isOpen);
@@ -51,6 +71,7 @@ export function WhatsNewSheet() {
   const { t } = useTranslation("whatsNew");
   const sheetRef = useRef<BottomSheetModal>(null);
   const { entries, markSeen } = useWhatsNew();
+  const hasEntries = entries.length > 0;
   // Offline is read from the shared connectivity hook, not useWhatsNew — the feed hook is untouched.
   // Undefined (first probe) is treated as online so we never flash the offline state on open.
   const { data: online } = useIsOnline();
@@ -143,8 +164,10 @@ export function WhatsNewSheet() {
           gap: 16,
         }}
       >
-        {isOffline && entries.length === 0 ? (
+        {isOffline && !hasEntries ? (
           <WhatsNewOfflineState />
+        ) : !hasEntries ? (
+          <WhatsNewEmptyState />
         ) : (
           <WhatsNewFeed entries={entries} linkBaseHref={releaseNotesBaseUrl} />
         )}

--- a/apps/mobile/src/features/release-notes/hooks/use-active-release-notes.ts
+++ b/apps/mobile/src/features/release-notes/hooks/use-active-release-notes.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchActiveReleaseNotes } from "~/features/release-notes/services/fetch-active-release-notes";
+import { useEnvironmentStore } from "~/shared/stores/environment-store";
+
+import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "@repo/cms/lib/__generated/sdk";
+
+const FIVE_MINUTES = 5 * 60 * 1000;
+
+/** Active mobile release notes from Contentful, cached 5 min (mirrors useActiveAlerts). */
+export function useActiveReleaseNotes(locale = "en-US"): ReleaseNoteFields[] {
+  const envLoaded = useEnvironmentStore((s) => s.isLoaded);
+
+  const { data } = useQuery({
+    queryKey: ["contentful", "release-notes", locale],
+    queryFn: () => fetchActiveReleaseNotes(locale),
+    enabled: envLoaded,
+    staleTime: FIVE_MINUTES,
+    gcTime: FIVE_MINUTES,
+    refetchOnMount: true,
+  });
+
+  return data ?? [];
+}

--- a/apps/mobile/src/features/release-notes/hooks/use-whats-new.ts
+++ b/apps/mobile/src/features/release-notes/hooks/use-whats-new.ts
@@ -3,10 +3,12 @@ import { useMemo } from "react";
 import { useActiveReleaseNotes } from "~/features/release-notes/hooks/use-active-release-notes";
 import { tsr } from "~/shared/api/tsr";
 import { useTranslation } from "~/shared/i18n";
+import { createLogger } from "~/shared/observability/logger";
 
 import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "@repo/cms/lib/__generated/sdk";
 
 const LAST_SEEN_QUERY_KEY = ["whats-new", "last-seen"];
+const log = createLogger("whats-new");
 
 /** Entries published after the user last opened the panel (null = never → all unread). */
 function countUnread(entries: ReleaseNoteFields[], lastSeenAt: string | null): number {
@@ -56,6 +58,10 @@ export function useWhatsNew(): UseWhatsNewResult {
       {
         onSuccess: () => {
           void queryClient.invalidateQueries({ queryKey: LAST_SEEN_QUERY_KEY });
+        },
+        onError: (error) => {
+          // Log quietly rather than surfacing an error to the user.
+          log.debug("failed to mark What's new as seen", { error });
         },
       },
     );

--- a/apps/mobile/src/features/release-notes/hooks/use-whats-new.ts
+++ b/apps/mobile/src/features/release-notes/hooks/use-whats-new.ts
@@ -1,0 +1,65 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { useActiveReleaseNotes } from "~/features/release-notes/hooks/use-active-release-notes";
+import { tsr } from "~/shared/api/tsr";
+import { useTranslation } from "~/shared/i18n";
+
+import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "@repo/cms/lib/__generated/sdk";
+
+const LAST_SEEN_QUERY_KEY = ["whats-new", "last-seen"];
+
+/** Entries published after the user last opened the panel (null = never → all unread). */
+function countUnread(entries: ReleaseNoteFields[], lastSeenAt: string | null): number {
+  if (!lastSeenAt) return entries.length;
+  const seenMs = new Date(lastSeenAt).getTime();
+  if (Number.isNaN(seenMs)) return entries.length;
+  return entries.filter((entry) => {
+    if (!entry.publishedAt) return false;
+    const publishedMs = new Date(entry.publishedAt as string).getTime();
+    return !Number.isNaN(publishedMs) && publishedMs > seenMs;
+  }).length;
+}
+
+interface UseWhatsNewResult {
+  entries: ReleaseNoteFields[];
+  unreadCount: number;
+  /** Stamps "seen" on the backend (cross-device) when there's something unread. */
+  markSeen: () => void;
+}
+
+/**
+ * Combines the Contentful release notes (content) with the backend last-seen timestamp
+ * (cross-device unread state) for the mobile "What's new" drawer (OJD-1510). Safe to call from
+ * multiple components — React Query dedupes both the Contentful and backend requests.
+ */
+export function useWhatsNew(): UseWhatsNewResult {
+  const { i18n } = useTranslation();
+  const entries = useActiveReleaseNotes(i18n.language || "en-US");
+
+  const queryClient = useQueryClient();
+  const lastSeenQuery = tsr.users.getWhatsNewSeen.useQuery({
+    queryKey: LAST_SEEN_QUERY_KEY,
+    staleTime: 5 * 60 * 1000,
+    refetchOnMount: "always",
+    refetchOnReconnect: "always",
+    refetchOnWindowFocus: "always",
+  });
+  const markSeenMutation = tsr.users.markWhatsNewSeen.useMutation();
+
+  const lastSeenAt = lastSeenQuery.data?.body.lastSeenAt ?? null;
+  const unreadCount = useMemo(() => countUnread(entries, lastSeenAt), [entries, lastSeenAt]);
+
+  const markSeen = () => {
+    if (unreadCount === 0) return;
+    markSeenMutation.mutate(
+      { body: {} },
+      {
+        onSuccess: () => {
+          void queryClient.invalidateQueries({ queryKey: LAST_SEEN_QUERY_KEY });
+        },
+      },
+    );
+  };
+
+  return { entries, unreadCount, markSeen };
+}

--- a/apps/mobile/src/features/release-notes/services/fetch-active-release-notes.ts
+++ b/apps/mobile/src/features/release-notes/services/fetch-active-release-notes.ts
@@ -1,0 +1,64 @@
+import { getEnvVar } from "~/shared/stores/environment-store";
+
+import { createContentfulClient } from "@repo/cms/client";
+import type { ComponentReleaseNoteFieldsFragment } from "@repo/cms/lib/__generated/sdk";
+
+type ContentfulSdk = ReturnType<typeof createContentfulClient>["client"];
+
+let cachedSdk: ContentfulSdk | null = null;
+let cachedKey = "";
+
+// Mirrors fetch-active-alerts.ts: cache the SDK client, re-create when env switches (dev ↔ prod).
+function getClient(): ContentfulSdk | null {
+  let spaceId: string;
+  let accessToken: string;
+  let environment: string;
+  try {
+    spaceId = getEnvVar("CONTENTFUL_SPACE_ID", false);
+    accessToken = getEnvVar("CONTENTFUL_ACCESS_TOKEN", false);
+    environment = getEnvVar("CONTENTFUL_SPACE_ENVIRONMENT", false) || "master";
+  } catch {
+    return null;
+  }
+
+  if (!spaceId || !accessToken) return null;
+
+  const key = `${spaceId}:${environment}`;
+  if (cachedSdk && cachedKey === key) return cachedSdk;
+
+  const { client } = createContentfulClient({
+    spaceId,
+    accessToken,
+    previewAccessToken: "",
+    previewSecret: "",
+    environment,
+  });
+
+  cachedSdk = client;
+  cachedKey = key;
+  return client;
+}
+
+export async function fetchActiveReleaseNotes(
+  locale: string,
+): Promise<ComponentReleaseNoteFieldsFragment[]> {
+  const client = getClient();
+  if (!client) return [];
+
+  try {
+    const data = await client.activeReleaseNotes({
+      preview: false,
+      now: new Date().toISOString(),
+      locale,
+      surfaces: ["mobile", "both"],
+    });
+
+    return (data.componentReleaseNoteCollection?.items ?? []).filter(
+      (item): item is ComponentReleaseNoteFieldsFragment => item !== null,
+    );
+  } catch (error) {
+    // Fail-safe: degrade to an empty feed rather than surfacing a global error toast.
+    console.warn("[contentful] failed to fetch release notes:", error);
+    return [];
+  }
+}

--- a/apps/mobile/src/features/release-notes/services/fetch-active-release-notes.ts
+++ b/apps/mobile/src/features/release-notes/services/fetch-active-release-notes.ts
@@ -1,48 +1,11 @@
-import { getEnvVar } from "~/shared/stores/environment-store";
+import { getContentfulClient } from "~/shared/api/contentful-client";
 
-import { createContentfulClient } from "@repo/cms/client";
 import type { ComponentReleaseNoteFieldsFragment } from "@repo/cms/lib/__generated/sdk";
-
-type ContentfulSdk = ReturnType<typeof createContentfulClient>["client"];
-
-let cachedSdk: ContentfulSdk | null = null;
-let cachedKey = "";
-
-// Mirrors fetch-active-alerts.ts: cache the SDK client, re-create when env switches (dev ↔ prod).
-function getClient(): ContentfulSdk | null {
-  let spaceId: string;
-  let accessToken: string;
-  let environment: string;
-  try {
-    spaceId = getEnvVar("CONTENTFUL_SPACE_ID", false);
-    accessToken = getEnvVar("CONTENTFUL_ACCESS_TOKEN", false);
-    environment = getEnvVar("CONTENTFUL_SPACE_ENVIRONMENT", false) || "master";
-  } catch {
-    return null;
-  }
-
-  if (!spaceId || !accessToken) return null;
-
-  const key = `${spaceId}:${environment}`;
-  if (cachedSdk && cachedKey === key) return cachedSdk;
-
-  const { client } = createContentfulClient({
-    spaceId,
-    accessToken,
-    previewAccessToken: "",
-    previewSecret: "",
-    environment,
-  });
-
-  cachedSdk = client;
-  cachedKey = key;
-  return client;
-}
 
 export async function fetchActiveReleaseNotes(
   locale: string,
 ): Promise<ComponentReleaseNoteFieldsFragment[]> {
-  const client = getClient();
+  const client = getContentfulClient();
   if (!client) return [];
 
   try {

--- a/apps/mobile/src/features/release-notes/stores/use-whats-new-sheet-store.ts
+++ b/apps/mobile/src/features/release-notes/stores/use-whats-new-sheet-store.ts
@@ -1,0 +1,14 @@
+import { create } from "zustand";
+
+interface WhatsNewSheetState {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+/** Drives the What's new full-screen drawer; mirrors useDeviceSheetStore. */
+export const useWhatsNewSheetStore = create<WhatsNewSheetState>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}));

--- a/apps/mobile/src/shared/i18n/index.ts
+++ b/apps/mobile/src/shared/i18n/index.ts
@@ -12,6 +12,7 @@ import homeEn from "./locales/en-US/home.json";
 import measurementFlowEn from "./locales/en-US/measurement-flow.json";
 import profileEn from "./locales/en-US/profile.json";
 import recentMeasurementsEn from "./locales/en-US/recent-measurements.json";
+import whatsNewEn from "./locales/en-US/whats-new.json";
 import authNl from "./locales/nl-NL/auth.json";
 import commonNl from "./locales/nl-NL/common.json";
 import connectionNl from "./locales/nl-NL/connection.json";
@@ -21,6 +22,7 @@ import homeNl from "./locales/nl-NL/home.json";
 import measurementFlowNl from "./locales/nl-NL/measurement-flow.json";
 import profileNl from "./locales/nl-NL/profile.json";
 import recentMeasurementsNl from "./locales/nl-NL/recent-measurements.json";
+import whatsNewNl from "./locales/nl-NL/whats-new.json";
 
 export const SUPPORTED_LOCALES = ["en-US", "nl-NL"] as const;
 export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
@@ -39,6 +41,7 @@ const bundledResources = {
     recentMeasurements: recentMeasurementsEn,
     home: homeEn,
     forceUpdate: forceUpdateEn,
+    whatsNew: whatsNewEn,
   },
   "nl-NL": {
     common: commonNl,
@@ -50,6 +53,7 @@ const bundledResources = {
     recentMeasurements: recentMeasurementsNl,
     home: homeNl,
     forceUpdate: forceUpdateNl,
+    whatsNew: whatsNewNl,
   },
 } as const;
 
@@ -89,6 +93,7 @@ export function initI18n(): Promise<typeof i18next> {
         "recentMeasurements",
         "home",
         "forceUpdate",
+        "whatsNew",
       ],
       defaultNS: "common",
       resources: bundledResources,

--- a/apps/mobile/src/shared/i18n/locales/en-US/whats-new.json
+++ b/apps/mobile/src/shared/i18n/locales/en-US/whats-new.json
@@ -5,6 +5,10 @@
   "showMore": "Read more",
   "showLess": "Show less",
   "empty": "No release notes yet.",
+  "offline": {
+    "title": "You're offline",
+    "subtitle": "Connect to the internet to see the latest updates."
+  },
   "card": {
     "title": "What's new",
     "subtitleUnread_one": "{{count}} new update",

--- a/apps/mobile/src/shared/i18n/locales/en-US/whats-new.json
+++ b/apps/mobile/src/shared/i18n/locales/en-US/whats-new.json
@@ -5,6 +5,7 @@
   "showMore": "Read more",
   "showLess": "Show less",
   "empty": "No release notes yet.",
+  "emptySubtitle": "When there is something new to share, it will show up here.",
   "offline": {
     "title": "You're offline",
     "subtitle": "Connect to the internet to see the latest updates."

--- a/apps/mobile/src/shared/i18n/locales/en-US/whats-new.json
+++ b/apps/mobile/src/shared/i18n/locales/en-US/whats-new.json
@@ -1,6 +1,6 @@
 {
   "navLabel": "What's new",
-  "title": "What's new",
+  "title": "What's new on mobile",
   "fullChangelog": "Full changelog",
   "showMore": "Read more",
   "showLess": "Show less",

--- a/apps/mobile/src/shared/i18n/locales/en-US/whats-new.json
+++ b/apps/mobile/src/shared/i18n/locales/en-US/whats-new.json
@@ -1,0 +1,20 @@
+{
+  "navLabel": "What's new",
+  "title": "What's new",
+  "fullChangelog": "Full changelog",
+  "showMore": "Read more",
+  "showLess": "Show less",
+  "empty": "No release notes yet.",
+  "card": {
+    "title": "What's new",
+    "subtitleUnread_one": "{{count}} new update",
+    "subtitleUnread_other": "{{count}} new updates",
+    "subtitleCaughtUp": "You're all caught up"
+  },
+  "category": {
+    "new_feature": "New feature",
+    "improvement": "Improvement",
+    "bug_fix": "Bug fix",
+    "announcement": "Announcement"
+  }
+}

--- a/apps/mobile/src/shared/i18n/locales/nl-NL/whats-new.json
+++ b/apps/mobile/src/shared/i18n/locales/nl-NL/whats-new.json
@@ -5,6 +5,7 @@
   "showMore": "Meer lezen",
   "showLess": "Minder tonen",
   "empty": "Nog geen release-notities.",
+  "emptySubtitle": "Zodra er iets nieuws is, verschijnt het hier.",
   "offline": {
     "title": "Je bent offline",
     "subtitle": "Maak verbinding met internet om de nieuwste updates te zien."

--- a/apps/mobile/src/shared/i18n/locales/nl-NL/whats-new.json
+++ b/apps/mobile/src/shared/i18n/locales/nl-NL/whats-new.json
@@ -1,6 +1,6 @@
 {
   "navLabel": "Wat is er nieuw",
-  "title": "Wat is er nieuw",
+  "title": "Wat is er nieuw op mobiel",
   "fullChangelog": "Volledig wijzigingslogboek",
   "showMore": "Meer lezen",
   "showLess": "Minder tonen",

--- a/apps/mobile/src/shared/i18n/locales/nl-NL/whats-new.json
+++ b/apps/mobile/src/shared/i18n/locales/nl-NL/whats-new.json
@@ -1,0 +1,20 @@
+{
+  "navLabel": "Wat is er nieuw",
+  "title": "Wat is er nieuw",
+  "fullChangelog": "Volledig wijzigingslogboek",
+  "showMore": "Meer lezen",
+  "showLess": "Minder tonen",
+  "empty": "Nog geen release-notities.",
+  "card": {
+    "title": "Wat is er nieuw",
+    "subtitleUnread_one": "{{count}} nieuwe update",
+    "subtitleUnread_other": "{{count}} nieuwe updates",
+    "subtitleCaughtUp": "Je bent helemaal bij"
+  },
+  "category": {
+    "new_feature": "Nieuwe functie",
+    "improvement": "Verbetering",
+    "bug_fix": "Bugfix",
+    "announcement": "Aankondiging"
+  }
+}

--- a/apps/mobile/src/shared/i18n/locales/nl-NL/whats-new.json
+++ b/apps/mobile/src/shared/i18n/locales/nl-NL/whats-new.json
@@ -5,6 +5,10 @@
   "showMore": "Meer lezen",
   "showLess": "Minder tonen",
   "empty": "Nog geen release-notities.",
+  "offline": {
+    "title": "Je bent offline",
+    "subtitle": "Maak verbinding met internet om de nieuwste updates te zien."
+  },
   "card": {
     "title": "Wat is er nieuw",
     "subtitleUnread_one": "{{count}} nieuwe update",

--- a/apps/mobile/src/shared/utils/resolve-external-url.test.ts
+++ b/apps/mobile/src/shared/utils/resolve-external-url.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+
+import { resolveExternalUrl } from "./resolve-external-url";
+
+describe("resolveExternalUrl", () => {
+  const base = "https://app.example.com/releases";
+
+  it("returns absolute http(s) urls unchanged", () => {
+    expect(resolveExternalUrl("https://docs.example.com/x", base)).toBe(
+      "https://docs.example.com/x",
+    );
+    expect(resolveExternalUrl("http://foo.test", base)).toBe("http://foo.test");
+  });
+
+  it("returns other schemes (mailto, tel, deep links) unchanged", () => {
+    expect(resolveExternalUrl("mailto:a@b.com", base)).toBe("mailto:a@b.com");
+    expect(resolveExternalUrl("tel:+1234", base)).toBe("tel:+1234");
+    expect(resolveExternalUrl("myapp://screen/1", base)).toBe("myapp://screen/1");
+  });
+
+  it("joins a site-relative path onto the base ORIGIN (not the base path)", () => {
+    expect(resolveExternalUrl("/platform/experiments", base)).toBe(
+      "https://app.example.com/platform/experiments",
+    );
+    expect(resolveExternalUrl("platform/experiments", base)).toBe(
+      "https://app.example.com/platform/experiments",
+    );
+  });
+
+  it("collapses leading slashes so the join never double-slashes", () => {
+    expect(resolveExternalUrl("///foo", base)).toBe("https://app.example.com/foo");
+  });
+
+  it("returns the url unchanged when no usable http(s) base is given", () => {
+    expect(resolveExternalUrl("/foo")).toBe("/foo");
+    expect(resolveExternalUrl("/foo", "not-a-url")).toBe("/foo");
+  });
+});

--- a/apps/mobile/src/shared/utils/resolve-external-url.ts
+++ b/apps/mobile/src/shared/utils/resolve-external-url.ts
@@ -1,0 +1,10 @@
+/**
+ * Makes a CMS link (release-note CTA, alert banner) openable by `Linking.openURL`, which needs a
+ * scheme. Values with a scheme (http:, mailto:, deep links, …) pass through; a relative path is
+ * joined onto the origin of `base` (only its scheme+host matter). Unchanged if there's no http(s) base.
+ */
+export function resolveExternalUrl(url: string, base?: string): string {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(url)) return url;
+  const origin = base?.match(/^https?:\/\/[^/]+/)?.[0];
+  return origin ? `${origin}/${url.replace(/^\/+/, "")}` : url;
+}

--- a/apps/web/app/[locale]/(info)/releases/[...notFound]/page.tsx
+++ b/apps/web/app/[locale]/(info)/releases/[...notFound]/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from "next/navigation";
+
+export default function NotFoundCatchAll() {
+  notFound();
+}

--- a/apps/web/app/[locale]/(info)/releases/[slug]/page.tsx
+++ b/apps/web/app/[locale]/(info)/releases/[slug]/page.tsx
@@ -13,7 +13,7 @@ import { safeMetadata } from "~/lib/safe-metadata";
 
 import { ReleaseNoteArticle } from "@repo/cms";
 import { Container } from "@repo/cms/container";
-import { defaultLocale, locales } from "@repo/i18n/config";
+import { locales } from "@repo/i18n/config";
 import initTranslations from "@repo/i18n/server";
 
 interface ReleaseDetailPageProps {
@@ -29,12 +29,13 @@ export function generateMetadata({ params }: ReleaseDetailPageProps): Promise<Me
     const { isEnabled: preview } = await draftMode();
     const entry = await getReleaseNoteBySlug(locale, slug, preview);
 
-    const languages = Object.fromEntries(
-      locales.map((l) => [l, l === defaultLocale ? `/releases/${slug}` : `/${l}/releases/${slug}`]),
-    );
+    // The proxy middleware redirects unprefixed paths to `/{defaultLocale}/…`, so every hreflang
+    // (including the default locale) and the canonical must carry the locale prefix to point at the
+    // real, non-redirecting URL.
+    const languages = Object.fromEntries(locales.map((l) => [l, `/${l}/releases/${slug}`]));
     const metadata: Metadata = {
       alternates: {
-        canonical: `/releases/${slug}`,
+        canonical: `/${locale}/releases/${slug}`,
         languages,
       },
     };

--- a/apps/web/app/[locale]/(info)/releases/[slug]/page.tsx
+++ b/apps/web/app/[locale]/(info)/releases/[slug]/page.tsx
@@ -1,0 +1,105 @@
+import { TranslationsProvider } from "@/components/translations-provider";
+import { ArrowLeft } from "lucide-react";
+import type { Metadata } from "next";
+import { draftMode } from "next/headers";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import {
+  getAllReleaseNotes,
+  getReleaseNoteBySlug,
+} from "~/components/releases/fetch-public-release-notes";
+import { ReleaseNav } from "~/components/releases/release-nav";
+import { safeMetadata } from "~/lib/safe-metadata";
+
+import { ReleaseNoteArticle } from "@repo/cms";
+import { Container } from "@repo/cms/container";
+import { defaultLocale, locales } from "@repo/i18n/config";
+import initTranslations from "@repo/i18n/server";
+
+interface ReleaseDetailPageProps {
+  params: Promise<{
+    locale: string;
+    slug: string;
+  }>;
+}
+
+export function generateMetadata({ params }: ReleaseDetailPageProps): Promise<Metadata> {
+  return safeMetadata(async () => {
+    const { locale, slug } = await params;
+    const { isEnabled: preview } = await draftMode();
+    const entry = await getReleaseNoteBySlug(locale, slug, preview);
+
+    const languages = Object.fromEntries(
+      locales.map((l) => [l, l === defaultLocale ? `/releases/${slug}` : `/${l}/releases/${slug}`]),
+    );
+    const metadata: Metadata = {
+      alternates: {
+        canonical: `/releases/${slug}`,
+        languages,
+      },
+    };
+
+    if (entry?.seoFields) {
+      metadata.title = entry.seoFields.pageTitle;
+      metadata.description = entry.seoFields.pageDescription;
+      metadata.robots = {
+        follow: !entry.seoFields.nofollow,
+        index: !entry.seoFields.noindex,
+      };
+    } else if (entry) {
+      // No ComponentSeo authored — fall back to the note's own title/summary.
+      metadata.title = entry.title;
+      metadata.description = entry.summary;
+    }
+
+    return metadata;
+  });
+}
+
+/** Public per-note permalink (openjii.org/releases/[slug]). */
+export default async function ReleaseDetailPage({ params }: ReleaseDetailPageProps) {
+  const { locale, slug } = await params;
+  const { isEnabled: preview } = await draftMode();
+  const { t, resources } = await initTranslations({ locale, namespaces: ["navigation"] });
+  const [entry, all] = await Promise.all([
+    getReleaseNoteBySlug(locale, slug, preview),
+    getAllReleaseNotes(locale, preview),
+  ]);
+
+  if (!entry) {
+    notFound();
+  }
+
+  // Neighbours for prev/next. `all` is newest-first, so the newer note sits at index-1 ("Next") and
+  // the older note at index+1 ("Previous"). A slug with no title falls back to its slug.
+  const currentIndex = all.findIndex((note) => note.slug === entry.slug);
+  const toNeighbor = (note: (typeof all)[number] | undefined) =>
+    note?.slug ? { slug: note.slug, title: note.title ?? note.slug } : null;
+  const newer = currentIndex > 0 ? toNeighbor(all[currentIndex - 1]) : null;
+  const older =
+    currentIndex >= 0 && currentIndex < all.length - 1 ? toNeighbor(all[currentIndex + 1]) : null;
+
+  return (
+    <TranslationsProvider locale={locale} namespaces={["navigation"]} resources={resources}>
+      <div className="py-16 md:py-20">
+        <Container className="max-w-3xl">
+          <Link
+            href={`/${locale}/releases`}
+            className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1.5 text-sm"
+          >
+            <ArrowLeft className="size-4" />
+            {t("releases.backToReleases")}
+          </Link>
+          <ReleaseNoteArticle entry={entry} />
+          <ReleaseNav
+            locale={locale}
+            previous={older}
+            next={newer}
+            previousLabel={t("releases.previous")}
+            nextLabel={t("releases.next")}
+          />
+        </Container>
+      </div>
+    </TranslationsProvider>
+  );
+}

--- a/apps/web/app/[locale]/(info)/releases/[slug]/page.tsx
+++ b/apps/web/app/[locale]/(info)/releases/[slug]/page.tsx
@@ -82,7 +82,7 @@ export default async function ReleaseDetailPage({ params }: ReleaseDetailPagePro
   return (
     <TranslationsProvider locale={locale} namespaces={["navigation"]} resources={resources}>
       <div className="py-16 md:py-20">
-        <Container className="max-w-3xl">
+        <Container className="max-w-4xl">
           <Link
             href={`/${locale}/releases`}
             className="text-muted-foreground hover:text-foreground mb-8 inline-flex items-center gap-1.5 text-sm"

--- a/apps/web/app/[locale]/(info)/releases/not-found.tsx
+++ b/apps/web/app/[locale]/(info)/releases/not-found.tsx
@@ -1,0 +1,27 @@
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import React from "react";
+
+import { Container } from "@repo/cms/container";
+import initTranslations from "@repo/i18n/server";
+
+export default async function ReleaseNotFound() {
+  // notFound() doesn't forward route params, so default to en-US (same limitation as the blog
+  // not-found page).
+  const { t } = await initTranslations({ locale: "en-US", namespaces: ["navigation"] });
+
+  return (
+    <Container className="py-20">
+      <title>{t("releases.notFoundTitle")}</title>
+      <h1 className="text-2xl font-semibold">{t("releases.notFoundTitle")}</h1>
+      <p className="text-muted-foreground mt-4">{t("releases.notFoundDescription")}</p>
+      <Link
+        href="/releases"
+        className="text-primary mt-6 inline-flex items-center gap-1.5 text-sm font-medium hover:underline"
+      >
+        <ArrowLeft className="size-4" />
+        {t("releases.backToReleases")}
+      </Link>
+    </Container>
+  );
+}

--- a/apps/web/app/[locale]/(info)/releases/page.tsx
+++ b/apps/web/app/[locale]/(info)/releases/page.tsx
@@ -1,0 +1,55 @@
+import { TranslationsProvider } from "@/components/translations-provider";
+import type { Metadata } from "next";
+import { draftMode } from "next/headers";
+import { getAllReleaseNotes } from "~/components/releases/fetch-public-release-notes";
+import { ReleasesChangelog } from "~/components/releases/releases-changelog";
+
+import { Container } from "@repo/cms/container";
+import { defaultLocale, locales } from "@repo/i18n/config";
+import initTranslations from "@repo/i18n/server";
+
+interface ReleasesPageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export async function generateMetadata({ params }: ReleasesPageProps): Promise<Metadata> {
+  const { locale } = await params;
+  const { t } = await initTranslations({ locale, namespaces: ["navigation"] });
+
+  const languages = Object.fromEntries(
+    locales.map((l) => [l, l === defaultLocale ? "/releases" : `/${l}/releases`]),
+  );
+
+  return {
+    title: t("releases.metaTitle"),
+    description: t("releases.metaDescription"),
+    alternates: { canonical: "/releases", languages },
+  };
+}
+
+/**
+ * Public changelog (openjii.org/releases). Lists every active release note — the same
+ * Contentful `ComponentReleaseNote` entries that power the in-app "What's new" feed — newest
+ * first, grouped by month. Each note links to its own /releases/[slug] detail page.
+ */
+export default async function ReleasesPage({ params }: ReleasesPageProps) {
+  const { locale } = await params;
+  const { isEnabled: preview } = await draftMode();
+  const { t, resources } = await initTranslations({ locale, namespaces: ["navigation"] });
+  const entries = await getAllReleaseNotes(locale, preview);
+
+  return (
+    <TranslationsProvider locale={locale} namespaces={["navigation"]} resources={resources}>
+      <Container className="max-w-4xl pb-20 pt-10 md:pt-14">
+        <header className="mb-10 flex flex-col gap-2">
+          <p className="text-primary font-mono text-xs font-medium uppercase tracking-[0.16em]">
+            {t("releases.eyebrow")}
+          </p>
+          <h1 className="text-3xl font-bold tracking-tight md:text-4xl">{t("releases.heading")}</h1>
+          <p className="text-muted-foreground max-w-2xl">{t("releases.subheading")}</p>
+        </header>
+        <ReleasesChangelog entries={entries} linkBaseHref={`/${locale}/releases`} />
+      </Container>
+    </TranslationsProvider>
+  );
+}

--- a/apps/web/app/[locale]/(info)/releases/page.tsx
+++ b/apps/web/app/[locale]/(info)/releases/page.tsx
@@ -5,7 +5,7 @@ import { getAllReleaseNotes } from "~/components/releases/fetch-public-release-n
 import { ReleasesChangelog } from "~/components/releases/releases-changelog";
 
 import { Container } from "@repo/cms/container";
-import { defaultLocale, locales } from "@repo/i18n/config";
+import { locales } from "@repo/i18n/config";
 import initTranslations from "@repo/i18n/server";
 
 interface ReleasesPageProps {
@@ -16,14 +16,14 @@ export async function generateMetadata({ params }: ReleasesPageProps): Promise<M
   const { locale } = await params;
   const { t } = await initTranslations({ locale, namespaces: ["navigation"] });
 
-  const languages = Object.fromEntries(
-    locales.map((l) => [l, l === defaultLocale ? "/releases" : `/${l}/releases`]),
-  );
+  // The proxy middleware redirects unprefixed paths to `/{defaultLocale}/…`, so every hreflang
+  // (including the default locale) and the canonical must carry the locale prefix.
+  const languages = Object.fromEntries(locales.map((l) => [l, `/${l}/releases`]));
 
   return {
     title: t("releases.metaTitle"),
     description: t("releases.metaDescription"),
-    alternates: { canonical: "/releases", languages },
+    alternates: { canonical: `/${locale}/releases`, languages },
   };
 }
 

--- a/apps/web/app/[locale]/(info)/releases/page.tsx
+++ b/apps/web/app/[locale]/(info)/releases/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { draftMode } from "next/headers";
 import { getAllReleaseNotes } from "~/components/releases/fetch-public-release-notes";
 import { ReleasesChangelog } from "~/components/releases/releases-changelog";
+import { safeMetadata } from "~/lib/safe-metadata";
 
 import { Container } from "@repo/cms/container";
 import { locales } from "@repo/i18n/config";
@@ -12,19 +13,21 @@ interface ReleasesPageProps {
   params: Promise<{ locale: string }>;
 }
 
-export async function generateMetadata({ params }: ReleasesPageProps): Promise<Metadata> {
-  const { locale } = await params;
-  const { t } = await initTranslations({ locale, namespaces: ["navigation"] });
+export function generateMetadata({ params }: ReleasesPageProps): Promise<Metadata> {
+  return safeMetadata(async () => {
+    const { locale } = await params;
+    const { t } = await initTranslations({ locale, namespaces: ["navigation"] });
 
-  // The proxy middleware redirects unprefixed paths to `/{defaultLocale}/…`, so every hreflang
-  // (including the default locale) and the canonical must carry the locale prefix.
-  const languages = Object.fromEntries(locales.map((l) => [l, `/${l}/releases`]));
+    // The proxy middleware redirects unprefixed paths to `/{defaultLocale}/…`, so every hreflang
+    // (including the default locale) and the canonical must carry the locale prefix.
+    const languages = Object.fromEntries(locales.map((l) => [l, `/${l}/releases`]));
 
-  return {
-    title: t("releases.metaTitle"),
-    description: t("releases.metaDescription"),
-    alternates: { canonical: `/${locale}/releases`, languages },
-  };
+    return {
+      title: t("releases.metaTitle"),
+      description: t("releases.metaDescription"),
+      alternates: { canonical: `/${locale}/releases`, languages },
+    };
+  });
 }
 
 /**

--- a/apps/web/app/[locale]/platform/layout.test.tsx
+++ b/apps/web/app/[locale]/platform/layout.test.tsx
@@ -18,6 +18,10 @@ vi.mock("@/components/navigation/navigation-topbar/navigation-topbar", () => ({
   NavigationTopbar: () => <header aria-label="topbar">Topbar</header>,
 }));
 
+vi.mock("@/components/whats-new/whats-new-sheet", () => ({
+  WhatsNewSheet: () => null,
+}));
+
 describe("AppLayout", () => {
   const defaultProps = {
     children: <div>Page content</div>,

--- a/apps/web/app/[locale]/platform/layout.tsx
+++ b/apps/web/app/[locale]/platform/layout.tsx
@@ -4,6 +4,8 @@ import { NavigationSidebarWrapper } from "@/components/navigation/navigation-sid
 import { PageContainer } from "@/components/page-container";
 import { ShortcutHint } from "@/components/shortcuts/shortcut-hint";
 import { ShortcutsRoot } from "@/components/shortcuts/shortcuts-root";
+import { fetchWebReleaseNotes } from "@/components/whats-new/fetch-release-notes";
+import { WhatsNewSheet } from "@/components/whats-new/whats-new-sheet";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import type React from "react";
@@ -53,10 +55,12 @@ export default async function AppLayout({
     redirect(`/${locale}/register?callbackUrl=${callbackUrl}`);
   }
 
+  const releaseNotes = await fetchWebReleaseNotes(locale);
+
   return (
     <SidebarProvider>
       <ActivityProvider>
-        <NavigationSidebarWrapper locale={locale} />
+        <NavigationSidebarWrapper locale={locale} releaseNotes={releaseNotes} />
         <SidebarEdgePeek />
         <SidebarFloatingReopen />
         <SidebarInset>
@@ -72,6 +76,7 @@ export default async function AppLayout({
         <CommandPalette locale={locale} />
         <Toaster />
         <ShortcutHint />
+        <WhatsNewSheet entries={releaseNotes} />
       </ActivityProvider>
     </SidebarProvider>
   );

--- a/apps/web/components/command/command-palette.test.tsx
+++ b/apps/web/components/command/command-palette.test.tsx
@@ -2,6 +2,7 @@ import {
   CHEATSHEET_OPEN_EVENT,
   COMMAND_PALETTE_OPEN_EVENT,
 } from "@/components/shortcuts/shortcuts-root";
+import { WHATS_NEW_OPEN_EVENT } from "@/components/whats-new/whats-new-shared";
 import { render, screen, userEvent, act, waitFor } from "@/test/test-utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
@@ -22,8 +23,8 @@ describe("CommandPalette", () => {
     expect(await screen.findByPlaceholderText("Search pages and actions…")).toBeInTheDocument();
     expect(screen.getByText("Home")).toBeInTheDocument();
     expect(screen.getByText("Create experiment")).toBeInTheDocument();
+    expect(screen.getByText("Open What's new")).toBeInTheDocument();
     expect(screen.getByText("Open documentation")).toBeInTheDocument();
-    expect(screen.queryByText(/Open What's new/i)).not.toBeInTheDocument();
   });
 
   it("navigates to each page / create action it lists", async () => {
@@ -55,6 +56,17 @@ describe("CommandPalette", () => {
     await user.click(await screen.findByText("Show keyboard shortcuts"));
     expect(handler).toHaveBeenCalledTimes(1);
     window.removeEventListener(CHEATSHEET_OPEN_EVENT, handler);
+  });
+
+  it("dispatches the whats-new event from the palette action", async () => {
+    const handler = vi.fn();
+    window.addEventListener(WHATS_NEW_OPEN_EVENT, handler);
+    const user = userEvent.setup();
+    render(<CommandPalette locale="en-US" />);
+    openPalette();
+    await user.click(await screen.findByText("Open What's new"));
+    expect(handler).toHaveBeenCalledTimes(1);
+    window.removeEventListener(WHATS_NEW_OPEN_EVENT, handler);
   });
 
   it("opens external docs without navigating", async () => {

--- a/apps/web/components/command/command-palette.tsx
+++ b/apps/web/components/command/command-palette.tsx
@@ -5,7 +5,8 @@ import {
   CHEATSHEET_OPEN_EVENT,
   COMMAND_PALETTE_OPEN_EVENT,
 } from "@/components/shortcuts/shortcuts-root";
-import { HelpCircle, Keyboard, Send } from "lucide-react";
+import { WHATS_NEW_OPEN_EVENT } from "@/components/whats-new/whats-new-shared";
+import { HelpCircle, Keyboard, Send, Sparkles } from "lucide-react";
 import { useRouter } from "next/navigation";
 import * as React from "react";
 
@@ -113,6 +114,17 @@ export function CommandPalette({ locale }: { locale: string }) {
         group: "Actions",
         icon: iconMap.CirclePlus,
         run: () => navigate(`/${locale}/platform/experiments/new`),
+      },
+      {
+        id: "action.whats-new",
+        label: "Open What's new",
+        group: "Actions",
+        icon: Sparkles,
+        shortcut: "G R",
+        run: () => {
+          setOpen(false);
+          window.dispatchEvent(new Event(WHATS_NEW_OPEN_EVENT));
+        },
       },
       {
         id: "action.cheatsheet",

--- a/apps/web/components/navigation/navigation-sidebar/navigation-sidebar.tsx
+++ b/apps/web/components/navigation/navigation-sidebar/navigation-sidebar.tsx
@@ -2,11 +2,13 @@
 
 import { CommandKHint } from "@/components/command/kbd";
 import { COMMAND_PALETTE_OPEN_EVENT } from "@/components/shortcuts/shortcuts-root";
+import { WhatsNewFooterItem } from "@/components/whats-new/whats-new-footer-item";
 import { Search } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import * as React from "react";
 
+import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "@repo/cms";
 import { Sidebar, SidebarRail, SidebarTrigger } from "@repo/ui/components/sidebar";
 
 import { NavItems } from "../nav-items/nav-items";
@@ -50,11 +52,13 @@ export function AppSidebar({
   locale,
   navigationData,
   translations,
+  releaseNotes = [],
   ...props
 }: React.ComponentProps<typeof Sidebar> & {
   locale: string;
   navigationData: NavigationData;
   translations: Translations;
+  releaseNotes?: ReleaseNoteFields[];
 }) {
   // const { toggleSidebar, state } = useSidebar();
   // const searchInputRef = React.useRef<HTMLInputElement>(null);
@@ -124,6 +128,10 @@ export function AppSidebar({
           <NavItems items={processedNavExperiments} />
           <NavItems items={processedNavWorkbooks} />
           <NavItems items={processedNavLibrary} />
+        </div>
+
+        <div className="border-t border-white/10 px-4 py-2">
+          <WhatsNewFooterItem entries={releaseNotes} />
         </div>
       </div>
       <SidebarRail resizable />

--- a/apps/web/components/navigation/unified-navbar/unified-navbar.tsx
+++ b/apps/web/components/navigation/unified-navbar/unified-navbar.tsx
@@ -236,6 +236,7 @@ export function UnifiedNavbar({ locale, session, isHomePage = false }: UnifiedNa
     pathname.startsWith(`/${locale}/about`) ||
     pathname.startsWith(`/${locale}/blog`) ||
     pathname.startsWith(`/${locale}/faq`) ||
+    pathname.startsWith(`/${locale}/releases`) ||
     pathname.startsWith(`/${locale}/policies`);
 
   const showSolid = (isHomePage && !isIntersecting) || isGreenMode;

--- a/apps/web/components/releases/fetch-public-release-notes.ts
+++ b/apps/web/components/releases/fetch-public-release-notes.ts
@@ -1,0 +1,41 @@
+import { cache } from "react";
+import { getContentfulClients } from "~/lib/contentful";
+
+import type { ComponentReleaseNoteFieldsFragment } from "@repo/cms";
+
+/**
+ * Public-changelog fetchers for the openjii.org/releases page + per-note detail pages.
+ * Unlike the in-app "What's new" feed (which filters by `surfaces`), the public page shows every
+ * active note. Wrapped in React `cache()` so `generateMetadata` and the page body share one
+ * Contentful request per render (mirrors the blog's getBlogData / getBlogDetailData).
+ */
+
+/** All active release notes (no surface filter), newest first. */
+export const getAllReleaseNotes = cache(
+  async (locale: string, preview: boolean): Promise<ComponentReleaseNoteFieldsFragment[]> => {
+    const { previewClient, client } = await getContentfulClients();
+    const gqlClient = preview ? previewClient : client;
+    const data = await gqlClient.allReleaseNotes({
+      preview,
+      now: new Date().toISOString(),
+      locale,
+    });
+    return (data.componentReleaseNoteCollection?.items ?? []).filter(
+      (item): item is ComponentReleaseNoteFieldsFragment => item !== null,
+    );
+  },
+);
+
+/** A single active release note by slug, or null when none matches. */
+export const getReleaseNoteBySlug = cache(
+  async (
+    locale: string,
+    slug: string,
+    preview: boolean,
+  ): Promise<ComponentReleaseNoteFieldsFragment | null> => {
+    const { previewClient, client } = await getContentfulClients();
+    const gqlClient = preview ? previewClient : client;
+    const data = await gqlClient.releaseNoteBySlug({ slug, locale, preview });
+    return data.componentReleaseNoteCollection?.items[0] ?? null;
+  },
+);

--- a/apps/web/components/releases/fetch-public-release-notes.ts
+++ b/apps/web/components/releases/fetch-public-release-notes.ts
@@ -36,6 +36,17 @@ export const getReleaseNoteBySlug = cache(
     const { previewClient, client } = await getContentfulClients();
     const gqlClient = preview ? previewClient : client;
     const data = await gqlClient.releaseNoteBySlug({ slug, locale, preview });
-    return data.componentReleaseNoteCollection?.items[0] ?? null;
+    const entry = data.componentReleaseNoteCollection?.items[0] ?? null;
+
+    // Honor the scheduled `publishedAt` reveal (the list query filters `publishedAt_lte: now`), so a
+    // future-dated note isn't reachable early via its direct URL. Draft mode still previews it.
+    if (!preview && entry?.publishedAt) {
+      const publishedMs = new Date(entry.publishedAt as string).getTime();
+      if (!Number.isNaN(publishedMs) && publishedMs > Date.now()) {
+        return null;
+      }
+    }
+
+    return entry;
   },
 );

--- a/apps/web/components/releases/release-nav.tsx
+++ b/apps/web/components/releases/release-nav.tsx
@@ -1,0 +1,61 @@
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import Link from "next/link";
+
+interface Neighbor {
+  slug: string;
+  title: string;
+}
+
+interface ReleaseNavProps {
+  locale: string;
+  /** The chronologically older note (rendered on the left). */
+  previous?: Neighbor | null;
+  /** The chronologically newer note (rendered on the right). */
+  next?: Neighbor | null;
+  previousLabel: string;
+  nextLabel: string;
+}
+
+/**
+ * Previous/next release links at the foot of a /releases/[slug] page (OJD-1394). A changelog reads
+ * chronologically, so this replaces the blog's "related posts" grid: left = older, right = newer.
+ */
+export function ReleaseNav({ locale, previous, next, previousLabel, nextLabel }: ReleaseNavProps) {
+  if (!previous && !next) return null;
+
+  return (
+    <nav className="border-border mt-14 grid gap-4 border-t pt-8 sm:grid-cols-2">
+      {previous ? (
+        <Link
+          href={`/${locale}/releases/${previous.slug}`}
+          className="border-border hover:border-primary/40 bg-muted/30 group flex flex-col gap-1.5 rounded-xl border p-4 transition-colors"
+        >
+          <span className="text-muted-foreground inline-flex items-center gap-1.5 font-mono text-[11px] uppercase tracking-wider">
+            <ArrowLeft className="size-3.5" />
+            {previousLabel}
+          </span>
+          <span className="text-foreground group-hover:text-primary font-medium transition-colors">
+            {previous.title}
+          </span>
+        </Link>
+      ) : (
+        <span className="hidden sm:block" />
+      )}
+
+      {next && (
+        <Link
+          href={`/${locale}/releases/${next.slug}`}
+          className="border-border hover:border-primary/40 bg-muted/30 group flex flex-col gap-1.5 rounded-xl border p-4 text-right transition-colors sm:col-start-2"
+        >
+          <span className="text-muted-foreground inline-flex items-center justify-end gap-1.5 font-mono text-[11px] uppercase tracking-wider">
+            {nextLabel}
+            <ArrowRight className="size-3.5" />
+          </span>
+          <span className="text-foreground group-hover:text-primary font-medium transition-colors">
+            {next.title}
+          </span>
+        </Link>
+      )}
+    </nav>
+  );
+}

--- a/apps/web/components/releases/releases-changelog.tsx
+++ b/apps/web/components/releases/releases-changelog.tsx
@@ -32,7 +32,7 @@ export function ReleasesChangelog({ entries, linkBaseHref }: ReleasesChangelogPr
   const [filter, setFilter] = React.useState<Filter>("all");
 
   if (entries.length === 0) {
-    return <p className="text-muted-foreground text-sm">{t("whatsNew.empty")}</p>;
+    return <ReleaseNotesFeed entries={entries} linkBaseHref={linkBaseHref} linkTarget="_self" />;
   }
 
   const [featured, ...rest] = entries;

--- a/apps/web/components/releases/releases-changelog.tsx
+++ b/apps/web/components/releases/releases-changelog.tsx
@@ -6,7 +6,7 @@ import type {
   ComponentReleaseNoteFieldsFragment as ReleaseNoteFields,
   ReleaseCategory,
 } from "@repo/cms";
-import { RELEASE_CATEGORIES, ReleaseFeature, ReleaseNotesFeed } from "@repo/cms";
+import { RELEASE_CATEGORIES, ReleaseHero, ReleaseNotesFeed } from "@repo/cms";
 import { useTranslation } from "@repo/i18n";
 import { cn } from "@repo/ui/lib/utils";
 
@@ -73,7 +73,7 @@ export function ReleasesChangelog({ entries, linkBaseHref }: ReleasesChangelogPr
 
   return (
     <div className="flex flex-col gap-10">
-      <ReleaseFeature entry={featured} linkBaseHref={linkBaseHref} />
+      <ReleaseHero entry={featured} linkBaseHref={linkBaseHref} linkTarget="_self" />
 
       {presentCategories.length > 0 && (
         <div className="flex flex-wrap gap-2" role="group" aria-label={t("releases.heading")}>

--- a/apps/web/components/releases/releases-changelog.tsx
+++ b/apps/web/components/releases/releases-changelog.tsx
@@ -6,7 +6,7 @@ import type {
   ComponentReleaseNoteFieldsFragment as ReleaseNoteFields,
   ReleaseCategory,
 } from "@repo/cms";
-import { RELEASE_CATEGORIES, ReleaseHero, ReleaseNotesFeed } from "@repo/cms";
+import { RELEASE_CATEGORIES, ReleaseHero, ReleaseNotesFeed, normalizeCategory } from "@repo/cms";
 import { useTranslation } from "@repo/i18n";
 import { NavTabs, NavTabsList, NavTabsTrigger } from "@repo/ui/components/nav-tabs";
 
@@ -37,12 +37,15 @@ export function ReleasesChangelog({ entries, linkBaseHref }: ReleasesChangelogPr
 
   const [featured, ...rest] = entries;
   const isAll = filter === "all";
-  // The featured note is always the hero, so keep it out of the timeline regardless of filter.
-  const feedEntries = isAll ? rest : rest.filter((entry) => entry.category === filter);
+  // Group by the same normalized category the badges display (unknown/blank → announcement), so a
+  // note shown as "Announcement" is also filtered into the Announcement tab.
+  const feedEntries = isAll
+    ? rest
+    : rest.filter((entry) => normalizeCategory(entry.category) === filter);
   // Chips come from `rest`, not all entries — otherwise a category whose only note is the pinned
   // featured hero would get a chip that filters to an empty timeline.
   const presentCategories = RELEASE_CATEGORIES.filter((category) =>
-    rest.some((entry) => entry.category === category),
+    rest.some((entry) => normalizeCategory(entry.category) === category),
   );
 
   return (
@@ -59,7 +62,9 @@ export function ReleasesChangelog({ entries, linkBaseHref }: ReleasesChangelogPr
               <NavTabsTrigger
                 key={category}
                 value={category}
-                count={rest.filter((entry) => entry.category === category).length}
+                count={
+                  rest.filter((entry) => normalizeCategory(entry.category) === category).length
+                }
               >
                 {t(`whatsNew.category.${category}`)}
               </NavTabsTrigger>

--- a/apps/web/components/releases/releases-changelog.tsx
+++ b/apps/web/components/releases/releases-changelog.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import * as React from "react";
+
+import type {
+  ComponentReleaseNoteFieldsFragment as ReleaseNoteFields,
+  ReleaseCategory,
+} from "@repo/cms";
+import { RELEASE_CATEGORIES, ReleaseFeature, ReleaseNotesFeed } from "@repo/cms";
+import { useTranslation } from "@repo/i18n";
+import { cn } from "@repo/ui/lib/utils";
+
+interface ReleasesChangelogProps {
+  /** All active release notes, newest first (from getAllReleaseNotes). */
+  entries: ReleaseNoteFields[];
+  /** Base path for detail links, e.g. `/en-US/releases`. */
+  linkBaseHref: string;
+}
+
+type Filter = "all" | ReleaseCategory;
+
+function FilterChip({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        "focus-visible:ring-ring rounded-full border px-3.5 py-1.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+        active
+          ? "border-primary bg-primary text-primary-foreground"
+          : "border-border text-muted-foreground hover:text-foreground hover:border-primary/40 bg-white",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * Client shell for the public /releases changelog: spotlights the newest note as a
+ * featured hero, then a category filter row, then the month-grouped timeline for the rest. Filtering
+ * is purely client-side over the already-fetched entries. The hero stays pinned to the top across
+ * every filter — today it's a fallback to the most recent note, but it's the seam where a dedicated
+ * "feature banner" field will slot in once /releases gets its own content model. Only categories
+ * actually present get a chip.
+ */
+export function ReleasesChangelog({ entries, linkBaseHref }: ReleasesChangelogProps) {
+  const { t } = useTranslation("navigation");
+  const [filter, setFilter] = React.useState<Filter>("all");
+
+  if (entries.length === 0) {
+    return <p className="text-muted-foreground text-sm">{t("whatsNew.empty")}</p>;
+  }
+
+  const [featured, ...rest] = entries;
+  const isAll = filter === "all";
+  // The featured note is always the hero, so keep it out of the timeline regardless of filter.
+  const feedEntries = isAll ? rest : rest.filter((entry) => entry.category === filter);
+  // Chips come from `rest`, not all entries — otherwise a category whose only note is the pinned
+  // featured hero would get a chip that filters to an empty timeline.
+  const presentCategories = RELEASE_CATEGORIES.filter((category) =>
+    rest.some((entry) => entry.category === category),
+  );
+
+  return (
+    <div className="flex flex-col gap-10">
+      <ReleaseFeature entry={featured} linkBaseHref={linkBaseHref} />
+
+      {presentCategories.length > 0 && (
+        <div className="flex flex-wrap gap-2" role="group" aria-label={t("releases.heading")}>
+          <FilterChip active={isAll} onClick={() => setFilter("all")}>
+            {t("releases.filterAll")}
+          </FilterChip>
+          {presentCategories.map((category) => (
+            <FilterChip
+              key={category}
+              active={filter === category}
+              onClick={() => setFilter(category)}
+            >
+              {t(`whatsNew.category.${category}`)}
+            </FilterChip>
+          ))}
+        </div>
+      )}
+
+      {feedEntries.length > 0 ? (
+        <ReleaseNotesFeed entries={feedEntries} linkBaseHref={linkBaseHref} linkTarget="_self" />
+      ) : (
+        !isAll && <p className="text-muted-foreground text-sm">{t("whatsNew.empty")}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/releases/releases-changelog.tsx
+++ b/apps/web/components/releases/releases-changelog.tsx
@@ -8,7 +8,7 @@ import type {
 } from "@repo/cms";
 import { RELEASE_CATEGORIES, ReleaseHero, ReleaseNotesFeed } from "@repo/cms";
 import { useTranslation } from "@repo/i18n";
-import { cn } from "@repo/ui/lib/utils";
+import { NavTabs, NavTabsList, NavTabsTrigger } from "@repo/ui/components/nav-tabs";
 
 interface ReleasesChangelogProps {
   /** All active release notes, newest first (from getAllReleaseNotes). */
@@ -19,39 +19,13 @@ interface ReleasesChangelogProps {
 
 type Filter = "all" | ReleaseCategory;
 
-function FilterChip({
-  active,
-  onClick,
-  children,
-}: {
-  active: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-pressed={active}
-      className={cn(
-        "focus-visible:ring-ring rounded-full border px-3.5 py-1.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
-        active
-          ? "border-primary bg-primary text-primary-foreground"
-          : "border-border text-muted-foreground hover:text-foreground hover:border-primary/40 bg-white",
-      )}
-    >
-      {children}
-    </button>
-  );
-}
-
 /**
  * Client shell for the public /releases changelog: spotlights the newest note as a
- * featured hero, then a category filter row, then the month-grouped timeline for the rest. Filtering
- * is purely client-side over the already-fetched entries. The hero stays pinned to the top across
- * every filter — today it's a fallback to the most recent note, but it's the seam where a dedicated
- * "feature banner" field will slot in once /releases gets its own content model. Only categories
- * actually present get a chip.
+ * featured hero, then a category filter tab row, then the month-grouped timeline for the rest.
+ * Filtering is purely client-side over the already-fetched entries. The hero stays pinned to the
+ * top across every filter — today it's a fallback to the most recent note, but it's the seam where
+ * a dedicated "feature banner" field will slot in once /releases gets its own content model. Only
+ * categories actually present get a tab.
  */
 export function ReleasesChangelog({ entries, linkBaseHref }: ReleasesChangelogProps) {
   const { t } = useTranslation("navigation");
@@ -76,20 +50,22 @@ export function ReleasesChangelog({ entries, linkBaseHref }: ReleasesChangelogPr
       <ReleaseHero entry={featured} linkBaseHref={linkBaseHref} linkTarget="_self" />
 
       {presentCategories.length > 0 && (
-        <div className="flex flex-wrap gap-2" role="group" aria-label={t("releases.heading")}>
-          <FilterChip active={isAll} onClick={() => setFilter("all")}>
-            {t("releases.filterAll")}
-          </FilterChip>
-          {presentCategories.map((category) => (
-            <FilterChip
-              key={category}
-              active={filter === category}
-              onClick={() => setFilter(category)}
-            >
-              {t(`whatsNew.category.${category}`)}
-            </FilterChip>
-          ))}
-        </div>
+        <NavTabs value={filter} onValueChange={(value) => setFilter(value as Filter)}>
+          <NavTabsList aria-label={t("releases.heading")}>
+            <NavTabsTrigger value="all" count={rest.length}>
+              {t("releases.filterAll")}
+            </NavTabsTrigger>
+            {presentCategories.map((category) => (
+              <NavTabsTrigger
+                key={category}
+                value={category}
+                count={rest.filter((entry) => entry.category === category).length}
+              >
+                {t(`whatsNew.category.${category}`)}
+              </NavTabsTrigger>
+            ))}
+          </NavTabsList>
+        </NavTabs>
       )}
 
       {feedEntries.length > 0 ? (

--- a/apps/web/components/shortcuts/shortcuts-root.test.tsx
+++ b/apps/web/components/shortcuts/shortcuts-root.test.tsx
@@ -1,4 +1,5 @@
 import { NOTIFICATION_BELL_OPEN_EVENT } from "@/components/navigation/navigation-topbar/activity-popover";
+import { WHATS_NEW_OPEN_EVENT } from "@/components/whats-new/whats-new-shared";
 import { render, fireEvent, screen } from "@/test/test-utils";
 import type { ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -59,6 +60,17 @@ describe("ShortcutsRoot", () => {
     expect(handler).toHaveBeenCalledTimes(1);
     expect(router.push).not.toHaveBeenCalled();
     window.removeEventListener(NOTIFICATION_BELL_OPEN_EVENT, handler);
+  });
+
+  it("g-then-r opens the What's new panel instead of navigating", () => {
+    const handler = vi.fn();
+    window.addEventListener(WHATS_NEW_OPEN_EVENT, handler);
+    const { router } = renderShortcuts();
+    key("g");
+    key("r");
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(router.push).not.toHaveBeenCalled();
+    window.removeEventListener(WHATS_NEW_OPEN_EVENT, handler);
   });
 
   it("C creates route-aware (on /platform/experiments -> new)", () => {

--- a/apps/web/components/shortcuts/shortcuts-root.tsx
+++ b/apps/web/components/shortcuts/shortcuts-root.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { NOTIFICATION_BELL_OPEN_EVENT } from "@/components/navigation/navigation-topbar/activity-popover";
+import { WHATS_NEW_OPEN_EVENT } from "@/components/whats-new/whats-new-shared";
 import { modifierLabel } from "@/lib/platform";
 import { useHotkey, useHotkeySequence } from "@tanstack/react-hotkeys";
 import type { Hotkey } from "@tanstack/react-hotkeys";
@@ -96,6 +97,11 @@ export function ShortcutsRoot({ locale }: { locale: string }) {
         key: "N",
         label: "Notifications",
         action: () => window.dispatchEvent(new Event(NOTIFICATION_BELL_OPEN_EVENT)),
+      },
+      {
+        key: "R",
+        label: "What's new",
+        action: () => window.dispatchEvent(new Event(WHATS_NEW_OPEN_EVENT)),
       },
       { key: "A", label: "Account", path: `/${locale}/platform/account` },
     ],

--- a/apps/web/components/whats-new/fetch-release-notes.test.ts
+++ b/apps/web/components/whats-new/fetch-release-notes.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getContentfulClients } from "~/lib/contentful";
+
+import { fetchWebReleaseNotes } from "./fetch-release-notes";
+
+// unstable_cache requires Next.js incremental cache context unavailable in vitest — strip it to a passthrough
+vi.mock("next/cache", () => ({
+  unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
+const mockActiveReleaseNotes = vi.fn();
+
+const makeNote = (id: string, overrides: Record<string, unknown> = {}) => ({
+  __typename: "ComponentReleaseNote",
+  sys: { id },
+  slug: `release-${id}`,
+  title: `Release ${id}`,
+  summary: "Summary",
+  category: "feature",
+  surfaces: ["web"],
+  publishedAt: "2026-06-20T00:00:00.000Z",
+  active: true,
+  ...overrides,
+});
+
+describe("fetchWebReleaseNotes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getContentfulClients).mockResolvedValue({
+      client: { activeReleaseNotes: mockActiveReleaseNotes },
+      previewClient: { activeReleaseNotes: mockActiveReleaseNotes },
+    } as never);
+  });
+
+  it("queries Contentful for active web release notes in the given locale", async () => {
+    mockActiveReleaseNotes.mockResolvedValue({
+      componentReleaseNoteCollection: { items: [] },
+    });
+
+    await fetchWebReleaseNotes("de-DE");
+
+    expect(mockActiveReleaseNotes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preview: false,
+        locale: "de-DE",
+        surfaces: ["web", "both"],
+      }),
+    );
+  });
+
+  it("returns the fetched release notes", async () => {
+    const notes = [makeNote("1"), makeNote("2")];
+    mockActiveReleaseNotes.mockResolvedValue({
+      componentReleaseNoteCollection: { items: notes },
+    });
+
+    await expect(fetchWebReleaseNotes("en-US")).resolves.toEqual(notes);
+  });
+
+  it("filters out null items from the collection", async () => {
+    const note = makeNote("1");
+    mockActiveReleaseNotes.mockResolvedValue({
+      componentReleaseNoteCollection: { items: [null, note, null] },
+    });
+
+    await expect(fetchWebReleaseNotes("en-US")).resolves.toEqual([note]);
+  });
+
+  it("returns an empty list when the collection is missing", async () => {
+    mockActiveReleaseNotes.mockResolvedValue({ componentReleaseNoteCollection: null });
+
+    await expect(fetchWebReleaseNotes("en-US")).resolves.toEqual([]);
+  });
+
+  it("returns an empty list when the Contentful query fails", async () => {
+    mockActiveReleaseNotes.mockRejectedValue(new Error("Contentful down"));
+
+    await expect(fetchWebReleaseNotes("en-US")).resolves.toEqual([]);
+  });
+
+  it("returns an empty list when the Contentful client cannot be created", async () => {
+    vi.mocked(getContentfulClients).mockRejectedValue(new Error("missing credentials"));
+
+    await expect(fetchWebReleaseNotes("en-US")).resolves.toEqual([]);
+  });
+});

--- a/apps/web/components/whats-new/fetch-release-notes.ts
+++ b/apps/web/components/whats-new/fetch-release-notes.ts
@@ -1,0 +1,37 @@
+import { unstable_cache } from "next/cache";
+import { getContentfulClients } from "~/lib/contentful";
+
+import type { ComponentReleaseNoteFieldsFragment } from "@repo/cms";
+
+// Cached across all requests for 5 minutes — one Contentful hit per TTL window per locale,
+// mirroring the alerts bar (components/alerts-bar.tsx).
+const getCachedReleaseNotes = unstable_cache(
+  async (locale: string): Promise<ComponentReleaseNoteFieldsFragment[]> => {
+    const { client } = await getContentfulClients();
+    const data = await client.activeReleaseNotes({
+      preview: false,
+      now: new Date().toISOString(),
+      locale,
+      surfaces: ["web", "both"],
+    });
+    return (data.componentReleaseNoteCollection?.items ?? []).filter(
+      (item): item is ComponentReleaseNoteFieldsFragment => item !== null,
+    );
+  },
+  ["whats-new-release-notes"],
+  { revalidate: 300 },
+);
+
+/**
+ * Fetches active web release notes for the "What's new" panel. Fail-safe: returns an
+ * empty list on any Contentful error, so the platform layout never breaks.
+ */
+export async function fetchWebReleaseNotes(
+  locale: string,
+): Promise<ComponentReleaseNoteFieldsFragment[]> {
+  try {
+    return await getCachedReleaseNotes(locale);
+  } catch {
+    return [];
+  }
+}

--- a/apps/web/components/whats-new/whats-new-footer-item.tsx
+++ b/apps/web/components/whats-new/whats-new-footer-item.tsx
@@ -16,7 +16,9 @@ import { WHATS_NEW_OPEN_EVENT, countUnread } from "./whats-new-shared";
 export function WhatsNewFooterItem({ entries }: { entries: ReleaseNoteFields[] }) {
   const { t } = useTranslation("navigation");
   const lastSeen = useWhatsNewLastSeen();
-  const unreadCount = countUnread(entries, lastSeen.data?.body.lastSeenAt ?? null);
+  // Wait for the query to resolve — treating a loading `undefined` as "never seen" flashes every
+  // note as unread. A resolved null `lastSeenAt` still correctly means all unread.
+  const unreadCount = lastSeen.data ? countUnread(entries, lastSeen.data.body.lastSeenAt) : 0;
   const hasUnread = unreadCount > 0;
   const label = t("whatsNew.navLabel");
 

--- a/apps/web/components/whats-new/whats-new-footer-item.tsx
+++ b/apps/web/components/whats-new/whats-new-footer-item.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useWhatsNewLastSeen } from "@/hooks/whats-new/useWhatsNewLastSeen/useWhatsNewLastSeen";
+import { Sparkles } from "lucide-react";
+
+import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "@repo/cms";
+import { useTranslation } from "@repo/i18n";
+
+import { WHATS_NEW_OPEN_EVENT, countUnread } from "./whats-new-shared";
+
+/**
+ * Standalone sidebar-footer row that opens the What's new sheet. Shows a brand-green
+ * unread dot when there are new entries. Styled for the dark sidebar (white text), matching the
+ * search button above it.
+ */
+export function WhatsNewFooterItem({ entries }: { entries: ReleaseNoteFields[] }) {
+  const { t } = useTranslation("navigation");
+  const lastSeen = useWhatsNewLastSeen();
+  const unreadCount = countUnread(entries, lastSeen.data?.body.lastSeenAt ?? null);
+  const hasUnread = unreadCount > 0;
+  const label = t("whatsNew.navLabel");
+
+  return (
+    <button
+      type="button"
+      onClick={() => window.dispatchEvent(new Event(WHATS_NEW_OPEN_EVENT))}
+      aria-label={
+        hasUnread ? `${label} (${t("whatsNew.unreadBadge", { count: unreadCount })})` : label
+      }
+      className="flex h-9 w-full items-center gap-2 rounded-md px-3 text-left text-sm text-white/70 transition-colors hover:bg-white/10 hover:text-white"
+    >
+      <Sparkles className="size-4 shrink-0" />
+      <span className="flex-1 truncate">{label}</span>
+      {hasUnread && (
+        <span
+          className="bg-jii-bright-green ml-auto size-2 shrink-0 rounded-full"
+          aria-hidden="true"
+        />
+      )}
+    </button>
+  );
+}

--- a/apps/web/components/whats-new/whats-new-shared.test.ts
+++ b/apps/web/components/whats-new/whats-new-shared.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import type { ComponentReleaseNoteFieldsFragment } from "@repo/cms";
+
+import { countUnread } from "./whats-new-shared";
+
+const makeEntry = (id: string, publishedAt: string | null) =>
+  ({
+    __typename: "ComponentReleaseNote",
+    sys: { id },
+    publishedAt,
+  }) as unknown as ComponentReleaseNoteFieldsFragment;
+
+describe("countUnread", () => {
+  it("treats every entry as unread when the user has never opened the panel", () => {
+    const entries = [
+      makeEntry("1", "2026-06-01T00:00:00.000Z"),
+      makeEntry("2", "2026-06-15T00:00:00.000Z"),
+    ];
+
+    expect(countUnread(entries, null)).toBe(2);
+  });
+
+  it("treats every entry as unread when the last-seen timestamp is unparseable", () => {
+    const entries = [
+      makeEntry("1", "2026-06-01T00:00:00.000Z"),
+      makeEntry("2", "2026-06-15T00:00:00.000Z"),
+    ];
+
+    expect(countUnread(entries, "not-a-date")).toBe(2);
+  });
+
+  it("counts only entries published after the last-seen timestamp", () => {
+    const entries = [
+      makeEntry("older", "2026-06-01T00:00:00.000Z"),
+      makeEntry("newer", "2026-06-20T00:00:00.000Z"),
+    ];
+
+    expect(countUnread(entries, "2026-06-10T00:00:00.000Z")).toBe(1);
+  });
+
+  it("does not count an entry published exactly at the last-seen timestamp", () => {
+    const entries = [makeEntry("same", "2026-06-10T00:00:00.000Z")];
+
+    expect(countUnread(entries, "2026-06-10T00:00:00.000Z")).toBe(0);
+  });
+
+  it("ignores entries without a publishedAt date", () => {
+    const entries = [makeEntry("no-date", null), makeEntry("newer", "2026-06-20T00:00:00.000Z")];
+
+    expect(countUnread(entries, "2026-06-10T00:00:00.000Z")).toBe(1);
+  });
+
+  it("ignores entries with an unparseable publishedAt date", () => {
+    const entries = [
+      makeEntry("bad-date", "not-a-date"),
+      makeEntry("newer", "2026-06-20T00:00:00.000Z"),
+    ];
+
+    expect(countUnread(entries, "2026-06-10T00:00:00.000Z")).toBe(1);
+  });
+
+  it("returns 0 for an empty list", () => {
+    expect(countUnread([], null)).toBe(0);
+    expect(countUnread([], "2026-06-10T00:00:00.000Z")).toBe(0);
+  });
+});

--- a/apps/web/components/whats-new/whats-new-shared.ts
+++ b/apps/web/components/whats-new/whats-new-shared.ts
@@ -1,0 +1,16 @@
+import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "@repo/cms";
+
+/** Dispatched (by the footer item or the `G R` shortcut) to open the What's new sheet. */
+export const WHATS_NEW_OPEN_EVENT = "openjii:open-whats-new";
+
+/** Number of entries published after the user last opened the panel (null = never → all unread). */
+export function countUnread(entries: ReleaseNoteFields[], lastSeenAt: string | null): number {
+  if (!lastSeenAt) return entries.length;
+  const seenMs = new Date(lastSeenAt).getTime();
+  if (Number.isNaN(seenMs)) return entries.length;
+  return entries.filter((entry) => {
+    if (!entry.publishedAt) return false;
+    const publishedMs = new Date(entry.publishedAt as string).getTime();
+    return !Number.isNaN(publishedMs) && publishedMs > seenMs;
+  }).length;
+}

--- a/apps/web/components/whats-new/whats-new-sheet.tsx
+++ b/apps/web/components/whats-new/whats-new-sheet.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useMarkWhatsNewSeen } from "@/hooks/whats-new/useMarkWhatsNewSeen/useMarkWhatsNewSeen";
+import { useWhatsNewLastSeen } from "@/hooks/whats-new/useWhatsNewLastSeen/useWhatsNewLastSeen";
+import { ExternalLink } from "lucide-react";
+import Link from "next/link";
+import * as React from "react";
+import { env } from "~/env";
+
+import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "@repo/cms";
+import { ReleaseNotesFeed } from "@repo/cms";
+import { useTranslation } from "@repo/i18n";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@repo/ui/components/sheet";
+
+import { WHATS_NEW_OPEN_EVENT, countUnread } from "./whats-new-shared";
+
+// The public /releases page lives in this same app, so anchor it to this deployment's own origin
+// (localhost / dev / prod) rather than a hardcoded domain — mirrors how the support link uses env.
+const RELEASES_BASE_URL = `${env.NEXT_PUBLIC_BASE_URL}/releases`;
+
+/** Right-side 480px panel listing release notes, grouped by month, with a "Full changelog" link. */
+export function WhatsNewSheet({ entries }: { entries: ReleaseNoteFields[] }) {
+  const { t } = useTranslation("navigation");
+  const lastSeen = useWhatsNewLastSeen();
+  const markSeen = useMarkWhatsNewSeen();
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  // Opened by the footer item / `G R` shortcut via a window event (no shared context needed).
+  React.useEffect(() => {
+    const handler = () => setIsOpen(true);
+    window.addEventListener(WHATS_NEW_OPEN_EVENT, handler);
+    return () => window.removeEventListener(WHATS_NEW_OPEN_EVENT, handler);
+  }, []);
+
+  const handleOpenChange = (next: boolean) => {
+    setIsOpen(next);
+    // On close, stamp "seen" (cross-device) only when something was actually unread.
+    if (!next && countUnread(entries, lastSeen.data?.body.lastSeenAt ?? null) > 0) {
+      markSeen.mutate({ body: {} });
+    }
+  };
+
+  return (
+    <Sheet open={isOpen} onOpenChange={handleOpenChange}>
+      <SheetContent side="right" className="sm:max-w-120 flex w-full flex-col gap-0 p-0">
+        <SheetHeader className="border-border border-b px-6 py-4">
+          <SheetTitle>{t("whatsNew.title")}</SheetTitle>
+          <SheetDescription className="sr-only">{t("whatsNew.description")}</SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 overflow-y-auto px-6 py-6">
+          <ReleaseNotesFeed
+            entries={entries}
+            linkBaseHref={RELEASES_BASE_URL}
+            linkTarget="_blank"
+            variant="sheet"
+          />
+        </div>
+
+        <div className="border-border border-t px-6 py-4">
+          <Link
+            href={RELEASES_BASE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary inline-flex items-center gap-1.5 text-sm font-medium hover:underline"
+          >
+            {t("whatsNew.fullChangelog")}
+            <ExternalLink className="size-3.5" />
+          </Link>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/web/components/whats-new/whats-new-sheet.tsx
+++ b/apps/web/components/whats-new/whats-new-sheet.tsx
@@ -9,7 +9,8 @@ import { env } from "~/env";
 
 import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "@repo/cms";
 import { ReleaseNotesFeed } from "@repo/cms";
-import { useTranslation } from "@repo/i18n";
+import { useCurrentLocale, useTranslation } from "@repo/i18n";
+import i18nConfig from "@repo/i18n/config";
 import {
   Sheet,
   SheetContent,
@@ -20,13 +21,13 @@ import {
 
 import { WHATS_NEW_OPEN_EVENT, countUnread } from "./whats-new-shared";
 
-// The public /releases page lives in this same app, so anchor it to this deployment's own origin
-// (localhost / dev / prod) rather than a hardcoded domain — mirrors how the support link uses env.
-const RELEASES_BASE_URL = `${env.NEXT_PUBLIC_BASE_URL}/releases`;
-
 /** Right-side 480px panel listing release notes, grouped by month, with a "Full changelog" link. */
 export function WhatsNewSheet({ entries }: { entries: ReleaseNoteFields[] }) {
   const { t } = useTranslation("navigation");
+  const locale = useCurrentLocale(i18nConfig) ?? "en-US";
+  // Same-app origin (env, not a hardcoded domain), locale in the path so the proxy doesn't redirect
+  // an unprefixed URL to the default locale.
+  const releasesBaseUrl = `${env.NEXT_PUBLIC_BASE_URL}/${locale}/releases`;
   const lastSeen = useWhatsNewLastSeen();
   const markSeen = useMarkWhatsNewSeen();
   const [isOpen, setIsOpen] = React.useState(false);
@@ -57,7 +58,7 @@ export function WhatsNewSheet({ entries }: { entries: ReleaseNoteFields[] }) {
         <div className="flex-1 overflow-y-auto px-6 py-6">
           <ReleaseNotesFeed
             entries={entries}
-            linkBaseHref={RELEASES_BASE_URL}
+            linkBaseHref={releasesBaseUrl}
             linkTarget="_blank"
             variant="sheet"
           />
@@ -65,7 +66,7 @@ export function WhatsNewSheet({ entries }: { entries: ReleaseNoteFields[] }) {
 
         <div className="border-border border-t px-6 py-4">
           <Link
-            href={RELEASES_BASE_URL}
+            href={releasesBaseUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="text-primary inline-flex items-center gap-1.5 text-sm font-medium hover:underline"

--- a/apps/web/hooks/whats-new/useMarkWhatsNewSeen/useMarkWhatsNewSeen.test.tsx
+++ b/apps/web/hooks/whats-new/useMarkWhatsNewSeen/useMarkWhatsNewSeen.test.tsx
@@ -1,0 +1,72 @@
+import { server } from "@/test/msw/server";
+import { renderHook, waitFor, act, createTestQueryClient } from "@/test/test-utils";
+import { describe, it, expect, vi } from "vitest";
+
+import { contract } from "@repo/api/contract";
+
+import { WHATS_NEW_LAST_SEEN_KEY } from "../useWhatsNewLastSeen/useWhatsNewLastSeen";
+import { useMarkWhatsNewSeen } from "./useMarkWhatsNewSeen";
+
+describe("useMarkWhatsNewSeen", () => {
+  it("sends POST request to mark What's new as seen", async () => {
+    const spy = server.mount(contract.users.markWhatsNewSeen, {
+      body: { lastSeenAt: "2026-07-02T00:00:00.000Z" },
+    });
+
+    const { result } = renderHook(() => useMarkWhatsNewSeen());
+
+    act(() => {
+      result.current.mutate({ body: {} });
+    });
+
+    await waitFor(() => {
+      expect(spy.called).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+
+  it("invalidates the last-seen query on success", async () => {
+    server.mount(contract.users.markWhatsNewSeen, {
+      body: { lastSeenAt: "2026-07-02T00:00:00.000Z" },
+    });
+
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useMarkWhatsNewSeen(), { queryClient });
+
+    act(() => {
+      result.current.mutate({ body: {} });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: WHATS_NEW_LAST_SEEN_KEY }),
+      );
+    });
+  });
+
+  it("invalidates the last-seen query even when the request fails", async () => {
+    server.mount(contract.users.markWhatsNewSeen, { status: 401 });
+
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useMarkWhatsNewSeen(), { queryClient });
+
+    act(() => {
+      result.current.mutate({ body: {} });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: WHATS_NEW_LAST_SEEN_KEY }),
+    );
+  });
+});

--- a/apps/web/hooks/whats-new/useMarkWhatsNewSeen/useMarkWhatsNewSeen.ts
+++ b/apps/web/hooks/whats-new/useMarkWhatsNewSeen/useMarkWhatsNewSeen.ts
@@ -1,0 +1,17 @@
+import { tsr } from "@/lib/tsr";
+
+import { WHATS_NEW_LAST_SEEN_KEY } from "../useWhatsNewLastSeen/useWhatsNewLastSeen";
+
+/**
+ * Marks What's-new as seen — stamps now() on the backend (cross-device) and refetches the
+ * last-seen query so the unread dot clears everywhere.
+ */
+export const useMarkWhatsNewSeen = () => {
+  const queryClient = tsr.useQueryClient();
+
+  return tsr.users.markWhatsNewSeen.useMutation({
+    onSettled: async () => {
+      await queryClient.invalidateQueries({ queryKey: WHATS_NEW_LAST_SEEN_KEY });
+    },
+  });
+};

--- a/apps/web/hooks/whats-new/useWhatsNewLastSeen/useWhatsNewLastSeen.ts
+++ b/apps/web/hooks/whats-new/useWhatsNewLastSeen/useWhatsNewLastSeen.ts
@@ -1,0 +1,15 @@
+import { tsr } from "@/lib/tsr";
+
+/** Shared query key for the cross-device "last seen" timestamp (the mutation invalidates it). */
+export const WHATS_NEW_LAST_SEEN_KEY = ["whats-new", "last-seen"];
+
+/**
+ * Fetches the current user's What's-new "last seen" timestamp from the backend.
+ * Thin ts-rest query wrapper, matching the rest of apps/web/hooks (e.g. useProtocol, useUserSearch).
+ */
+export const useWhatsNewLastSeen = () => {
+  return tsr.users.getWhatsNewSeen.useQuery({
+    queryKey: WHATS_NEW_LAST_SEEN_KEY,
+    staleTime: 5 * 60 * 1000,
+  });
+};

--- a/packages/api/src/contracts/user.contract.ts
+++ b/packages/api/src/contracts/user.contract.ts
@@ -180,6 +180,7 @@ export const userContract = c.router({
     responses: {
       200: zWhatsNewSeenResponse,
       401: zErrorResponse,
+      404: zErrorResponse,
     },
     summary: "Get the caller's What's new last-seen timestamp",
     description:
@@ -193,6 +194,7 @@ export const userContract = c.router({
     responses: {
       200: zWhatsNewSeenResponse,
       401: zErrorResponse,
+      404: zErrorResponse,
     },
     summary: "Mark What's new as seen",
     description:

--- a/packages/api/src/contracts/user.contract.ts
+++ b/packages/api/src/contracts/user.contract.ts
@@ -20,6 +20,8 @@ import {
   zInvitationIdPathParam,
   zListInvitationsQuery,
   zDeletionBlockersResponse,
+  zWhatsNewSeenResponse,
+  zMarkWhatsNewSeenBody,
 } from "../schemas/user.schema";
 
 const c = initContract();
@@ -170,5 +172,30 @@ export const userContract = c.router({
     },
     summary: "Revoke invitation",
     description: "Revokes a pending invitation so it can no longer be accepted.",
+  },
+
+  getWhatsNewSeen: {
+    method: "GET",
+    path: "/api/v1/whats-new/seen",
+    responses: {
+      200: zWhatsNewSeenResponse,
+      401: zErrorResponse,
+    },
+    summary: "Get the caller's What's new last-seen timestamp",
+    description:
+      "Returns the timestamp the authenticated user last opened the What's new panel, used to compute the unread indicator. null means the user has never opened it.",
+  },
+
+  markWhatsNewSeen: {
+    method: "POST",
+    path: "/api/v1/whats-new/seen",
+    body: zMarkWhatsNewSeenBody,
+    responses: {
+      200: zWhatsNewSeenResponse,
+      401: zErrorResponse,
+    },
+    summary: "Mark What's new as seen",
+    description:
+      "Sets the authenticated user's What's new last-seen timestamp to now, clearing the unread indicator across their devices. Returns the new timestamp.",
   },
 });

--- a/packages/api/src/schemas/user.schema.ts
+++ b/packages/api/src/schemas/user.schema.ts
@@ -176,6 +176,16 @@ export const zListInvitationsQuery = z.object({
   resourceId: z.string().uuid(),
 });
 
+export const zWhatsNewSeenResponse = z.object({
+  lastSeenAt: z
+    .string()
+    .datetime()
+    .nullable()
+    .describe("ISO timestamp the user last opened the What's new panel; null = never seen"),
+});
+
+export const zMarkWhatsNewSeenBody = z.object({});
+
 // Invitation types
 export type InvitationStatus = z.infer<typeof zInvitationStatus>;
 export type InvitationResourceType = z.infer<typeof zInvitationResourceType>;
@@ -184,3 +194,5 @@ export type CreateInvitationBody = z.infer<typeof zCreateInvitationBody>;
 export type UpdateInvitationRoleBody = z.infer<typeof zUpdateInvitationRoleBody>;
 export type InvitationIdPathParam = z.infer<typeof zInvitationIdPathParam>;
 export type ListInvitationsQuery = z.infer<typeof zListInvitationsQuery>;
+export type WhatsNewSeenResponse = z.infer<typeof zWhatsNewSeenResponse>;
+export type MarkWhatsNewSeenBody = z.infer<typeof zMarkWhatsNewSeenBody>;

--- a/packages/cms/src/features/release-notes/category.ts
+++ b/packages/cms/src/features/release-notes/category.ts
@@ -44,10 +44,15 @@ const CATEGORY_META: Record<ReleaseCategory, CategoryMeta> = {
   },
 };
 
-/** Normalizes the free-text `category` field to known {@link CategoryMeta}; unknown → announcement. */
-export function getCategoryMeta(category?: string | null): CategoryMeta {
+/** Normalizes the free-text `category` field to a known {@link ReleaseCategory}; unknown → announcement. */
+export function normalizeCategory(category?: string | null): ReleaseCategory {
   if (category && category in CATEGORY_META) {
-    return CATEGORY_META[category as ReleaseCategory];
+    return category as ReleaseCategory;
   }
-  return CATEGORY_META.announcement;
+  return "announcement";
+}
+
+/** Resolves the free-text `category` field to its {@link CategoryMeta}; unknown → announcement. */
+export function getCategoryMeta(category?: string | null): CategoryMeta {
+  return CATEGORY_META[normalizeCategory(category)];
 }

--- a/packages/cms/src/features/release-notes/category.ts
+++ b/packages/cms/src/features/release-notes/category.ts
@@ -1,0 +1,53 @@
+/**
+ * Release-note categories. The CMS field is free-text (a single-select enum in
+ * Contentful, but typed as `string` here), so we normalize to a known category and fall back
+ * gracefully. Mirrors the alert feature's severity.ts.
+ */
+export const RELEASE_CATEGORIES = [
+  "new_feature",
+  "improvement",
+  "bug_fix",
+  "announcement",
+] as const;
+
+export type ReleaseCategory = (typeof RELEASE_CATEGORIES)[number];
+
+export interface CategoryMeta {
+  /** i18n key under the `navigation` namespace. */
+  labelKey: `whatsNew.category.${ReleaseCategory}`;
+  /** Tailwind classes for the category Badge (brand teal / sky / muted / highlight yellow). */
+  badgeClassName: string;
+  /** Tailwind background class for the timeline rail dot on the public /releases page. */
+  dotClassName: string;
+}
+
+const CATEGORY_META: Record<ReleaseCategory, CategoryMeta> = {
+  new_feature: {
+    labelKey: "whatsNew.category.new_feature",
+    badgeClassName: "border-transparent bg-jii-bright-green/15 text-gray-800",
+    dotClassName: "bg-jii-bright-green",
+  },
+  improvement: {
+    labelKey: "whatsNew.category.improvement",
+    badgeClassName: "border-transparent bg-jii-light-blue/20 text-gray-800",
+    dotClassName: "bg-jii-light-blue",
+  },
+  bug_fix: {
+    labelKey: "whatsNew.category.bug_fix",
+    badgeClassName: "border-transparent bg-muted text-muted-foreground",
+    dotClassName: "bg-gray-300",
+  },
+  announcement: {
+    labelKey: "whatsNew.category.announcement",
+    badgeClassName: "border-transparent bg-highlight/40 text-gray-800",
+    dotClassName: "bg-jii-light-yellow",
+  },
+};
+
+/** Normalizes the free-text `category` field to known {@link CategoryMeta}; unknown → announcement. */
+export function getCategoryMeta(category?: string | null): CategoryMeta {
+  if (category && category in CATEGORY_META) {
+    return CATEGORY_META[category as ReleaseCategory];
+  }
+  return CATEGORY_META.announcement;
+}

--- a/packages/cms/src/features/release-notes/release-feature.tsx
+++ b/packages/cms/src/features/release-notes/release-feature.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import {
+  useContentfulInspectorMode,
+  useContentfulLiveUpdates,
+} from "@contentful/live-preview/react";
+import { ArrowRight } from "lucide-react";
+import React from "react";
+
+import { useCurrentLocale, useTranslation } from "@repo/i18n";
+import i18nConfig from "@repo/i18n/config";
+import { Badge } from "@repo/ui/components/badge";
+import { Button } from "@repo/ui/components/button";
+import { cn } from "@repo/ui/lib/utils";
+
+import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "../../lib/__generated/sdk";
+import { isVideoAsset } from "../contentful/ctf-video";
+import { getCategoryMeta } from "./category";
+
+interface ReleaseFeatureProps {
+  entry: ReleaseNoteFields;
+  /** Base path for the detail link; the hero links to `${linkBaseHref}/${slug}`. */
+  linkBaseHref?: string;
+  /** Target for the detail link (default same-tab). */
+  linkTarget?: "_blank" | "_self";
+}
+
+/** Absolute publish date ("July 1, 2026") — matches the /releases/[slug] article header. */
+function formatDate(iso: string, locale: string): string | null {
+  const ms = new Date(iso).getTime();
+  if (Number.isNaN(ms)) return null;
+  try {
+    return new Intl.DateTimeFormat(locale, { dateStyle: "long" }).format(new Date(ms));
+  } catch {
+    return new Date(ms).toDateString();
+  }
+}
+
+/**
+ * Spotlights the newest release note at the top of the public /releases page (OJD-1394) — the
+ * changelog's answer to the blog's featured ArticleHero: a large split card, media on one side and
+ * title/summary/CTA on the other. Falls back to a full-width, text-forward layout when the note has
+ * no media, so a media-less release still reads as intentional rather than broken.
+ */
+export const ReleaseFeature: React.FC<ReleaseFeatureProps> = ({
+  entry,
+  linkBaseHref,
+  linkTarget = "_self",
+}) => {
+  const { t } = useTranslation("navigation");
+  const locale = useCurrentLocale(i18nConfig) ?? "en-US";
+
+  const live = useContentfulLiveUpdates(entry);
+  const inspectorProps = useContentfulInspectorMode({ entryId: entry.sys.id });
+
+  const category = getCategoryMeta(live.category);
+  const media = live.media;
+  const hasMedia = Boolean(media?.url);
+  const isImage = hasMedia && !isVideoAsset(media?.contentType);
+  const dateLabel = live.publishedAt ? formatDate(live.publishedAt as string, locale) : null;
+
+  const href = linkBaseHref && live.slug ? `${linkBaseHref}/${live.slug}` : undefined;
+  const linkRel = linkTarget === "_blank" ? "noopener noreferrer" : undefined;
+
+  return (
+    <article
+      className={cn(
+        "border-border grid overflow-hidden rounded-2xl border bg-white shadow-sm",
+        hasMedia && "lg:grid-cols-2",
+      )}
+    >
+      {hasMedia && (
+        <div
+          className="bg-primary/5 relative min-h-56 lg:min-h-full"
+          {...inspectorProps({ fieldId: "media" })}
+        >
+          {isImage ? (
+            <img
+              src={`${media?.url}?w=1200&fm=webp&fit=fill`}
+              alt={media?.description ?? media?.title ?? live.title ?? ""}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <video
+              src={media?.url ?? undefined}
+              title={media?.title ?? undefined}
+              autoPlay
+              muted
+              loop
+              playsInline
+              preload="metadata"
+              className="h-full w-full object-cover"
+            >
+              {media?.contentType && (
+                <source src={media?.url ?? undefined} type={media.contentType} />
+              )}
+            </video>
+          )}
+        </div>
+      )}
+
+      <div className="flex flex-col justify-center gap-4 p-8 lg:p-12">
+        <div className="flex flex-wrap items-center gap-3">
+          <Badge className={category.badgeClassName} {...inspectorProps({ fieldId: "category" })}>
+            {t(category.labelKey)}
+          </Badge>
+          {dateLabel && (
+            <span
+              className="text-muted-foreground font-mono text-xs tabular-nums"
+              {...inspectorProps({ fieldId: "publishedAt" })}
+            >
+              {dateLabel}
+            </span>
+          )}
+        </div>
+
+        <h2
+          className="text-foreground text-2xl font-semibold leading-tight tracking-tight md:text-3xl"
+          {...inspectorProps({ fieldId: "title" })}
+        >
+          {href ? (
+            <a
+              href={href}
+              target={linkTarget}
+              rel={linkRel}
+              className="hover:text-primary transition-colors"
+            >
+              {live.title}
+            </a>
+          ) : (
+            live.title
+          )}
+        </h2>
+
+        {live.summary && (
+          <p
+            className="text-muted-foreground text-base"
+            {...inspectorProps({ fieldId: "summary" })}
+          >
+            {live.summary}
+          </p>
+        )}
+
+        <div className="mt-1 flex flex-wrap items-center gap-2">
+          {href && (
+            <a
+              href={href}
+              target={linkTarget}
+              rel={linkRel}
+              className="bg-primary text-primary-foreground hover:bg-primary-light inline-flex w-fit items-center gap-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
+            >
+              {t("whatsNew.readMore")}
+              <ArrowRight className="size-3.5" />
+            </a>
+          )}
+          {live.cta?.url && live.cta.label && (
+            <Button
+              asChild
+              size="sm"
+              variant="secondary"
+              className="w-fit"
+              {...inspectorProps({ fieldId: "cta" })}
+            >
+              <a href={live.cta.url} target="_blank" rel="noopener noreferrer">
+                {live.cta.label}
+                <ArrowRight className="size-3.5" />
+              </a>
+            </Button>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+};

--- a/packages/cms/src/features/release-notes/release-hero.tsx
+++ b/packages/cms/src/features/release-notes/release-hero.tsx
@@ -17,15 +17,19 @@ import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "..
 import { isVideoAsset } from "../contentful/ctf-video";
 import { getCategoryMeta } from "./category";
 
-interface ReleaseFeatureProps {
+interface ReleaseHeroProps {
   entry: ReleaseNoteFields;
-  /** Base path for the detail link; the hero links to `${linkBaseHref}/${slug}`. */
+  /** Title heading level: the /releases index hero uses "h2"; the /releases/[slug] permalink uses "h1". */
+  headingLevel?: "h1" | "h2";
+  /** Base path for the detail link; when set (and the note has a slug) the title links to `${linkBaseHref}/${slug}`. Omit on the detail page itself so the title stays a plain heading. */
   linkBaseHref?: string;
-  /** Target for the detail link (default same-tab). */
+  /** Target for the title / "Read more" link (default same-tab). */
   linkTarget?: "_blank" | "_self";
+  /** Render the "Read more" link to the detail page. Turn off on the detail page — you're already there. */
+  showReadMore?: boolean;
 }
 
-/** Absolute publish date ("July 1, 2026") — matches the /releases/[slug] article header. */
+/** Absolute publish date ("July 1, 2026") — shared by the /releases hero and the /releases/[slug] header. */
 function formatDate(iso: string, locale: string): string | null {
   const ms = new Date(iso).getTime();
   if (Number.isNaN(ms)) return null;
@@ -37,15 +41,19 @@ function formatDate(iso: string, locale: string): string | null {
 }
 
 /**
- * Spotlights the newest release note at the top of the public /releases page (OJD-1394) — the
- * changelog's answer to the blog's featured ArticleHero: a large split card, media on one side and
- * title/summary/CTA on the other. Falls back to a full-width, text-forward layout when the note has
- * no media, so a media-less release still reads as intentional rather than broken.
+ * The split-card release-note hero shared by the public /releases index (spotlighting the newest
+ * note, `ReleaseNotesFeed`'s companion) and the top of the /releases/[slug] permalink
+ * (`ReleaseNoteArticle`, which renders the full body below it). Media on one side, badge/date/
+ * title/summary/CTA on the other, collapsing to a text-forward layout when the note has no media.
+ * The two surfaces differ only in `headingLevel` (h1 on the permalink for SEO) and `showReadMore`
+ * (off on the permalink). Wired for Contentful draft preview + live updates + inspector.
  */
-export const ReleaseFeature: React.FC<ReleaseFeatureProps> = ({
+export const ReleaseHero: React.FC<ReleaseHeroProps> = ({
   entry,
+  headingLevel = "h2",
   linkBaseHref,
   linkTarget = "_self",
+  showReadMore = true,
 }) => {
   const { t } = useTranslation("navigation");
   const locale = useCurrentLocale(i18nConfig) ?? "en-US";
@@ -61,6 +69,10 @@ export const ReleaseFeature: React.FC<ReleaseFeatureProps> = ({
 
   const href = linkBaseHref && live.slug ? `${linkBaseHref}/${live.slug}` : undefined;
   const linkRel = linkTarget === "_blank" ? "noopener noreferrer" : undefined;
+  const Heading = headingLevel;
+
+  const hasReadMore = Boolean(href && showReadMore);
+  const hasCta = Boolean(live.cta?.url && live.cta.label);
 
   return (
     <article
@@ -114,7 +126,7 @@ export const ReleaseFeature: React.FC<ReleaseFeatureProps> = ({
           )}
         </div>
 
-        <h2
+        <Heading
           className="text-foreground text-2xl font-semibold leading-tight tracking-tight md:text-3xl"
           {...inspectorProps({ fieldId: "title" })}
         >
@@ -130,7 +142,7 @@ export const ReleaseFeature: React.FC<ReleaseFeatureProps> = ({
           ) : (
             live.title
           )}
-        </h2>
+        </Heading>
 
         {live.summary && (
           <p
@@ -141,33 +153,35 @@ export const ReleaseFeature: React.FC<ReleaseFeatureProps> = ({
           </p>
         )}
 
-        <div className="mt-1 flex flex-wrap items-center gap-2">
-          {href && (
-            <a
-              href={href}
-              target={linkTarget}
-              rel={linkRel}
-              className="bg-primary text-primary-foreground hover:bg-primary-light inline-flex w-fit items-center gap-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
-            >
-              {t("whatsNew.readMore")}
-              <ArrowRight className="size-3.5" />
-            </a>
-          )}
-          {live.cta?.url && live.cta.label && (
-            <Button
-              asChild
-              size="sm"
-              variant="secondary"
-              className="w-fit"
-              {...inspectorProps({ fieldId: "cta" })}
-            >
-              <a href={live.cta.url} target="_blank" rel="noopener noreferrer">
-                {live.cta.label}
+        {(hasReadMore || hasCta) && (
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            {hasReadMore && (
+              <a
+                href={href}
+                target={linkTarget}
+                rel={linkRel}
+                className="bg-primary text-primary-foreground hover:bg-primary-light inline-flex w-fit items-center gap-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
+              >
+                {t("whatsNew.readMore")}
                 <ArrowRight className="size-3.5" />
               </a>
-            </Button>
-          )}
-        </div>
+            )}
+            {live.cta?.url && live.cta.label && (
+              <Button
+                asChild
+                size="sm"
+                variant="secondary"
+                className="w-fit"
+                {...inspectorProps({ fieldId: "cta" })}
+              >
+                <a href={live.cta.url} target="_blank" rel="noopener noreferrer">
+                  {live.cta.label}
+                  <ArrowRight className="size-3.5" />
+                </a>
+              </Button>
+            )}
+          </div>
+        )}
       </div>
     </article>
   );

--- a/packages/cms/src/features/release-notes/release-hero.tsx
+++ b/packages/cms/src/features/release-notes/release-hero.tsx
@@ -16,6 +16,7 @@ import { cn } from "@repo/ui/lib/utils";
 import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "../../lib/__generated/sdk";
 import { isVideoAsset } from "../contentful/ctf-video";
 import { getCategoryMeta } from "./category";
+import { SurfaceBadges } from "./surface-badges";
 
 interface ReleaseHeroProps {
   entry: ReleaseNoteFields;
@@ -116,6 +117,10 @@ export const ReleaseHero: React.FC<ReleaseHeroProps> = ({
           <Badge className={category.badgeClassName} {...inspectorProps({ fieldId: "category" })}>
             {t(category.labelKey)}
           </Badge>
+          <SurfaceBadges
+            surfaces={live.surfaces}
+            inspectorProps={inspectorProps({ fieldId: "surfaces" })}
+          />
           {dateLabel && (
             <span
               className="text-muted-foreground font-mono text-xs tabular-nums"

--- a/packages/cms/src/features/release-notes/release-note-article.tsx
+++ b/packages/cms/src/features/release-notes/release-note-article.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import {
+  useContentfulInspectorMode,
+  useContentfulLiveUpdates,
+} from "@contentful/live-preview/react";
+import type { Document } from "@contentful/rich-text-types";
+import { ArrowRight } from "lucide-react";
+import React from "react";
+
+import { useCurrentLocale, useTranslation } from "@repo/i18n";
+import i18nConfig from "@repo/i18n/config";
+import { Badge } from "@repo/ui/components/badge";
+import { Button } from "@repo/ui/components/button";
+
+import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "../../lib/__generated/sdk";
+import { CtfRichText } from "../contentful/ctf-rich-text";
+import { isVideoAsset } from "../contentful/ctf-video";
+import { getCategoryMeta } from "./category";
+
+interface ReleaseNoteArticleProps {
+  entry: ReleaseNoteFields;
+}
+
+/** Absolute publish date ("June 30, 2026"); better than relative time on a permalink page. */
+function formatAbsoluteDate(iso: string, locale: string): string | null {
+  const ms = new Date(iso).getTime();
+  if (Number.isNaN(ms)) return null;
+  try {
+    return new Intl.DateTimeFormat(locale, { dateStyle: "long" }).format(new Date(ms));
+  } catch {
+    return new Date(ms).toDateString();
+  }
+}
+
+/**
+ * Full single release-note render for the public /releases/[slug] detail page (OJD-1394).
+ * Shares the category + rich-text + media helpers with the in-app feed entry, but lays the note
+ * out as a full article. Wired for Contentful draft preview + live updates + inspector (click-to-edit),
+ * the same way the blog's ArticleContent/ArticleHero are (provider is mounted in [locale]/layout.tsx).
+ */
+export const ReleaseNoteArticle: React.FC<ReleaseNoteArticleProps> = ({ entry }) => {
+  const { t } = useTranslation("navigation");
+  const locale = useCurrentLocale(i18nConfig) ?? "en-US";
+
+  // Live updates reflect unpublished edits in the Contentful preview iframe in real time.
+  const live = useContentfulLiveUpdates(entry);
+  const inspectorProps = useContentfulInspectorMode({ entryId: entry.sys.id });
+
+  const category = getCategoryMeta(live.category);
+  const media = live.media;
+  const publishedLabel = live.publishedAt
+    ? formatAbsoluteDate(live.publishedAt as string, locale)
+    : null;
+
+  return (
+    <article className="flex flex-col gap-6">
+      <header className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <Badge className={category.badgeClassName} {...inspectorProps({ fieldId: "category" })}>
+            {t(category.labelKey)}
+          </Badge>
+          {publishedLabel && (
+            <span
+              className="text-muted-foreground text-sm"
+              {...inspectorProps({ fieldId: "publishedAt" })}
+            >
+              {publishedLabel}
+            </span>
+          )}
+        </div>
+        <h1
+          className="text-foreground text-3xl font-semibold leading-tight md:text-4xl"
+          {...inspectorProps({ fieldId: "title" })}
+        >
+          {live.title}
+        </h1>
+        {live.summary && (
+          <p className="text-muted-foreground text-lg" {...inspectorProps({ fieldId: "summary" })}>
+            {live.summary}
+          </p>
+        )}
+      </header>
+
+      {media?.url && (
+        <div {...inspectorProps({ fieldId: "media" })}>
+          {isVideoAsset(media.contentType) ? (
+            <video
+              src={media.url}
+              title={media.title ?? undefined}
+              autoPlay
+              muted
+              loop
+              playsInline
+              preload="metadata"
+              className="aspect-video w-full rounded-xl object-cover"
+            >
+              {media.contentType && <source src={media.url} type={media.contentType} />}
+            </video>
+          ) : (
+            <img
+              src={`${media.url}?w=1280&fm=webp&fit=fill`}
+              alt={media.description ?? media.title ?? live.title ?? ""}
+              className="aspect-video w-full rounded-xl object-cover"
+            />
+          )}
+        </div>
+      )}
+
+      {live.body?.json && (
+        <div className="max-w-none" {...inspectorProps({ fieldId: "body" })}>
+          <CtfRichText json={live.body.json as Document} />
+        </div>
+      )}
+
+      {live.cta?.url && live.cta.label && (
+        <Button asChild className="w-fit" {...inspectorProps({ fieldId: "cta" })}>
+          <a href={live.cta.url} target="_blank" rel="noopener noreferrer">
+            {live.cta.label}
+            <ArrowRight className="size-4" />
+          </a>
+        </Button>
+      )}
+    </article>
+  );
+};

--- a/packages/cms/src/features/release-notes/release-note-article.tsx
+++ b/packages/cms/src/features/release-notes/release-note-article.tsx
@@ -5,121 +5,36 @@ import {
   useContentfulLiveUpdates,
 } from "@contentful/live-preview/react";
 import type { Document } from "@contentful/rich-text-types";
-import { ArrowRight } from "lucide-react";
 import React from "react";
-
-import { useCurrentLocale, useTranslation } from "@repo/i18n";
-import i18nConfig from "@repo/i18n/config";
-import { Badge } from "@repo/ui/components/badge";
-import { Button } from "@repo/ui/components/button";
 
 import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "../../lib/__generated/sdk";
 import { CtfRichText } from "../contentful/ctf-rich-text";
-import { isVideoAsset } from "../contentful/ctf-video";
-import { getCategoryMeta } from "./category";
+import { ReleaseHero } from "./release-hero";
 
 interface ReleaseNoteArticleProps {
   entry: ReleaseNoteFields;
 }
 
-/** Absolute publish date ("June 30, 2026"); better than relative time on a permalink page. */
-function formatAbsoluteDate(iso: string, locale: string): string | null {
-  const ms = new Date(iso).getTime();
-  if (Number.isNaN(ms)) return null;
-  try {
-    return new Intl.DateTimeFormat(locale, { dateStyle: "long" }).format(new Date(ms));
-  } catch {
-    return new Date(ms).toDateString();
-  }
-}
-
 /**
  * Full single release-note render for the public /releases/[slug] detail page (OJD-1394).
- * Shares the category + rich-text + media helpers with the in-app feed entry, but lays the note
- * out as a full article. Wired for Contentful draft preview + live updates + inspector (click-to-edit),
- * the same way the blog's ArticleContent/ArticleHero are (provider is mounted in [locale]/layout.tsx).
+ * The top reuses the shared `ReleaseHero` (same split card as the /releases index hero) as an
+ * <h1> with no "Read more" self-link, then renders the full rich-text body below it. Wired for
+ * Contentful draft preview + live updates + inspector (click-to-edit) on the body, matching how
+ * the blog's ArticleContent works (provider is mounted in [locale]/layout.tsx).
  */
 export const ReleaseNoteArticle: React.FC<ReleaseNoteArticleProps> = ({ entry }) => {
-  const { t } = useTranslation("navigation");
-  const locale = useCurrentLocale(i18nConfig) ?? "en-US";
-
   // Live updates reflect unpublished edits in the Contentful preview iframe in real time.
   const live = useContentfulLiveUpdates(entry);
   const inspectorProps = useContentfulInspectorMode({ entryId: entry.sys.id });
 
-  const category = getCategoryMeta(live.category);
-  const media = live.media;
-  const publishedLabel = live.publishedAt
-    ? formatAbsoluteDate(live.publishedAt as string, locale)
-    : null;
-
   return (
-    <article className="flex flex-col gap-6">
-      <header className="flex flex-col gap-3">
-        <div className="flex flex-wrap items-center gap-3">
-          <Badge className={category.badgeClassName} {...inspectorProps({ fieldId: "category" })}>
-            {t(category.labelKey)}
-          </Badge>
-          {publishedLabel && (
-            <span
-              className="text-muted-foreground text-sm"
-              {...inspectorProps({ fieldId: "publishedAt" })}
-            >
-              {publishedLabel}
-            </span>
-          )}
-        </div>
-        <h1
-          className="text-foreground text-3xl font-semibold leading-tight md:text-4xl"
-          {...inspectorProps({ fieldId: "title" })}
-        >
-          {live.title}
-        </h1>
-        {live.summary && (
-          <p className="text-muted-foreground text-lg" {...inspectorProps({ fieldId: "summary" })}>
-            {live.summary}
-          </p>
-        )}
-      </header>
-
-      {media?.url && (
-        <div {...inspectorProps({ fieldId: "media" })}>
-          {isVideoAsset(media.contentType) ? (
-            <video
-              src={media.url}
-              title={media.title ?? undefined}
-              autoPlay
-              muted
-              loop
-              playsInline
-              preload="metadata"
-              className="aspect-video w-full rounded-xl object-cover"
-            >
-              {media.contentType && <source src={media.url} type={media.contentType} />}
-            </video>
-          ) : (
-            <img
-              src={`${media.url}?w=1280&fm=webp&fit=fill`}
-              alt={media.description ?? media.title ?? live.title ?? ""}
-              className="aspect-video w-full rounded-xl object-cover"
-            />
-          )}
-        </div>
-      )}
+    <article className="flex flex-col gap-8 lg:gap-10">
+      <ReleaseHero entry={entry} headingLevel="h1" showReadMore={false} />
 
       {live.body?.json && (
         <div className="max-w-none" {...inspectorProps({ fieldId: "body" })}>
           <CtfRichText json={live.body.json as Document} />
         </div>
-      )}
-
-      {live.cta?.url && live.cta.label && (
-        <Button asChild className="w-fit" {...inspectorProps({ fieldId: "cta" })}>
-          <a href={live.cta.url} target="_blank" rel="noopener noreferrer">
-            {live.cta.label}
-            <ArrowRight className="size-4" />
-          </a>
-        </Button>
       )}
     </article>
   );

--- a/packages/cms/src/features/release-notes/release-note-entry.tsx
+++ b/packages/cms/src/features/release-notes/release-note-entry.tsx
@@ -18,6 +18,7 @@ import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "..
 import { CtfRichText } from "../contentful/ctf-rich-text";
 import { isVideoAsset } from "../contentful/ctf-video";
 import { getCategoryMeta } from "./category";
+import { SurfaceBadges } from "./surface-badges";
 
 interface ReleaseNoteEntryProps {
   entry: ReleaseNoteFields;
@@ -125,6 +126,10 @@ export const ReleaseNoteEntry: React.FC<ReleaseNoteEntryProps> = ({
               >
                 {t(category.labelKey)}
               </Badge>
+              <SurfaceBadges
+                surfaces={live.surfaces}
+                inspectorProps={inspectorProps({ fieldId: "surfaces" })}
+              />
               {dateLabel && (
                 <span
                   className="text-muted-foreground font-mono text-xs tabular-nums"

--- a/packages/cms/src/features/release-notes/release-note-entry.tsx
+++ b/packages/cms/src/features/release-notes/release-note-entry.tsx
@@ -1,0 +1,374 @@
+"use client";
+
+import {
+  useContentfulInspectorMode,
+  useContentfulLiveUpdates,
+} from "@contentful/live-preview/react";
+import type { Document } from "@contentful/rich-text-types";
+import { ArrowRight } from "lucide-react";
+import React, { useState } from "react";
+
+import { useCurrentLocale, useTranslation } from "@repo/i18n";
+import i18nConfig from "@repo/i18n/config";
+import { Badge } from "@repo/ui/components/badge";
+import { Button } from "@repo/ui/components/button";
+import { cn } from "@repo/ui/lib/utils";
+
+import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "../../lib/__generated/sdk";
+import { CtfRichText } from "../contentful/ctf-rich-text";
+import { isVideoAsset } from "../contentful/ctf-video";
+import { getCategoryMeta } from "./category";
+
+interface ReleaseNoteEntryProps {
+  entry: ReleaseNoteFields;
+  /**
+   * Base path/URL for the detail page; the entry links to `${linkBaseHref}/${slug}` ("Read more →")
+   * instead of expanding the body inline. A plain string (not a function) so it can cross the
+   * Server→Client component boundary. Omitted, or an entry without a slug, keeps the inline-expand
+   * fallback. e.g. `/en-US/releases` (public list) or `https://openjii.org/releases` (in-app sheet).
+   */
+  linkBaseHref?: string;
+  /** Target for the detail link; `_blank` (e.g. from the in-app sheet to the public site) gets rel=noopener. */
+  linkTarget?: "_blank" | "_self";
+  /** Visual treatment for the entry. `sheet` is denser and card-like for the What's new drawer. */
+  variant?: "default" | "sheet";
+  /**
+   * `default` (timeline) variant only: when true, this is the last node in its month group, so the
+   * vertical rail connector below the dot is omitted. Ignored by the `sheet` variant.
+   */
+  isLast?: boolean;
+}
+
+/** Builds a short relative-time label ("3 days ago") with no extra deps. */
+function formatRelativeTime(iso: string, locale: string): string | null {
+  const ms = new Date(iso).getTime();
+  if (Number.isNaN(ms)) return null;
+
+  const diffSec = Math.round((ms - Date.now()) / 1000);
+  const abs = Math.abs(diffSec);
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+
+  if (abs < 60) return rtf.format(diffSec, "second");
+  if (abs < 3600) return rtf.format(Math.round(diffSec / 60), "minute");
+  if (abs < 86400) return rtf.format(Math.round(diffSec / 3600), "hour");
+  if (abs < 2592000) return rtf.format(Math.round(diffSec / 86400), "day");
+  if (abs < 31536000) return rtf.format(Math.round(diffSec / 2592000), "month");
+  return rtf.format(Math.round(diffSec / 31536000), "year");
+}
+
+/** Compact absolute date ("Jul 1, 2026") — better than relative time on the dated public timeline. */
+function formatShortDate(iso: string, locale: string): string | null {
+  const ms = new Date(iso).getTime();
+  if (Number.isNaN(ms)) return null;
+  try {
+    return new Intl.DateTimeFormat(locale, { dateStyle: "medium" }).format(new Date(ms));
+  } catch {
+    return new Date(ms).toDateString();
+  }
+}
+
+export const ReleaseNoteEntry: React.FC<ReleaseNoteEntryProps> = ({
+  entry,
+  linkBaseHref,
+  linkTarget = "_self",
+  variant = "default",
+  isLast = false,
+}) => {
+  const { t } = useTranslation("navigation");
+  const locale = useCurrentLocale(i18nConfig) ?? "en-US";
+  const [expanded, setExpanded] = useState(false);
+
+  // Live updates reflect unpublished edits in the Contentful preview iframe in real time; inspector
+  // props add click-to-edit overlays. No-ops outside preview. Mirrors the blog's ArticleTile.
+  const live = useContentfulLiveUpdates(entry);
+  const inspectorProps = useContentfulInspectorMode({ entryId: entry.sys.id });
+
+  const category = getCategoryMeta(live.category);
+  const media = live.media;
+  const relativeTime = live.publishedAt
+    ? formatRelativeTime(live.publishedAt as string, locale)
+    : null;
+
+  const href = linkBaseHref && live.slug ? `${linkBaseHref}/${live.slug}` : undefined;
+  const linkRel = linkTarget === "_blank" ? "noopener noreferrer" : undefined;
+  const isSheet = variant === "sheet";
+
+  if (!isSheet) {
+    // Public /releases timeline node (OJD-1394): a category-colored rail dot + connector, then the
+    // note's metadata, title, summary and an optional thumbnail. The rail is what separates this
+    // changelog from the blog's photo-tile grid. The optional CTA sits next to Read more as a
+    // secondary outline button, mirroring the featured hero.
+    const dateLabel = live.publishedAt ? formatShortDate(live.publishedAt as string, locale) : null;
+    const isImage = Boolean(media?.url) && !isVideoAsset(media?.contentType);
+    const canExpand = !href && Boolean(live.body?.json);
+    const hasCta = Boolean(live.cta?.url && live.cta.label);
+
+    return (
+      <article className="relative flex gap-4">
+        {/* rail: category dot + connector down to the next node (omitted on a group's last node) */}
+        <div className="relative flex w-3.5 flex-none flex-col items-center" aria-hidden="true">
+          <span
+            className={cn(
+              "ring-background mt-1.5 size-3.5 flex-none rounded-full ring-4",
+              category.dotClassName,
+            )}
+          />
+          {!isLast && <span className="bg-border mt-1 w-px flex-1" />}
+        </div>
+
+        <div className="flex flex-1 gap-5 pb-9">
+          <div className="flex flex-1 flex-col gap-2">
+            <div className="flex flex-wrap items-center gap-3">
+              <Badge
+                className={category.badgeClassName}
+                {...inspectorProps({ fieldId: "category" })}
+              >
+                {t(category.labelKey)}
+              </Badge>
+              {dateLabel && (
+                <span
+                  className="text-muted-foreground font-mono text-xs tabular-nums"
+                  {...inspectorProps({ fieldId: "publishedAt" })}
+                >
+                  {dateLabel}
+                </span>
+              )}
+            </div>
+
+            <h3
+              className="text-foreground text-lg font-semibold leading-snug"
+              {...inspectorProps({ fieldId: "title" })}
+            >
+              {href ? (
+                <a
+                  href={href}
+                  target={linkTarget}
+                  rel={linkRel}
+                  className="hover:text-primary transition-colors"
+                >
+                  {live.title}
+                </a>
+              ) : (
+                live.title
+              )}
+            </h3>
+
+            {live.summary && (
+              <p
+                className="text-muted-foreground text-sm"
+                {...inspectorProps({ fieldId: "summary" })}
+              >
+                {live.summary}
+              </p>
+            )}
+
+            {(canExpand || hasCta || Boolean(href)) && (
+              <div className="mt-0.5 flex flex-col gap-2">
+                <div className="flex flex-wrap items-center gap-3">
+                  {href ? (
+                    <a
+                      href={href}
+                      target={linkTarget}
+                      rel={linkRel}
+                      className="text-primary inline-flex w-fit items-center gap-1 text-sm font-medium hover:underline"
+                    >
+                      {t("whatsNew.readMore")}
+                      <ArrowRight className="size-3.5" />
+                    </a>
+                  ) : (
+                    canExpand && (
+                      <button
+                        type="button"
+                        onClick={() => setExpanded((prev) => !prev)}
+                        className="text-primary w-fit text-sm font-medium hover:underline"
+                        aria-expanded={expanded}
+                      >
+                        {expanded ? t("whatsNew.showLess") : t("whatsNew.showMore")}
+                      </button>
+                    )
+                  )}
+
+                  {hasCta && (
+                    <a
+                      href={live.cta?.url ?? undefined}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-muted-foreground hover:text-foreground inline-flex w-fit items-center gap-1 text-sm transition-colors"
+                      {...inspectorProps({ fieldId: "cta" })}
+                    >
+                      {live.cta?.label}
+                      <ArrowRight className="size-3.5" />
+                    </a>
+                  )}
+                </div>
+
+                {canExpand && expanded && (
+                  <div className="text-sm [&_*]:text-sm" {...inspectorProps({ fieldId: "body" })}>
+                    <CtfRichText json={live.body?.json as Document} />
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Optional thumbnail — video notes keep a looping preview, images get a fixed crop. */}
+          {media?.url && (
+            <div
+              className="hidden h-24 w-40 flex-none overflow-hidden rounded-lg sm:block"
+              {...inspectorProps({ fieldId: "media" })}
+            >
+              {isImage ? (
+                <img
+                  src={`${media.url}?w=480&h=288&fm=webp&fit=fill`}
+                  alt={media.description ?? media.title ?? live.title ?? ""}
+                  loading="lazy"
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <video
+                  src={media.url}
+                  title={media.title ?? undefined}
+                  autoPlay
+                  muted
+                  loop
+                  playsInline
+                  preload="metadata"
+                  className="h-full w-full object-cover"
+                >
+                  {media.contentType && <source src={media.url} type={media.contentType} />}
+                </video>
+              )}
+            </div>
+          )}
+        </div>
+      </article>
+    );
+  }
+
+  return (
+    <article className="border-border bg-card shadow-xs hover:border-primary/30 overflow-hidden rounded-lg border transition-colors">
+      {media?.url && (
+        <div {...inspectorProps({ fieldId: "media" })}>
+          {isVideoAsset(media.contentType) ? (
+            <video
+              src={media.url}
+              title={media.title ?? undefined}
+              autoPlay
+              muted
+              loop
+              playsInline
+              preload="metadata"
+              className="aspect-video w-full object-cover"
+            >
+              {media.contentType && <source src={media.url} type={media.contentType} />}
+            </video>
+          ) : (
+            <img
+              src={`${media.url}?w=960&fm=webp&fit=fill`}
+              alt={media.description ?? media.title ?? live.title ?? ""}
+              loading="lazy"
+              className="aspect-video w-full object-cover"
+            />
+          )}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2 p-4">
+        <div className="flex items-center justify-between gap-3">
+          <Badge
+            className={cn("shrink-0", category.badgeClassName)}
+            {...inspectorProps({ fieldId: "category" })}
+          >
+            {t(category.labelKey)}
+          </Badge>
+          {relativeTime && (
+            <p
+              className="text-muted-foreground text-xs"
+              {...inspectorProps({ fieldId: "publishedAt" })}
+            >
+              {relativeTime}
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-start justify-between gap-3">
+          <h3
+            className="text-foreground flex-1 text-[15px] font-semibold leading-snug"
+            {...inspectorProps({ fieldId: "title" })}
+          >
+            {href ? (
+              <a
+                href={href}
+                target={linkTarget}
+                rel={linkRel}
+                className="hover:text-primary transition-colors"
+              >
+                {live.title}
+              </a>
+            ) : (
+              live.title
+            )}
+          </h3>
+        </div>
+
+        {live.summary && (
+          <p
+            className="text-muted-foreground text-sm leading-5"
+            {...inspectorProps({ fieldId: "summary" })}
+          >
+            {live.summary}
+          </p>
+        )}
+
+        <div className="flex flex-wrap items-center gap-2 pt-1">
+          {href ? (
+            <a
+              href={href}
+              target={linkTarget}
+              rel={linkRel}
+              className="bg-primary text-primary-foreground hover:bg-primary-light inline-flex w-fit items-center gap-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
+            >
+              {t("whatsNew.readMore")}
+              <ArrowRight className="size-3.5" />
+            </a>
+          ) : (
+            live.body?.json && (
+              <button
+                type="button"
+                onClick={() => setExpanded((prev) => !prev)}
+                className="text-primary hover:bg-primary/10 w-fit rounded-md px-3 py-1.5 text-sm font-medium transition-colors"
+                aria-expanded={expanded}
+              >
+                {expanded ? t("whatsNew.showLess") : t("whatsNew.showMore")}
+              </button>
+            )
+          )}
+
+          {live.cta?.url && live.cta.label && (
+            <Button
+              asChild
+              size="sm"
+              variant="secondary"
+              className="w-fit"
+              {...inspectorProps({ fieldId: "cta" })}
+            >
+              <a href={live.cta.url} target="_blank" rel="noopener noreferrer">
+                {live.cta.label}
+                <ArrowRight className="size-3.5" />
+              </a>
+            </Button>
+          )}
+        </div>
+
+        {expanded && live.body?.json && (
+          <div
+            className="border-border border-t pt-3 text-sm [&_*]:text-sm"
+            {...inspectorProps({ fieldId: "body" })}
+          >
+            <CtfRichText json={live.body.json as Document} />
+          </div>
+        )}
+      </div>
+    </article>
+  );
+};

--- a/packages/cms/src/features/release-notes/release-notes-feed.tsx
+++ b/packages/cms/src/features/release-notes/release-notes-feed.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import React from "react";
+
+import { useCurrentLocale, useTranslation } from "@repo/i18n";
+import i18nConfig from "@repo/i18n/config";
+import { cn } from "@repo/ui/lib/utils";
+
+import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "../../lib/__generated/sdk";
+import { ReleaseNoteEntry } from "./release-note-entry";
+
+interface ReleaseNotesFeedProps {
+  entries: ReleaseNoteFields[];
+  /** Passed through to each entry; entries link to `${linkBaseHref}/${slug}` when both are present. */
+  linkBaseHref?: string;
+  /** Target for entry detail links (default same-tab). */
+  linkTarget?: "_blank" | "_self";
+  /** Visual treatment for the feed entries. `sheet` is used by the in-app What's new panel. */
+  variant?: "default" | "sheet";
+}
+
+interface MonthGroup {
+  key: string;
+  label: string;
+  entries: ReleaseNoteFields[];
+}
+
+/** Groups entries by month, preserving the incoming newest-first order. */
+function groupByMonth(entries: ReleaseNoteFields[], locale: string): MonthGroup[] {
+  const order: MonthGroup[] = [];
+  const byKey = new Map<string, MonthGroup>();
+
+  for (const entry of entries) {
+    const date = entry.publishedAt ? new Date(entry.publishedAt as string) : null;
+    const valid = date !== null && !Number.isNaN(date.getTime());
+    const key = valid ? `${date.getFullYear()}-${date.getMonth()}` : "undated";
+
+    let group = byKey.get(key);
+    if (!group) {
+      const label =
+        valid && date
+          ? new Intl.DateTimeFormat(locale, { month: "long", year: "numeric" }).format(date)
+          : "";
+      group = { key, label, entries: [] };
+      byKey.set(key, group);
+      order.push(group);
+    }
+    group.entries.push(entry);
+  }
+
+  return order;
+}
+
+/**
+ * Renders release notes grouped by month (newest first). Shared between the web "What's new"
+ * sheet and (later) the public openjii.org/releases page — entries come from Contentful via the
+ * generated `activeReleaseNotes` query. Pure presentation; read-state lives in the consuming app.
+ */
+export const ReleaseNotesFeed: React.FC<ReleaseNotesFeedProps> = ({
+  entries,
+  linkBaseHref,
+  linkTarget,
+  variant = "default",
+}) => {
+  const { t } = useTranslation("navigation");
+  const locale = useCurrentLocale(i18nConfig) ?? "en-US";
+
+  if (entries.length === 0) {
+    return <p className="text-muted-foreground text-sm">{t("whatsNew.empty")}</p>;
+  }
+
+  const groups = groupByMonth(entries, locale);
+  const isSheet = variant === "sheet";
+
+  return (
+    <div className={cn("flex flex-col", isSheet ? "gap-8" : "gap-10")}>
+      {groups.map((group) => (
+        <section key={group.key} className={cn("flex flex-col", isSheet ? "gap-5" : "gap-4")}>
+          {group.label && (
+            <h2
+              className={cn(
+                "text-muted-foreground uppercase",
+                isSheet
+                  ? "text-xs font-semibold tracking-wide"
+                  : "font-mono text-xs font-medium tracking-[0.14em]",
+              )}
+            >
+              {group.label}
+            </h2>
+          )}
+          {isSheet ? (
+            group.entries.map((entry) => (
+              <ReleaseNoteEntry
+                key={entry.sys.id}
+                entry={entry}
+                linkBaseHref={linkBaseHref}
+                linkTarget={linkTarget}
+                variant={variant}
+              />
+            ))
+          ) : (
+            // Timeline: no gap between nodes — each node's rail connector bridges the spacing.
+            <div className="flex flex-col">
+              {group.entries.map((entry, index) => (
+                <ReleaseNoteEntry
+                  key={entry.sys.id}
+                  entry={entry}
+                  linkBaseHref={linkBaseHref}
+                  linkTarget={linkTarget}
+                  variant={variant}
+                  isLast={index === group.entries.length - 1}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      ))}
+    </div>
+  );
+};

--- a/packages/cms/src/features/release-notes/release-notes-feed.tsx
+++ b/packages/cms/src/features/release-notes/release-notes-feed.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Newspaper } from "lucide-react";
 import React from "react";
 
 import { useCurrentLocale, useTranslation } from "@repo/i18n";
@@ -23,6 +24,47 @@ interface MonthGroup {
   key: string;
   label: string;
   entries: ReleaseNoteFields[];
+}
+
+function ReleaseNotesEmptyState({ variant }: { variant: "default" | "sheet" }) {
+  const { t } = useTranslation("navigation");
+  const isSheet = variant === "sheet";
+
+  return (
+    <section
+      className={cn(
+        "flex flex-col items-center justify-center text-center",
+        isSheet
+          ? "min-h-72 px-4 py-12"
+          : "border-border bg-muted/20 min-h-96 rounded-lg border border-dashed px-6 py-20",
+      )}
+    >
+      <div
+        className={cn(
+          "border-border bg-background text-muted-foreground flex items-center justify-center rounded-full border",
+          isSheet ? "size-14" : "size-16",
+        )}
+      >
+        <Newspaper className={isSheet ? "size-6" : "size-7"} aria-hidden="true" />
+      </div>
+      <h2
+        className={cn(
+          "text-foreground mt-5 font-semibold",
+          isSheet ? "text-base" : "text-xl sm:text-2xl",
+        )}
+      >
+        {isSheet ? t("whatsNew.emptyTitle") : t("releases.emptyTitle")}
+      </h2>
+      <p
+        className={cn(
+          "text-muted-foreground mt-2 max-w-md text-sm leading-6",
+          !isSheet && "sm:text-base",
+        )}
+      >
+        {isSheet ? t("whatsNew.emptyDescription") : t("releases.emptyDescription")}
+      </p>
+    </section>
+  );
 }
 
 /** Groups entries by month, preserving the incoming newest-first order. */
@@ -62,15 +104,14 @@ export const ReleaseNotesFeed: React.FC<ReleaseNotesFeedProps> = ({
   linkTarget,
   variant = "default",
 }) => {
-  const { t } = useTranslation("navigation");
   const locale = useCurrentLocale(i18nConfig) ?? "en-US";
+  const isSheet = variant === "sheet";
 
   if (entries.length === 0) {
-    return <p className="text-muted-foreground text-sm">{t("whatsNew.empty")}</p>;
+    return <ReleaseNotesEmptyState variant={variant} />;
   }
 
   const groups = groupByMonth(entries, locale);
-  const isSheet = variant === "sheet";
 
   return (
     <div className={cn("flex flex-col", isSheet ? "gap-8" : "gap-10")}>

--- a/packages/cms/src/features/release-notes/surface-badges.tsx
+++ b/packages/cms/src/features/release-notes/surface-badges.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Monitor, Smartphone } from "lucide-react";
+import React from "react";
+
+import { useTranslation } from "@repo/i18n";
+import { Badge } from "@repo/ui/components/badge";
+
+type SurfaceKey = "web" | "mobile";
+
+const SURFACE_META: Record<
+  SurfaceKey,
+  { labelKey: `whatsNew.surface.${SurfaceKey}`; Icon: typeof Monitor }
+> = {
+  web: { labelKey: "whatsNew.surface.web", Icon: Monitor },
+  mobile: { labelKey: "whatsNew.surface.mobile", Icon: Smartphone },
+};
+
+/**
+ * Resolves the single-select `surfaces` field to the surface badges to show. `both` renders both
+ * a Web and a Mobile badge (rather than one "Both" badge); an unset/unknown value renders nothing.
+ */
+function surfaceKeys(surfaces?: string | null): SurfaceKey[] {
+  switch (surfaces) {
+    case "web":
+      return ["web"];
+    case "mobile":
+      return ["mobile"];
+    case "both":
+      return ["web", "mobile"];
+    default:
+      return [];
+  }
+}
+
+interface SurfaceBadgesProps {
+  /** The release note's `surfaces` value (web / mobile / both). */
+  surfaces?: string | null;
+  /** Spread onto each badge for Contentful inspector click-to-edit (the `surfaces` field). */
+  inspectorProps?: Record<string, unknown> | null;
+}
+
+/**
+ * Neutral outline badges marking which app(s) a release note targets — shown next to the category
+ * badge on the public /releases hero and timeline. Visually distinct from the (colored) category
+ * badge so the two read as separate dimensions.
+ */
+export const SurfaceBadges: React.FC<SurfaceBadgesProps> = ({ surfaces, inspectorProps }) => {
+  const { t } = useTranslation("navigation");
+  const keys = surfaceKeys(surfaces);
+
+  return (
+    <>
+      {keys.map((key) => {
+        const { labelKey, Icon } = SURFACE_META[key];
+        return (
+          <Badge
+            key={key}
+            variant="outline"
+            className="border-border text-muted-foreground gap-1 font-normal"
+            {...inspectorProps}
+          >
+            <Icon className="size-3" />
+            {t(labelKey)}
+          </Badge>
+        );
+      })}
+    </>
+  );
+};

--- a/packages/cms/src/index.ts
+++ b/packages/cms/src/index.ts
@@ -31,7 +31,7 @@ export type { PageForceUpdateFieldsFragment } from "./lib/__generated/sdk";
 export { ReleaseNotesFeed } from "./features/release-notes/release-notes-feed";
 export { ReleaseNoteEntry } from "./features/release-notes/release-note-entry";
 export { ReleaseNoteArticle } from "./features/release-notes/release-note-article";
-export { ReleaseFeature } from "./features/release-notes/release-feature";
+export { ReleaseHero } from "./features/release-notes/release-hero";
 export type { ComponentReleaseNoteFieldsFragment } from "./lib/__generated/sdk";
 export {
   getCategoryMeta,

--- a/packages/cms/src/index.ts
+++ b/packages/cms/src/index.ts
@@ -35,6 +35,7 @@ export { ReleaseHero } from "./features/release-notes/release-hero";
 export type { ComponentReleaseNoteFieldsFragment } from "./lib/__generated/sdk";
 export {
   getCategoryMeta,
+  normalizeCategory,
   RELEASE_CATEGORIES,
   type ReleaseCategory,
   type CategoryMeta,

--- a/packages/cms/src/index.ts
+++ b/packages/cms/src/index.ts
@@ -26,3 +26,16 @@ export { HomeFooter } from "./features/footer";
 export { AlertsContainer } from "./features/alert/alerts-container";
 export type { ComponentAlertFieldsFragment } from "./lib/__generated/sdk";
 export type { PageForceUpdateFieldsFragment } from "./lib/__generated/sdk";
+
+// What's new / release notes + public /releases page (OJD-1394)
+export { ReleaseNotesFeed } from "./features/release-notes/release-notes-feed";
+export { ReleaseNoteEntry } from "./features/release-notes/release-note-entry";
+export { ReleaseNoteArticle } from "./features/release-notes/release-note-article";
+export { ReleaseFeature } from "./features/release-notes/release-feature";
+export type { ComponentReleaseNoteFieldsFragment } from "./lib/__generated/sdk";
+export {
+  getCategoryMeta,
+  RELEASE_CATEGORIES,
+  type ReleaseCategory,
+  type CategoryMeta,
+} from "./features/release-notes/category";

--- a/packages/cms/src/lib/__generated/graphql.schema.graphql
+++ b/packages/cms/src/lib/__generated/graphql.schema.graphql
@@ -118,6 +118,8 @@ type AssetLinkingCollections {
   componentFeatureCursorCollection(limit: Int = 100, locale: String, pageNext: String, pagePrev: String, preview: Boolean, useFallbackLocale: Boolean): ComponentFeatureCursorCollection
   componentPartnerCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0, useFallbackLocale: Boolean): ComponentPartnerCollection
   componentPartnerCursorCollection(limit: Int = 100, locale: String, pageNext: String, pagePrev: String, preview: Boolean, useFallbackLocale: Boolean): ComponentPartnerCursorCollection
+  componentReleaseNoteCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0, useFallbackLocale: Boolean): ComponentReleaseNoteCollection
+  componentReleaseNoteCursorCollection(limit: Int = 100, locale: String, pageNext: String, pagePrev: String, preview: Boolean, useFallbackLocale: Boolean): ComponentReleaseNoteCursorCollection
   componentRichImageCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0, useFallbackLocale: Boolean): ComponentRichImageCollection
   componentRichImageCursorCollection(limit: Int = 100, locale: String, pageNext: String, pagePrev: String, preview: Boolean, useFallbackLocale: Boolean): ComponentRichImageCursorCollection
   componentSeoCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0, useFallbackLocale: Boolean): ComponentSeoCollection
@@ -515,6 +517,8 @@ input ComponentButtonFilter {
 type ComponentButtonLinkingCollections {
   componentAlertCollection(limit: Int = 100, locale: String, order: [ComponentButtonLinkingCollectionsComponentAlertCollectionOrder], preview: Boolean, skip: Int = 0, useFallbackLocale: Boolean): ComponentAlertCollection
   componentAlertCursorCollection(limit: Int = 100, locale: String, order: [ComponentButtonLinkingCollectionsComponentAlertCursorCollectionOrder], pageNext: String, pagePrev: String, preview: Boolean, useFallbackLocale: Boolean): ComponentAlertCursorCollection
+  componentReleaseNoteCollection(limit: Int = 100, locale: String, order: [ComponentButtonLinkingCollectionsComponentReleaseNoteCollectionOrder], preview: Boolean, skip: Int = 0, useFallbackLocale: Boolean): ComponentReleaseNoteCollection
+  componentReleaseNoteCursorCollection(limit: Int = 100, locale: String, order: [ComponentButtonLinkingCollectionsComponentReleaseNoteCursorCollectionOrder], pageNext: String, pagePrev: String, preview: Boolean, useFallbackLocale: Boolean): ComponentReleaseNoteCursorCollection
   entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0, useFallbackLocale: Boolean): EntryCollection
   entryCursorCollection(limit: Int = 100, locale: String, pageNext: String, pagePrev: String, preview: Boolean, useFallbackLocale: Boolean): EntryCursorCollection
   footerCollection(limit: Int = 100, locale: String, order: [ComponentButtonLinkingCollectionsFooterCollectionOrder], preview: Boolean, skip: Int = 0, useFallbackLocale: Boolean): FooterCollection
@@ -581,6 +585,60 @@ enum ComponentButtonLinkingCollectionsComponentAlertCursorCollectionOrder {
   title_DESC
   type_ASC
   type_DESC
+}
+
+enum ComponentButtonLinkingCollectionsComponentReleaseNoteCollectionOrder {
+  active_ASC
+  active_DESC
+  category_ASC
+  category_DESC
+  internalName_ASC
+  internalName_DESC
+  publishedAt_ASC
+  publishedAt_DESC
+  slug_ASC
+  slug_DESC
+  summary_ASC
+  summary_DESC
+  surfaces_ASC
+  surfaces_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
+}
+
+enum ComponentButtonLinkingCollectionsComponentReleaseNoteCursorCollectionOrder {
+  active_ASC
+  active_DESC
+  category_ASC
+  category_DESC
+  internalName_ASC
+  internalName_DESC
+  publishedAt_ASC
+  publishedAt_DESC
+  slug_ASC
+  slug_DESC
+  summary_ASC
+  summary_DESC
+  surfaces_ASC
+  surfaces_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
 }
 
 enum ComponentButtonLinkingCollectionsFooterCollectionOrder {
@@ -1259,6 +1317,182 @@ enum ComponentPartnerOrder {
 }
 
 """
+[See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote)
+"""
+type ComponentReleaseNote implements Entry & _Node {
+  _id: ID!
+  active(locale: String, useFallbackLocale: Boolean): Boolean
+  body(locale: String, useFallbackLocale: Boolean): ComponentReleaseNoteBody
+  category(locale: String, useFallbackLocale: Boolean): String
+  contentfulMetadata: ContentfulMetadata!
+  cta(locale: String, preview: Boolean, useFallbackLocale: Boolean, where: ComponentButtonFilter): ComponentButton
+  internalName(locale: String, useFallbackLocale: Boolean): String
+  linkedFrom(allowedLocales: [String]): ComponentReleaseNoteLinkingCollections
+  media(locale: String, preview: Boolean, useFallbackLocale: Boolean): Asset
+  publishedAt(locale: String, useFallbackLocale: Boolean): DateTime
+  seoFields(locale: String, preview: Boolean, useFallbackLocale: Boolean, where: ComponentSeoFilter): ComponentSeo
+  slug(locale: String, useFallbackLocale: Boolean): String
+  summary(locale: String, useFallbackLocale: Boolean): String
+  surfaces(locale: String, useFallbackLocale: Boolean): String
+  sys: Sys!
+  title(locale: String, useFallbackLocale: Boolean): String
+}
+
+type ComponentReleaseNoteBody {
+  json: JSON!
+  links: ComponentReleaseNoteBodyLinks!
+}
+
+type ComponentReleaseNoteBodyAssets {
+  block: [Asset]!
+  hyperlink: [Asset]!
+}
+
+type ComponentReleaseNoteBodyEntries {
+  block: [Entry]!
+  hyperlink: [Entry]!
+  inline: [Entry]!
+}
+
+type ComponentReleaseNoteBodyLinks {
+  assets: ComponentReleaseNoteBodyAssets!
+  entries: ComponentReleaseNoteBodyEntries!
+  resources: ComponentReleaseNoteBodyResources!
+}
+
+type ComponentReleaseNoteBodyResources {
+  block: [ComponentReleaseNoteBodyResourcesBlock!]!
+  hyperlink: [ComponentReleaseNoteBodyResourcesHyperlink!]!
+  inline: [ComponentReleaseNoteBodyResourcesInline!]!
+}
+
+type ComponentReleaseNoteBodyResourcesBlock implements ResourceLink {
+  sys: ResourceSys!
+}
+
+type ComponentReleaseNoteBodyResourcesHyperlink implements ResourceLink {
+  sys: ResourceSys!
+}
+
+type ComponentReleaseNoteBodyResourcesInline implements ResourceLink {
+  sys: ResourceSys!
+}
+
+type ComponentReleaseNoteCollection {
+  items: [ComponentReleaseNote]!
+  limit: Int!
+  skip: Int!
+  total: Int!
+}
+
+type ComponentReleaseNoteCursorCollection {
+  items: [ComponentReleaseNote]!
+  limit: Int!
+  pages: CursorPages!
+}
+
+input ComponentReleaseNoteFilter {
+  AND: [ComponentReleaseNoteFilter]
+  OR: [ComponentReleaseNoteFilter]
+  active: Boolean
+  active_exists: Boolean
+  active_not: Boolean
+  body_contains: String
+  body_exists: Boolean
+  body_not_contains: String
+  category: String
+  category_contains: String
+  category_exists: Boolean
+  category_in: [String]
+  category_not: String
+  category_not_contains: String
+  category_not_in: [String]
+  contentfulMetadata: ContentfulMetadataFilter
+  cta: cfComponentButtonNestedFilter
+  cta_exists: Boolean
+  internalName: String
+  internalName_contains: String
+  internalName_exists: Boolean
+  internalName_in: [String]
+  internalName_not: String
+  internalName_not_contains: String
+  internalName_not_in: [String]
+  media_exists: Boolean
+  publishedAt: DateTime
+  publishedAt_exists: Boolean
+  publishedAt_gt: DateTime
+  publishedAt_gte: DateTime
+  publishedAt_in: [DateTime]
+  publishedAt_lt: DateTime
+  publishedAt_lte: DateTime
+  publishedAt_not: DateTime
+  publishedAt_not_in: [DateTime]
+  seoFields: cfComponentSeoNestedFilter
+  seoFields_exists: Boolean
+  slug: String
+  slug_contains: String
+  slug_exists: Boolean
+  slug_in: [String]
+  slug_not: String
+  slug_not_contains: String
+  slug_not_in: [String]
+  summary: String
+  summary_contains: String
+  summary_exists: Boolean
+  summary_in: [String]
+  summary_not: String
+  summary_not_contains: String
+  summary_not_in: [String]
+  surfaces: String
+  surfaces_contains: String
+  surfaces_exists: Boolean
+  surfaces_in: [String]
+  surfaces_not: String
+  surfaces_not_contains: String
+  surfaces_not_in: [String]
+  sys: SysFilter
+  title: String
+  title_contains: String
+  title_exists: Boolean
+  title_in: [String]
+  title_not: String
+  title_not_contains: String
+  title_not_in: [String]
+}
+
+type ComponentReleaseNoteLinkingCollections {
+  entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0, useFallbackLocale: Boolean): EntryCollection
+  entryCursorCollection(limit: Int = 100, locale: String, pageNext: String, pagePrev: String, preview: Boolean, useFallbackLocale: Boolean): EntryCursorCollection
+}
+
+enum ComponentReleaseNoteOrder {
+  active_ASC
+  active_DESC
+  category_ASC
+  category_DESC
+  internalName_ASC
+  internalName_DESC
+  publishedAt_ASC
+  publishedAt_DESC
+  slug_ASC
+  slug_DESC
+  summary_ASC
+  summary_DESC
+  surfaces_ASC
+  surfaces_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
+}
+
+"""
 [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentRichImage)
 """
 type ComponentRichImage implements Entry & _Node {
@@ -1406,12 +1640,68 @@ input ComponentSeoFilter {
 }
 
 type ComponentSeoLinkingCollections {
+  componentReleaseNoteCollection(limit: Int = 100, locale: String, order: [ComponentSeoLinkingCollectionsComponentReleaseNoteCollectionOrder], preview: Boolean, skip: Int = 0, useFallbackLocale: Boolean): ComponentReleaseNoteCollection
+  componentReleaseNoteCursorCollection(limit: Int = 100, locale: String, order: [ComponentSeoLinkingCollectionsComponentReleaseNoteCursorCollectionOrder], pageNext: String, pagePrev: String, preview: Boolean, useFallbackLocale: Boolean): ComponentReleaseNoteCursorCollection
   entryCollection(limit: Int = 100, locale: String, preview: Boolean, skip: Int = 0, useFallbackLocale: Boolean): EntryCollection
   entryCursorCollection(limit: Int = 100, locale: String, pageNext: String, pagePrev: String, preview: Boolean, useFallbackLocale: Boolean): EntryCursorCollection
   pageBlogPostCollection(limit: Int = 100, locale: String, order: [ComponentSeoLinkingCollectionsPageBlogPostCollectionOrder], preview: Boolean, skip: Int = 0, useFallbackLocale: Boolean): PageBlogPostCollection
   pageBlogPostCursorCollection(limit: Int = 100, locale: String, order: [ComponentSeoLinkingCollectionsPageBlogPostCursorCollectionOrder], pageNext: String, pagePrev: String, preview: Boolean, useFallbackLocale: Boolean): PageBlogPostCursorCollection
   pageLandingCollection(limit: Int = 100, locale: String, order: [ComponentSeoLinkingCollectionsPageLandingCollectionOrder], preview: Boolean, skip: Int = 0, useFallbackLocale: Boolean): PageLandingCollection
   pageLandingCursorCollection(limit: Int = 100, locale: String, order: [ComponentSeoLinkingCollectionsPageLandingCursorCollectionOrder], pageNext: String, pagePrev: String, preview: Boolean, useFallbackLocale: Boolean): PageLandingCursorCollection
+}
+
+enum ComponentSeoLinkingCollectionsComponentReleaseNoteCollectionOrder {
+  active_ASC
+  active_DESC
+  category_ASC
+  category_DESC
+  internalName_ASC
+  internalName_DESC
+  publishedAt_ASC
+  publishedAt_DESC
+  slug_ASC
+  slug_DESC
+  summary_ASC
+  summary_DESC
+  surfaces_ASC
+  surfaces_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
+}
+
+enum ComponentSeoLinkingCollectionsComponentReleaseNoteCursorCollectionOrder {
+  active_ASC
+  active_DESC
+  category_ASC
+  category_DESC
+  internalName_ASC
+  internalName_DESC
+  publishedAt_ASC
+  publishedAt_DESC
+  slug_ASC
+  slug_DESC
+  summary_ASC
+  summary_DESC
+  surfaces_ASC
+  surfaces_DESC
+  sys_firstPublishedAt_ASC
+  sys_firstPublishedAt_DESC
+  sys_id_ASC
+  sys_id_DESC
+  sys_publishedAt_ASC
+  sys_publishedAt_DESC
+  sys_publishedVersion_ASC
+  sys_publishedVersion_DESC
+  title_ASC
+  title_DESC
 }
 
 enum ComponentSeoLinkingCollectionsPageBlogPostCollectionOrder {
@@ -3865,6 +4155,9 @@ type Query {
   componentPartner(id: String!, locale: String, preview: Boolean, useFallbackLocale: Boolean): ComponentPartner
   componentPartnerCollection(limit: Int = 100, locale: String, order: [ComponentPartnerOrder], preview: Boolean, skip: Int = 0, useFallbackLocale: Boolean, where: ComponentPartnerFilter): ComponentPartnerCollection
   componentPartnerCursorCollection(limit: Int = 100, locale: String, order: [ComponentPartnerOrder], pageNext: String, pagePrev: String, preview: Boolean, useFallbackLocale: Boolean, where: ComponentPartnerFilter): ComponentPartnerCursorCollection
+  componentReleaseNote(id: String!, locale: String, preview: Boolean, useFallbackLocale: Boolean): ComponentReleaseNote
+  componentReleaseNoteCollection(limit: Int = 100, locale: String, order: [ComponentReleaseNoteOrder], preview: Boolean, skip: Int = 0, useFallbackLocale: Boolean, where: ComponentReleaseNoteFilter): ComponentReleaseNoteCollection
+  componentReleaseNoteCursorCollection(limit: Int = 100, locale: String, order: [ComponentReleaseNoteOrder], pageNext: String, pagePrev: String, preview: Boolean, useFallbackLocale: Boolean, where: ComponentReleaseNoteFilter): ComponentReleaseNoteCursorCollection
   componentRichImage(id: String!, locale: String, preview: Boolean, useFallbackLocale: Boolean): ComponentRichImage
   componentRichImageCollection(limit: Int = 100, locale: String, order: [ComponentRichImageOrder], preview: Boolean, skip: Int = 0, useFallbackLocale: Boolean, where: ComponentRichImageFilter): ComponentRichImageCollection
   componentRichImageCursorCollection(limit: Int = 100, locale: String, order: [ComponentRichImageOrder], pageNext: String, pagePrev: String, preview: Boolean, useFallbackLocale: Boolean, where: ComponentRichImageFilter): ComponentRichImageCursorCollection

--- a/packages/cms/src/lib/__generated/graphql.schema.json
+++ b/packages/cms/src/lib/__generated/graphql.schema.json
@@ -63309,18 +63309,14 @@
         "name": "contentSourceMaps",
         "description": null,
         "isRepeatable": false,
-        "locations": [
-          "QUERY"
-        ],
+        "locations": ["QUERY"],
         "args": []
       },
       {
         "name": "contentfulSchemaMetadata",
         "description": null,
         "isRepeatable": false,
-        "locations": [
-          "SCHEMA"
-        ],
+        "locations": ["SCHEMA"],
         "args": [
           {
             "name": "contentTypePublishedCounters",
@@ -63340,10 +63336,7 @@
         "name": "delegatedResourceLink",
         "description": null,
         "isRepeatable": false,
-        "locations": [
-          "FIELD_DEFINITION",
-          "OBJECT"
-        ],
+        "locations": ["FIELD_DEFINITION", "OBJECT"],
         "args": [
           {
             "name": "contentTypeId",
@@ -63400,9 +63393,7 @@
         "name": "enumMapper",
         "description": null,
         "isRepeatable": false,
-        "locations": [
-          "ENUM_VALUE"
-        ],
+        "locations": ["ENUM_VALUE"],
         "args": [
           {
             "name": "value",
@@ -63422,9 +63413,7 @@
         "name": "featureFlag",
         "description": null,
         "isRepeatable": false,
-        "locations": [
-          "FIELD"
-        ],
+        "locations": ["FIELD"],
         "args": [
           {
             "name": "featureName",
@@ -63444,9 +63433,7 @@
         "name": "fieldResolver",
         "description": null,
         "isRepeatable": false,
-        "locations": [
-          "FIELD_DEFINITION"
-        ],
+        "locations": ["FIELD_DEFINITION"],
         "args": [
           {
             "name": "data",
@@ -63478,11 +63465,7 @@
         "name": "include",
         "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
         "isRepeatable": false,
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "args": [
           {
             "name": "if",
@@ -63506,20 +63489,14 @@
         "name": "oneOf",
         "description": "Indicates exactly one field must be supplied and this field must not be `null`.",
         "isRepeatable": false,
-        "locations": [
-          "INPUT_OBJECT"
-        ],
+        "locations": ["INPUT_OBJECT"],
         "args": []
       },
       {
         "name": "skip",
         "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
         "isRepeatable": false,
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "args": [
           {
             "name": "if",
@@ -63543,9 +63520,7 @@
         "name": "specifiedBy",
         "description": "Exposes a URL that specifies the behavior of this scalar.",
         "isRepeatable": false,
-        "locations": [
-          "SCALAR"
-        ],
+        "locations": ["SCALAR"],
         "args": [
           {
             "name": "url",
@@ -63569,9 +63544,7 @@
         "name": "timeline",
         "description": null,
         "isRepeatable": false,
-        "locations": [
-          "QUERY"
-        ],
+        "locations": ["QUERY"],
         "args": [
           {
             "name": "where",
@@ -63595,9 +63568,7 @@
         "name": "typeIdentifier",
         "description": null,
         "isRepeatable": false,
-        "locations": [
-          "OBJECT"
-        ],
+        "locations": ["OBJECT"],
         "args": [
           {
             "name": "contentTypeId",

--- a/packages/cms/src/lib/__generated/graphql.schema.json
+++ b/packages/cms/src/lib/__generated/graphql.schema.json
@@ -1889,6 +1889,164 @@
             "deprecationReason": null
           },
           {
+            "name": "componentReleaseNoteCollection",
+            "description": null,
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "100",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "preview",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "skip",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "0",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ComponentReleaseNoteCollection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "componentReleaseNoteCursorCollection",
+            "description": null,
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "100",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "pageNext",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "pagePrev",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "preview",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ComponentReleaseNoteCursorCollection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "componentRichImageCollection",
             "description": null,
             "args": [
@@ -8106,6 +8264,196 @@
             "deprecationReason": null
           },
           {
+            "name": "componentReleaseNoteCollection",
+            "description": null,
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "100",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "ComponentButtonLinkingCollectionsComponentReleaseNoteCollectionOrder",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "preview",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "skip",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "0",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ComponentReleaseNoteCollection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "componentReleaseNoteCursorCollection",
+            "description": null,
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "100",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "ComponentButtonLinkingCollectionsComponentReleaseNoteCursorCollectionOrder",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "pageNext",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "pagePrev",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "preview",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ComponentReleaseNoteCursorCollection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "entryCollection",
             "description": null,
             "args": [
@@ -9168,6 +9516,318 @@
           },
           {
             "name": "type_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ComponentButtonLinkingCollectionsComponentReleaseNoteCollectionOrder",
+        "description": null,
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "active_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "category_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "category_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalName_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalName_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "surfaces_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "surfaces_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_firstPublishedAt_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_firstPublishedAt_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_id_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_id_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedAt_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedAt_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedVersion_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedVersion_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ComponentButtonLinkingCollectionsComponentReleaseNoteCursorCollectionOrder",
+        "description": null,
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "active_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "category_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "category_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalName_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalName_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "surfaces_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "surfaces_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_firstPublishedAt_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_firstPublishedAt_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_id_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_id_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedAt_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedAt_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedVersion_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedVersion_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title_DESC",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -16348,6 +17008,2362 @@
       },
       {
         "kind": "OBJECT",
+        "name": "ComponentReleaseNote",
+        "description": "[See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote)",
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "_id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "body",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ComponentReleaseNoteBody",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "category",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contentfulMetadata",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ContentfulMetadata",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cta",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "preview",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ComponentButtonFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ComponentButton",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalName",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "linkedFrom",
+            "description": null,
+            "args": [
+              {
+                "name": "allowedLocales",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ComponentReleaseNoteLinkingCollections",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "media",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "preview",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Asset",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "seoFields",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "preview",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ComponentSeoFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ComponentSeo",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "surfaces",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Sys",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": null,
+            "args": [
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Entry",
+            "ofType": null
+          },
+          {
+            "kind": "INTERFACE",
+            "name": "_Node",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ComponentReleaseNoteBody",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "json",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "links",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ComponentReleaseNoteBodyLinks",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ComponentReleaseNoteBodyAssets",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "block",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Asset",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hyperlink",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Asset",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ComponentReleaseNoteBodyEntries",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "block",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "Entry",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hyperlink",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "Entry",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "inline",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "Entry",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ComponentReleaseNoteBodyLinks",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "assets",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ComponentReleaseNoteBodyAssets",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "entries",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ComponentReleaseNoteBodyEntries",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "resources",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ComponentReleaseNoteBodyResources",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ComponentReleaseNoteBodyResources",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "block",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ComponentReleaseNoteBodyResourcesBlock",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "hyperlink",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ComponentReleaseNoteBodyResourcesHyperlink",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "inline",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ComponentReleaseNoteBodyResourcesInline",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ComponentReleaseNoteBodyResourcesBlock",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "sys",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ResourceSys",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "ResourceLink",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ComponentReleaseNoteBodyResourcesHyperlink",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "sys",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ResourceSys",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "ResourceLink",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ComponentReleaseNoteBodyResourcesInline",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "sys",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ResourceSys",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "ResourceLink",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ComponentReleaseNoteCollection",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "items",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ComponentReleaseNote",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "limit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "skip",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "total",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ComponentReleaseNoteCursorCollection",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "items",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ComponentReleaseNote",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "limit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pages",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "CursorPages",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ComponentReleaseNoteFilter",
+        "description": null,
+        "isOneOf": false,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "AND",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "ComponentReleaseNoteFilter",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "OR",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "ComponentReleaseNoteFilter",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active_not",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "body_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "body_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "body_not_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "category",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "category_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "category_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "category_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "category_not",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "category_not_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "category_not_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "contentfulMetadata",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ContentfulMetadataFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cta",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "cfComponentButtonNestedFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "cta_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalName",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalName_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalName_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalName_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalName_not",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalName_not_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalName_not_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "media_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt_gt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt_gte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt_lt",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt_lte",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt_not",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "DateTime",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt_not_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "seoFields",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "cfComponentSeoNestedFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "seoFields_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug_not",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug_not_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug_not_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary_not",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary_not_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary_not_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "surfaces",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "surfaces_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "surfaces_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "surfaces_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "surfaces_not",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "surfaces_not_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "surfaces_not_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "SysFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title_exists",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title_not",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title_not_contains",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title_not_in",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ComponentReleaseNoteLinkingCollections",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "entryCollection",
+            "description": null,
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "100",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "preview",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "skip",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "0",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "EntryCollection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "entryCursorCollection",
+            "description": null,
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "100",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "pageNext",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "pagePrev",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "preview",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "EntryCursorCollection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ComponentReleaseNoteOrder",
+        "description": null,
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "active_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "category_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "category_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalName_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalName_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "surfaces_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "surfaces_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_firstPublishedAt_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_firstPublishedAt_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_id_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_id_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedAt_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedAt_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedVersion_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedVersion_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "ComponentRichImage",
         "description": "[See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentRichImage)",
         "isOneOf": null,
@@ -18467,6 +21483,196 @@
         "isOneOf": null,
         "fields": [
           {
+            "name": "componentReleaseNoteCollection",
+            "description": null,
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "100",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "ComponentSeoLinkingCollectionsComponentReleaseNoteCollectionOrder",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "preview",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "skip",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "0",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ComponentReleaseNoteCollection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "componentReleaseNoteCursorCollection",
+            "description": null,
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "100",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "ComponentSeoLinkingCollectionsComponentReleaseNoteCursorCollectionOrder",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "pageNext",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "pagePrev",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "preview",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ComponentReleaseNoteCursorCollection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "entryCollection",
             "description": null,
             "args": [
@@ -19008,6 +22214,318 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ComponentSeoLinkingCollectionsComponentReleaseNoteCollectionOrder",
+        "description": null,
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "active_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "category_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "category_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalName_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalName_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "surfaces_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "surfaces_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_firstPublishedAt_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_firstPublishedAt_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_id_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_id_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedAt_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedAt_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedVersion_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedVersion_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "ComponentSeoLinkingCollectionsComponentReleaseNoteCursorCollectionOrder",
+        "description": null,
+        "isOneOf": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "active_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "active_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "category_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "category_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalName_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "internalName_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "publishedAt_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "summary_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "surfaces_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "surfaces_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_firstPublishedAt_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_firstPublishedAt_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_id_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_id_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedAt_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedAt_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedVersion_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sys_publishedVersion_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title_ASC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "title_DESC",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -19964,6 +23482,11 @@
           {
             "kind": "OBJECT",
             "name": "ComponentPartner",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ComponentReleaseNote",
             "ofType": null
           },
           {
@@ -49338,6 +52861,285 @@
             "deprecationReason": null
           },
           {
+            "name": "componentReleaseNote",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "preview",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ComponentReleaseNote",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "componentReleaseNoteCollection",
+            "description": null,
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "100",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "ComponentReleaseNoteOrder",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "preview",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "skip",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "0",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ComponentReleaseNoteFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ComponentReleaseNoteCollection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "componentReleaseNoteCursorCollection",
+            "description": null,
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": "100",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "locale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "ComponentReleaseNoteOrder",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "pageNext",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "pagePrev",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "preview",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "useFallbackLocale",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ComponentReleaseNoteFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ComponentReleaseNoteCursorCollection",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "componentRichImage",
             "description": null,
             "args": [
@@ -54374,6 +58176,21 @@
           },
           {
             "kind": "OBJECT",
+            "name": "ComponentReleaseNoteBodyResourcesBlock",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ComponentReleaseNoteBodyResourcesHyperlink",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ComponentReleaseNoteBodyResourcesInline",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
             "name": "PageAboutDescriptionResourcesBlock",
             "ofType": null
           },
@@ -55229,6 +59046,11 @@
           {
             "kind": "OBJECT",
             "name": "ComponentPartner",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "ComponentReleaseNote",
             "ofType": null
           },
           {
@@ -59487,14 +63309,18 @@
         "name": "contentSourceMaps",
         "description": null,
         "isRepeatable": false,
-        "locations": ["QUERY"],
+        "locations": [
+          "QUERY"
+        ],
         "args": []
       },
       {
         "name": "contentfulSchemaMetadata",
         "description": null,
         "isRepeatable": false,
-        "locations": ["SCHEMA"],
+        "locations": [
+          "SCHEMA"
+        ],
         "args": [
           {
             "name": "contentTypePublishedCounters",
@@ -59514,7 +63340,10 @@
         "name": "delegatedResourceLink",
         "description": null,
         "isRepeatable": false,
-        "locations": ["FIELD_DEFINITION", "OBJECT"],
+        "locations": [
+          "FIELD_DEFINITION",
+          "OBJECT"
+        ],
         "args": [
           {
             "name": "contentTypeId",
@@ -59571,7 +63400,9 @@
         "name": "enumMapper",
         "description": null,
         "isRepeatable": false,
-        "locations": ["ENUM_VALUE"],
+        "locations": [
+          "ENUM_VALUE"
+        ],
         "args": [
           {
             "name": "value",
@@ -59591,7 +63422,9 @@
         "name": "featureFlag",
         "description": null,
         "isRepeatable": false,
-        "locations": ["FIELD"],
+        "locations": [
+          "FIELD"
+        ],
         "args": [
           {
             "name": "featureName",
@@ -59611,7 +63444,9 @@
         "name": "fieldResolver",
         "description": null,
         "isRepeatable": false,
-        "locations": ["FIELD_DEFINITION"],
+        "locations": [
+          "FIELD_DEFINITION"
+        ],
         "args": [
           {
             "name": "data",
@@ -59643,7 +63478,11 @@
         "name": "include",
         "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
         "isRepeatable": false,
-        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
         "args": [
           {
             "name": "if",
@@ -59667,14 +63506,20 @@
         "name": "oneOf",
         "description": "Indicates exactly one field must be supplied and this field must not be `null`.",
         "isRepeatable": false,
-        "locations": ["INPUT_OBJECT"],
+        "locations": [
+          "INPUT_OBJECT"
+        ],
         "args": []
       },
       {
         "name": "skip",
         "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
         "isRepeatable": false,
-        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
+        "locations": [
+          "FIELD",
+          "FRAGMENT_SPREAD",
+          "INLINE_FRAGMENT"
+        ],
         "args": [
           {
             "name": "if",
@@ -59698,7 +63543,9 @@
         "name": "specifiedBy",
         "description": "Exposes a URL that specifies the behavior of this scalar.",
         "isRepeatable": false,
-        "locations": ["SCALAR"],
+        "locations": [
+          "SCALAR"
+        ],
         "args": [
           {
             "name": "url",
@@ -59722,7 +63569,9 @@
         "name": "timeline",
         "description": null,
         "isRepeatable": false,
-        "locations": ["QUERY"],
+        "locations": [
+          "QUERY"
+        ],
         "args": [
           {
             "name": "where",
@@ -59746,7 +63595,9 @@
         "name": "typeIdentifier",
         "description": null,
         "isRepeatable": false,
-        "locations": ["OBJECT"],
+        "locations": [
+          "OBJECT"
+        ],
         "args": [
           {
             "name": "contentTypeId",

--- a/packages/cms/src/lib/__generated/sdk.ts
+++ b/packages/cms/src/lib/__generated/sdk.ts
@@ -1,194 +1,200 @@
-import { GraphQLClient, RequestOptions } from "graphql-request";
-import gql from "graphql-tag";
-
+import { GraphQLClient, RequestOptions } from 'graphql-request';
+import gql from 'graphql-tag';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = {
-  [_ in K]?: never;
-};
-export type Incremental<T> =
-  | T
-  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
-type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+type GraphQLClientRequestHeaders = RequestOptions['requestHeaders'];
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string };
-  String: { input: string; output: string };
-  Boolean: { input: boolean; output: boolean };
-  Int: { input: number; output: number };
-  Float: { input: number; output: number };
-  DateTime: { input: any; output: any };
-  Dimension: { input: any; output: any };
-  HexColor: { input: any; output: any };
-  JSON: { input: any; output: any };
-  Quality: { input: any; output: any };
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  DateTime: { input: any; output: any; }
+  Dimension: { input: any; output: any; }
+  HexColor: { input: any; output: any; }
+  JSON: { input: any; output: any; }
+  Quality: { input: any; output: any; }
 };
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type Asset = {
-  __typename?: "Asset";
-  contentType?: Maybe<Scalars["String"]["output"]>;
+  __typename?: 'Asset';
+  contentType?: Maybe<Scalars['String']['output']>;
   contentfulMetadata: ContentfulMetadata;
-  description?: Maybe<Scalars["String"]["output"]>;
-  fileName?: Maybe<Scalars["String"]["output"]>;
-  height?: Maybe<Scalars["Int"]["output"]>;
+  description?: Maybe<Scalars['String']['output']>;
+  fileName?: Maybe<Scalars['String']['output']>;
+  height?: Maybe<Scalars['Int']['output']>;
   linkedFrom?: Maybe<AssetLinkingCollections>;
-  size?: Maybe<Scalars["Int"]["output"]>;
+  size?: Maybe<Scalars['Int']['output']>;
   sys: Sys;
-  title?: Maybe<Scalars["String"]["output"]>;
-  url?: Maybe<Scalars["String"]["output"]>;
-  width?: Maybe<Scalars["Int"]["output"]>;
+  title?: Maybe<Scalars['String']['output']>;
+  url?: Maybe<Scalars['String']['output']>;
+  width?: Maybe<Scalars['Int']['output']>;
 };
+
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type AssetContentTypeArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type AssetDescriptionArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type AssetFileNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type AssetHeightArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type AssetLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type AssetSizeArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type AssetTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type AssetUrlArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   transform?: InputMaybe<ImageTransformOptions>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type AssetWidthArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type AssetCollection = {
-  __typename?: "AssetCollection";
+  __typename?: 'AssetCollection';
   items: Array<Maybe<Asset>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type AssetCursorCollection = {
-  __typename?: "AssetCursorCollection";
+  __typename?: 'AssetCursorCollection';
   items: Array<Maybe<Asset>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export type AssetFilter = {
   AND?: InputMaybe<Array<InputMaybe<AssetFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<AssetFilter>>>;
-  contentType?: InputMaybe<Scalars["String"]["input"]>;
-  contentType_contains?: InputMaybe<Scalars["String"]["input"]>;
-  contentType_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  contentType_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  contentType_not?: InputMaybe<Scalars["String"]["input"]>;
-  contentType_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  contentType_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  contentType?: InputMaybe<Scalars['String']['input']>;
+  contentType_contains?: InputMaybe<Scalars['String']['input']>;
+  contentType_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  contentType_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  contentType_not?: InputMaybe<Scalars['String']['input']>;
+  contentType_not_contains?: InputMaybe<Scalars['String']['input']>;
+  contentType_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  description?: InputMaybe<Scalars["String"]["input"]>;
-  description_contains?: InputMaybe<Scalars["String"]["input"]>;
-  description_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  description_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  description_not?: InputMaybe<Scalars["String"]["input"]>;
-  description_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  description_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  fileName?: InputMaybe<Scalars["String"]["input"]>;
-  fileName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  fileName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  fileName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  fileName_not?: InputMaybe<Scalars["String"]["input"]>;
-  fileName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  fileName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  height?: InputMaybe<Scalars["Int"]["input"]>;
-  height_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  height_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  height_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  height_in?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
-  height_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  height_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  height_not?: InputMaybe<Scalars["Int"]["input"]>;
-  height_not_in?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
-  size?: InputMaybe<Scalars["Int"]["input"]>;
-  size_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  size_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  size_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  size_in?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
-  size_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  size_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  size_not?: InputMaybe<Scalars["Int"]["input"]>;
-  size_not_in?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  description_contains?: InputMaybe<Scalars['String']['input']>;
+  description_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  description_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  description_not?: InputMaybe<Scalars['String']['input']>;
+  description_not_contains?: InputMaybe<Scalars['String']['input']>;
+  description_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  fileName?: InputMaybe<Scalars['String']['input']>;
+  fileName_contains?: InputMaybe<Scalars['String']['input']>;
+  fileName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  fileName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  fileName_not?: InputMaybe<Scalars['String']['input']>;
+  fileName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  fileName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  height?: InputMaybe<Scalars['Int']['input']>;
+  height_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  height_gt?: InputMaybe<Scalars['Int']['input']>;
+  height_gte?: InputMaybe<Scalars['Int']['input']>;
+  height_in?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
+  height_lt?: InputMaybe<Scalars['Int']['input']>;
+  height_lte?: InputMaybe<Scalars['Int']['input']>;
+  height_not?: InputMaybe<Scalars['Int']['input']>;
+  height_not_in?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
+  size?: InputMaybe<Scalars['Int']['input']>;
+  size_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  size_gt?: InputMaybe<Scalars['Int']['input']>;
+  size_gte?: InputMaybe<Scalars['Int']['input']>;
+  size_in?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
+  size_lt?: InputMaybe<Scalars['Int']['input']>;
+  size_lte?: InputMaybe<Scalars['Int']['input']>;
+  size_not?: InputMaybe<Scalars['Int']['input']>;
+  size_not_in?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  title_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  title_not?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  url?: InputMaybe<Scalars["String"]["input"]>;
-  url_contains?: InputMaybe<Scalars["String"]["input"]>;
-  url_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  url_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  url_not?: InputMaybe<Scalars["String"]["input"]>;
-  url_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  url_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  width?: InputMaybe<Scalars["Int"]["input"]>;
-  width_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  width_gt?: InputMaybe<Scalars["Int"]["input"]>;
-  width_gte?: InputMaybe<Scalars["Int"]["input"]>;
-  width_in?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
-  width_lt?: InputMaybe<Scalars["Int"]["input"]>;
-  width_lte?: InputMaybe<Scalars["Int"]["input"]>;
-  width_not?: InputMaybe<Scalars["Int"]["input"]>;
-  width_not_in?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  url?: InputMaybe<Scalars['String']['input']>;
+  url_contains?: InputMaybe<Scalars['String']['input']>;
+  url_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  url_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  url_not?: InputMaybe<Scalars['String']['input']>;
+  url_not_contains?: InputMaybe<Scalars['String']['input']>;
+  url_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  width?: InputMaybe<Scalars['Int']['input']>;
+  width_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  width_gt?: InputMaybe<Scalars['Int']['input']>;
+  width_gte?: InputMaybe<Scalars['Int']['input']>;
+  width_in?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
+  width_lt?: InputMaybe<Scalars['Int']['input']>;
+  width_lte?: InputMaybe<Scalars['Int']['input']>;
+  width_not?: InputMaybe<Scalars['Int']['input']>;
+  width_not_in?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
 };
 
 export type AssetLinkingCollections = {
-  __typename?: "AssetLinkingCollections";
+  __typename?: 'AssetLinkingCollections';
   componentAuthorCollection?: Maybe<ComponentAuthorCollection>;
   componentAuthorCursorCollection?: Maybe<ComponentAuthorCursorCollection>;
   componentFeatureCollection?: Maybe<ComponentFeatureCollection>;
   componentFeatureCursorCollection?: Maybe<ComponentFeatureCursorCollection>;
   componentPartnerCollection?: Maybe<ComponentPartnerCollection>;
   componentPartnerCursorCollection?: Maybe<ComponentPartnerCursorCollection>;
+  componentReleaseNoteCollection?: Maybe<ComponentReleaseNoteCollection>;
+  componentReleaseNoteCursorCollection?: Maybe<ComponentReleaseNoteCursorCollection>;
   componentRichImageCollection?: Maybe<ComponentRichImageCollection>;
   componentRichImageCursorCollection?: Maybe<ComponentRichImageCursorCollection>;
   componentSeoCollection?: Maybe<ComponentSeoCollection>;
@@ -209,752 +215,815 @@ export type AssetLinkingCollections = {
   pageHomePartnersCursorCollection?: Maybe<PageHomePartnersCursorCollection>;
 };
 
+
 export type AssetLinkingCollectionsComponentAuthorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsComponentAuthorCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsComponentFeatureCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsComponentFeatureCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsComponentPartnerCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsComponentPartnerCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
+
+export type AssetLinkingCollectionsComponentReleaseNoteCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type AssetLinkingCollectionsComponentReleaseNoteCursorCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
 
 export type AssetLinkingCollectionsComponentRichImageCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsComponentRichImageCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsComponentSeoCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsComponentSeoCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsPageAboutCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsPageAboutCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsPageBlogPostCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsPageBlogPostCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsPageHomeFeaturesCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsPageHomeFeaturesCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsPageHomeHeroCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsPageHomeHeroCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsPageHomeMissionCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsPageHomeMissionCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type AssetLinkingCollectionsPageHomePartnersCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type AssetLinkingCollectionsPageHomePartnersCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum AssetOrder {
-  ContentTypeAsc = "contentType_ASC",
-  ContentTypeDesc = "contentType_DESC",
-  FileNameAsc = "fileName_ASC",
-  FileNameDesc = "fileName_DESC",
-  HeightAsc = "height_ASC",
-  HeightDesc = "height_DESC",
-  SizeAsc = "size_ASC",
-  SizeDesc = "size_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  UrlAsc = "url_ASC",
-  UrlDesc = "url_DESC",
-  WidthAsc = "width_ASC",
-  WidthDesc = "width_DESC",
+  ContentTypeAsc = 'contentType_ASC',
+  ContentTypeDesc = 'contentType_DESC',
+  FileNameAsc = 'fileName_ASC',
+  FileNameDesc = 'fileName_DESC',
+  HeightAsc = 'height_ASC',
+  HeightDesc = 'height_DESC',
+  SizeAsc = 'size_ASC',
+  SizeDesc = 'size_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  UrlAsc = 'url_ASC',
+  UrlDesc = 'url_DESC',
+  WidthAsc = 'width_ASC',
+  WidthDesc = 'width_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
-export type ComponentAlert = Entry &
-  _Node & {
-    __typename?: "ComponentAlert";
-    _id: Scalars["ID"]["output"];
-    active?: Maybe<Scalars["Boolean"]["output"]>;
-    audience?: Maybe<Scalars["String"]["output"]>;
-    body?: Maybe<ComponentAlertBody>;
-    contentfulMetadata: ContentfulMetadata;
-    dismissible?: Maybe<Scalars["Boolean"]["output"]>;
-    endAt?: Maybe<Scalars["DateTime"]["output"]>;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    link?: Maybe<ComponentButton>;
-    linkedFrom?: Maybe<ComponentAlertLinkingCollections>;
-    severity?: Maybe<Scalars["String"]["output"]>;
-    startAt?: Maybe<Scalars["DateTime"]["output"]>;
-    sys: Sys;
-    title?: Maybe<Scalars["String"]["output"]>;
-    type?: Maybe<Scalars["String"]["output"]>;
-  };
+export type ComponentAlert = Entry & _Node & {
+  __typename?: 'ComponentAlert';
+  _id: Scalars['ID']['output'];
+  active?: Maybe<Scalars['Boolean']['output']>;
+  audience?: Maybe<Scalars['String']['output']>;
+  body?: Maybe<ComponentAlertBody>;
+  contentfulMetadata: ContentfulMetadata;
+  dismissible?: Maybe<Scalars['Boolean']['output']>;
+  endAt?: Maybe<Scalars['DateTime']['output']>;
+  internalName?: Maybe<Scalars['String']['output']>;
+  link?: Maybe<ComponentButton>;
+  linkedFrom?: Maybe<ComponentAlertLinkingCollections>;
+  severity?: Maybe<Scalars['String']['output']>;
+  startAt?: Maybe<Scalars['DateTime']['output']>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+  type?: Maybe<Scalars['String']['output']>;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertActiveArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertAudienceArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertBodyArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertDismissibleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertEndAtArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertLinkArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
 
+
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertSeverityArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertStartAtArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertTypeArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type ComponentAlertBody = {
-  __typename?: "ComponentAlertBody";
-  json: Scalars["JSON"]["output"];
+  __typename?: 'ComponentAlertBody';
+  json: Scalars['JSON']['output'];
   links: ComponentAlertBodyLinks;
 };
 
 export type ComponentAlertBodyAssets = {
-  __typename?: "ComponentAlertBodyAssets";
+  __typename?: 'ComponentAlertBodyAssets';
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type ComponentAlertBodyEntries = {
-  __typename?: "ComponentAlertBodyEntries";
+  __typename?: 'ComponentAlertBodyEntries';
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type ComponentAlertBodyLinks = {
-  __typename?: "ComponentAlertBodyLinks";
+  __typename?: 'ComponentAlertBodyLinks';
   assets: ComponentAlertBodyAssets;
   entries: ComponentAlertBodyEntries;
   resources: ComponentAlertBodyResources;
 };
 
 export type ComponentAlertBodyResources = {
-  __typename?: "ComponentAlertBodyResources";
+  __typename?: 'ComponentAlertBodyResources';
   block: Array<ComponentAlertBodyResourcesBlock>;
   hyperlink: Array<ComponentAlertBodyResourcesHyperlink>;
   inline: Array<ComponentAlertBodyResourcesInline>;
 };
 
 export type ComponentAlertBodyResourcesBlock = ResourceLink & {
-  __typename?: "ComponentAlertBodyResourcesBlock";
+  __typename?: 'ComponentAlertBodyResourcesBlock';
   sys: ResourceSys;
 };
 
 export type ComponentAlertBodyResourcesHyperlink = ResourceLink & {
-  __typename?: "ComponentAlertBodyResourcesHyperlink";
+  __typename?: 'ComponentAlertBodyResourcesHyperlink';
   sys: ResourceSys;
 };
 
 export type ComponentAlertBodyResourcesInline = ResourceLink & {
-  __typename?: "ComponentAlertBodyResourcesInline";
+  __typename?: 'ComponentAlertBodyResourcesInline';
   sys: ResourceSys;
 };
 
 export type ComponentAlertCollection = {
-  __typename?: "ComponentAlertCollection";
+  __typename?: 'ComponentAlertCollection';
   items: Array<Maybe<ComponentAlert>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type ComponentAlertCursorCollection = {
-  __typename?: "ComponentAlertCursorCollection";
+  __typename?: 'ComponentAlertCursorCollection';
   items: Array<Maybe<ComponentAlert>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export type ComponentAlertFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentAlertFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentAlertFilter>>>;
-  active?: InputMaybe<Scalars["Boolean"]["input"]>;
-  active_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  active_not?: InputMaybe<Scalars["Boolean"]["input"]>;
-  audience?: InputMaybe<Scalars["String"]["input"]>;
-  audience_contains?: InputMaybe<Scalars["String"]["input"]>;
-  audience_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  audience_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  audience_not?: InputMaybe<Scalars["String"]["input"]>;
-  audience_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  audience_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  body_contains?: InputMaybe<Scalars["String"]["input"]>;
-  body_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  body_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  active?: InputMaybe<Scalars['Boolean']['input']>;
+  active_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  active_not?: InputMaybe<Scalars['Boolean']['input']>;
+  audience?: InputMaybe<Scalars['String']['input']>;
+  audience_contains?: InputMaybe<Scalars['String']['input']>;
+  audience_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  audience_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  audience_not?: InputMaybe<Scalars['String']['input']>;
+  audience_not_contains?: InputMaybe<Scalars['String']['input']>;
+  audience_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  body_contains?: InputMaybe<Scalars['String']['input']>;
+  body_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  body_not_contains?: InputMaybe<Scalars['String']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  dismissible?: InputMaybe<Scalars["Boolean"]["input"]>;
-  dismissible_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  dismissible_not?: InputMaybe<Scalars["Boolean"]["input"]>;
-  endAt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  endAt_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  endAt_gt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  endAt_gte?: InputMaybe<Scalars["DateTime"]["input"]>;
-  endAt_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
-  endAt_lt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  endAt_lte?: InputMaybe<Scalars["DateTime"]["input"]>;
-  endAt_not?: InputMaybe<Scalars["DateTime"]["input"]>;
-  endAt_not_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  dismissible?: InputMaybe<Scalars['Boolean']['input']>;
+  dismissible_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  dismissible_not?: InputMaybe<Scalars['Boolean']['input']>;
+  endAt?: InputMaybe<Scalars['DateTime']['input']>;
+  endAt_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  endAt_gt?: InputMaybe<Scalars['DateTime']['input']>;
+  endAt_gte?: InputMaybe<Scalars['DateTime']['input']>;
+  endAt_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  endAt_lt?: InputMaybe<Scalars['DateTime']['input']>;
+  endAt_lte?: InputMaybe<Scalars['DateTime']['input']>;
+  endAt_not?: InputMaybe<Scalars['DateTime']['input']>;
+  endAt_not_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   link?: InputMaybe<CfComponentButtonNestedFilter>;
-  link_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  severity?: InputMaybe<Scalars["String"]["input"]>;
-  severity_contains?: InputMaybe<Scalars["String"]["input"]>;
-  severity_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  severity_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  severity_not?: InputMaybe<Scalars["String"]["input"]>;
-  severity_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  severity_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  startAt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  startAt_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  startAt_gt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  startAt_gte?: InputMaybe<Scalars["DateTime"]["input"]>;
-  startAt_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
-  startAt_lt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  startAt_lte?: InputMaybe<Scalars["DateTime"]["input"]>;
-  startAt_not?: InputMaybe<Scalars["DateTime"]["input"]>;
-  startAt_not_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
+  link_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  severity?: InputMaybe<Scalars['String']['input']>;
+  severity_contains?: InputMaybe<Scalars['String']['input']>;
+  severity_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  severity_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  severity_not?: InputMaybe<Scalars['String']['input']>;
+  severity_not_contains?: InputMaybe<Scalars['String']['input']>;
+  severity_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  startAt?: InputMaybe<Scalars['DateTime']['input']>;
+  startAt_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  startAt_gt?: InputMaybe<Scalars['DateTime']['input']>;
+  startAt_gte?: InputMaybe<Scalars['DateTime']['input']>;
+  startAt_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  startAt_lt?: InputMaybe<Scalars['DateTime']['input']>;
+  startAt_lte?: InputMaybe<Scalars['DateTime']['input']>;
+  startAt_not?: InputMaybe<Scalars['DateTime']['input']>;
+  startAt_not_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  title_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  title_not?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  type?: InputMaybe<Scalars["String"]["input"]>;
-  type_contains?: InputMaybe<Scalars["String"]["input"]>;
-  type_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  type_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  type_not?: InputMaybe<Scalars["String"]["input"]>;
-  type_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  type_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  type?: InputMaybe<Scalars['String']['input']>;
+  type_contains?: InputMaybe<Scalars['String']['input']>;
+  type_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  type_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  type_not?: InputMaybe<Scalars['String']['input']>;
+  type_not_contains?: InputMaybe<Scalars['String']['input']>;
+  type_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type ComponentAlertLinkingCollections = {
-  __typename?: "ComponentAlertLinkingCollections";
+  __typename?: 'ComponentAlertLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
+
 export type ComponentAlertLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type ComponentAlertLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum ComponentAlertOrder {
-  ActiveAsc = "active_ASC",
-  ActiveDesc = "active_DESC",
-  AudienceAsc = "audience_ASC",
-  AudienceDesc = "audience_DESC",
-  DismissibleAsc = "dismissible_ASC",
-  DismissibleDesc = "dismissible_DESC",
-  EndAtAsc = "endAt_ASC",
-  EndAtDesc = "endAt_DESC",
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SeverityAsc = "severity_ASC",
-  SeverityDesc = "severity_DESC",
-  StartAtAsc = "startAt_ASC",
-  StartAtDesc = "startAt_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
-  TypeAsc = "type_ASC",
-  TypeDesc = "type_DESC",
+  ActiveAsc = 'active_ASC',
+  ActiveDesc = 'active_DESC',
+  AudienceAsc = 'audience_ASC',
+  AudienceDesc = 'audience_DESC',
+  DismissibleAsc = 'dismissible_ASC',
+  DismissibleDesc = 'dismissible_DESC',
+  EndAtAsc = 'endAt_ASC',
+  EndAtDesc = 'endAt_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SeverityAsc = 'severity_ASC',
+  SeverityDesc = 'severity_DESC',
+  StartAtAsc = 'startAt_ASC',
+  StartAtDesc = 'startAt_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC',
+  TypeAsc = 'type_ASC',
+  TypeDesc = 'type_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAuthor) */
-export type ComponentAuthor = Entry &
-  _Node & {
-    __typename?: "ComponentAuthor";
-    _id: Scalars["ID"]["output"];
-    avatar?: Maybe<Asset>;
-    contentfulMetadata: ContentfulMetadata;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<ComponentAuthorLinkingCollections>;
-    name?: Maybe<Scalars["String"]["output"]>;
-    profession?: Maybe<Scalars["String"]["output"]>;
-    sys: Sys;
-  };
+export type ComponentAuthor = Entry & _Node & {
+  __typename?: 'ComponentAuthor';
+  _id: Scalars['ID']['output'];
+  avatar?: Maybe<Asset>;
+  contentfulMetadata: ContentfulMetadata;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<ComponentAuthorLinkingCollections>;
+  name?: Maybe<Scalars['String']['output']>;
+  profession?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAuthor) */
 export type ComponentAuthorAvatarArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAuthor) */
 export type ComponentAuthorInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAuthor) */
 export type ComponentAuthorLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAuthor) */
 export type ComponentAuthorNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAuthor) */
 export type ComponentAuthorProfessionArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type ComponentAuthorCollection = {
-  __typename?: "ComponentAuthorCollection";
+  __typename?: 'ComponentAuthorCollection';
   items: Array<Maybe<ComponentAuthor>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type ComponentAuthorCursorCollection = {
-  __typename?: "ComponentAuthorCursorCollection";
+  __typename?: 'ComponentAuthorCursorCollection';
   items: Array<Maybe<ComponentAuthor>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export type ComponentAuthorFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentAuthorFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentAuthorFilter>>>;
-  avatar_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  avatar_exists?: InputMaybe<Scalars['Boolean']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  name?: InputMaybe<Scalars["String"]["input"]>;
-  name_contains?: InputMaybe<Scalars["String"]["input"]>;
-  name_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  name_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  name_not?: InputMaybe<Scalars["String"]["input"]>;
-  name_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  name_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  profession?: InputMaybe<Scalars["String"]["input"]>;
-  profession_contains?: InputMaybe<Scalars["String"]["input"]>;
-  profession_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  profession_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  profession_not?: InputMaybe<Scalars["String"]["input"]>;
-  profession_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  profession_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  name_contains?: InputMaybe<Scalars['String']['input']>;
+  name_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  name_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  name_not?: InputMaybe<Scalars['String']['input']>;
+  name_not_contains?: InputMaybe<Scalars['String']['input']>;
+  name_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  profession?: InputMaybe<Scalars['String']['input']>;
+  profession_contains?: InputMaybe<Scalars['String']['input']>;
+  profession_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  profession_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  profession_not?: InputMaybe<Scalars['String']['input']>;
+  profession_not_contains?: InputMaybe<Scalars['String']['input']>;
+  profession_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
 };
 
 export type ComponentAuthorLinkingCollections = {
-  __typename?: "ComponentAuthorLinkingCollections";
+  __typename?: 'ComponentAuthorLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
   pageBlogPostCollection?: Maybe<PageBlogPostCollection>;
   pageBlogPostCursorCollection?: Maybe<PageBlogPostCursorCollection>;
 };
 
+
 export type ComponentAuthorLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentAuthorLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentAuthorLinkingCollectionsPageBlogPostCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<ComponentAuthorLinkingCollectionsPageBlogPostCollectionOrder>>
-  >;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentAuthorLinkingCollectionsPageBlogPostCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type ComponentAuthorLinkingCollectionsPageBlogPostCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<ComponentAuthorLinkingCollectionsPageBlogPostCursorCollectionOrder>>
-  >;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentAuthorLinkingCollectionsPageBlogPostCursorCollectionOrder>>>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum ComponentAuthorLinkingCollectionsPageBlogPostCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  PublishedDateAsc = "publishedDate_ASC",
-  PublishedDateDesc = "publishedDate_DESC",
-  SlugAsc = "slug_ASC",
-  SlugDesc = "slug_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PublishedDateAsc = 'publishedDate_ASC',
+  PublishedDateDesc = 'publishedDate_DESC',
+  SlugAsc = 'slug_ASC',
+  SlugDesc = 'slug_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum ComponentAuthorLinkingCollectionsPageBlogPostCursorCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  PublishedDateAsc = "publishedDate_ASC",
-  PublishedDateDesc = "publishedDate_DESC",
-  SlugAsc = "slug_ASC",
-  SlugDesc = "slug_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PublishedDateAsc = 'publishedDate_ASC',
+  PublishedDateDesc = 'publishedDate_DESC',
+  SlugAsc = 'slug_ASC',
+  SlugDesc = 'slug_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum ComponentAuthorOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  NameAsc = "name_ASC",
-  NameDesc = "name_DESC",
-  ProfessionAsc = "profession_ASC",
-  ProfessionDesc = "profession_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  NameAsc = 'name_ASC',
+  NameDesc = 'name_DESC',
+  ProfessionAsc = 'profession_ASC',
+  ProfessionDesc = 'profession_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentButton) */
-export type ComponentButton = Entry &
-  _Node & {
-    __typename?: "ComponentButton";
-    _id: Scalars["ID"]["output"];
-    contentfulMetadata: ContentfulMetadata;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    label?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<ComponentButtonLinkingCollections>;
-    sys: Sys;
-    url?: Maybe<Scalars["String"]["output"]>;
-  };
+export type ComponentButton = Entry & _Node & {
+  __typename?: 'ComponentButton';
+  _id: Scalars['ID']['output'];
+  contentfulMetadata: ContentfulMetadata;
+  internalName?: Maybe<Scalars['String']['output']>;
+  label?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<ComponentButtonLinkingCollections>;
+  sys: Sys;
+  url?: Maybe<Scalars['String']['output']>;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentButton) */
 export type ComponentButtonInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentButton) */
 export type ComponentButtonLabelArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentButton) */
 export type ComponentButtonLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentButton) */
 export type ComponentButtonUrlArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type ComponentButtonCollection = {
-  __typename?: "ComponentButtonCollection";
+  __typename?: 'ComponentButtonCollection';
   items: Array<Maybe<ComponentButton>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type ComponentButtonCursorCollection = {
-  __typename?: "ComponentButtonCursorCollection";
+  __typename?: 'ComponentButtonCursorCollection';
   items: Array<Maybe<ComponentButton>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
@@ -962,34 +1031,36 @@ export type ComponentButtonFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentButtonFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentButtonFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  label?: InputMaybe<Scalars["String"]["input"]>;
-  label_contains?: InputMaybe<Scalars["String"]["input"]>;
-  label_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  label_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  label_not?: InputMaybe<Scalars["String"]["input"]>;
-  label_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  label_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  label?: InputMaybe<Scalars['String']['input']>;
+  label_contains?: InputMaybe<Scalars['String']['input']>;
+  label_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  label_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  label_not?: InputMaybe<Scalars['String']['input']>;
+  label_not_contains?: InputMaybe<Scalars['String']['input']>;
+  label_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  url?: InputMaybe<Scalars["String"]["input"]>;
-  url_contains?: InputMaybe<Scalars["String"]["input"]>;
-  url_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  url_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  url_not?: InputMaybe<Scalars["String"]["input"]>;
-  url_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  url_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  url?: InputMaybe<Scalars['String']['input']>;
+  url_contains?: InputMaybe<Scalars['String']['input']>;
+  url_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  url_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  url_not?: InputMaybe<Scalars['String']['input']>;
+  url_not_contains?: InputMaybe<Scalars['String']['input']>;
+  url_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type ComponentButtonLinkingCollections = {
-  __typename?: "ComponentButtonLinkingCollections";
+  __typename?: 'ComponentButtonLinkingCollections';
   componentAlertCollection?: Maybe<ComponentAlertCollection>;
   componentAlertCursorCollection?: Maybe<ComponentAlertCursorCollection>;
+  componentReleaseNoteCollection?: Maybe<ComponentReleaseNoteCollection>;
+  componentReleaseNoteCursorCollection?: Maybe<ComponentReleaseNoteCursorCollection>;
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
   footerCollection?: Maybe<FooterCollection>;
@@ -1000,826 +1071,910 @@ export type ComponentButtonLinkingCollections = {
   pageHomeHeroCursorCollection?: Maybe<PageHomeHeroCursorCollection>;
 };
 
+
 export type ComponentButtonLinkingCollectionsComponentAlertCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<ComponentButtonLinkingCollectionsComponentAlertCollectionOrder>>
-  >;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsComponentAlertCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentButtonLinkingCollectionsComponentAlertCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<ComponentButtonLinkingCollectionsComponentAlertCursorCollectionOrder>>
-  >;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsComponentAlertCursorCollectionOrder>>>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
+
+export type ComponentButtonLinkingCollectionsComponentReleaseNoteCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsComponentReleaseNoteCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type ComponentButtonLinkingCollectionsComponentReleaseNoteCursorCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsComponentReleaseNoteCursorCollectionOrder>>>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
 
 export type ComponentButtonLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentButtonLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentButtonLinkingCollectionsFooterCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsFooterCollectionOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentButtonLinkingCollectionsFooterCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<ComponentButtonLinkingCollectionsFooterCursorCollectionOrder>>
-  >;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsFooterCursorCollectionOrder>>>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentButtonLinkingCollectionsPageForceUpdateCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<ComponentButtonLinkingCollectionsPageForceUpdateCollectionOrder>>
-  >;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsPageForceUpdateCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentButtonLinkingCollectionsPageForceUpdateCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<ComponentButtonLinkingCollectionsPageForceUpdateCursorCollectionOrder>>
-  >;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsPageForceUpdateCursorCollectionOrder>>>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentButtonLinkingCollectionsPageHomeHeroCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<ComponentButtonLinkingCollectionsPageHomeHeroCollectionOrder>>
-  >;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsPageHomeHeroCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type ComponentButtonLinkingCollectionsPageHomeHeroCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<ComponentButtonLinkingCollectionsPageHomeHeroCursorCollectionOrder>>
-  >;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsPageHomeHeroCursorCollectionOrder>>>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum ComponentButtonLinkingCollectionsComponentAlertCollectionOrder {
-  ActiveAsc = "active_ASC",
-  ActiveDesc = "active_DESC",
-  AudienceAsc = "audience_ASC",
-  AudienceDesc = "audience_DESC",
-  DismissibleAsc = "dismissible_ASC",
-  DismissibleDesc = "dismissible_DESC",
-  EndAtAsc = "endAt_ASC",
-  EndAtDesc = "endAt_DESC",
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SeverityAsc = "severity_ASC",
-  SeverityDesc = "severity_DESC",
-  StartAtAsc = "startAt_ASC",
-  StartAtDesc = "startAt_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
-  TypeAsc = "type_ASC",
-  TypeDesc = "type_DESC",
+  ActiveAsc = 'active_ASC',
+  ActiveDesc = 'active_DESC',
+  AudienceAsc = 'audience_ASC',
+  AudienceDesc = 'audience_DESC',
+  DismissibleAsc = 'dismissible_ASC',
+  DismissibleDesc = 'dismissible_DESC',
+  EndAtAsc = 'endAt_ASC',
+  EndAtDesc = 'endAt_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SeverityAsc = 'severity_ASC',
+  SeverityDesc = 'severity_DESC',
+  StartAtAsc = 'startAt_ASC',
+  StartAtDesc = 'startAt_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC',
+  TypeAsc = 'type_ASC',
+  TypeDesc = 'type_DESC'
 }
 
 export enum ComponentButtonLinkingCollectionsComponentAlertCursorCollectionOrder {
-  ActiveAsc = "active_ASC",
-  ActiveDesc = "active_DESC",
-  AudienceAsc = "audience_ASC",
-  AudienceDesc = "audience_DESC",
-  DismissibleAsc = "dismissible_ASC",
-  DismissibleDesc = "dismissible_DESC",
-  EndAtAsc = "endAt_ASC",
-  EndAtDesc = "endAt_DESC",
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SeverityAsc = "severity_ASC",
-  SeverityDesc = "severity_DESC",
-  StartAtAsc = "startAt_ASC",
-  StartAtDesc = "startAt_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
-  TypeAsc = "type_ASC",
-  TypeDesc = "type_DESC",
+  ActiveAsc = 'active_ASC',
+  ActiveDesc = 'active_DESC',
+  AudienceAsc = 'audience_ASC',
+  AudienceDesc = 'audience_DESC',
+  DismissibleAsc = 'dismissible_ASC',
+  DismissibleDesc = 'dismissible_DESC',
+  EndAtAsc = 'endAt_ASC',
+  EndAtDesc = 'endAt_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SeverityAsc = 'severity_ASC',
+  SeverityDesc = 'severity_DESC',
+  StartAtAsc = 'startAt_ASC',
+  StartAtDesc = 'startAt_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC',
+  TypeAsc = 'type_ASC',
+  TypeDesc = 'type_DESC'
+}
+
+export enum ComponentButtonLinkingCollectionsComponentReleaseNoteCollectionOrder {
+  ActiveAsc = 'active_ASC',
+  ActiveDesc = 'active_DESC',
+  CategoryAsc = 'category_ASC',
+  CategoryDesc = 'category_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PublishedAtAsc = 'publishedAt_ASC',
+  PublishedAtDesc = 'publishedAt_DESC',
+  SlugAsc = 'slug_ASC',
+  SlugDesc = 'slug_DESC',
+  SummaryAsc = 'summary_ASC',
+  SummaryDesc = 'summary_DESC',
+  SurfacesAsc = 'surfaces_ASC',
+  SurfacesDesc = 'surfaces_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
+}
+
+export enum ComponentButtonLinkingCollectionsComponentReleaseNoteCursorCollectionOrder {
+  ActiveAsc = 'active_ASC',
+  ActiveDesc = 'active_DESC',
+  CategoryAsc = 'category_ASC',
+  CategoryDesc = 'category_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PublishedAtAsc = 'publishedAt_ASC',
+  PublishedAtDesc = 'publishedAt_DESC',
+  SlugAsc = 'slug_ASC',
+  SlugDesc = 'slug_DESC',
+  SummaryAsc = 'summary_ASC',
+  SummaryDesc = 'summary_DESC',
+  SurfacesAsc = 'surfaces_ASC',
+  SurfacesDesc = 'surfaces_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum ComponentButtonLinkingCollectionsFooterCollectionOrder {
-  BadgeAsc = "badge_ASC",
-  BadgeDesc = "badge_DESC",
-  BrandAsc = "brand_ASC",
-  BrandDesc = "brand_DESC",
-  CopyrightAsc = "copyright_ASC",
-  CopyrightDesc = "copyright_DESC",
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  MenuTitleAsc = "menuTitle_ASC",
-  MenuTitleDesc = "menuTitle_DESC",
-  SupportTitleAsc = "supportTitle_ASC",
-  SupportTitleDesc = "supportTitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  BadgeAsc = 'badge_ASC',
+  BadgeDesc = 'badge_DESC',
+  BrandAsc = 'brand_ASC',
+  BrandDesc = 'brand_DESC',
+  CopyrightAsc = 'copyright_ASC',
+  CopyrightDesc = 'copyright_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  MenuTitleAsc = 'menuTitle_ASC',
+  MenuTitleDesc = 'menuTitle_DESC',
+  SupportTitleAsc = 'supportTitle_ASC',
+  SupportTitleDesc = 'supportTitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum ComponentButtonLinkingCollectionsFooterCursorCollectionOrder {
-  BadgeAsc = "badge_ASC",
-  BadgeDesc = "badge_DESC",
-  BrandAsc = "brand_ASC",
-  BrandDesc = "brand_DESC",
-  CopyrightAsc = "copyright_ASC",
-  CopyrightDesc = "copyright_DESC",
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  MenuTitleAsc = "menuTitle_ASC",
-  MenuTitleDesc = "menuTitle_DESC",
-  SupportTitleAsc = "supportTitle_ASC",
-  SupportTitleDesc = "supportTitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  BadgeAsc = 'badge_ASC',
+  BadgeDesc = 'badge_DESC',
+  BrandAsc = 'brand_ASC',
+  BrandDesc = 'brand_DESC',
+  CopyrightAsc = 'copyright_ASC',
+  CopyrightDesc = 'copyright_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  MenuTitleAsc = 'menuTitle_ASC',
+  MenuTitleDesc = 'menuTitle_DESC',
+  SupportTitleAsc = 'supportTitle_ASC',
+  SupportTitleDesc = 'supportTitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum ComponentButtonLinkingCollectionsPageForceUpdateCollectionOrder {
-  ActiveAsc = "active_ASC",
-  ActiveDesc = "active_DESC",
-  EffectiveAtAsc = "effectiveAt_ASC",
-  EffectiveAtDesc = "effectiveAt_DESC",
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  MinVersionAsc = "minVersion_ASC",
-  MinVersionDesc = "minVersion_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  ActiveAsc = 'active_ASC',
+  ActiveDesc = 'active_DESC',
+  EffectiveAtAsc = 'effectiveAt_ASC',
+  EffectiveAtDesc = 'effectiveAt_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  MinVersionAsc = 'minVersion_ASC',
+  MinVersionDesc = 'minVersion_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum ComponentButtonLinkingCollectionsPageForceUpdateCursorCollectionOrder {
-  ActiveAsc = "active_ASC",
-  ActiveDesc = "active_DESC",
-  EffectiveAtAsc = "effectiveAt_ASC",
-  EffectiveAtDesc = "effectiveAt_DESC",
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  MinVersionAsc = "minVersion_ASC",
-  MinVersionDesc = "minVersion_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  ActiveAsc = 'active_ASC',
+  ActiveDesc = 'active_DESC',
+  EffectiveAtAsc = 'effectiveAt_ASC',
+  EffectiveAtDesc = 'effectiveAt_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  MinVersionAsc = 'minVersion_ASC',
+  MinVersionDesc = 'minVersion_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum ComponentButtonLinkingCollectionsPageHomeHeroCollectionOrder {
-  BadgeAsc = "badge_ASC",
-  BadgeDesc = "badge_DESC",
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SubtitleAsc = "subtitle_ASC",
-  SubtitleDesc = "subtitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  BadgeAsc = 'badge_ASC',
+  BadgeDesc = 'badge_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SubtitleAsc = 'subtitle_ASC',
+  SubtitleDesc = 'subtitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum ComponentButtonLinkingCollectionsPageHomeHeroCursorCollectionOrder {
-  BadgeAsc = "badge_ASC",
-  BadgeDesc = "badge_DESC",
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SubtitleAsc = "subtitle_ASC",
-  SubtitleDesc = "subtitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  BadgeAsc = 'badge_ASC',
+  BadgeDesc = 'badge_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SubtitleAsc = 'subtitle_ASC',
+  SubtitleDesc = 'subtitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum ComponentButtonOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  LabelAsc = "label_ASC",
-  LabelDesc = "label_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  UrlAsc = "url_ASC",
-  UrlDesc = "url_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  LabelAsc = 'label_ASC',
+  LabelDesc = 'label_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  UrlAsc = 'url_ASC',
+  UrlDesc = 'url_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentEmail) */
-export type ComponentEmail = Entry &
-  _Node & {
-    __typename?: "ComponentEmail";
-    _id: Scalars["ID"]["output"];
-    availableVariables?: Maybe<Scalars["String"]["output"]>;
-    content?: Maybe<ComponentEmailContent>;
-    contentfulMetadata: ContentfulMetadata;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<ComponentEmailLinkingCollections>;
-    preview?: Maybe<Scalars["String"]["output"]>;
-    sys: Sys;
-  };
+export type ComponentEmail = Entry & _Node & {
+  __typename?: 'ComponentEmail';
+  _id: Scalars['ID']['output'];
+  availableVariables?: Maybe<Scalars['String']['output']>;
+  content?: Maybe<ComponentEmailContent>;
+  contentfulMetadata: ContentfulMetadata;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<ComponentEmailLinkingCollections>;
+  preview?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentEmail) */
 export type ComponentEmailAvailableVariablesArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentEmail) */
 export type ComponentEmailContentArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentEmail) */
 export type ComponentEmailInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentEmail) */
 export type ComponentEmailLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentEmail) */
 export type ComponentEmailPreviewArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type ComponentEmailCollection = {
-  __typename?: "ComponentEmailCollection";
+  __typename?: 'ComponentEmailCollection';
   items: Array<Maybe<ComponentEmail>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type ComponentEmailContent = {
-  __typename?: "ComponentEmailContent";
-  json: Scalars["JSON"]["output"];
+  __typename?: 'ComponentEmailContent';
+  json: Scalars['JSON']['output'];
   links: ComponentEmailContentLinks;
 };
 
 export type ComponentEmailContentAssets = {
-  __typename?: "ComponentEmailContentAssets";
+  __typename?: 'ComponentEmailContentAssets';
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type ComponentEmailContentEntries = {
-  __typename?: "ComponentEmailContentEntries";
+  __typename?: 'ComponentEmailContentEntries';
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type ComponentEmailContentLinks = {
-  __typename?: "ComponentEmailContentLinks";
+  __typename?: 'ComponentEmailContentLinks';
   assets: ComponentEmailContentAssets;
   entries: ComponentEmailContentEntries;
   resources: ComponentEmailContentResources;
 };
 
 export type ComponentEmailContentResources = {
-  __typename?: "ComponentEmailContentResources";
+  __typename?: 'ComponentEmailContentResources';
   block: Array<ComponentEmailContentResourcesBlock>;
   hyperlink: Array<ComponentEmailContentResourcesHyperlink>;
   inline: Array<ComponentEmailContentResourcesInline>;
 };
 
 export type ComponentEmailContentResourcesBlock = ResourceLink & {
-  __typename?: "ComponentEmailContentResourcesBlock";
+  __typename?: 'ComponentEmailContentResourcesBlock';
   sys: ResourceSys;
 };
 
 export type ComponentEmailContentResourcesHyperlink = ResourceLink & {
-  __typename?: "ComponentEmailContentResourcesHyperlink";
+  __typename?: 'ComponentEmailContentResourcesHyperlink';
   sys: ResourceSys;
 };
 
 export type ComponentEmailContentResourcesInline = ResourceLink & {
-  __typename?: "ComponentEmailContentResourcesInline";
+  __typename?: 'ComponentEmailContentResourcesInline';
   sys: ResourceSys;
 };
 
 export type ComponentEmailCursorCollection = {
-  __typename?: "ComponentEmailCursorCollection";
+  __typename?: 'ComponentEmailCursorCollection';
   items: Array<Maybe<ComponentEmail>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export type ComponentEmailFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentEmailFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentEmailFilter>>>;
-  availableVariables?: InputMaybe<Scalars["String"]["input"]>;
-  availableVariables_contains?: InputMaybe<Scalars["String"]["input"]>;
-  availableVariables_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  availableVariables_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  availableVariables_not?: InputMaybe<Scalars["String"]["input"]>;
-  availableVariables_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  availableVariables_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  content_contains?: InputMaybe<Scalars["String"]["input"]>;
-  content_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  content_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  availableVariables?: InputMaybe<Scalars['String']['input']>;
+  availableVariables_contains?: InputMaybe<Scalars['String']['input']>;
+  availableVariables_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  availableVariables_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  availableVariables_not?: InputMaybe<Scalars['String']['input']>;
+  availableVariables_not_contains?: InputMaybe<Scalars['String']['input']>;
+  availableVariables_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  content_contains?: InputMaybe<Scalars['String']['input']>;
+  content_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  content_not_contains?: InputMaybe<Scalars['String']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  preview?: InputMaybe<Scalars["String"]["input"]>;
-  preview_contains?: InputMaybe<Scalars["String"]["input"]>;
-  preview_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  preview_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  preview_not?: InputMaybe<Scalars["String"]["input"]>;
-  preview_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  preview_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  preview?: InputMaybe<Scalars['String']['input']>;
+  preview_contains?: InputMaybe<Scalars['String']['input']>;
+  preview_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  preview_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  preview_not?: InputMaybe<Scalars['String']['input']>;
+  preview_not_contains?: InputMaybe<Scalars['String']['input']>;
+  preview_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
 };
 
 export type ComponentEmailLinkingCollections = {
-  __typename?: "ComponentEmailLinkingCollections";
+  __typename?: 'ComponentEmailLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
   pageEmailsCollection?: Maybe<PageEmailsCollection>;
   pageEmailsCursorCollection?: Maybe<PageEmailsCursorCollection>;
 };
 
+
 export type ComponentEmailLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentEmailLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentEmailLinkingCollectionsPageEmailsCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentEmailLinkingCollectionsPageEmailsCollectionOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type ComponentEmailLinkingCollectionsPageEmailsCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<ComponentEmailLinkingCollectionsPageEmailsCursorCollectionOrder>>
-  >;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentEmailLinkingCollectionsPageEmailsCursorCollectionOrder>>>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum ComponentEmailLinkingCollectionsPageEmailsCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 export enum ComponentEmailLinkingCollectionsPageEmailsCursorCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 export enum ComponentEmailOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  PreviewAsc = "preview_ASC",
-  PreviewDesc = "preview_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PreviewAsc = 'preview_ASC',
+  PreviewDesc = 'preview_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFaqQuestion) */
-export type ComponentFaqQuestion = Entry &
-  _Node & {
-    __typename?: "ComponentFaqQuestion";
-    _id: Scalars["ID"]["output"];
-    answer?: Maybe<ComponentFaqQuestionAnswer>;
-    contentfulMetadata: ContentfulMetadata;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<ComponentFaqQuestionLinkingCollections>;
-    question?: Maybe<Scalars["String"]["output"]>;
-    sys: Sys;
-  };
+export type ComponentFaqQuestion = Entry & _Node & {
+  __typename?: 'ComponentFaqQuestion';
+  _id: Scalars['ID']['output'];
+  answer?: Maybe<ComponentFaqQuestionAnswer>;
+  contentfulMetadata: ContentfulMetadata;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<ComponentFaqQuestionLinkingCollections>;
+  question?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFaqQuestion) */
 export type ComponentFaqQuestionAnswerArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFaqQuestion) */
 export type ComponentFaqQuestionInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFaqQuestion) */
 export type ComponentFaqQuestionLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFaqQuestion) */
 export type ComponentFaqQuestionQuestionArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type ComponentFaqQuestionAnswer = {
-  __typename?: "ComponentFaqQuestionAnswer";
-  json: Scalars["JSON"]["output"];
+  __typename?: 'ComponentFaqQuestionAnswer';
+  json: Scalars['JSON']['output'];
   links: ComponentFaqQuestionAnswerLinks;
 };
 
 export type ComponentFaqQuestionAnswerAssets = {
-  __typename?: "ComponentFaqQuestionAnswerAssets";
+  __typename?: 'ComponentFaqQuestionAnswerAssets';
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type ComponentFaqQuestionAnswerEntries = {
-  __typename?: "ComponentFaqQuestionAnswerEntries";
+  __typename?: 'ComponentFaqQuestionAnswerEntries';
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type ComponentFaqQuestionAnswerLinks = {
-  __typename?: "ComponentFaqQuestionAnswerLinks";
+  __typename?: 'ComponentFaqQuestionAnswerLinks';
   assets: ComponentFaqQuestionAnswerAssets;
   entries: ComponentFaqQuestionAnswerEntries;
   resources: ComponentFaqQuestionAnswerResources;
 };
 
 export type ComponentFaqQuestionAnswerResources = {
-  __typename?: "ComponentFaqQuestionAnswerResources";
+  __typename?: 'ComponentFaqQuestionAnswerResources';
   block: Array<ComponentFaqQuestionAnswerResourcesBlock>;
   hyperlink: Array<ComponentFaqQuestionAnswerResourcesHyperlink>;
   inline: Array<ComponentFaqQuestionAnswerResourcesInline>;
 };
 
 export type ComponentFaqQuestionAnswerResourcesBlock = ResourceLink & {
-  __typename?: "ComponentFaqQuestionAnswerResourcesBlock";
+  __typename?: 'ComponentFaqQuestionAnswerResourcesBlock';
   sys: ResourceSys;
 };
 
 export type ComponentFaqQuestionAnswerResourcesHyperlink = ResourceLink & {
-  __typename?: "ComponentFaqQuestionAnswerResourcesHyperlink";
+  __typename?: 'ComponentFaqQuestionAnswerResourcesHyperlink';
   sys: ResourceSys;
 };
 
 export type ComponentFaqQuestionAnswerResourcesInline = ResourceLink & {
-  __typename?: "ComponentFaqQuestionAnswerResourcesInline";
+  __typename?: 'ComponentFaqQuestionAnswerResourcesInline';
   sys: ResourceSys;
 };
 
 export type ComponentFaqQuestionCollection = {
-  __typename?: "ComponentFaqQuestionCollection";
+  __typename?: 'ComponentFaqQuestionCollection';
   items: Array<Maybe<ComponentFaqQuestion>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type ComponentFaqQuestionCursorCollection = {
-  __typename?: "ComponentFaqQuestionCursorCollection";
+  __typename?: 'ComponentFaqQuestionCursorCollection';
   items: Array<Maybe<ComponentFaqQuestion>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export type ComponentFaqQuestionFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentFaqQuestionFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentFaqQuestionFilter>>>;
-  answer_contains?: InputMaybe<Scalars["String"]["input"]>;
-  answer_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  answer_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  answer_contains?: InputMaybe<Scalars['String']['input']>;
+  answer_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  answer_not_contains?: InputMaybe<Scalars['String']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  question?: InputMaybe<Scalars["String"]["input"]>;
-  question_contains?: InputMaybe<Scalars["String"]["input"]>;
-  question_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  question_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  question_not?: InputMaybe<Scalars["String"]["input"]>;
-  question_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  question_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  question?: InputMaybe<Scalars['String']['input']>;
+  question_contains?: InputMaybe<Scalars['String']['input']>;
+  question_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  question_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  question_not?: InputMaybe<Scalars['String']['input']>;
+  question_not_contains?: InputMaybe<Scalars['String']['input']>;
+  question_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
 };
 
 export type ComponentFaqQuestionLinkingCollections = {
-  __typename?: "ComponentFaqQuestionLinkingCollections";
+  __typename?: 'ComponentFaqQuestionLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
   pageFaqCollection?: Maybe<PageFaqCollection>;
   pageFaqCursorCollection?: Maybe<PageFaqCursorCollection>;
 };
 
+
 export type ComponentFaqQuestionLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentFaqQuestionLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentFaqQuestionLinkingCollectionsPageFaqCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<ComponentFaqQuestionLinkingCollectionsPageFaqCollectionOrder>>
-  >;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentFaqQuestionLinkingCollectionsPageFaqCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type ComponentFaqQuestionLinkingCollectionsPageFaqCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<ComponentFaqQuestionLinkingCollectionsPageFaqCursorCollectionOrder>>
-  >;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentFaqQuestionLinkingCollectionsPageFaqCursorCollectionOrder>>>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum ComponentFaqQuestionLinkingCollectionsPageFaqCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  IntroAsc = "intro_ASC",
-  IntroDesc = "intro_DESC",
-  PageDescriptionAsc = "pageDescription_ASC",
-  PageDescriptionDesc = "pageDescription_DESC",
-  PageTitleAsc = "pageTitle_ASC",
-  PageTitleDesc = "pageTitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  IntroAsc = 'intro_ASC',
+  IntroDesc = 'intro_DESC',
+  PageDescriptionAsc = 'pageDescription_ASC',
+  PageDescriptionDesc = 'pageDescription_DESC',
+  PageTitleAsc = 'pageTitle_ASC',
+  PageTitleDesc = 'pageTitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum ComponentFaqQuestionLinkingCollectionsPageFaqCursorCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  IntroAsc = "intro_ASC",
-  IntroDesc = "intro_DESC",
-  PageDescriptionAsc = "pageDescription_ASC",
-  PageDescriptionDesc = "pageDescription_DESC",
-  PageTitleAsc = "pageTitle_ASC",
-  PageTitleDesc = "pageTitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  IntroAsc = 'intro_ASC',
+  IntroDesc = 'intro_DESC',
+  PageDescriptionAsc = 'pageDescription_ASC',
+  PageDescriptionDesc = 'pageDescription_DESC',
+  PageTitleAsc = 'pageTitle_ASC',
+  PageTitleDesc = 'pageTitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum ComponentFaqQuestionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  QuestionAsc = "question_ASC",
-  QuestionDesc = "question_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  QuestionAsc = 'question_ASC',
+  QuestionDesc = 'question_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFeature) */
-export type ComponentFeature = Entry &
-  _Node & {
-    __typename?: "ComponentFeature";
-    _id: Scalars["ID"]["output"];
-    contentfulMetadata: ContentfulMetadata;
-    icon?: Maybe<Asset>;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<ComponentFeatureLinkingCollections>;
-    subtitle?: Maybe<Scalars["String"]["output"]>;
-    sys: Sys;
-    title?: Maybe<Scalars["String"]["output"]>;
-  };
+export type ComponentFeature = Entry & _Node & {
+  __typename?: 'ComponentFeature';
+  _id: Scalars['ID']['output'];
+  contentfulMetadata: ContentfulMetadata;
+  icon?: Maybe<Asset>;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<ComponentFeatureLinkingCollections>;
+  subtitle?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFeature) */
 export type ComponentFeatureIconArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFeature) */
 export type ComponentFeatureInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFeature) */
 export type ComponentFeatureLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFeature) */
 export type ComponentFeatureSubtitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFeature) */
 export type ComponentFeatureTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type ComponentFeatureCollection = {
-  __typename?: "ComponentFeatureCollection";
+  __typename?: 'ComponentFeatureCollection';
   items: Array<Maybe<ComponentFeature>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type ComponentFeatureCursorCollection = {
-  __typename?: "ComponentFeatureCursorCollection";
+  __typename?: 'ComponentFeatureCursorCollection';
   items: Array<Maybe<ComponentFeature>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
@@ -1827,186 +1982,190 @@ export type ComponentFeatureFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentFeatureFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentFeatureFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  icon_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  subtitle?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_contains?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  subtitle_not?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  icon_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  subtitle?: InputMaybe<Scalars['String']['input']>;
+  subtitle_contains?: InputMaybe<Scalars['String']['input']>;
+  subtitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  subtitle_not?: InputMaybe<Scalars['String']['input']>;
+  subtitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  title_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  title_not?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type ComponentFeatureLinkingCollections = {
-  __typename?: "ComponentFeatureLinkingCollections";
+  __typename?: 'ComponentFeatureLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
   pageHomeFeaturesCollection?: Maybe<PageHomeFeaturesCollection>;
   pageHomeFeaturesCursorCollection?: Maybe<PageHomeFeaturesCursorCollection>;
 };
 
+
 export type ComponentFeatureLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentFeatureLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentFeatureLinkingCollectionsPageHomeFeaturesCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<ComponentFeatureLinkingCollectionsPageHomeFeaturesCollectionOrder>>
-  >;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentFeatureLinkingCollectionsPageHomeFeaturesCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type ComponentFeatureLinkingCollectionsPageHomeFeaturesCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<ComponentFeatureLinkingCollectionsPageHomeFeaturesCursorCollectionOrder>>
-  >;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentFeatureLinkingCollectionsPageHomeFeaturesCursorCollectionOrder>>>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum ComponentFeatureLinkingCollectionsPageHomeFeaturesCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SubtitleAsc = "subtitle_ASC",
-  SubtitleDesc = "subtitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SubtitleAsc = 'subtitle_ASC',
+  SubtitleDesc = 'subtitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum ComponentFeatureLinkingCollectionsPageHomeFeaturesCursorCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SubtitleAsc = "subtitle_ASC",
-  SubtitleDesc = "subtitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SubtitleAsc = 'subtitle_ASC',
+  SubtitleDesc = 'subtitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum ComponentFeatureOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SubtitleAsc = "subtitle_ASC",
-  SubtitleDesc = "subtitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SubtitleAsc = 'subtitle_ASC',
+  SubtitleDesc = 'subtitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentPartner) */
-export type ComponentPartner = Entry &
-  _Node & {
-    __typename?: "ComponentPartner";
-    _id: Scalars["ID"]["output"];
-    contentfulMetadata: ContentfulMetadata;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<ComponentPartnerLinkingCollections>;
-    logo?: Maybe<Asset>;
-    subtitle?: Maybe<Scalars["String"]["output"]>;
-    sys: Sys;
-    url?: Maybe<Scalars["String"]["output"]>;
-  };
+export type ComponentPartner = Entry & _Node & {
+  __typename?: 'ComponentPartner';
+  _id: Scalars['ID']['output'];
+  contentfulMetadata: ContentfulMetadata;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<ComponentPartnerLinkingCollections>;
+  logo?: Maybe<Asset>;
+  subtitle?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+  url?: Maybe<Scalars['String']['output']>;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentPartner) */
 export type ComponentPartnerInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentPartner) */
 export type ComponentPartnerLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentPartner) */
 export type ComponentPartnerLogoArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentPartner) */
 export type ComponentPartnerSubtitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentPartner) */
 export type ComponentPartnerUrlArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type ComponentPartnerCollection = {
-  __typename?: "ComponentPartnerCollection";
+  __typename?: 'ComponentPartnerCollection';
   items: Array<Maybe<ComponentPartner>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type ComponentPartnerCursorCollection = {
-  __typename?: "ComponentPartnerCursorCollection";
+  __typename?: 'ComponentPartnerCursorCollection';
   items: Array<Maybe<ComponentPartner>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
@@ -2014,391 +2173,707 @@ export type ComponentPartnerFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentPartnerFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentPartnerFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  logo_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  subtitle?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_contains?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  subtitle_not?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  logo_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  subtitle?: InputMaybe<Scalars['String']['input']>;
+  subtitle_contains?: InputMaybe<Scalars['String']['input']>;
+  subtitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  subtitle_not?: InputMaybe<Scalars['String']['input']>;
+  subtitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  url?: InputMaybe<Scalars["String"]["input"]>;
-  url_contains?: InputMaybe<Scalars["String"]["input"]>;
-  url_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  url_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  url_not?: InputMaybe<Scalars["String"]["input"]>;
-  url_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  url_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  url?: InputMaybe<Scalars['String']['input']>;
+  url_contains?: InputMaybe<Scalars['String']['input']>;
+  url_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  url_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  url_not?: InputMaybe<Scalars['String']['input']>;
+  url_not_contains?: InputMaybe<Scalars['String']['input']>;
+  url_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type ComponentPartnerLinkingCollections = {
-  __typename?: "ComponentPartnerLinkingCollections";
+  __typename?: 'ComponentPartnerLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
   pageHomePartnersCollection?: Maybe<PageHomePartnersCollection>;
   pageHomePartnersCursorCollection?: Maybe<PageHomePartnersCursorCollection>;
 };
 
+
 export type ComponentPartnerLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentPartnerLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentPartnerLinkingCollectionsPageHomePartnersCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<ComponentPartnerLinkingCollectionsPageHomePartnersCollectionOrder>>
-  >;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentPartnerLinkingCollectionsPageHomePartnersCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type ComponentPartnerLinkingCollectionsPageHomePartnersCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<ComponentPartnerLinkingCollectionsPageHomePartnersCursorCollectionOrder>>
-  >;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentPartnerLinkingCollectionsPageHomePartnersCursorCollectionOrder>>>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum ComponentPartnerLinkingCollectionsPageHomePartnersCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SubtitleAsc = "subtitle_ASC",
-  SubtitleDesc = "subtitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SubtitleAsc = 'subtitle_ASC',
+  SubtitleDesc = 'subtitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum ComponentPartnerLinkingCollectionsPageHomePartnersCursorCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SubtitleAsc = "subtitle_ASC",
-  SubtitleDesc = "subtitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SubtitleAsc = 'subtitle_ASC',
+  SubtitleDesc = 'subtitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum ComponentPartnerOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SubtitleAsc = "subtitle_ASC",
-  SubtitleDesc = "subtitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  UrlAsc = "url_ASC",
-  UrlDesc = "url_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SubtitleAsc = 'subtitle_ASC',
+  SubtitleDesc = 'subtitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  UrlAsc = 'url_ASC',
+  UrlDesc = 'url_DESC'
+}
+
+/** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
+export type ComponentReleaseNote = Entry & _Node & {
+  __typename?: 'ComponentReleaseNote';
+  _id: Scalars['ID']['output'];
+  active?: Maybe<Scalars['Boolean']['output']>;
+  body?: Maybe<ComponentReleaseNoteBody>;
+  category?: Maybe<Scalars['String']['output']>;
+  contentfulMetadata: ContentfulMetadata;
+  cta?: Maybe<ComponentButton>;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<ComponentReleaseNoteLinkingCollections>;
+  media?: Maybe<Asset>;
+  publishedAt?: Maybe<Scalars['DateTime']['output']>;
+  seoFields?: Maybe<ComponentSeo>;
+  slug?: Maybe<Scalars['String']['output']>;
+  summary?: Maybe<Scalars['String']['output']>;
+  surfaces?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
+export type ComponentReleaseNoteActiveArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
+export type ComponentReleaseNoteBodyArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
+export type ComponentReleaseNoteCategoryArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
+export type ComponentReleaseNoteCtaArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<ComponentButtonFilter>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
+export type ComponentReleaseNoteInternalNameArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
+export type ComponentReleaseNoteLinkedFromArgs = {
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
+export type ComponentReleaseNoteMediaArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
+export type ComponentReleaseNotePublishedAtArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
+export type ComponentReleaseNoteSeoFieldsArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<ComponentSeoFilter>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
+export type ComponentReleaseNoteSlugArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
+export type ComponentReleaseNoteSummaryArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
+export type ComponentReleaseNoteSurfacesArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+/** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
+export type ComponentReleaseNoteTitleArgs = {
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type ComponentReleaseNoteBody = {
+  __typename?: 'ComponentReleaseNoteBody';
+  json: Scalars['JSON']['output'];
+  links: ComponentReleaseNoteBodyLinks;
+};
+
+export type ComponentReleaseNoteBodyAssets = {
+  __typename?: 'ComponentReleaseNoteBodyAssets';
+  block: Array<Maybe<Asset>>;
+  hyperlink: Array<Maybe<Asset>>;
+};
+
+export type ComponentReleaseNoteBodyEntries = {
+  __typename?: 'ComponentReleaseNoteBodyEntries';
+  block: Array<Maybe<Entry>>;
+  hyperlink: Array<Maybe<Entry>>;
+  inline: Array<Maybe<Entry>>;
+};
+
+export type ComponentReleaseNoteBodyLinks = {
+  __typename?: 'ComponentReleaseNoteBodyLinks';
+  assets: ComponentReleaseNoteBodyAssets;
+  entries: ComponentReleaseNoteBodyEntries;
+  resources: ComponentReleaseNoteBodyResources;
+};
+
+export type ComponentReleaseNoteBodyResources = {
+  __typename?: 'ComponentReleaseNoteBodyResources';
+  block: Array<ComponentReleaseNoteBodyResourcesBlock>;
+  hyperlink: Array<ComponentReleaseNoteBodyResourcesHyperlink>;
+  inline: Array<ComponentReleaseNoteBodyResourcesInline>;
+};
+
+export type ComponentReleaseNoteBodyResourcesBlock = ResourceLink & {
+  __typename?: 'ComponentReleaseNoteBodyResourcesBlock';
+  sys: ResourceSys;
+};
+
+export type ComponentReleaseNoteBodyResourcesHyperlink = ResourceLink & {
+  __typename?: 'ComponentReleaseNoteBodyResourcesHyperlink';
+  sys: ResourceSys;
+};
+
+export type ComponentReleaseNoteBodyResourcesInline = ResourceLink & {
+  __typename?: 'ComponentReleaseNoteBodyResourcesInline';
+  sys: ResourceSys;
+};
+
+export type ComponentReleaseNoteCollection = {
+  __typename?: 'ComponentReleaseNoteCollection';
+  items: Array<Maybe<ComponentReleaseNote>>;
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
+};
+
+export type ComponentReleaseNoteCursorCollection = {
+  __typename?: 'ComponentReleaseNoteCursorCollection';
+  items: Array<Maybe<ComponentReleaseNote>>;
+  limit: Scalars['Int']['output'];
+  pages: CursorPages;
+};
+
+export type ComponentReleaseNoteFilter = {
+  AND?: InputMaybe<Array<InputMaybe<ComponentReleaseNoteFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<ComponentReleaseNoteFilter>>>;
+  active?: InputMaybe<Scalars['Boolean']['input']>;
+  active_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  active_not?: InputMaybe<Scalars['Boolean']['input']>;
+  body_contains?: InputMaybe<Scalars['String']['input']>;
+  body_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  body_not_contains?: InputMaybe<Scalars['String']['input']>;
+  category?: InputMaybe<Scalars['String']['input']>;
+  category_contains?: InputMaybe<Scalars['String']['input']>;
+  category_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  category_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  category_not?: InputMaybe<Scalars['String']['input']>;
+  category_not_contains?: InputMaybe<Scalars['String']['input']>;
+  category_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
+  cta?: InputMaybe<CfComponentButtonNestedFilter>;
+  cta_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  media_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  publishedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedAt_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  publishedAt_gt?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedAt_gte?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedAt_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  publishedAt_lt?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedAt_lte?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedAt_not?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedAt_not_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  seoFields?: InputMaybe<CfComponentSeoNestedFilter>;
+  seoFields_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  slug_contains?: InputMaybe<Scalars['String']['input']>;
+  slug_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  slug_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  slug_not?: InputMaybe<Scalars['String']['input']>;
+  slug_not_contains?: InputMaybe<Scalars['String']['input']>;
+  slug_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  summary?: InputMaybe<Scalars['String']['input']>;
+  summary_contains?: InputMaybe<Scalars['String']['input']>;
+  summary_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  summary_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  summary_not?: InputMaybe<Scalars['String']['input']>;
+  summary_not_contains?: InputMaybe<Scalars['String']['input']>;
+  summary_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  surfaces?: InputMaybe<Scalars['String']['input']>;
+  surfaces_contains?: InputMaybe<Scalars['String']['input']>;
+  surfaces_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  surfaces_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  surfaces_not?: InputMaybe<Scalars['String']['input']>;
+  surfaces_not_contains?: InputMaybe<Scalars['String']['input']>;
+  surfaces_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  sys?: InputMaybe<SysFilter>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+};
+
+export type ComponentReleaseNoteLinkingCollections = {
+  __typename?: 'ComponentReleaseNoteLinkingCollections';
+  entryCollection?: Maybe<EntryCollection>;
+  entryCursorCollection?: Maybe<EntryCursorCollection>;
+};
+
+
+export type ComponentReleaseNoteLinkingCollectionsEntryCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type ComponentReleaseNoteLinkingCollectionsEntryCursorCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export enum ComponentReleaseNoteOrder {
+  ActiveAsc = 'active_ASC',
+  ActiveDesc = 'active_DESC',
+  CategoryAsc = 'category_ASC',
+  CategoryDesc = 'category_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PublishedAtAsc = 'publishedAt_ASC',
+  PublishedAtDesc = 'publishedAt_DESC',
+  SlugAsc = 'slug_ASC',
+  SlugDesc = 'slug_DESC',
+  SummaryAsc = 'summary_ASC',
+  SummaryDesc = 'summary_DESC',
+  SurfacesAsc = 'surfaces_ASC',
+  SurfacesDesc = 'surfaces_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentRichImage) */
-export type ComponentRichImage = Entry &
-  _Node & {
-    __typename?: "ComponentRichImage";
-    _id: Scalars["ID"]["output"];
-    caption?: Maybe<Scalars["String"]["output"]>;
-    contentfulMetadata: ContentfulMetadata;
-    fullWidth?: Maybe<Scalars["Boolean"]["output"]>;
-    image?: Maybe<Asset>;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<ComponentRichImageLinkingCollections>;
-    sys: Sys;
-  };
+export type ComponentRichImage = Entry & _Node & {
+  __typename?: 'ComponentRichImage';
+  _id: Scalars['ID']['output'];
+  caption?: Maybe<Scalars['String']['output']>;
+  contentfulMetadata: ContentfulMetadata;
+  fullWidth?: Maybe<Scalars['Boolean']['output']>;
+  image?: Maybe<Asset>;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<ComponentRichImageLinkingCollections>;
+  sys: Sys;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentRichImage) */
 export type ComponentRichImageCaptionArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentRichImage) */
 export type ComponentRichImageFullWidthArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentRichImage) */
 export type ComponentRichImageImageArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentRichImage) */
 export type ComponentRichImageInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentRichImage) */
 export type ComponentRichImageLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type ComponentRichImageCollection = {
-  __typename?: "ComponentRichImageCollection";
+  __typename?: 'ComponentRichImageCollection';
   items: Array<Maybe<ComponentRichImage>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type ComponentRichImageCursorCollection = {
-  __typename?: "ComponentRichImageCursorCollection";
+  __typename?: 'ComponentRichImageCursorCollection';
   items: Array<Maybe<ComponentRichImage>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export type ComponentRichImageFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentRichImageFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentRichImageFilter>>>;
-  caption?: InputMaybe<Scalars["String"]["input"]>;
-  caption_contains?: InputMaybe<Scalars["String"]["input"]>;
-  caption_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  caption_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  caption_not?: InputMaybe<Scalars["String"]["input"]>;
-  caption_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  caption_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  caption?: InputMaybe<Scalars['String']['input']>;
+  caption_contains?: InputMaybe<Scalars['String']['input']>;
+  caption_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  caption_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  caption_not?: InputMaybe<Scalars['String']['input']>;
+  caption_not_contains?: InputMaybe<Scalars['String']['input']>;
+  caption_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  fullWidth?: InputMaybe<Scalars["Boolean"]["input"]>;
-  fullWidth_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  fullWidth_not?: InputMaybe<Scalars["Boolean"]["input"]>;
-  image_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  fullWidth?: InputMaybe<Scalars['Boolean']['input']>;
+  fullWidth_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  fullWidth_not?: InputMaybe<Scalars['Boolean']['input']>;
+  image_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
 };
 
 export type ComponentRichImageLinkingCollections = {
-  __typename?: "ComponentRichImageLinkingCollections";
+  __typename?: 'ComponentRichImageLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
+
 export type ComponentRichImageLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type ComponentRichImageLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum ComponentRichImageOrder {
-  CaptionAsc = "caption_ASC",
-  CaptionDesc = "caption_DESC",
-  FullWidthAsc = "fullWidth_ASC",
-  FullWidthDesc = "fullWidth_DESC",
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  CaptionAsc = 'caption_ASC',
+  CaptionDesc = 'caption_DESC',
+  FullWidthAsc = 'fullWidth_ASC',
+  FullWidthDesc = 'fullWidth_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
-export type ComponentSeo = Entry &
-  _Node & {
-    __typename?: "ComponentSeo";
-    _id: Scalars["ID"]["output"];
-    canonicalUrl?: Maybe<Scalars["String"]["output"]>;
-    contentfulMetadata: ContentfulMetadata;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<ComponentSeoLinkingCollections>;
-    nofollow?: Maybe<Scalars["Boolean"]["output"]>;
-    noindex?: Maybe<Scalars["Boolean"]["output"]>;
-    pageDescription?: Maybe<Scalars["String"]["output"]>;
-    pageTitle?: Maybe<Scalars["String"]["output"]>;
-    shareImagesCollection?: Maybe<AssetCollection>;
-    shareImagesCursorCollection?: Maybe<AssetCursorCollection>;
-    sys: Sys;
-  };
+export type ComponentSeo = Entry & _Node & {
+  __typename?: 'ComponentSeo';
+  _id: Scalars['ID']['output'];
+  canonicalUrl?: Maybe<Scalars['String']['output']>;
+  contentfulMetadata: ContentfulMetadata;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<ComponentSeoLinkingCollections>;
+  nofollow?: Maybe<Scalars['Boolean']['output']>;
+  noindex?: Maybe<Scalars['Boolean']['output']>;
+  pageDescription?: Maybe<Scalars['String']['output']>;
+  pageTitle?: Maybe<Scalars['String']['output']>;
+  shareImagesCollection?: Maybe<AssetCollection>;
+  shareImagesCursorCollection?: Maybe<AssetCursorCollection>;
+  sys: Sys;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
 export type ComponentSeoCanonicalUrlArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
 export type ComponentSeoInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
 export type ComponentSeoLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
 export type ComponentSeoNofollowArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
 export type ComponentSeoNoindexArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
 export type ComponentSeoPageDescriptionArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
 export type ComponentSeoPageTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
 export type ComponentSeoShareImagesCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
 export type ComponentSeoShareImagesCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type ComponentSeoCollection = {
-  __typename?: "ComponentSeoCollection";
+  __typename?: 'ComponentSeoCollection';
   items: Array<Maybe<ComponentSeo>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type ComponentSeoCursorCollection = {
-  __typename?: "ComponentSeoCursorCollection";
+  __typename?: 'ComponentSeoCursorCollection';
   items: Array<Maybe<ComponentSeo>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export type ComponentSeoFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentSeoFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentSeoFilter>>>;
-  canonicalUrl?: InputMaybe<Scalars["String"]["input"]>;
-  canonicalUrl_contains?: InputMaybe<Scalars["String"]["input"]>;
-  canonicalUrl_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  canonicalUrl_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  canonicalUrl_not?: InputMaybe<Scalars["String"]["input"]>;
-  canonicalUrl_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  canonicalUrl_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  canonicalUrl?: InputMaybe<Scalars['String']['input']>;
+  canonicalUrl_contains?: InputMaybe<Scalars['String']['input']>;
+  canonicalUrl_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  canonicalUrl_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  canonicalUrl_not?: InputMaybe<Scalars['String']['input']>;
+  canonicalUrl_not_contains?: InputMaybe<Scalars['String']['input']>;
+  canonicalUrl_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  nofollow?: InputMaybe<Scalars["Boolean"]["input"]>;
-  nofollow_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  nofollow_not?: InputMaybe<Scalars["Boolean"]["input"]>;
-  noindex?: InputMaybe<Scalars["Boolean"]["input"]>;
-  noindex_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  noindex_not?: InputMaybe<Scalars["Boolean"]["input"]>;
-  pageDescription?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageDescription_not?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageTitle?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageTitle_not?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  shareImagesCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  nofollow?: InputMaybe<Scalars['Boolean']['input']>;
+  nofollow_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  nofollow_not?: InputMaybe<Scalars['Boolean']['input']>;
+  noindex?: InputMaybe<Scalars['Boolean']['input']>;
+  noindex_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  noindex_not?: InputMaybe<Scalars['Boolean']['input']>;
+  pageDescription?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_contains?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageDescription_not?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageTitle?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_contains?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageTitle_not?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  shareImagesCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
   sys?: InputMaybe<SysFilter>;
 };
 
 export type ComponentSeoLinkingCollections = {
-  __typename?: "ComponentSeoLinkingCollections";
+  __typename?: 'ComponentSeoLinkingCollections';
+  componentReleaseNoteCollection?: Maybe<ComponentReleaseNoteCollection>;
+  componentReleaseNoteCursorCollection?: Maybe<ComponentReleaseNoteCursorCollection>;
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
   pageBlogPostCollection?: Maybe<PageBlogPostCollection>;
@@ -2407,180 +2882,257 @@ export type ComponentSeoLinkingCollections = {
   pageLandingCursorCollection?: Maybe<PageLandingCursorCollection>;
 };
 
-export type ComponentSeoLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+
+export type ComponentSeoLinkingCollectionsComponentReleaseNoteCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentSeoLinkingCollectionsComponentReleaseNoteCollectionOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
+
+export type ComponentSeoLinkingCollectionsComponentReleaseNoteCursorCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentSeoLinkingCollectionsComponentReleaseNoteCursorCollectionOrder>>>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+
+export type ComponentSeoLinkingCollectionsEntryCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
 
 export type ComponentSeoLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentSeoLinkingCollectionsPageBlogPostCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentSeoLinkingCollectionsPageBlogPostCollectionOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentSeoLinkingCollectionsPageBlogPostCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<ComponentSeoLinkingCollectionsPageBlogPostCursorCollectionOrder>>
-  >;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentSeoLinkingCollectionsPageBlogPostCursorCollectionOrder>>>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentSeoLinkingCollectionsPageLandingCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentSeoLinkingCollectionsPageLandingCollectionOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type ComponentSeoLinkingCollectionsPageLandingCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<ComponentSeoLinkingCollectionsPageLandingCursorCollectionOrder>>
-  >;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentSeoLinkingCollectionsPageLandingCursorCollectionOrder>>>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+export enum ComponentSeoLinkingCollectionsComponentReleaseNoteCollectionOrder {
+  ActiveAsc = 'active_ASC',
+  ActiveDesc = 'active_DESC',
+  CategoryAsc = 'category_ASC',
+  CategoryDesc = 'category_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PublishedAtAsc = 'publishedAt_ASC',
+  PublishedAtDesc = 'publishedAt_DESC',
+  SlugAsc = 'slug_ASC',
+  SlugDesc = 'slug_DESC',
+  SummaryAsc = 'summary_ASC',
+  SummaryDesc = 'summary_DESC',
+  SurfacesAsc = 'surfaces_ASC',
+  SurfacesDesc = 'surfaces_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
+}
+
+export enum ComponentSeoLinkingCollectionsComponentReleaseNoteCursorCollectionOrder {
+  ActiveAsc = 'active_ASC',
+  ActiveDesc = 'active_DESC',
+  CategoryAsc = 'category_ASC',
+  CategoryDesc = 'category_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PublishedAtAsc = 'publishedAt_ASC',
+  PublishedAtDesc = 'publishedAt_DESC',
+  SlugAsc = 'slug_ASC',
+  SlugDesc = 'slug_DESC',
+  SummaryAsc = 'summary_ASC',
+  SummaryDesc = 'summary_DESC',
+  SurfacesAsc = 'surfaces_ASC',
+  SurfacesDesc = 'surfaces_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
+}
+
 export enum ComponentSeoLinkingCollectionsPageBlogPostCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  PublishedDateAsc = "publishedDate_ASC",
-  PublishedDateDesc = "publishedDate_DESC",
-  SlugAsc = "slug_ASC",
-  SlugDesc = "slug_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PublishedDateAsc = 'publishedDate_ASC',
+  PublishedDateDesc = 'publishedDate_DESC',
+  SlugAsc = 'slug_ASC',
+  SlugDesc = 'slug_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum ComponentSeoLinkingCollectionsPageBlogPostCursorCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  PublishedDateAsc = "publishedDate_ASC",
-  PublishedDateDesc = "publishedDate_DESC",
-  SlugAsc = "slug_ASC",
-  SlugDesc = "slug_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PublishedDateAsc = 'publishedDate_ASC',
+  PublishedDateDesc = 'publishedDate_DESC',
+  SlugAsc = 'slug_ASC',
+  SlugDesc = 'slug_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum ComponentSeoLinkingCollectionsPageLandingCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 export enum ComponentSeoLinkingCollectionsPageLandingCursorCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 export enum ComponentSeoOrder {
-  CanonicalUrlAsc = "canonicalUrl_ASC",
-  CanonicalUrlDesc = "canonicalUrl_DESC",
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  NofollowAsc = "nofollow_ASC",
-  NofollowDesc = "nofollow_DESC",
-  NoindexAsc = "noindex_ASC",
-  NoindexDesc = "noindex_DESC",
-  PageTitleAsc = "pageTitle_ASC",
-  PageTitleDesc = "pageTitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  CanonicalUrlAsc = 'canonicalUrl_ASC',
+  CanonicalUrlDesc = 'canonicalUrl_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  NofollowAsc = 'nofollow_ASC',
+  NofollowDesc = 'nofollow_DESC',
+  NoindexAsc = 'noindex_ASC',
+  NoindexDesc = 'noindex_DESC',
+  PageTitleAsc = 'pageTitle_ASC',
+  PageTitleDesc = 'pageTitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 export type ContentfulMetadata = {
-  __typename?: "ContentfulMetadata";
+  __typename?: 'ContentfulMetadata';
   concepts: Array<Maybe<TaxonomyConcept>>;
   tags: Array<Maybe<ContentfulTag>>;
 };
 
 export type ContentfulMetadataConceptsDescendantsFilter = {
-  id_contains_all?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  id_contains_none?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  id_contains_some?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  id_contains_all?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  id_contains_none?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  id_contains_some?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type ContentfulMetadataConceptsFilter = {
   descendants?: InputMaybe<ContentfulMetadataConceptsDescendantsFilter>;
-  id_contains_all?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  id_contains_none?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  id_contains_some?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  id_contains_all?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  id_contains_none?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  id_contains_some?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type ContentfulMetadataFilter = {
   concepts?: InputMaybe<ContentfulMetadataConceptsFilter>;
-  concepts_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  concepts_exists?: InputMaybe<Scalars['Boolean']['input']>;
   tags?: InputMaybe<ContentfulMetadataTagsFilter>;
-  tags_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  tags_exists?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type ContentfulMetadataTagsFilter = {
-  id_contains_all?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  id_contains_none?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  id_contains_some?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  id_contains_all?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  id_contains_none?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  id_contains_some?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 /**
@@ -2588,15 +3140,15 @@ export type ContentfulMetadataTagsFilter = {
  *       Find out more here: https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/content-tags
  */
 export type ContentfulTag = {
-  __typename?: "ContentfulTag";
-  id?: Maybe<Scalars["String"]["output"]>;
-  name?: Maybe<Scalars["String"]["output"]>;
+  __typename?: 'ContentfulTag';
+  id?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
 };
 
 export type CursorPages = {
-  __typename?: "CursorPages";
-  next?: Maybe<Scalars["String"]["output"]>;
-  prev?: Maybe<Scalars["String"]["output"]>;
+  __typename?: 'CursorPages';
+  next?: Maybe<Scalars['String']['output']>;
+  prev?: Maybe<Scalars['String']['output']>;
 };
 
 export type Entry = {
@@ -2605,17 +3157,17 @@ export type Entry = {
 };
 
 export type EntryCollection = {
-  __typename?: "EntryCollection";
+  __typename?: 'EntryCollection';
   items: Array<Maybe<Entry>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type EntryCursorCollection = {
-  __typename?: "EntryCursorCollection";
+  __typename?: 'EntryCursorCollection';
   items: Array<Maybe<Entry>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
@@ -2627,415 +3179,428 @@ export type EntryFilter = {
 };
 
 export enum EntryOrder {
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
-export type Footer = Entry &
-  _Node & {
-    __typename?: "Footer";
-    _id: Scalars["ID"]["output"];
-    badge?: Maybe<Scalars["String"]["output"]>;
-    brand?: Maybe<Scalars["String"]["output"]>;
-    contentfulMetadata: ContentfulMetadata;
-    copyright?: Maybe<Scalars["String"]["output"]>;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<FooterLinkingCollections>;
-    menuButtonsCollection?: Maybe<FooterMenuButtonsCollection>;
-    menuButtonsCursorCollection?: Maybe<FooterMenuButtonsCursorCollection>;
-    menuTitle?: Maybe<Scalars["String"]["output"]>;
-    supportButtonsCollection?: Maybe<FooterSupportButtonsCollection>;
-    supportButtonsCursorCollection?: Maybe<FooterSupportButtonsCursorCollection>;
-    supportTitle?: Maybe<Scalars["String"]["output"]>;
-    sys: Sys;
-    title?: Maybe<Scalars["String"]["output"]>;
-  };
+export type Footer = Entry & _Node & {
+  __typename?: 'Footer';
+  _id: Scalars['ID']['output'];
+  badge?: Maybe<Scalars['String']['output']>;
+  brand?: Maybe<Scalars['String']['output']>;
+  contentfulMetadata: ContentfulMetadata;
+  copyright?: Maybe<Scalars['String']['output']>;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<FooterLinkingCollections>;
+  menuButtonsCollection?: Maybe<FooterMenuButtonsCollection>;
+  menuButtonsCursorCollection?: Maybe<FooterMenuButtonsCursorCollection>;
+  menuTitle?: Maybe<Scalars['String']['output']>;
+  supportButtonsCollection?: Maybe<FooterSupportButtonsCollection>;
+  supportButtonsCursorCollection?: Maybe<FooterSupportButtonsCursorCollection>;
+  supportTitle?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterBadgeArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterBrandArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterCopyrightArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterMenuButtonsCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<FooterMenuButtonsCollectionOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterMenuButtonsCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<FooterMenuButtonsCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterMenuTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterSupportButtonsCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<FooterSupportButtonsCollectionOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterSupportButtonsCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<FooterSupportButtonsCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
 
+
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterSupportTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type FooterCollection = {
-  __typename?: "FooterCollection";
+  __typename?: 'FooterCollection';
   items: Array<Maybe<Footer>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type FooterCursorCollection = {
-  __typename?: "FooterCursorCollection";
+  __typename?: 'FooterCursorCollection';
   items: Array<Maybe<Footer>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export type FooterFilter = {
   AND?: InputMaybe<Array<InputMaybe<FooterFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<FooterFilter>>>;
-  badge?: InputMaybe<Scalars["String"]["input"]>;
-  badge_contains?: InputMaybe<Scalars["String"]["input"]>;
-  badge_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  badge_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  badge_not?: InputMaybe<Scalars["String"]["input"]>;
-  badge_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  badge_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  brand?: InputMaybe<Scalars["String"]["input"]>;
-  brand_contains?: InputMaybe<Scalars["String"]["input"]>;
-  brand_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  brand_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  brand_not?: InputMaybe<Scalars["String"]["input"]>;
-  brand_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  brand_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  badge?: InputMaybe<Scalars['String']['input']>;
+  badge_contains?: InputMaybe<Scalars['String']['input']>;
+  badge_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  badge_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  badge_not?: InputMaybe<Scalars['String']['input']>;
+  badge_not_contains?: InputMaybe<Scalars['String']['input']>;
+  badge_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  brand?: InputMaybe<Scalars['String']['input']>;
+  brand_contains?: InputMaybe<Scalars['String']['input']>;
+  brand_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  brand_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  brand_not?: InputMaybe<Scalars['String']['input']>;
+  brand_not_contains?: InputMaybe<Scalars['String']['input']>;
+  brand_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  copyright?: InputMaybe<Scalars["String"]["input"]>;
-  copyright_contains?: InputMaybe<Scalars["String"]["input"]>;
-  copyright_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  copyright_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  copyright_not?: InputMaybe<Scalars["String"]["input"]>;
-  copyright_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  copyright_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  copyright?: InputMaybe<Scalars['String']['input']>;
+  copyright_contains?: InputMaybe<Scalars['String']['input']>;
+  copyright_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  copyright_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  copyright_not?: InputMaybe<Scalars['String']['input']>;
+  copyright_not_contains?: InputMaybe<Scalars['String']['input']>;
+  copyright_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   menuButtons?: InputMaybe<CfComponentButtonNestedFilter>;
-  menuButtonsCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  menuTitle?: InputMaybe<Scalars["String"]["input"]>;
-  menuTitle_contains?: InputMaybe<Scalars["String"]["input"]>;
-  menuTitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  menuTitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  menuTitle_not?: InputMaybe<Scalars["String"]["input"]>;
-  menuTitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  menuTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  menuButtonsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  menuTitle?: InputMaybe<Scalars['String']['input']>;
+  menuTitle_contains?: InputMaybe<Scalars['String']['input']>;
+  menuTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  menuTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  menuTitle_not?: InputMaybe<Scalars['String']['input']>;
+  menuTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  menuTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   supportButtons?: InputMaybe<CfComponentButtonNestedFilter>;
-  supportButtonsCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  supportTitle?: InputMaybe<Scalars["String"]["input"]>;
-  supportTitle_contains?: InputMaybe<Scalars["String"]["input"]>;
-  supportTitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  supportTitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  supportTitle_not?: InputMaybe<Scalars["String"]["input"]>;
-  supportTitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  supportTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  supportButtonsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  supportTitle?: InputMaybe<Scalars['String']['input']>;
+  supportTitle_contains?: InputMaybe<Scalars['String']['input']>;
+  supportTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  supportTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  supportTitle_not?: InputMaybe<Scalars['String']['input']>;
+  supportTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  supportTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  title_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  title_not?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type FooterLinkingCollections = {
-  __typename?: "FooterLinkingCollections";
+  __typename?: 'FooterLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
+
 export type FooterLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type FooterLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type FooterMenuButtonsCollection = {
-  __typename?: "FooterMenuButtonsCollection";
+  __typename?: 'FooterMenuButtonsCollection';
   items: Array<Maybe<ComponentButton>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export enum FooterMenuButtonsCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  LabelAsc = "label_ASC",
-  LabelDesc = "label_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  UrlAsc = "url_ASC",
-  UrlDesc = "url_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  LabelAsc = 'label_ASC',
+  LabelDesc = 'label_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  UrlAsc = 'url_ASC',
+  UrlDesc = 'url_DESC'
 }
 
 export type FooterMenuButtonsCursorCollection = {
-  __typename?: "FooterMenuButtonsCursorCollection";
+  __typename?: 'FooterMenuButtonsCursorCollection';
   items: Array<Maybe<ComponentButton>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export enum FooterMenuButtonsCursorCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  LabelAsc = "label_ASC",
-  LabelDesc = "label_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  UrlAsc = "url_ASC",
-  UrlDesc = "url_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  LabelAsc = 'label_ASC',
+  LabelDesc = 'label_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  UrlAsc = 'url_ASC',
+  UrlDesc = 'url_DESC'
 }
 
 export enum FooterOrder {
-  BadgeAsc = "badge_ASC",
-  BadgeDesc = "badge_DESC",
-  BrandAsc = "brand_ASC",
-  BrandDesc = "brand_DESC",
-  CopyrightAsc = "copyright_ASC",
-  CopyrightDesc = "copyright_DESC",
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  MenuTitleAsc = "menuTitle_ASC",
-  MenuTitleDesc = "menuTitle_DESC",
-  SupportTitleAsc = "supportTitle_ASC",
-  SupportTitleDesc = "supportTitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  BadgeAsc = 'badge_ASC',
+  BadgeDesc = 'badge_DESC',
+  BrandAsc = 'brand_ASC',
+  BrandDesc = 'brand_DESC',
+  CopyrightAsc = 'copyright_ASC',
+  CopyrightDesc = 'copyright_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  MenuTitleAsc = 'menuTitle_ASC',
+  MenuTitleDesc = 'menuTitle_DESC',
+  SupportTitleAsc = 'supportTitle_ASC',
+  SupportTitleDesc = 'supportTitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export type FooterSupportButtonsCollection = {
-  __typename?: "FooterSupportButtonsCollection";
+  __typename?: 'FooterSupportButtonsCollection';
   items: Array<Maybe<ComponentButton>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export enum FooterSupportButtonsCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  LabelAsc = "label_ASC",
-  LabelDesc = "label_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  UrlAsc = "url_ASC",
-  UrlDesc = "url_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  LabelAsc = 'label_ASC',
+  LabelDesc = 'label_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  UrlAsc = 'url_ASC',
+  UrlDesc = 'url_DESC'
 }
 
 export type FooterSupportButtonsCursorCollection = {
-  __typename?: "FooterSupportButtonsCursorCollection";
+  __typename?: 'FooterSupportButtonsCursorCollection';
   items: Array<Maybe<ComponentButton>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export enum FooterSupportButtonsCursorCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  LabelAsc = "label_ASC",
-  LabelDesc = "label_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  UrlAsc = "url_ASC",
-  UrlDesc = "url_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  LabelAsc = 'label_ASC',
+  LabelDesc = 'label_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  UrlAsc = 'url_ASC',
+  UrlDesc = 'url_DESC'
 }
 
 export enum ImageFormat {
   /** AVIF image format. */
-  Avif = "AVIF",
+  Avif = 'AVIF',
   /** JPG image format. */
-  Jpg = "JPG",
+  Jpg = 'JPG',
   /**
    * Progressive JPG format stores multiple passes of an image in progressively higher detail.
    *         When a progressive image is loading, the viewer will first see a lower quality pixelated version which
    *         will gradually improve in detail, until the image is fully downloaded. This is to display an image as
    *         early as possible to make the layout look as designed.
    */
-  JpgProgressive = "JPG_PROGRESSIVE",
+  JpgProgressive = 'JPG_PROGRESSIVE',
   /** PNG image format */
-  Png = "PNG",
+  Png = 'PNG',
   /**
    * 8-bit PNG images support up to 256 colors and weigh less than the standard 24-bit PNG equivalent.
    *         The 8-bit PNG format is mostly used for simple images, such as icons or logos.
    */
-  Png8 = "PNG8",
+  Png8 = 'PNG8',
   /** WebP image format. */
-  Webp = "WEBP",
+  Webp = 'WEBP'
 }
 
 export enum ImageResizeFocus {
   /** Focus the resizing on the bottom. */
-  Bottom = "BOTTOM",
+  Bottom = 'BOTTOM',
   /** Focus the resizing on the bottom left. */
-  BottomLeft = "BOTTOM_LEFT",
+  BottomLeft = 'BOTTOM_LEFT',
   /** Focus the resizing on the bottom right. */
-  BottomRight = "BOTTOM_RIGHT",
+  BottomRight = 'BOTTOM_RIGHT',
   /** Focus the resizing on the center. */
-  Center = "CENTER",
+  Center = 'CENTER',
   /** Focus the resizing on the largest face. */
-  Face = "FACE",
+  Face = 'FACE',
   /** Focus the resizing on the area containing all the faces. */
-  Faces = "FACES",
+  Faces = 'FACES',
   /** Focus the resizing on the left. */
-  Left = "LEFT",
+  Left = 'LEFT',
   /** Focus the resizing on the right. */
-  Right = "RIGHT",
+  Right = 'RIGHT',
   /** Focus the resizing on the top. */
-  Top = "TOP",
+  Top = 'TOP',
   /** Focus the resizing on the top left. */
-  TopLeft = "TOP_LEFT",
+  TopLeft = 'TOP_LEFT',
   /** Focus the resizing on the top right. */
-  TopRight = "TOP_RIGHT",
+  TopRight = 'TOP_RIGHT'
 }
 
 export enum ImageResizeStrategy {
   /** Crops a part of the original image to fit into the specified dimensions. */
-  Crop = "CROP",
+  Crop = 'CROP',
   /** Resizes the image to the specified dimensions, cropping the image if needed. */
-  Fill = "FILL",
+  Fill = 'FILL',
   /** Resizes the image to fit into the specified dimensions. */
-  Fit = "FIT",
+  Fit = 'FIT',
   /**
    * Resizes the image to the specified dimensions, padding the image if needed.
    *         Uses desired background color as padding color.
    */
-  Pad = "PAD",
+  Pad = 'PAD',
   /** Resizes the image to the specified dimensions, changing the original aspect ratio if needed. */
-  Scale = "SCALE",
+  Scale = 'SCALE',
   /** Creates a thumbnail from the image. */
-  Thumb = "THUMB",
+  Thumb = 'THUMB'
 }
 
 export type ImageTransformOptions = {
@@ -3043,79 +3608,82 @@ export type ImageTransformOptions = {
    * Desired background color, used with corner radius or `PAD` resize strategy.
    *         Defaults to transparent (for `PNG`, `PNG8` and `WEBP`) or white (for `JPG` and `JPG_PROGRESSIVE`).
    */
-  backgroundColor?: InputMaybe<Scalars["HexColor"]["input"]>;
+  backgroundColor?: InputMaybe<Scalars['HexColor']['input']>;
   /**
    * Desired corner radius in pixels.
    *         Results in an image with rounded corners (pass `-1` for a full circle/ellipse).
    *         Defaults to `0`. Uses desired background color as padding color,
    *         unless the format is `JPG` or `JPG_PROGRESSIVE` and resize strategy is `PAD`, then defaults to white.
    */
-  cornerRadius?: InputMaybe<Scalars["Int"]["input"]>;
+  cornerRadius?: InputMaybe<Scalars['Int']['input']>;
   /** Desired image format. Defaults to the original image format. */
   format?: InputMaybe<ImageFormat>;
   /** Desired height in pixels. Defaults to the original image height. */
-  height?: InputMaybe<Scalars["Dimension"]["input"]>;
+  height?: InputMaybe<Scalars['Dimension']['input']>;
   /**
    * Desired quality of the image in percents.
    *         Used for `PNG8`, `JPG`, `JPG_PROGRESSIVE` and `WEBP` formats.
    */
-  quality?: InputMaybe<Scalars["Quality"]["input"]>;
+  quality?: InputMaybe<Scalars['Quality']['input']>;
   /** Desired resize focus area. Defaults to `CENTER`. */
   resizeFocus?: InputMaybe<ImageResizeFocus>;
   /** Desired resize strategy. Defaults to `FIT`. */
   resizeStrategy?: InputMaybe<ImageResizeStrategy>;
   /** Desired width in pixels. Defaults to the original image width. */
-  width?: InputMaybe<Scalars["Dimension"]["input"]>;
+  width?: InputMaybe<Scalars['Dimension']['input']>;
 };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/landingMetadata) */
-export type LandingMetadata = Entry &
-  _Node & {
-    __typename?: "LandingMetadata";
-    _id: Scalars["ID"]["output"];
-    contentfulMetadata: ContentfulMetadata;
-    description?: Maybe<Scalars["String"]["output"]>;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<LandingMetadataLinkingCollections>;
-    sys: Sys;
-    title?: Maybe<Scalars["String"]["output"]>;
-  };
+export type LandingMetadata = Entry & _Node & {
+  __typename?: 'LandingMetadata';
+  _id: Scalars['ID']['output'];
+  contentfulMetadata: ContentfulMetadata;
+  description?: Maybe<Scalars['String']['output']>;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<LandingMetadataLinkingCollections>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/landingMetadata) */
 export type LandingMetadataDescriptionArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/landingMetadata) */
 export type LandingMetadataInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/landingMetadata) */
 export type LandingMetadataLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/landingMetadata) */
 export type LandingMetadataTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type LandingMetadataCollection = {
-  __typename?: "LandingMetadataCollection";
+  __typename?: 'LandingMetadataCollection';
   items: Array<Maybe<LandingMetadata>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type LandingMetadataCursorCollection = {
-  __typename?: "LandingMetadataCursorCollection";
+  __typename?: 'LandingMetadataCursorCollection';
   items: Array<Maybe<LandingMetadata>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
@@ -3123,188 +3691,196 @@ export type LandingMetadataFilter = {
   AND?: InputMaybe<Array<InputMaybe<LandingMetadataFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<LandingMetadataFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  description?: InputMaybe<Scalars["String"]["input"]>;
-  description_contains?: InputMaybe<Scalars["String"]["input"]>;
-  description_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  description_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  description_not?: InputMaybe<Scalars["String"]["input"]>;
-  description_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  description_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  description?: InputMaybe<Scalars['String']['input']>;
+  description_contains?: InputMaybe<Scalars['String']['input']>;
+  description_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  description_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  description_not?: InputMaybe<Scalars['String']['input']>;
+  description_not_contains?: InputMaybe<Scalars['String']['input']>;
+  description_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  title_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  title_not?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type LandingMetadataLinkingCollections = {
-  __typename?: "LandingMetadataLinkingCollections";
+  __typename?: 'LandingMetadataLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
+
 export type LandingMetadataLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type LandingMetadataLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum LandingMetadataOrder {
-  DescriptionAsc = "description_ASC",
-  DescriptionDesc = "description_DESC",
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  DescriptionAsc = 'description_ASC',
+  DescriptionDesc = 'description_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageAbout) */
-export type PageAbout = Entry &
-  _Node & {
-    __typename?: "PageAbout";
-    _id: Scalars["ID"]["output"];
-    contentfulMetadata: ContentfulMetadata;
-    description?: Maybe<PageAboutDescription>;
-    image?: Maybe<Asset>;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<PageAboutLinkingCollections>;
-    pageDescription?: Maybe<Scalars["String"]["output"]>;
-    pageTitle?: Maybe<Scalars["String"]["output"]>;
-    sys: Sys;
-    title?: Maybe<Scalars["String"]["output"]>;
-  };
+export type PageAbout = Entry & _Node & {
+  __typename?: 'PageAbout';
+  _id: Scalars['ID']['output'];
+  contentfulMetadata: ContentfulMetadata;
+  description?: Maybe<PageAboutDescription>;
+  image?: Maybe<Asset>;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<PageAboutLinkingCollections>;
+  pageDescription?: Maybe<Scalars['String']['output']>;
+  pageTitle?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageAbout) */
 export type PageAboutDescriptionArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageAbout) */
 export type PageAboutImageArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageAbout) */
 export type PageAboutInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageAbout) */
 export type PageAboutLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageAbout) */
 export type PageAboutPageDescriptionArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageAbout) */
 export type PageAboutPageTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageAbout) */
 export type PageAboutTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type PageAboutCollection = {
-  __typename?: "PageAboutCollection";
+  __typename?: 'PageAboutCollection';
   items: Array<Maybe<PageAbout>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type PageAboutCursorCollection = {
-  __typename?: "PageAboutCursorCollection";
+  __typename?: 'PageAboutCursorCollection';
   items: Array<Maybe<PageAbout>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export type PageAboutDescription = {
-  __typename?: "PageAboutDescription";
-  json: Scalars["JSON"]["output"];
+  __typename?: 'PageAboutDescription';
+  json: Scalars['JSON']['output'];
   links: PageAboutDescriptionLinks;
 };
 
 export type PageAboutDescriptionAssets = {
-  __typename?: "PageAboutDescriptionAssets";
+  __typename?: 'PageAboutDescriptionAssets';
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type PageAboutDescriptionEntries = {
-  __typename?: "PageAboutDescriptionEntries";
+  __typename?: 'PageAboutDescriptionEntries';
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type PageAboutDescriptionLinks = {
-  __typename?: "PageAboutDescriptionLinks";
+  __typename?: 'PageAboutDescriptionLinks';
   assets: PageAboutDescriptionAssets;
   entries: PageAboutDescriptionEntries;
   resources: PageAboutDescriptionResources;
 };
 
 export type PageAboutDescriptionResources = {
-  __typename?: "PageAboutDescriptionResources";
+  __typename?: 'PageAboutDescriptionResources';
   block: Array<PageAboutDescriptionResourcesBlock>;
   hyperlink: Array<PageAboutDescriptionResourcesHyperlink>;
   inline: Array<PageAboutDescriptionResourcesInline>;
 };
 
 export type PageAboutDescriptionResourcesBlock = ResourceLink & {
-  __typename?: "PageAboutDescriptionResourcesBlock";
+  __typename?: 'PageAboutDescriptionResourcesBlock';
   sys: ResourceSys;
 };
 
 export type PageAboutDescriptionResourcesHyperlink = ResourceLink & {
-  __typename?: "PageAboutDescriptionResourcesHyperlink";
+  __typename?: 'PageAboutDescriptionResourcesHyperlink';
   sys: ResourceSys;
 };
 
 export type PageAboutDescriptionResourcesInline = ResourceLink & {
-  __typename?: "PageAboutDescriptionResourcesInline";
+  __typename?: 'PageAboutDescriptionResourcesInline';
   sys: ResourceSys;
 };
 
@@ -3312,251 +3888,264 @@ export type PageAboutFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageAboutFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageAboutFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  description_contains?: InputMaybe<Scalars["String"]["input"]>;
-  description_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  description_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  image_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageDescription?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageDescription_not?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageTitle?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageTitle_not?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  description_contains?: InputMaybe<Scalars['String']['input']>;
+  description_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  description_not_contains?: InputMaybe<Scalars['String']['input']>;
+  image_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageDescription?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_contains?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageDescription_not?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageTitle?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_contains?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageTitle_not?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  title_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  title_not?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type PageAboutLinkingCollections = {
-  __typename?: "PageAboutLinkingCollections";
+  __typename?: 'PageAboutLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
+
 export type PageAboutLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type PageAboutLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum PageAboutOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  PageDescriptionAsc = "pageDescription_ASC",
-  PageDescriptionDesc = "pageDescription_DESC",
-  PageTitleAsc = "pageTitle_ASC",
-  PageTitleDesc = "pageTitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PageDescriptionAsc = 'pageDescription_ASC',
+  PageDescriptionDesc = 'pageDescription_DESC',
+  PageTitleAsc = 'pageTitle_ASC',
+  PageTitleDesc = 'pageTitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
-export type PageBlogPost = Entry &
-  _Node & {
-    __typename?: "PageBlogPost";
-    _id: Scalars["ID"]["output"];
-    author?: Maybe<ComponentAuthor>;
-    content?: Maybe<PageBlogPostContent>;
-    contentfulMetadata: ContentfulMetadata;
-    featuredImage?: Maybe<Asset>;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<PageBlogPostLinkingCollections>;
-    publishedDate?: Maybe<Scalars["DateTime"]["output"]>;
-    relatedBlogPostsCollection?: Maybe<PageBlogPostRelatedBlogPostsCollection>;
-    relatedBlogPostsCursorCollection?: Maybe<PageBlogPostRelatedBlogPostsCursorCollection>;
-    seoFields?: Maybe<ComponentSeo>;
-    shortDescription?: Maybe<Scalars["String"]["output"]>;
-    slug?: Maybe<Scalars["String"]["output"]>;
-    sys: Sys;
-    title?: Maybe<Scalars["String"]["output"]>;
-  };
+export type PageBlogPost = Entry & _Node & {
+  __typename?: 'PageBlogPost';
+  _id: Scalars['ID']['output'];
+  author?: Maybe<ComponentAuthor>;
+  content?: Maybe<PageBlogPostContent>;
+  contentfulMetadata: ContentfulMetadata;
+  featuredImage?: Maybe<Asset>;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<PageBlogPostLinkingCollections>;
+  publishedDate?: Maybe<Scalars['DateTime']['output']>;
+  relatedBlogPostsCollection?: Maybe<PageBlogPostRelatedBlogPostsCollection>;
+  relatedBlogPostsCursorCollection?: Maybe<PageBlogPostRelatedBlogPostsCursorCollection>;
+  seoFields?: Maybe<ComponentSeo>;
+  shortDescription?: Maybe<Scalars['String']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostAuthorArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentAuthorFilter>;
 };
 
+
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostContentArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostFeaturedImageArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostPublishedDateArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostRelatedBlogPostsCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageBlogPostRelatedBlogPostsCollectionOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageBlogPostFilter>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostRelatedBlogPostsCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageBlogPostRelatedBlogPostsCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageBlogPostFilter>;
 };
 
+
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostSeoFieldsArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentSeoFilter>;
 };
 
+
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostShortDescriptionArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostSlugArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type PageBlogPostCollection = {
-  __typename?: "PageBlogPostCollection";
+  __typename?: 'PageBlogPostCollection';
   items: Array<Maybe<PageBlogPost>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type PageBlogPostContent = {
-  __typename?: "PageBlogPostContent";
-  json: Scalars["JSON"]["output"];
+  __typename?: 'PageBlogPostContent';
+  json: Scalars['JSON']['output'];
   links: PageBlogPostContentLinks;
 };
 
 export type PageBlogPostContentAssets = {
-  __typename?: "PageBlogPostContentAssets";
+  __typename?: 'PageBlogPostContentAssets';
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type PageBlogPostContentEntries = {
-  __typename?: "PageBlogPostContentEntries";
+  __typename?: 'PageBlogPostContentEntries';
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type PageBlogPostContentLinks = {
-  __typename?: "PageBlogPostContentLinks";
+  __typename?: 'PageBlogPostContentLinks';
   assets: PageBlogPostContentAssets;
   entries: PageBlogPostContentEntries;
   resources: PageBlogPostContentResources;
 };
 
 export type PageBlogPostContentResources = {
-  __typename?: "PageBlogPostContentResources";
+  __typename?: 'PageBlogPostContentResources';
   block: Array<PageBlogPostContentResourcesBlock>;
   hyperlink: Array<PageBlogPostContentResourcesHyperlink>;
   inline: Array<PageBlogPostContentResourcesInline>;
 };
 
 export type PageBlogPostContentResourcesBlock = ResourceLink & {
-  __typename?: "PageBlogPostContentResourcesBlock";
+  __typename?: 'PageBlogPostContentResourcesBlock';
   sys: ResourceSys;
 };
 
 export type PageBlogPostContentResourcesHyperlink = ResourceLink & {
-  __typename?: "PageBlogPostContentResourcesHyperlink";
+  __typename?: 'PageBlogPostContentResourcesHyperlink';
   sys: ResourceSys;
 };
 
 export type PageBlogPostContentResourcesInline = ResourceLink & {
-  __typename?: "PageBlogPostContentResourcesInline";
+  __typename?: 'PageBlogPostContentResourcesInline';
   sys: ResourceSys;
 };
 
 export type PageBlogPostCursorCollection = {
-  __typename?: "PageBlogPostCursorCollection";
+  __typename?: 'PageBlogPostCursorCollection';
   items: Array<Maybe<PageBlogPost>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
@@ -3564,58 +4153,58 @@ export type PageBlogPostFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageBlogPostFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageBlogPostFilter>>>;
   author?: InputMaybe<CfComponentAuthorNestedFilter>;
-  author_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  content_contains?: InputMaybe<Scalars["String"]["input"]>;
-  content_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  content_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  author_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  content_contains?: InputMaybe<Scalars['String']['input']>;
+  content_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  content_not_contains?: InputMaybe<Scalars['String']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  featuredImage_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  publishedDate?: InputMaybe<Scalars["DateTime"]["input"]>;
-  publishedDate_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  publishedDate_gt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  publishedDate_gte?: InputMaybe<Scalars["DateTime"]["input"]>;
-  publishedDate_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
-  publishedDate_lt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  publishedDate_lte?: InputMaybe<Scalars["DateTime"]["input"]>;
-  publishedDate_not?: InputMaybe<Scalars["DateTime"]["input"]>;
-  publishedDate_not_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
+  featuredImage_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  publishedDate?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedDate_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  publishedDate_gt?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedDate_gte?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedDate_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  publishedDate_lt?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedDate_lte?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedDate_not?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedDate_not_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
   relatedBlogPosts?: InputMaybe<CfPageBlogPostNestedFilter>;
-  relatedBlogPostsCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  relatedBlogPostsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
   seoFields?: InputMaybe<CfComponentSeoNestedFilter>;
-  seoFields_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  shortDescription?: InputMaybe<Scalars["String"]["input"]>;
-  shortDescription_contains?: InputMaybe<Scalars["String"]["input"]>;
-  shortDescription_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  shortDescription_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  shortDescription_not?: InputMaybe<Scalars["String"]["input"]>;
-  shortDescription_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  shortDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  slug?: InputMaybe<Scalars["String"]["input"]>;
-  slug_contains?: InputMaybe<Scalars["String"]["input"]>;
-  slug_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  slug_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  slug_not?: InputMaybe<Scalars["String"]["input"]>;
-  slug_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  slug_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  seoFields_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  shortDescription?: InputMaybe<Scalars['String']['input']>;
+  shortDescription_contains?: InputMaybe<Scalars['String']['input']>;
+  shortDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  shortDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  shortDescription_not?: InputMaybe<Scalars['String']['input']>;
+  shortDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
+  shortDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  slug_contains?: InputMaybe<Scalars['String']['input']>;
+  slug_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  slug_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  slug_not?: InputMaybe<Scalars['String']['input']>;
+  slug_not_contains?: InputMaybe<Scalars['String']['input']>;
+  slug_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  title_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  title_not?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type PageBlogPostLinkingCollections = {
-  __typename?: "PageBlogPostLinkingCollections";
+  __typename?: 'PageBlogPostLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
   pageBlogPostCollection?: Maybe<PageBlogPostCollection>;
@@ -3624,499 +4213,511 @@ export type PageBlogPostLinkingCollections = {
   pageLandingCursorCollection?: Maybe<PageLandingCursorCollection>;
 };
 
+
 export type PageBlogPostLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type PageBlogPostLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type PageBlogPostLinkingCollectionsPageBlogPostCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageBlogPostLinkingCollectionsPageBlogPostCollectionOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type PageBlogPostLinkingCollectionsPageBlogPostCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<PageBlogPostLinkingCollectionsPageBlogPostCursorCollectionOrder>>
-  >;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<PageBlogPostLinkingCollectionsPageBlogPostCursorCollectionOrder>>>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type PageBlogPostLinkingCollectionsPageLandingCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageBlogPostLinkingCollectionsPageLandingCollectionOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type PageBlogPostLinkingCollectionsPageLandingCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  order?: InputMaybe<
-    Array<InputMaybe<PageBlogPostLinkingCollectionsPageLandingCursorCollectionOrder>>
-  >;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<PageBlogPostLinkingCollectionsPageLandingCursorCollectionOrder>>>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum PageBlogPostLinkingCollectionsPageBlogPostCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  PublishedDateAsc = "publishedDate_ASC",
-  PublishedDateDesc = "publishedDate_DESC",
-  SlugAsc = "slug_ASC",
-  SlugDesc = "slug_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PublishedDateAsc = 'publishedDate_ASC',
+  PublishedDateDesc = 'publishedDate_DESC',
+  SlugAsc = 'slug_ASC',
+  SlugDesc = 'slug_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum PageBlogPostLinkingCollectionsPageBlogPostCursorCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  PublishedDateAsc = "publishedDate_ASC",
-  PublishedDateDesc = "publishedDate_DESC",
-  SlugAsc = "slug_ASC",
-  SlugDesc = "slug_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PublishedDateAsc = 'publishedDate_ASC',
+  PublishedDateDesc = 'publishedDate_DESC',
+  SlugAsc = 'slug_ASC',
+  SlugDesc = 'slug_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export enum PageBlogPostLinkingCollectionsPageLandingCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 export enum PageBlogPostLinkingCollectionsPageLandingCursorCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 export enum PageBlogPostOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  PublishedDateAsc = "publishedDate_ASC",
-  PublishedDateDesc = "publishedDate_DESC",
-  SlugAsc = "slug_ASC",
-  SlugDesc = "slug_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PublishedDateAsc = 'publishedDate_ASC',
+  PublishedDateDesc = 'publishedDate_DESC',
+  SlugAsc = 'slug_ASC',
+  SlugDesc = 'slug_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export type PageBlogPostRelatedBlogPostsCollection = {
-  __typename?: "PageBlogPostRelatedBlogPostsCollection";
+  __typename?: 'PageBlogPostRelatedBlogPostsCollection';
   items: Array<Maybe<PageBlogPost>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export enum PageBlogPostRelatedBlogPostsCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  PublishedDateAsc = "publishedDate_ASC",
-  PublishedDateDesc = "publishedDate_DESC",
-  SlugAsc = "slug_ASC",
-  SlugDesc = "slug_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PublishedDateAsc = 'publishedDate_ASC',
+  PublishedDateDesc = 'publishedDate_DESC',
+  SlugAsc = 'slug_ASC',
+  SlugDesc = 'slug_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export type PageBlogPostRelatedBlogPostsCursorCollection = {
-  __typename?: "PageBlogPostRelatedBlogPostsCursorCollection";
+  __typename?: 'PageBlogPostRelatedBlogPostsCursorCollection';
   items: Array<Maybe<PageBlogPost>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export enum PageBlogPostRelatedBlogPostsCursorCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  PublishedDateAsc = "publishedDate_ASC",
-  PublishedDateDesc = "publishedDate_DESC",
-  SlugAsc = "slug_ASC",
-  SlugDesc = "slug_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PublishedDateAsc = 'publishedDate_ASC',
+  PublishedDateDesc = 'publishedDate_DESC',
+  SlugAsc = 'slug_ASC',
+  SlugDesc = 'slug_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageCookiePolicy) */
-export type PageCookiePolicy = Entry &
-  _Node & {
-    __typename?: "PageCookiePolicy";
-    _id: Scalars["ID"]["output"];
-    content?: Maybe<PageCookiePolicyContent>;
-    contentfulMetadata: ContentfulMetadata;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<PageCookiePolicyLinkingCollections>;
-    pageDescription?: Maybe<Scalars["String"]["output"]>;
-    pageTitle?: Maybe<Scalars["String"]["output"]>;
-    sys: Sys;
-    title?: Maybe<Scalars["String"]["output"]>;
-  };
+export type PageCookiePolicy = Entry & _Node & {
+  __typename?: 'PageCookiePolicy';
+  _id: Scalars['ID']['output'];
+  content?: Maybe<PageCookiePolicyContent>;
+  contentfulMetadata: ContentfulMetadata;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<PageCookiePolicyLinkingCollections>;
+  pageDescription?: Maybe<Scalars['String']['output']>;
+  pageTitle?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageCookiePolicy) */
 export type PageCookiePolicyContentArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageCookiePolicy) */
 export type PageCookiePolicyInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageCookiePolicy) */
 export type PageCookiePolicyLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageCookiePolicy) */
 export type PageCookiePolicyPageDescriptionArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageCookiePolicy) */
 export type PageCookiePolicyPageTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageCookiePolicy) */
 export type PageCookiePolicyTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type PageCookiePolicyCollection = {
-  __typename?: "PageCookiePolicyCollection";
+  __typename?: 'PageCookiePolicyCollection';
   items: Array<Maybe<PageCookiePolicy>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type PageCookiePolicyContent = {
-  __typename?: "PageCookiePolicyContent";
-  json: Scalars["JSON"]["output"];
+  __typename?: 'PageCookiePolicyContent';
+  json: Scalars['JSON']['output'];
   links: PageCookiePolicyContentLinks;
 };
 
 export type PageCookiePolicyContentAssets = {
-  __typename?: "PageCookiePolicyContentAssets";
+  __typename?: 'PageCookiePolicyContentAssets';
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type PageCookiePolicyContentEntries = {
-  __typename?: "PageCookiePolicyContentEntries";
+  __typename?: 'PageCookiePolicyContentEntries';
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type PageCookiePolicyContentLinks = {
-  __typename?: "PageCookiePolicyContentLinks";
+  __typename?: 'PageCookiePolicyContentLinks';
   assets: PageCookiePolicyContentAssets;
   entries: PageCookiePolicyContentEntries;
   resources: PageCookiePolicyContentResources;
 };
 
 export type PageCookiePolicyContentResources = {
-  __typename?: "PageCookiePolicyContentResources";
+  __typename?: 'PageCookiePolicyContentResources';
   block: Array<PageCookiePolicyContentResourcesBlock>;
   hyperlink: Array<PageCookiePolicyContentResourcesHyperlink>;
   inline: Array<PageCookiePolicyContentResourcesInline>;
 };
 
 export type PageCookiePolicyContentResourcesBlock = ResourceLink & {
-  __typename?: "PageCookiePolicyContentResourcesBlock";
+  __typename?: 'PageCookiePolicyContentResourcesBlock';
   sys: ResourceSys;
 };
 
 export type PageCookiePolicyContentResourcesHyperlink = ResourceLink & {
-  __typename?: "PageCookiePolicyContentResourcesHyperlink";
+  __typename?: 'PageCookiePolicyContentResourcesHyperlink';
   sys: ResourceSys;
 };
 
 export type PageCookiePolicyContentResourcesInline = ResourceLink & {
-  __typename?: "PageCookiePolicyContentResourcesInline";
+  __typename?: 'PageCookiePolicyContentResourcesInline';
   sys: ResourceSys;
 };
 
 export type PageCookiePolicyCursorCollection = {
-  __typename?: "PageCookiePolicyCursorCollection";
+  __typename?: 'PageCookiePolicyCursorCollection';
   items: Array<Maybe<PageCookiePolicy>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export type PageCookiePolicyFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageCookiePolicyFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageCookiePolicyFilter>>>;
-  content_contains?: InputMaybe<Scalars["String"]["input"]>;
-  content_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  content_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  content_contains?: InputMaybe<Scalars['String']['input']>;
+  content_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  content_not_contains?: InputMaybe<Scalars['String']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageDescription?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageDescription_not?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageTitle?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageTitle_not?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageDescription?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_contains?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageDescription_not?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageTitle?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_contains?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageTitle_not?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  title_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  title_not?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type PageCookiePolicyLinkingCollections = {
-  __typename?: "PageCookiePolicyLinkingCollections";
+  __typename?: 'PageCookiePolicyLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
+
 export type PageCookiePolicyLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type PageCookiePolicyLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum PageCookiePolicyOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  PageDescriptionAsc = "pageDescription_ASC",
-  PageDescriptionDesc = "pageDescription_DESC",
-  PageTitleAsc = "pageTitle_ASC",
-  PageTitleDesc = "pageTitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PageDescriptionAsc = 'pageDescription_ASC',
+  PageDescriptionDesc = 'pageDescription_DESC',
+  PageTitleAsc = 'pageTitle_ASC',
+  PageTitleDesc = 'pageTitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageEmails) */
-export type PageEmails = Entry &
-  _Node & {
-    __typename?: "PageEmails";
-    _id: Scalars["ID"]["output"];
-    contentfulMetadata: ContentfulMetadata;
-    emailsCollection?: Maybe<PageEmailsEmailsCollection>;
-    emailsCursorCollection?: Maybe<PageEmailsEmailsCursorCollection>;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<PageEmailsLinkingCollections>;
-    sys: Sys;
-  };
+export type PageEmails = Entry & _Node & {
+  __typename?: 'PageEmails';
+  _id: Scalars['ID']['output'];
+  contentfulMetadata: ContentfulMetadata;
+  emailsCollection?: Maybe<PageEmailsEmailsCollection>;
+  emailsCursorCollection?: Maybe<PageEmailsEmailsCursorCollection>;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<PageEmailsLinkingCollections>;
+  sys: Sys;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageEmails) */
 export type PageEmailsEmailsCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageEmailsEmailsCollectionOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentEmailFilter>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageEmails) */
 export type PageEmailsEmailsCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageEmailsEmailsCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentEmailFilter>;
 };
 
+
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageEmails) */
 export type PageEmailsInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageEmails) */
 export type PageEmailsLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type PageEmailsCollection = {
-  __typename?: "PageEmailsCollection";
+  __typename?: 'PageEmailsCollection';
   items: Array<Maybe<PageEmails>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type PageEmailsCursorCollection = {
-  __typename?: "PageEmailsCursorCollection";
+  __typename?: 'PageEmailsCursorCollection';
   items: Array<Maybe<PageEmails>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export type PageEmailsEmailsCollection = {
-  __typename?: "PageEmailsEmailsCollection";
+  __typename?: 'PageEmailsEmailsCollection';
   items: Array<Maybe<ComponentEmail>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export enum PageEmailsEmailsCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  PreviewAsc = "preview_ASC",
-  PreviewDesc = "preview_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PreviewAsc = 'preview_ASC',
+  PreviewDesc = 'preview_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 export type PageEmailsEmailsCursorCollection = {
-  __typename?: "PageEmailsEmailsCursorCollection";
+  __typename?: 'PageEmailsEmailsCursorCollection';
   items: Array<Maybe<ComponentEmail>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export enum PageEmailsEmailsCursorCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  PreviewAsc = "preview_ASC",
-  PreviewDesc = "preview_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PreviewAsc = 'preview_ASC',
+  PreviewDesc = 'preview_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 export type PageEmailsFilter = {
@@ -4124,140 +4725,149 @@ export type PageEmailsFilter = {
   OR?: InputMaybe<Array<InputMaybe<PageEmailsFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
   emails?: InputMaybe<CfComponentEmailNestedFilter>;
-  emailsCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  emailsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
 };
 
 export type PageEmailsLinkingCollections = {
-  __typename?: "PageEmailsLinkingCollections";
+  __typename?: 'PageEmailsLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
+
 export type PageEmailsLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type PageEmailsLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum PageEmailsOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageFaq) */
-export type PageFaq = Entry &
-  _Node & {
-    __typename?: "PageFaq";
-    _id: Scalars["ID"]["output"];
-    contentfulMetadata: ContentfulMetadata;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    intro?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<PageFaqLinkingCollections>;
-    pageDescription?: Maybe<Scalars["String"]["output"]>;
-    pageTitle?: Maybe<Scalars["String"]["output"]>;
-    questionsCollection?: Maybe<PageFaqQuestionsCollection>;
-    questionsCursorCollection?: Maybe<PageFaqQuestionsCursorCollection>;
-    sys: Sys;
-    title?: Maybe<Scalars["String"]["output"]>;
-  };
+export type PageFaq = Entry & _Node & {
+  __typename?: 'PageFaq';
+  _id: Scalars['ID']['output'];
+  contentfulMetadata: ContentfulMetadata;
+  internalName?: Maybe<Scalars['String']['output']>;
+  intro?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<PageFaqLinkingCollections>;
+  pageDescription?: Maybe<Scalars['String']['output']>;
+  pageTitle?: Maybe<Scalars['String']['output']>;
+  questionsCollection?: Maybe<PageFaqQuestionsCollection>;
+  questionsCursorCollection?: Maybe<PageFaqQuestionsCursorCollection>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageFaq) */
 export type PageFaqInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageFaq) */
 export type PageFaqIntroArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageFaq) */
 export type PageFaqLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageFaq) */
 export type PageFaqPageDescriptionArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageFaq) */
 export type PageFaqPageTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageFaq) */
 export type PageFaqQuestionsCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageFaqQuestionsCollectionOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentFaqQuestionFilter>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageFaq) */
 export type PageFaqQuestionsCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageFaqQuestionsCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentFaqQuestionFilter>;
 };
 
+
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageFaq) */
 export type PageFaqTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type PageFaqCollection = {
-  __typename?: "PageFaqCollection";
+  __typename?: 'PageFaqCollection';
   items: Array<Maybe<PageFaq>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type PageFaqCursorCollection = {
-  __typename?: "PageFaqCursorCollection";
+  __typename?: 'PageFaqCursorCollection';
   items: Array<Maybe<PageFaq>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
@@ -4265,484 +4875,501 @@ export type PageFaqFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageFaqFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageFaqFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  intro?: InputMaybe<Scalars["String"]["input"]>;
-  intro_contains?: InputMaybe<Scalars["String"]["input"]>;
-  intro_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  intro_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  intro_not?: InputMaybe<Scalars["String"]["input"]>;
-  intro_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  intro_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageDescription?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageDescription_not?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageTitle?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageTitle_not?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  intro?: InputMaybe<Scalars['String']['input']>;
+  intro_contains?: InputMaybe<Scalars['String']['input']>;
+  intro_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  intro_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  intro_not?: InputMaybe<Scalars['String']['input']>;
+  intro_not_contains?: InputMaybe<Scalars['String']['input']>;
+  intro_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageDescription?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_contains?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageDescription_not?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageTitle?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_contains?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageTitle_not?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   questions?: InputMaybe<CfComponentFaqQuestionNestedFilter>;
-  questionsCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  questionsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  title_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  title_not?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type PageFaqLinkingCollections = {
-  __typename?: "PageFaqLinkingCollections";
+  __typename?: 'PageFaqLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
+
 export type PageFaqLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type PageFaqLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum PageFaqOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  IntroAsc = "intro_ASC",
-  IntroDesc = "intro_DESC",
-  PageDescriptionAsc = "pageDescription_ASC",
-  PageDescriptionDesc = "pageDescription_DESC",
-  PageTitleAsc = "pageTitle_ASC",
-  PageTitleDesc = "pageTitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  IntroAsc = 'intro_ASC',
+  IntroDesc = 'intro_DESC',
+  PageDescriptionAsc = 'pageDescription_ASC',
+  PageDescriptionDesc = 'pageDescription_DESC',
+  PageTitleAsc = 'pageTitle_ASC',
+  PageTitleDesc = 'pageTitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export type PageFaqQuestionsCollection = {
-  __typename?: "PageFaqQuestionsCollection";
+  __typename?: 'PageFaqQuestionsCollection';
   items: Array<Maybe<ComponentFaqQuestion>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export enum PageFaqQuestionsCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  QuestionAsc = "question_ASC",
-  QuestionDesc = "question_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  QuestionAsc = 'question_ASC',
+  QuestionDesc = 'question_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 export type PageFaqQuestionsCursorCollection = {
-  __typename?: "PageFaqQuestionsCursorCollection";
+  __typename?: 'PageFaqQuestionsCursorCollection';
   items: Array<Maybe<ComponentFaqQuestion>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export enum PageFaqQuestionsCursorCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  QuestionAsc = "question_ASC",
-  QuestionDesc = "question_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  QuestionAsc = 'question_ASC',
+  QuestionDesc = 'question_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageForceUpdate) */
-export type PageForceUpdate = Entry &
-  _Node & {
-    __typename?: "PageForceUpdate";
-    _id: Scalars["ID"]["output"];
-    active?: Maybe<Scalars["Boolean"]["output"]>;
-    body?: Maybe<PageForceUpdateBody>;
-    contentfulMetadata: ContentfulMetadata;
-    effectiveAt?: Maybe<Scalars["DateTime"]["output"]>;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<PageForceUpdateLinkingCollections>;
-    minVersion?: Maybe<Scalars["String"]["output"]>;
-    sys: Sys;
-    title?: Maybe<Scalars["String"]["output"]>;
-    updateCta?: Maybe<ComponentButton>;
-  };
+export type PageForceUpdate = Entry & _Node & {
+  __typename?: 'PageForceUpdate';
+  _id: Scalars['ID']['output'];
+  active?: Maybe<Scalars['Boolean']['output']>;
+  body?: Maybe<PageForceUpdateBody>;
+  contentfulMetadata: ContentfulMetadata;
+  effectiveAt?: Maybe<Scalars['DateTime']['output']>;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<PageForceUpdateLinkingCollections>;
+  minVersion?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+  updateCta?: Maybe<ComponentButton>;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageForceUpdate) */
 export type PageForceUpdateActiveArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageForceUpdate) */
 export type PageForceUpdateBodyArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageForceUpdate) */
 export type PageForceUpdateEffectiveAtArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageForceUpdate) */
 export type PageForceUpdateInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageForceUpdate) */
 export type PageForceUpdateLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageForceUpdate) */
 export type PageForceUpdateMinVersionArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageForceUpdate) */
 export type PageForceUpdateTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageForceUpdate) */
 export type PageForceUpdateUpdateCtaArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
 
 export type PageForceUpdateBody = {
-  __typename?: "PageForceUpdateBody";
-  json: Scalars["JSON"]["output"];
+  __typename?: 'PageForceUpdateBody';
+  json: Scalars['JSON']['output'];
   links: PageForceUpdateBodyLinks;
 };
 
 export type PageForceUpdateBodyAssets = {
-  __typename?: "PageForceUpdateBodyAssets";
+  __typename?: 'PageForceUpdateBodyAssets';
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type PageForceUpdateBodyEntries = {
-  __typename?: "PageForceUpdateBodyEntries";
+  __typename?: 'PageForceUpdateBodyEntries';
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type PageForceUpdateBodyLinks = {
-  __typename?: "PageForceUpdateBodyLinks";
+  __typename?: 'PageForceUpdateBodyLinks';
   assets: PageForceUpdateBodyAssets;
   entries: PageForceUpdateBodyEntries;
   resources: PageForceUpdateBodyResources;
 };
 
 export type PageForceUpdateBodyResources = {
-  __typename?: "PageForceUpdateBodyResources";
+  __typename?: 'PageForceUpdateBodyResources';
   block: Array<PageForceUpdateBodyResourcesBlock>;
   hyperlink: Array<PageForceUpdateBodyResourcesHyperlink>;
   inline: Array<PageForceUpdateBodyResourcesInline>;
 };
 
 export type PageForceUpdateBodyResourcesBlock = ResourceLink & {
-  __typename?: "PageForceUpdateBodyResourcesBlock";
+  __typename?: 'PageForceUpdateBodyResourcesBlock';
   sys: ResourceSys;
 };
 
 export type PageForceUpdateBodyResourcesHyperlink = ResourceLink & {
-  __typename?: "PageForceUpdateBodyResourcesHyperlink";
+  __typename?: 'PageForceUpdateBodyResourcesHyperlink';
   sys: ResourceSys;
 };
 
 export type PageForceUpdateBodyResourcesInline = ResourceLink & {
-  __typename?: "PageForceUpdateBodyResourcesInline";
+  __typename?: 'PageForceUpdateBodyResourcesInline';
   sys: ResourceSys;
 };
 
 export type PageForceUpdateCollection = {
-  __typename?: "PageForceUpdateCollection";
+  __typename?: 'PageForceUpdateCollection';
   items: Array<Maybe<PageForceUpdate>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type PageForceUpdateCursorCollection = {
-  __typename?: "PageForceUpdateCursorCollection";
+  __typename?: 'PageForceUpdateCursorCollection';
   items: Array<Maybe<PageForceUpdate>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export type PageForceUpdateFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageForceUpdateFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageForceUpdateFilter>>>;
-  active?: InputMaybe<Scalars["Boolean"]["input"]>;
-  active_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  active_not?: InputMaybe<Scalars["Boolean"]["input"]>;
-  body_contains?: InputMaybe<Scalars["String"]["input"]>;
-  body_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  body_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  active?: InputMaybe<Scalars['Boolean']['input']>;
+  active_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  active_not?: InputMaybe<Scalars['Boolean']['input']>;
+  body_contains?: InputMaybe<Scalars['String']['input']>;
+  body_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  body_not_contains?: InputMaybe<Scalars['String']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  effectiveAt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  effectiveAt_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  effectiveAt_gt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  effectiveAt_gte?: InputMaybe<Scalars["DateTime"]["input"]>;
-  effectiveAt_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
-  effectiveAt_lt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  effectiveAt_lte?: InputMaybe<Scalars["DateTime"]["input"]>;
-  effectiveAt_not?: InputMaybe<Scalars["DateTime"]["input"]>;
-  effectiveAt_not_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  minVersion?: InputMaybe<Scalars["String"]["input"]>;
-  minVersion_contains?: InputMaybe<Scalars["String"]["input"]>;
-  minVersion_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  minVersion_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  minVersion_not?: InputMaybe<Scalars["String"]["input"]>;
-  minVersion_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  minVersion_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  effectiveAt?: InputMaybe<Scalars['DateTime']['input']>;
+  effectiveAt_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  effectiveAt_gt?: InputMaybe<Scalars['DateTime']['input']>;
+  effectiveAt_gte?: InputMaybe<Scalars['DateTime']['input']>;
+  effectiveAt_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  effectiveAt_lt?: InputMaybe<Scalars['DateTime']['input']>;
+  effectiveAt_lte?: InputMaybe<Scalars['DateTime']['input']>;
+  effectiveAt_not?: InputMaybe<Scalars['DateTime']['input']>;
+  effectiveAt_not_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  minVersion?: InputMaybe<Scalars['String']['input']>;
+  minVersion_contains?: InputMaybe<Scalars['String']['input']>;
+  minVersion_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  minVersion_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  minVersion_not?: InputMaybe<Scalars['String']['input']>;
+  minVersion_not_contains?: InputMaybe<Scalars['String']['input']>;
+  minVersion_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  title_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  title_not?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   updateCta?: InputMaybe<CfComponentButtonNestedFilter>;
-  updateCta_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  updateCta_exists?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type PageForceUpdateLinkingCollections = {
-  __typename?: "PageForceUpdateLinkingCollections";
+  __typename?: 'PageForceUpdateLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
+
 export type PageForceUpdateLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type PageForceUpdateLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum PageForceUpdateOrder {
-  ActiveAsc = "active_ASC",
-  ActiveDesc = "active_DESC",
-  EffectiveAtAsc = "effectiveAt_ASC",
-  EffectiveAtDesc = "effectiveAt_DESC",
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  MinVersionAsc = "minVersion_ASC",
-  MinVersionDesc = "minVersion_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  ActiveAsc = 'active_ASC',
+  ActiveDesc = 'active_DESC',
+  EffectiveAtAsc = 'effectiveAt_ASC',
+  EffectiveAtDesc = 'effectiveAt_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  MinVersionAsc = 'minVersion_ASC',
+  MinVersionDesc = 'minVersion_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeFeatures) */
-export type PageHomeFeatures = Entry &
-  _Node & {
-    __typename?: "PageHomeFeatures";
-    _id: Scalars["ID"]["output"];
-    contentfulMetadata: ContentfulMetadata;
-    featuresCollection?: Maybe<PageHomeFeaturesFeaturesCollection>;
-    featuresCursorCollection?: Maybe<PageHomeFeaturesFeaturesCursorCollection>;
-    image?: Maybe<Asset>;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<PageHomeFeaturesLinkingCollections>;
-    subtitle?: Maybe<Scalars["String"]["output"]>;
-    sys: Sys;
-    title?: Maybe<Scalars["String"]["output"]>;
-  };
+export type PageHomeFeatures = Entry & _Node & {
+  __typename?: 'PageHomeFeatures';
+  _id: Scalars['ID']['output'];
+  contentfulMetadata: ContentfulMetadata;
+  featuresCollection?: Maybe<PageHomeFeaturesFeaturesCollection>;
+  featuresCursorCollection?: Maybe<PageHomeFeaturesFeaturesCursorCollection>;
+  image?: Maybe<Asset>;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<PageHomeFeaturesLinkingCollections>;
+  subtitle?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeFeatures) */
 export type PageHomeFeaturesFeaturesCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageHomeFeaturesFeaturesCollectionOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentFeatureFilter>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeFeatures) */
 export type PageHomeFeaturesFeaturesCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageHomeFeaturesFeaturesCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentFeatureFilter>;
 };
 
+
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeFeatures) */
 export type PageHomeFeaturesImageArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeFeatures) */
 export type PageHomeFeaturesInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeFeatures) */
 export type PageHomeFeaturesLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeFeatures) */
 export type PageHomeFeaturesSubtitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeFeatures) */
 export type PageHomeFeaturesTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type PageHomeFeaturesCollection = {
-  __typename?: "PageHomeFeaturesCollection";
+  __typename?: 'PageHomeFeaturesCollection';
   items: Array<Maybe<PageHomeFeatures>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type PageHomeFeaturesCursorCollection = {
-  __typename?: "PageHomeFeaturesCursorCollection";
+  __typename?: 'PageHomeFeaturesCursorCollection';
   items: Array<Maybe<PageHomeFeatures>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export type PageHomeFeaturesFeaturesCollection = {
-  __typename?: "PageHomeFeaturesFeaturesCollection";
+  __typename?: 'PageHomeFeaturesFeaturesCollection';
   items: Array<Maybe<ComponentFeature>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export enum PageHomeFeaturesFeaturesCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SubtitleAsc = "subtitle_ASC",
-  SubtitleDesc = "subtitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SubtitleAsc = 'subtitle_ASC',
+  SubtitleDesc = 'subtitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export type PageHomeFeaturesFeaturesCursorCollection = {
-  __typename?: "PageHomeFeaturesFeaturesCursorCollection";
+  __typename?: 'PageHomeFeaturesFeaturesCursorCollection';
   items: Array<Maybe<ComponentFeature>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export enum PageHomeFeaturesFeaturesCursorCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SubtitleAsc = "subtitle_ASC",
-  SubtitleDesc = "subtitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SubtitleAsc = 'subtitle_ASC',
+  SubtitleDesc = 'subtitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export type PageHomeFeaturesFilter = {
@@ -4750,652 +5377,680 @@ export type PageHomeFeaturesFilter = {
   OR?: InputMaybe<Array<InputMaybe<PageHomeFeaturesFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
   features?: InputMaybe<CfComponentFeatureNestedFilter>;
-  featuresCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  image_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  subtitle?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_contains?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  subtitle_not?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  featuresCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  image_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  subtitle?: InputMaybe<Scalars['String']['input']>;
+  subtitle_contains?: InputMaybe<Scalars['String']['input']>;
+  subtitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  subtitle_not?: InputMaybe<Scalars['String']['input']>;
+  subtitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  title_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  title_not?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type PageHomeFeaturesLinkingCollections = {
-  __typename?: "PageHomeFeaturesLinkingCollections";
+  __typename?: 'PageHomeFeaturesLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
+
 export type PageHomeFeaturesLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type PageHomeFeaturesLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum PageHomeFeaturesOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SubtitleAsc = "subtitle_ASC",
-  SubtitleDesc = "subtitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SubtitleAsc = 'subtitle_ASC',
+  SubtitleDesc = 'subtitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeHero) */
-export type PageHomeHero = Entry &
-  _Node & {
-    __typename?: "PageHomeHero";
-    _id: Scalars["ID"]["output"];
-    badge?: Maybe<Scalars["String"]["output"]>;
-    buttonsCollection?: Maybe<PageHomeHeroButtonsCollection>;
-    buttonsCursorCollection?: Maybe<PageHomeHeroButtonsCursorCollection>;
-    contentfulMetadata: ContentfulMetadata;
-    image?: Maybe<Asset>;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<PageHomeHeroLinkingCollections>;
-    subtitle?: Maybe<Scalars["String"]["output"]>;
-    sys: Sys;
-    title?: Maybe<Scalars["String"]["output"]>;
-  };
+export type PageHomeHero = Entry & _Node & {
+  __typename?: 'PageHomeHero';
+  _id: Scalars['ID']['output'];
+  badge?: Maybe<Scalars['String']['output']>;
+  buttonsCollection?: Maybe<PageHomeHeroButtonsCollection>;
+  buttonsCursorCollection?: Maybe<PageHomeHeroButtonsCursorCollection>;
+  contentfulMetadata: ContentfulMetadata;
+  image?: Maybe<Asset>;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<PageHomeHeroLinkingCollections>;
+  subtitle?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeHero) */
 export type PageHomeHeroBadgeArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeHero) */
 export type PageHomeHeroButtonsCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageHomeHeroButtonsCollectionOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeHero) */
 export type PageHomeHeroButtonsCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageHomeHeroButtonsCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
 
+
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeHero) */
 export type PageHomeHeroImageArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeHero) */
 export type PageHomeHeroInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeHero) */
 export type PageHomeHeroLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeHero) */
 export type PageHomeHeroSubtitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeHero) */
 export type PageHomeHeroTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type PageHomeHeroButtonsCollection = {
-  __typename?: "PageHomeHeroButtonsCollection";
+  __typename?: 'PageHomeHeroButtonsCollection';
   items: Array<Maybe<ComponentButton>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export enum PageHomeHeroButtonsCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  LabelAsc = "label_ASC",
-  LabelDesc = "label_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  UrlAsc = "url_ASC",
-  UrlDesc = "url_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  LabelAsc = 'label_ASC',
+  LabelDesc = 'label_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  UrlAsc = 'url_ASC',
+  UrlDesc = 'url_DESC'
 }
 
 export type PageHomeHeroButtonsCursorCollection = {
-  __typename?: "PageHomeHeroButtonsCursorCollection";
+  __typename?: 'PageHomeHeroButtonsCursorCollection';
   items: Array<Maybe<ComponentButton>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export enum PageHomeHeroButtonsCursorCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  LabelAsc = "label_ASC",
-  LabelDesc = "label_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  UrlAsc = "url_ASC",
-  UrlDesc = "url_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  LabelAsc = 'label_ASC',
+  LabelDesc = 'label_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  UrlAsc = 'url_ASC',
+  UrlDesc = 'url_DESC'
 }
 
 export type PageHomeHeroCollection = {
-  __typename?: "PageHomeHeroCollection";
+  __typename?: 'PageHomeHeroCollection';
   items: Array<Maybe<PageHomeHero>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type PageHomeHeroCursorCollection = {
-  __typename?: "PageHomeHeroCursorCollection";
+  __typename?: 'PageHomeHeroCursorCollection';
   items: Array<Maybe<PageHomeHero>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export type PageHomeHeroFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageHomeHeroFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageHomeHeroFilter>>>;
-  badge?: InputMaybe<Scalars["String"]["input"]>;
-  badge_contains?: InputMaybe<Scalars["String"]["input"]>;
-  badge_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  badge_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  badge_not?: InputMaybe<Scalars["String"]["input"]>;
-  badge_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  badge_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  badge?: InputMaybe<Scalars['String']['input']>;
+  badge_contains?: InputMaybe<Scalars['String']['input']>;
+  badge_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  badge_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  badge_not?: InputMaybe<Scalars['String']['input']>;
+  badge_not_contains?: InputMaybe<Scalars['String']['input']>;
+  badge_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   buttons?: InputMaybe<CfComponentButtonNestedFilter>;
-  buttonsCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  buttonsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  image_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  subtitle?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_contains?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  subtitle_not?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  image_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  subtitle?: InputMaybe<Scalars['String']['input']>;
+  subtitle_contains?: InputMaybe<Scalars['String']['input']>;
+  subtitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  subtitle_not?: InputMaybe<Scalars['String']['input']>;
+  subtitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  title_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  title_not?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type PageHomeHeroLinkingCollections = {
-  __typename?: "PageHomeHeroLinkingCollections";
+  __typename?: 'PageHomeHeroLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
+
 export type PageHomeHeroLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type PageHomeHeroLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum PageHomeHeroOrder {
-  BadgeAsc = "badge_ASC",
-  BadgeDesc = "badge_DESC",
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SubtitleAsc = "subtitle_ASC",
-  SubtitleDesc = "subtitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  BadgeAsc = 'badge_ASC',
+  BadgeDesc = 'badge_DESC',
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SubtitleAsc = 'subtitle_ASC',
+  SubtitleDesc = 'subtitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
-export type PageHomeMission = Entry &
-  _Node & {
-    __typename?: "PageHomeMission";
-    _id: Scalars["ID"]["output"];
-    about?: Maybe<PageHomeMissionAbout>;
-    contentfulMetadata: ContentfulMetadata;
-    image?: Maybe<Asset>;
-    imagesCollection?: Maybe<AssetCollection>;
-    imagesCursorCollection?: Maybe<AssetCursorCollection>;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<PageHomeMissionLinkingCollections>;
-    mission?: Maybe<PageHomeMissionMission>;
-    subtitle?: Maybe<Scalars["String"]["output"]>;
-    sys: Sys;
-    title?: Maybe<Scalars["String"]["output"]>;
-  };
+export type PageHomeMission = Entry & _Node & {
+  __typename?: 'PageHomeMission';
+  _id: Scalars['ID']['output'];
+  about?: Maybe<PageHomeMissionAbout>;
+  contentfulMetadata: ContentfulMetadata;
+  image?: Maybe<Asset>;
+  imagesCollection?: Maybe<AssetCollection>;
+  imagesCursorCollection?: Maybe<AssetCursorCollection>;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<PageHomeMissionLinkingCollections>;
+  mission?: Maybe<PageHomeMissionMission>;
+  subtitle?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
 export type PageHomeMissionAboutArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
 export type PageHomeMissionImageArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
 export type PageHomeMissionImagesCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
 export type PageHomeMissionImagesCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
 export type PageHomeMissionInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
 export type PageHomeMissionLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
 export type PageHomeMissionMissionArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
 export type PageHomeMissionSubtitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
 export type PageHomeMissionTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type PageHomeMissionAbout = {
-  __typename?: "PageHomeMissionAbout";
-  json: Scalars["JSON"]["output"];
+  __typename?: 'PageHomeMissionAbout';
+  json: Scalars['JSON']['output'];
   links: PageHomeMissionAboutLinks;
 };
 
 export type PageHomeMissionAboutAssets = {
-  __typename?: "PageHomeMissionAboutAssets";
+  __typename?: 'PageHomeMissionAboutAssets';
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type PageHomeMissionAboutEntries = {
-  __typename?: "PageHomeMissionAboutEntries";
+  __typename?: 'PageHomeMissionAboutEntries';
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type PageHomeMissionAboutLinks = {
-  __typename?: "PageHomeMissionAboutLinks";
+  __typename?: 'PageHomeMissionAboutLinks';
   assets: PageHomeMissionAboutAssets;
   entries: PageHomeMissionAboutEntries;
   resources: PageHomeMissionAboutResources;
 };
 
 export type PageHomeMissionAboutResources = {
-  __typename?: "PageHomeMissionAboutResources";
+  __typename?: 'PageHomeMissionAboutResources';
   block: Array<PageHomeMissionAboutResourcesBlock>;
   hyperlink: Array<PageHomeMissionAboutResourcesHyperlink>;
   inline: Array<PageHomeMissionAboutResourcesInline>;
 };
 
 export type PageHomeMissionAboutResourcesBlock = ResourceLink & {
-  __typename?: "PageHomeMissionAboutResourcesBlock";
+  __typename?: 'PageHomeMissionAboutResourcesBlock';
   sys: ResourceSys;
 };
 
 export type PageHomeMissionAboutResourcesHyperlink = ResourceLink & {
-  __typename?: "PageHomeMissionAboutResourcesHyperlink";
+  __typename?: 'PageHomeMissionAboutResourcesHyperlink';
   sys: ResourceSys;
 };
 
 export type PageHomeMissionAboutResourcesInline = ResourceLink & {
-  __typename?: "PageHomeMissionAboutResourcesInline";
+  __typename?: 'PageHomeMissionAboutResourcesInline';
   sys: ResourceSys;
 };
 
 export type PageHomeMissionCollection = {
-  __typename?: "PageHomeMissionCollection";
+  __typename?: 'PageHomeMissionCollection';
   items: Array<Maybe<PageHomeMission>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type PageHomeMissionCursorCollection = {
-  __typename?: "PageHomeMissionCursorCollection";
+  __typename?: 'PageHomeMissionCursorCollection';
   items: Array<Maybe<PageHomeMission>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export type PageHomeMissionFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageHomeMissionFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageHomeMissionFilter>>>;
-  about_contains?: InputMaybe<Scalars["String"]["input"]>;
-  about_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  about_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  about_contains?: InputMaybe<Scalars['String']['input']>;
+  about_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  about_not_contains?: InputMaybe<Scalars['String']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  image_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  imagesCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  mission_contains?: InputMaybe<Scalars["String"]["input"]>;
-  mission_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  mission_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_contains?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  subtitle_not?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  image_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  imagesCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  mission_contains?: InputMaybe<Scalars['String']['input']>;
+  mission_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  mission_not_contains?: InputMaybe<Scalars['String']['input']>;
+  subtitle?: InputMaybe<Scalars['String']['input']>;
+  subtitle_contains?: InputMaybe<Scalars['String']['input']>;
+  subtitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  subtitle_not?: InputMaybe<Scalars['String']['input']>;
+  subtitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  title_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  title_not?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type PageHomeMissionLinkingCollections = {
-  __typename?: "PageHomeMissionLinkingCollections";
+  __typename?: 'PageHomeMissionLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
+
 export type PageHomeMissionLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type PageHomeMissionLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type PageHomeMissionMission = {
-  __typename?: "PageHomeMissionMission";
-  json: Scalars["JSON"]["output"];
+  __typename?: 'PageHomeMissionMission';
+  json: Scalars['JSON']['output'];
   links: PageHomeMissionMissionLinks;
 };
 
 export type PageHomeMissionMissionAssets = {
-  __typename?: "PageHomeMissionMissionAssets";
+  __typename?: 'PageHomeMissionMissionAssets';
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type PageHomeMissionMissionEntries = {
-  __typename?: "PageHomeMissionMissionEntries";
+  __typename?: 'PageHomeMissionMissionEntries';
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type PageHomeMissionMissionLinks = {
-  __typename?: "PageHomeMissionMissionLinks";
+  __typename?: 'PageHomeMissionMissionLinks';
   assets: PageHomeMissionMissionAssets;
   entries: PageHomeMissionMissionEntries;
   resources: PageHomeMissionMissionResources;
 };
 
 export type PageHomeMissionMissionResources = {
-  __typename?: "PageHomeMissionMissionResources";
+  __typename?: 'PageHomeMissionMissionResources';
   block: Array<PageHomeMissionMissionResourcesBlock>;
   hyperlink: Array<PageHomeMissionMissionResourcesHyperlink>;
   inline: Array<PageHomeMissionMissionResourcesInline>;
 };
 
 export type PageHomeMissionMissionResourcesBlock = ResourceLink & {
-  __typename?: "PageHomeMissionMissionResourcesBlock";
+  __typename?: 'PageHomeMissionMissionResourcesBlock';
   sys: ResourceSys;
 };
 
 export type PageHomeMissionMissionResourcesHyperlink = ResourceLink & {
-  __typename?: "PageHomeMissionMissionResourcesHyperlink";
+  __typename?: 'PageHomeMissionMissionResourcesHyperlink';
   sys: ResourceSys;
 };
 
 export type PageHomeMissionMissionResourcesInline = ResourceLink & {
-  __typename?: "PageHomeMissionMissionResourcesInline";
+  __typename?: 'PageHomeMissionMissionResourcesInline';
   sys: ResourceSys;
 };
 
 export enum PageHomeMissionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SubtitleAsc = "subtitle_ASC",
-  SubtitleDesc = "subtitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SubtitleAsc = 'subtitle_ASC',
+  SubtitleDesc = 'subtitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomePartners) */
-export type PageHomePartners = Entry &
-  _Node & {
-    __typename?: "PageHomePartners";
-    _id: Scalars["ID"]["output"];
-    contentfulMetadata: ContentfulMetadata;
-    imagesCollection?: Maybe<AssetCollection>;
-    imagesCursorCollection?: Maybe<AssetCursorCollection>;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<PageHomePartnersLinkingCollections>;
-    partnersCollection?: Maybe<PageHomePartnersPartnersCollection>;
-    partnersCursorCollection?: Maybe<PageHomePartnersPartnersCursorCollection>;
-    subtitle?: Maybe<Scalars["String"]["output"]>;
-    sys: Sys;
-    title?: Maybe<Scalars["String"]["output"]>;
-  };
+export type PageHomePartners = Entry & _Node & {
+  __typename?: 'PageHomePartners';
+  _id: Scalars['ID']['output'];
+  contentfulMetadata: ContentfulMetadata;
+  imagesCollection?: Maybe<AssetCollection>;
+  imagesCursorCollection?: Maybe<AssetCursorCollection>;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<PageHomePartnersLinkingCollections>;
+  partnersCollection?: Maybe<PageHomePartnersPartnersCollection>;
+  partnersCursorCollection?: Maybe<PageHomePartnersPartnersCursorCollection>;
+  subtitle?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomePartners) */
 export type PageHomePartnersImagesCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomePartners) */
 export type PageHomePartnersImagesCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomePartners) */
 export type PageHomePartnersInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomePartners) */
 export type PageHomePartnersLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomePartners) */
 export type PageHomePartnersPartnersCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageHomePartnersPartnersCollectionOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentPartnerFilter>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomePartners) */
 export type PageHomePartnersPartnersCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageHomePartnersPartnersCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentPartnerFilter>;
 };
 
+
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomePartners) */
 export type PageHomePartnersSubtitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomePartners) */
 export type PageHomePartnersTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type PageHomePartnersCollection = {
-  __typename?: "PageHomePartnersCollection";
+  __typename?: 'PageHomePartnersCollection';
   items: Array<Maybe<PageHomePartners>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type PageHomePartnersCursorCollection = {
-  __typename?: "PageHomePartnersCursorCollection";
+  __typename?: 'PageHomePartnersCursorCollection';
   items: Array<Maybe<PageHomePartners>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
@@ -5403,174 +6058,179 @@ export type PageHomePartnersFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageHomePartnersFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageHomePartnersFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  imagesCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  imagesCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   partners?: InputMaybe<CfComponentPartnerNestedFilter>;
-  partnersCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  subtitle?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_contains?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  subtitle_not?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  partnersCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  subtitle?: InputMaybe<Scalars['String']['input']>;
+  subtitle_contains?: InputMaybe<Scalars['String']['input']>;
+  subtitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  subtitle_not?: InputMaybe<Scalars['String']['input']>;
+  subtitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  title_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  title_not?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type PageHomePartnersLinkingCollections = {
-  __typename?: "PageHomePartnersLinkingCollections";
+  __typename?: 'PageHomePartnersLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
+
 export type PageHomePartnersLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type PageHomePartnersLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum PageHomePartnersOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SubtitleAsc = "subtitle_ASC",
-  SubtitleDesc = "subtitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SubtitleAsc = 'subtitle_ASC',
+  SubtitleDesc = 'subtitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export type PageHomePartnersPartnersCollection = {
-  __typename?: "PageHomePartnersPartnersCollection";
+  __typename?: 'PageHomePartnersPartnersCollection';
   items: Array<Maybe<ComponentPartner>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export enum PageHomePartnersPartnersCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SubtitleAsc = "subtitle_ASC",
-  SubtitleDesc = "subtitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  UrlAsc = "url_ASC",
-  UrlDesc = "url_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SubtitleAsc = 'subtitle_ASC',
+  SubtitleDesc = 'subtitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  UrlAsc = 'url_ASC',
+  UrlDesc = 'url_DESC'
 }
 
 export type PageHomePartnersPartnersCursorCollection = {
-  __typename?: "PageHomePartnersPartnersCursorCollection";
+  __typename?: 'PageHomePartnersPartnersCursorCollection';
   items: Array<Maybe<ComponentPartner>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export enum PageHomePartnersPartnersCursorCollectionOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SubtitleAsc = "subtitle_ASC",
-  SubtitleDesc = "subtitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  UrlAsc = "url_ASC",
-  UrlDesc = "url_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SubtitleAsc = 'subtitle_ASC',
+  SubtitleDesc = 'subtitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  UrlAsc = 'url_ASC',
+  UrlDesc = 'url_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageLanding) */
-export type PageLanding = Entry &
-  _Node & {
-    __typename?: "PageLanding";
-    _id: Scalars["ID"]["output"];
-    contentfulMetadata: ContentfulMetadata;
-    featuredBlogPost?: Maybe<PageBlogPost>;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<PageLandingLinkingCollections>;
-    seoFields?: Maybe<ComponentSeo>;
-    sys: Sys;
-  };
+export type PageLanding = Entry & _Node & {
+  __typename?: 'PageLanding';
+  _id: Scalars['ID']['output'];
+  contentfulMetadata: ContentfulMetadata;
+  featuredBlogPost?: Maybe<PageBlogPost>;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<PageLandingLinkingCollections>;
+  seoFields?: Maybe<ComponentSeo>;
+  sys: Sys;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageLanding) */
 export type PageLandingFeaturedBlogPostArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageBlogPostFilter>;
 };
 
+
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageLanding) */
 export type PageLandingInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageLanding) */
 export type PageLandingLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageLanding) */
 export type PageLandingSeoFieldsArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentSeoFilter>;
 };
 
 export type PageLandingCollection = {
-  __typename?: "PageLandingCollection";
+  __typename?: 'PageLandingCollection';
   items: Array<Maybe<PageLanding>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type PageLandingCursorCollection = {
-  __typename?: "PageLandingCursorCollection";
+  __typename?: 'PageLandingCursorCollection';
   items: Array<Maybe<PageLanding>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
@@ -5579,443 +6239,459 @@ export type PageLandingFilter = {
   OR?: InputMaybe<Array<InputMaybe<PageLandingFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
   featuredBlogPost?: InputMaybe<CfPageBlogPostNestedFilter>;
-  featuredBlogPost_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  featuredBlogPost_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   seoFields?: InputMaybe<CfComponentSeoNestedFilter>;
-  seoFields_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  seoFields_exists?: InputMaybe<Scalars['Boolean']['input']>;
   sys?: InputMaybe<SysFilter>;
 };
 
 export type PageLandingLinkingCollections = {
-  __typename?: "PageLandingLinkingCollections";
+  __typename?: 'PageLandingLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
+
 export type PageLandingLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type PageLandingLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum PageLandingOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pagePolicies) */
-export type PagePolicies = Entry &
-  _Node & {
-    __typename?: "PagePolicies";
-    _id: Scalars["ID"]["output"];
-    content?: Maybe<PagePoliciesContent>;
-    contentfulMetadata: ContentfulMetadata;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<PagePoliciesLinkingCollections>;
-    pageDescription?: Maybe<Scalars["String"]["output"]>;
-    pageTitle?: Maybe<Scalars["String"]["output"]>;
-    sys: Sys;
-    title?: Maybe<Scalars["String"]["output"]>;
-  };
+export type PagePolicies = Entry & _Node & {
+  __typename?: 'PagePolicies';
+  _id: Scalars['ID']['output'];
+  content?: Maybe<PagePoliciesContent>;
+  contentfulMetadata: ContentfulMetadata;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<PagePoliciesLinkingCollections>;
+  pageDescription?: Maybe<Scalars['String']['output']>;
+  pageTitle?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pagePolicies) */
 export type PagePoliciesContentArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pagePolicies) */
 export type PagePoliciesInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pagePolicies) */
 export type PagePoliciesLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pagePolicies) */
 export type PagePoliciesPageDescriptionArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pagePolicies) */
 export type PagePoliciesPageTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pagePolicies) */
 export type PagePoliciesTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type PagePoliciesCollection = {
-  __typename?: "PagePoliciesCollection";
+  __typename?: 'PagePoliciesCollection';
   items: Array<Maybe<PagePolicies>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type PagePoliciesContent = {
-  __typename?: "PagePoliciesContent";
-  json: Scalars["JSON"]["output"];
+  __typename?: 'PagePoliciesContent';
+  json: Scalars['JSON']['output'];
   links: PagePoliciesContentLinks;
 };
 
 export type PagePoliciesContentAssets = {
-  __typename?: "PagePoliciesContentAssets";
+  __typename?: 'PagePoliciesContentAssets';
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type PagePoliciesContentEntries = {
-  __typename?: "PagePoliciesContentEntries";
+  __typename?: 'PagePoliciesContentEntries';
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type PagePoliciesContentLinks = {
-  __typename?: "PagePoliciesContentLinks";
+  __typename?: 'PagePoliciesContentLinks';
   assets: PagePoliciesContentAssets;
   entries: PagePoliciesContentEntries;
   resources: PagePoliciesContentResources;
 };
 
 export type PagePoliciesContentResources = {
-  __typename?: "PagePoliciesContentResources";
+  __typename?: 'PagePoliciesContentResources';
   block: Array<PagePoliciesContentResourcesBlock>;
   hyperlink: Array<PagePoliciesContentResourcesHyperlink>;
   inline: Array<PagePoliciesContentResourcesInline>;
 };
 
 export type PagePoliciesContentResourcesBlock = ResourceLink & {
-  __typename?: "PagePoliciesContentResourcesBlock";
+  __typename?: 'PagePoliciesContentResourcesBlock';
   sys: ResourceSys;
 };
 
 export type PagePoliciesContentResourcesHyperlink = ResourceLink & {
-  __typename?: "PagePoliciesContentResourcesHyperlink";
+  __typename?: 'PagePoliciesContentResourcesHyperlink';
   sys: ResourceSys;
 };
 
 export type PagePoliciesContentResourcesInline = ResourceLink & {
-  __typename?: "PagePoliciesContentResourcesInline";
+  __typename?: 'PagePoliciesContentResourcesInline';
   sys: ResourceSys;
 };
 
 export type PagePoliciesCursorCollection = {
-  __typename?: "PagePoliciesCursorCollection";
+  __typename?: 'PagePoliciesCursorCollection';
   items: Array<Maybe<PagePolicies>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export type PagePoliciesFilter = {
   AND?: InputMaybe<Array<InputMaybe<PagePoliciesFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PagePoliciesFilter>>>;
-  content_contains?: InputMaybe<Scalars["String"]["input"]>;
-  content_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  content_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  content_contains?: InputMaybe<Scalars['String']['input']>;
+  content_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  content_not_contains?: InputMaybe<Scalars['String']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageDescription?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageDescription_not?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageTitle?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageTitle_not?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageDescription?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_contains?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageDescription_not?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageTitle?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_contains?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageTitle_not?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  title_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  title_not?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type PagePoliciesLinkingCollections = {
-  __typename?: "PagePoliciesLinkingCollections";
+  __typename?: 'PagePoliciesLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
+
 export type PagePoliciesLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type PagePoliciesLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum PagePoliciesOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  PageDescriptionAsc = "pageDescription_ASC",
-  PageDescriptionDesc = "pageDescription_DESC",
-  PageTitleAsc = "pageTitle_ASC",
-  PageTitleDesc = "pageTitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PageDescriptionAsc = 'pageDescription_ASC',
+  PageDescriptionDesc = 'pageDescription_DESC',
+  PageTitleAsc = 'pageTitle_ASC',
+  PageTitleDesc = 'pageTitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageTermsAndConditions) */
-export type PageTermsAndConditions = Entry &
-  _Node & {
-    __typename?: "PageTermsAndConditions";
-    _id: Scalars["ID"]["output"];
-    content?: Maybe<PageTermsAndConditionsContent>;
-    contentfulMetadata: ContentfulMetadata;
-    internalName?: Maybe<Scalars["String"]["output"]>;
-    linkedFrom?: Maybe<PageTermsAndConditionsLinkingCollections>;
-    pageDescription?: Maybe<Scalars["String"]["output"]>;
-    pageTitle?: Maybe<Scalars["String"]["output"]>;
-    sys: Sys;
-    title?: Maybe<Scalars["String"]["output"]>;
-  };
+export type PageTermsAndConditions = Entry & _Node & {
+  __typename?: 'PageTermsAndConditions';
+  _id: Scalars['ID']['output'];
+  content?: Maybe<PageTermsAndConditionsContent>;
+  contentfulMetadata: ContentfulMetadata;
+  internalName?: Maybe<Scalars['String']['output']>;
+  linkedFrom?: Maybe<PageTermsAndConditionsLinkingCollections>;
+  pageDescription?: Maybe<Scalars['String']['output']>;
+  pageTitle?: Maybe<Scalars['String']['output']>;
+  sys: Sys;
+  title?: Maybe<Scalars['String']['output']>;
+};
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageTermsAndConditions) */
 export type PageTermsAndConditionsContentArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageTermsAndConditions) */
 export type PageTermsAndConditionsInternalNameArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageTermsAndConditions) */
 export type PageTermsAndConditionsLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageTermsAndConditions) */
 export type PageTermsAndConditionsPageDescriptionArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageTermsAndConditions) */
 export type PageTermsAndConditionsPageTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageTermsAndConditions) */
 export type PageTermsAndConditionsTitleArgs = {
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type PageTermsAndConditionsCollection = {
-  __typename?: "PageTermsAndConditionsCollection";
+  __typename?: 'PageTermsAndConditionsCollection';
   items: Array<Maybe<PageTermsAndConditions>>;
-  limit: Scalars["Int"]["output"];
-  skip: Scalars["Int"]["output"];
-  total: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
+  skip: Scalars['Int']['output'];
+  total: Scalars['Int']['output'];
 };
 
 export type PageTermsAndConditionsContent = {
-  __typename?: "PageTermsAndConditionsContent";
-  json: Scalars["JSON"]["output"];
+  __typename?: 'PageTermsAndConditionsContent';
+  json: Scalars['JSON']['output'];
   links: PageTermsAndConditionsContentLinks;
 };
 
 export type PageTermsAndConditionsContentAssets = {
-  __typename?: "PageTermsAndConditionsContentAssets";
+  __typename?: 'PageTermsAndConditionsContentAssets';
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type PageTermsAndConditionsContentEntries = {
-  __typename?: "PageTermsAndConditionsContentEntries";
+  __typename?: 'PageTermsAndConditionsContentEntries';
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type PageTermsAndConditionsContentLinks = {
-  __typename?: "PageTermsAndConditionsContentLinks";
+  __typename?: 'PageTermsAndConditionsContentLinks';
   assets: PageTermsAndConditionsContentAssets;
   entries: PageTermsAndConditionsContentEntries;
   resources: PageTermsAndConditionsContentResources;
 };
 
 export type PageTermsAndConditionsContentResources = {
-  __typename?: "PageTermsAndConditionsContentResources";
+  __typename?: 'PageTermsAndConditionsContentResources';
   block: Array<PageTermsAndConditionsContentResourcesBlock>;
   hyperlink: Array<PageTermsAndConditionsContentResourcesHyperlink>;
   inline: Array<PageTermsAndConditionsContentResourcesInline>;
 };
 
 export type PageTermsAndConditionsContentResourcesBlock = ResourceLink & {
-  __typename?: "PageTermsAndConditionsContentResourcesBlock";
+  __typename?: 'PageTermsAndConditionsContentResourcesBlock';
   sys: ResourceSys;
 };
 
 export type PageTermsAndConditionsContentResourcesHyperlink = ResourceLink & {
-  __typename?: "PageTermsAndConditionsContentResourcesHyperlink";
+  __typename?: 'PageTermsAndConditionsContentResourcesHyperlink';
   sys: ResourceSys;
 };
 
 export type PageTermsAndConditionsContentResourcesInline = ResourceLink & {
-  __typename?: "PageTermsAndConditionsContentResourcesInline";
+  __typename?: 'PageTermsAndConditionsContentResourcesInline';
   sys: ResourceSys;
 };
 
 export type PageTermsAndConditionsCursorCollection = {
-  __typename?: "PageTermsAndConditionsCursorCollection";
+  __typename?: 'PageTermsAndConditionsCursorCollection';
   items: Array<Maybe<PageTermsAndConditions>>;
-  limit: Scalars["Int"]["output"];
+  limit: Scalars['Int']['output'];
   pages: CursorPages;
 };
 
 export type PageTermsAndConditionsFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageTermsAndConditionsFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageTermsAndConditionsFilter>>>;
-  content_contains?: InputMaybe<Scalars["String"]["input"]>;
-  content_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  content_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  content_contains?: InputMaybe<Scalars['String']['input']>;
+  content_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  content_not_contains?: InputMaybe<Scalars['String']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageDescription?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageDescription_not?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageTitle?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageTitle_not?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageDescription?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_contains?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageDescription_not?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageTitle?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_contains?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageTitle_not?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  title_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  title_not?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type PageTermsAndConditionsLinkingCollections = {
-  __typename?: "PageTermsAndConditionsLinkingCollections";
+  __typename?: 'PageTermsAndConditionsLinkingCollections';
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
+
 export type PageTermsAndConditionsLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type PageTermsAndConditionsLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export enum PageTermsAndConditionsOrder {
-  InternalNameAsc = "internalName_ASC",
-  InternalNameDesc = "internalName_DESC",
-  PageDescriptionAsc = "pageDescription_ASC",
-  PageDescriptionDesc = "pageDescription_DESC",
-  PageTitleAsc = "pageTitle_ASC",
-  PageTitleDesc = "pageTitle_DESC",
-  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
-  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
-  SysIdAsc = "sys_id_ASC",
-  SysIdDesc = "sys_id_DESC",
-  SysPublishedAtAsc = "sys_publishedAt_ASC",
-  SysPublishedAtDesc = "sys_publishedAt_DESC",
-  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
-  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
-  TitleAsc = "title_ASC",
-  TitleDesc = "title_DESC",
+  InternalNameAsc = 'internalName_ASC',
+  InternalNameDesc = 'internalName_DESC',
+  PageDescriptionAsc = 'pageDescription_ASC',
+  PageDescriptionDesc = 'pageDescription_DESC',
+  PageTitleAsc = 'pageTitle_ASC',
+  PageTitleDesc = 'pageTitle_DESC',
+  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
+  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
+  SysIdAsc = 'sys_id_ASC',
+  SysIdDesc = 'sys_id_DESC',
+  SysPublishedAtAsc = 'sys_publishedAt_ASC',
+  SysPublishedAtDesc = 'sys_publishedAt_DESC',
+  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
+  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
+  TitleAsc = 'title_ASC',
+  TitleDesc = 'title_DESC'
 }
 
 export type Query = {
-  __typename?: "Query";
+  __typename?: 'Query';
   _node?: Maybe<_Node>;
   _nodes: Array<Maybe<_Node>>;
   asset?: Maybe<Asset>;
@@ -6042,6 +6718,9 @@ export type Query = {
   componentPartner?: Maybe<ComponentPartner>;
   componentPartnerCollection?: Maybe<ComponentPartnerCollection>;
   componentPartnerCursorCollection?: Maybe<ComponentPartnerCursorCollection>;
+  componentReleaseNote?: Maybe<ComponentReleaseNote>;
+  componentReleaseNoteCollection?: Maybe<ComponentReleaseNoteCollection>;
+  componentReleaseNoteCursorCollection?: Maybe<ComponentReleaseNoteCursorCollection>;
   componentRichImage?: Maybe<ComponentRichImage>;
   componentRichImageCollection?: Maybe<ComponentRichImageCollection>;
   componentRichImageCursorCollection?: Maybe<ComponentRichImageCursorCollection>;
@@ -6097,738 +6776,848 @@ export type Query = {
   pageTermsAndConditionsCursorCollection?: Maybe<PageTermsAndConditionsCursorCollection>;
 };
 
+
 export type Query_NodeArgs = {
-  id: Scalars["ID"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['ID']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type Query_NodesArgs = {
-  ids: Array<Scalars["ID"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  ids: Array<Scalars['ID']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryAssetArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryAssetCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<AssetOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<AssetFilter>;
 };
+
 
 export type QueryAssetCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<AssetOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<AssetFilter>;
 };
 
+
 export type QueryComponentAlertArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryComponentAlertCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentAlertOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentAlertFilter>;
 };
+
 
 export type QueryComponentAlertCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentAlertOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentAlertFilter>;
 };
 
+
 export type QueryComponentAuthorArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryComponentAuthorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentAuthorOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentAuthorFilter>;
 };
+
 
 export type QueryComponentAuthorCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentAuthorOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentAuthorFilter>;
 };
 
+
 export type QueryComponentButtonArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryComponentButtonCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentButtonOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
+
 
 export type QueryComponentButtonCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentButtonOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
 
+
 export type QueryComponentEmailArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryComponentEmailCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentEmailOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentEmailFilter>;
 };
+
 
 export type QueryComponentEmailCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentEmailOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentEmailFilter>;
 };
 
+
 export type QueryComponentFaqQuestionArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryComponentFaqQuestionCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentFaqQuestionOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentFaqQuestionFilter>;
 };
+
 
 export type QueryComponentFaqQuestionCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentFaqQuestionOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentFaqQuestionFilter>;
 };
 
+
 export type QueryComponentFeatureArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryComponentFeatureCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentFeatureOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentFeatureFilter>;
 };
+
 
 export type QueryComponentFeatureCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentFeatureOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentFeatureFilter>;
 };
 
+
 export type QueryComponentPartnerArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryComponentPartnerCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentPartnerOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentPartnerFilter>;
 };
+
 
 export type QueryComponentPartnerCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentPartnerOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentPartnerFilter>;
 };
 
-export type QueryComponentRichImageArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+
+export type QueryComponentReleaseNoteArgs = {
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
+
+export type QueryComponentReleaseNoteCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentReleaseNoteOrder>>>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<ComponentReleaseNoteFilter>;
+};
+
+
+export type QueryComponentReleaseNoteCursorCollectionArgs = {
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  order?: InputMaybe<Array<InputMaybe<ComponentReleaseNoteOrder>>>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  where?: InputMaybe<ComponentReleaseNoteFilter>;
+};
+
+
+export type QueryComponentRichImageArgs = {
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
 
 export type QueryComponentRichImageCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentRichImageOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentRichImageFilter>;
 };
+
 
 export type QueryComponentRichImageCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentRichImageOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentRichImageFilter>;
 };
 
+
 export type QueryComponentSeoArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryComponentSeoCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentSeoOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentSeoFilter>;
 };
+
 
 export type QueryComponentSeoCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<ComponentSeoOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<ComponentSeoFilter>;
 };
 
+
 export type QueryEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<EntryOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<EntryFilter>;
 };
+
 
 export type QueryEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<EntryOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<EntryFilter>;
 };
 
+
 export type QueryFooterArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryFooterCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<FooterOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<FooterFilter>;
 };
+
 
 export type QueryFooterCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<FooterOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<FooterFilter>;
 };
 
+
 export type QueryLandingMetadataArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryLandingMetadataCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<LandingMetadataOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<LandingMetadataFilter>;
 };
+
 
 export type QueryLandingMetadataCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<LandingMetadataOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<LandingMetadataFilter>;
 };
 
+
 export type QueryPageAboutArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryPageAboutCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageAboutOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageAboutFilter>;
 };
+
 
 export type QueryPageAboutCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageAboutOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageAboutFilter>;
 };
 
+
 export type QueryPageBlogPostArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryPageBlogPostCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageBlogPostOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageBlogPostFilter>;
 };
+
 
 export type QueryPageBlogPostCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageBlogPostOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageBlogPostFilter>;
 };
 
+
 export type QueryPageCookiePolicyArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryPageCookiePolicyCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageCookiePolicyOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageCookiePolicyFilter>;
 };
+
 
 export type QueryPageCookiePolicyCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageCookiePolicyOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageCookiePolicyFilter>;
 };
 
+
 export type QueryPageEmailsArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryPageEmailsCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageEmailsOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageEmailsFilter>;
 };
+
 
 export type QueryPageEmailsCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageEmailsOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageEmailsFilter>;
 };
 
+
 export type QueryPageFaqArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryPageFaqCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageFaqOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageFaqFilter>;
 };
+
 
 export type QueryPageFaqCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageFaqOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageFaqFilter>;
 };
 
+
 export type QueryPageForceUpdateArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryPageForceUpdateCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageForceUpdateOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageForceUpdateFilter>;
 };
+
 
 export type QueryPageForceUpdateCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageForceUpdateOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageForceUpdateFilter>;
 };
 
+
 export type QueryPageHomeFeaturesArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryPageHomeFeaturesCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageHomeFeaturesOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageHomeFeaturesFilter>;
 };
+
 
 export type QueryPageHomeFeaturesCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageHomeFeaturesOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageHomeFeaturesFilter>;
 };
 
+
 export type QueryPageHomeHeroArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryPageHomeHeroCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageHomeHeroOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageHomeHeroFilter>;
 };
+
 
 export type QueryPageHomeHeroCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageHomeHeroOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageHomeHeroFilter>;
 };
 
+
 export type QueryPageHomeMissionArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryPageHomeMissionCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageHomeMissionOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageHomeMissionFilter>;
 };
+
 
 export type QueryPageHomeMissionCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageHomeMissionOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageHomeMissionFilter>;
 };
 
+
 export type QueryPageHomePartnersArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryPageHomePartnersCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageHomePartnersOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageHomePartnersFilter>;
 };
+
 
 export type QueryPageHomePartnersCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageHomePartnersOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageHomePartnersFilter>;
 };
 
+
 export type QueryPageLandingArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryPageLandingCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageLandingOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageLandingFilter>;
 };
+
 
 export type QueryPageLandingCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageLandingOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageLandingFilter>;
 };
 
+
 export type QueryPagePoliciesArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
+
 
 export type QueryPagePoliciesCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PagePoliciesOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PagePoliciesFilter>;
 };
+
 
 export type QueryPagePoliciesCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PagePoliciesOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PagePoliciesFilter>;
 };
 
+
 export type QueryPageTermsAndConditionsArgs = {
-  id: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type QueryPageTermsAndConditionsCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageTermsAndConditionsOrder>>>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  skip?: InputMaybe<Scalars["Int"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  skip?: InputMaybe<Scalars['Int']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageTermsAndConditionsFilter>;
 };
 
+
 export type QueryPageTermsAndConditionsCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageTermsAndConditionsOrder>>>;
-  pageNext?: InputMaybe<Scalars["String"]["input"]>;
-  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageNext?: InputMaybe<Scalars['String']['input']>;
+  pagePrev?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
   where?: InputMaybe<PageTermsAndConditionsFilter>;
 };
 
@@ -6837,58 +7626,58 @@ export type ResourceLink = {
 };
 
 export type ResourceSys = {
-  __typename?: "ResourceSys";
-  linkType: Scalars["String"]["output"];
-  urn: Scalars["String"]["output"];
+  __typename?: 'ResourceSys';
+  linkType: Scalars['String']['output'];
+  urn: Scalars['String']['output'];
 };
 
 export type Sys = {
-  __typename?: "Sys";
-  environmentId: Scalars["String"]["output"];
-  firstPublishedAt?: Maybe<Scalars["DateTime"]["output"]>;
-  id: Scalars["String"]["output"];
+  __typename?: 'Sys';
+  environmentId: Scalars['String']['output'];
+  firstPublishedAt?: Maybe<Scalars['DateTime']['output']>;
+  id: Scalars['String']['output'];
   /** The locale that was requested. */
-  locale?: Maybe<Scalars["String"]["output"]>;
-  publishedAt?: Maybe<Scalars["DateTime"]["output"]>;
-  publishedVersion?: Maybe<Scalars["Int"]["output"]>;
-  spaceId: Scalars["String"]["output"];
+  locale?: Maybe<Scalars['String']['output']>;
+  publishedAt?: Maybe<Scalars['DateTime']['output']>;
+  publishedVersion?: Maybe<Scalars['Int']['output']>;
+  spaceId: Scalars['String']['output'];
 };
 
 export type SysFilter = {
-  firstPublishedAt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  firstPublishedAt_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  firstPublishedAt_gt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  firstPublishedAt_gte?: InputMaybe<Scalars["DateTime"]["input"]>;
-  firstPublishedAt_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
-  firstPublishedAt_lt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  firstPublishedAt_lte?: InputMaybe<Scalars["DateTime"]["input"]>;
-  firstPublishedAt_not?: InputMaybe<Scalars["DateTime"]["input"]>;
-  firstPublishedAt_not_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
-  id?: InputMaybe<Scalars["String"]["input"]>;
-  id_contains?: InputMaybe<Scalars["String"]["input"]>;
-  id_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  id_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  id_not?: InputMaybe<Scalars["String"]["input"]>;
-  id_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  id_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  publishedAt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  publishedAt_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  publishedAt_gt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  publishedAt_gte?: InputMaybe<Scalars["DateTime"]["input"]>;
-  publishedAt_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
-  publishedAt_lt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  publishedAt_lte?: InputMaybe<Scalars["DateTime"]["input"]>;
-  publishedAt_not?: InputMaybe<Scalars["DateTime"]["input"]>;
-  publishedAt_not_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
-  publishedVersion?: InputMaybe<Scalars["Float"]["input"]>;
-  publishedVersion_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  publishedVersion_gt?: InputMaybe<Scalars["Float"]["input"]>;
-  publishedVersion_gte?: InputMaybe<Scalars["Float"]["input"]>;
-  publishedVersion_in?: InputMaybe<Array<InputMaybe<Scalars["Float"]["input"]>>>;
-  publishedVersion_lt?: InputMaybe<Scalars["Float"]["input"]>;
-  publishedVersion_lte?: InputMaybe<Scalars["Float"]["input"]>;
-  publishedVersion_not?: InputMaybe<Scalars["Float"]["input"]>;
-  publishedVersion_not_in?: InputMaybe<Array<InputMaybe<Scalars["Float"]["input"]>>>;
+  firstPublishedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  firstPublishedAt_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  firstPublishedAt_gt?: InputMaybe<Scalars['DateTime']['input']>;
+  firstPublishedAt_gte?: InputMaybe<Scalars['DateTime']['input']>;
+  firstPublishedAt_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  firstPublishedAt_lt?: InputMaybe<Scalars['DateTime']['input']>;
+  firstPublishedAt_lte?: InputMaybe<Scalars['DateTime']['input']>;
+  firstPublishedAt_not?: InputMaybe<Scalars['DateTime']['input']>;
+  firstPublishedAt_not_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  id?: InputMaybe<Scalars['String']['input']>;
+  id_contains?: InputMaybe<Scalars['String']['input']>;
+  id_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  id_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  id_not?: InputMaybe<Scalars['String']['input']>;
+  id_not_contains?: InputMaybe<Scalars['String']['input']>;
+  id_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  publishedAt?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedAt_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  publishedAt_gt?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedAt_gte?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedAt_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  publishedAt_lt?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedAt_lte?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedAt_not?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedAt_not_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  publishedVersion?: InputMaybe<Scalars['Float']['input']>;
+  publishedVersion_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  publishedVersion_gt?: InputMaybe<Scalars['Float']['input']>;
+  publishedVersion_gte?: InputMaybe<Scalars['Float']['input']>;
+  publishedVersion_in?: InputMaybe<Array<InputMaybe<Scalars['Float']['input']>>>;
+  publishedVersion_lt?: InputMaybe<Scalars['Float']['input']>;
+  publishedVersion_lte?: InputMaybe<Scalars['Float']['input']>;
+  publishedVersion_not?: InputMaybe<Scalars['Float']['input']>;
+  publishedVersion_not_in?: InputMaybe<Array<InputMaybe<Scalars['Float']['input']>>>;
 };
 
 /**
@@ -6896,47 +7685,47 @@ export type SysFilter = {
  *         Find out more here: https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/content-concepts
  */
 export type TaxonomyConcept = {
-  __typename?: "TaxonomyConcept";
-  id?: Maybe<Scalars["String"]["output"]>;
+  __typename?: 'TaxonomyConcept';
+  id?: Maybe<Scalars['String']['output']>;
 };
 
 export type TimelineFilterInput = {
   /** Preview content starting from a given release date */
-  release_lte?: InputMaybe<Scalars["String"]["input"]>;
+  release_lte?: InputMaybe<Scalars['String']['input']>;
   /** Preview content starting from a given timestamp */
-  timestamp_lte?: InputMaybe<Scalars["DateTime"]["input"]>;
+  timestamp_lte?: InputMaybe<Scalars['DateTime']['input']>;
 };
 
 export type _Node = {
-  _id: Scalars["ID"]["output"];
+  _id: Scalars['ID']['output'];
 };
 
 export type CfComponentAuthorNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfComponentAuthorNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfComponentAuthorNestedFilter>>>;
-  avatar_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  avatar_exists?: InputMaybe<Scalars['Boolean']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  name?: InputMaybe<Scalars["String"]["input"]>;
-  name_contains?: InputMaybe<Scalars["String"]["input"]>;
-  name_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  name_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  name_not?: InputMaybe<Scalars["String"]["input"]>;
-  name_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  name_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  profession?: InputMaybe<Scalars["String"]["input"]>;
-  profession_contains?: InputMaybe<Scalars["String"]["input"]>;
-  profession_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  profession_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  profession_not?: InputMaybe<Scalars["String"]["input"]>;
-  profession_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  profession_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  name_contains?: InputMaybe<Scalars['String']['input']>;
+  name_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  name_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  name_not?: InputMaybe<Scalars['String']['input']>;
+  name_not_contains?: InputMaybe<Scalars['String']['input']>;
+  name_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  profession?: InputMaybe<Scalars['String']['input']>;
+  profession_contains?: InputMaybe<Scalars['String']['input']>;
+  profession_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  profession_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  profession_not?: InputMaybe<Scalars['String']['input']>;
+  profession_not_contains?: InputMaybe<Scalars['String']['input']>;
+  profession_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
 };
 
@@ -6944,82 +7733,82 @@ export type CfComponentButtonNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfComponentButtonNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfComponentButtonNestedFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  label?: InputMaybe<Scalars["String"]["input"]>;
-  label_contains?: InputMaybe<Scalars["String"]["input"]>;
-  label_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  label_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  label_not?: InputMaybe<Scalars["String"]["input"]>;
-  label_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  label_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  label?: InputMaybe<Scalars['String']['input']>;
+  label_contains?: InputMaybe<Scalars['String']['input']>;
+  label_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  label_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  label_not?: InputMaybe<Scalars['String']['input']>;
+  label_not_contains?: InputMaybe<Scalars['String']['input']>;
+  label_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  url?: InputMaybe<Scalars["String"]["input"]>;
-  url_contains?: InputMaybe<Scalars["String"]["input"]>;
-  url_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  url_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  url_not?: InputMaybe<Scalars["String"]["input"]>;
-  url_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  url_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  url?: InputMaybe<Scalars['String']['input']>;
+  url_contains?: InputMaybe<Scalars['String']['input']>;
+  url_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  url_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  url_not?: InputMaybe<Scalars['String']['input']>;
+  url_not_contains?: InputMaybe<Scalars['String']['input']>;
+  url_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type CfComponentEmailNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfComponentEmailNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfComponentEmailNestedFilter>>>;
-  availableVariables?: InputMaybe<Scalars["String"]["input"]>;
-  availableVariables_contains?: InputMaybe<Scalars["String"]["input"]>;
-  availableVariables_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  availableVariables_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  availableVariables_not?: InputMaybe<Scalars["String"]["input"]>;
-  availableVariables_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  availableVariables_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  content_contains?: InputMaybe<Scalars["String"]["input"]>;
-  content_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  content_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  availableVariables?: InputMaybe<Scalars['String']['input']>;
+  availableVariables_contains?: InputMaybe<Scalars['String']['input']>;
+  availableVariables_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  availableVariables_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  availableVariables_not?: InputMaybe<Scalars['String']['input']>;
+  availableVariables_not_contains?: InputMaybe<Scalars['String']['input']>;
+  availableVariables_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  content_contains?: InputMaybe<Scalars['String']['input']>;
+  content_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  content_not_contains?: InputMaybe<Scalars['String']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  preview?: InputMaybe<Scalars["String"]["input"]>;
-  preview_contains?: InputMaybe<Scalars["String"]["input"]>;
-  preview_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  preview_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  preview_not?: InputMaybe<Scalars["String"]["input"]>;
-  preview_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  preview_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  preview?: InputMaybe<Scalars['String']['input']>;
+  preview_contains?: InputMaybe<Scalars['String']['input']>;
+  preview_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  preview_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  preview_not?: InputMaybe<Scalars['String']['input']>;
+  preview_not_contains?: InputMaybe<Scalars['String']['input']>;
+  preview_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
 };
 
 export type CfComponentFaqQuestionNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfComponentFaqQuestionNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfComponentFaqQuestionNestedFilter>>>;
-  answer_contains?: InputMaybe<Scalars["String"]["input"]>;
-  answer_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  answer_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  answer_contains?: InputMaybe<Scalars['String']['input']>;
+  answer_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  answer_not_contains?: InputMaybe<Scalars['String']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  question?: InputMaybe<Scalars["String"]["input"]>;
-  question_contains?: InputMaybe<Scalars["String"]["input"]>;
-  question_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  question_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  question_not?: InputMaybe<Scalars["String"]["input"]>;
-  question_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  question_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  question?: InputMaybe<Scalars['String']['input']>;
+  question_contains?: InputMaybe<Scalars['String']['input']>;
+  question_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  question_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  question_not?: InputMaybe<Scalars['String']['input']>;
+  question_not_contains?: InputMaybe<Scalars['String']['input']>;
+  question_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
 };
 
@@ -7027,2357 +7816,1808 @@ export type CfComponentFeatureNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfComponentFeatureNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfComponentFeatureNestedFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  icon_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  subtitle?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_contains?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  subtitle_not?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  icon_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  subtitle?: InputMaybe<Scalars['String']['input']>;
+  subtitle_contains?: InputMaybe<Scalars['String']['input']>;
+  subtitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  subtitle_not?: InputMaybe<Scalars['String']['input']>;
+  subtitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  title_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  title_not?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type CfComponentPartnerNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfComponentPartnerNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfComponentPartnerNestedFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  logo_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  subtitle?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_contains?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  subtitle_not?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  logo_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  subtitle?: InputMaybe<Scalars['String']['input']>;
+  subtitle_contains?: InputMaybe<Scalars['String']['input']>;
+  subtitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  subtitle_not?: InputMaybe<Scalars['String']['input']>;
+  subtitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  url?: InputMaybe<Scalars["String"]["input"]>;
-  url_contains?: InputMaybe<Scalars["String"]["input"]>;
-  url_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  url_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  url_not?: InputMaybe<Scalars["String"]["input"]>;
-  url_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  url_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  url?: InputMaybe<Scalars['String']['input']>;
+  url_contains?: InputMaybe<Scalars['String']['input']>;
+  url_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  url_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  url_not?: InputMaybe<Scalars['String']['input']>;
+  url_not_contains?: InputMaybe<Scalars['String']['input']>;
+  url_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
 export type CfComponentSeoNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfComponentSeoNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfComponentSeoNestedFilter>>>;
-  canonicalUrl?: InputMaybe<Scalars["String"]["input"]>;
-  canonicalUrl_contains?: InputMaybe<Scalars["String"]["input"]>;
-  canonicalUrl_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  canonicalUrl_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  canonicalUrl_not?: InputMaybe<Scalars["String"]["input"]>;
-  canonicalUrl_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  canonicalUrl_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  canonicalUrl?: InputMaybe<Scalars['String']['input']>;
+  canonicalUrl_contains?: InputMaybe<Scalars['String']['input']>;
+  canonicalUrl_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  canonicalUrl_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  canonicalUrl_not?: InputMaybe<Scalars['String']['input']>;
+  canonicalUrl_not_contains?: InputMaybe<Scalars['String']['input']>;
+  canonicalUrl_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  nofollow?: InputMaybe<Scalars["Boolean"]["input"]>;
-  nofollow_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  nofollow_not?: InputMaybe<Scalars["Boolean"]["input"]>;
-  noindex?: InputMaybe<Scalars["Boolean"]["input"]>;
-  noindex_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  noindex_not?: InputMaybe<Scalars["Boolean"]["input"]>;
-  pageDescription?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageDescription_not?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageTitle?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  pageTitle_not?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  shareImagesCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  nofollow?: InputMaybe<Scalars['Boolean']['input']>;
+  nofollow_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  nofollow_not?: InputMaybe<Scalars['Boolean']['input']>;
+  noindex?: InputMaybe<Scalars['Boolean']['input']>;
+  noindex_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  noindex_not?: InputMaybe<Scalars['Boolean']['input']>;
+  pageDescription?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_contains?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageDescription_not?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
+  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageTitle?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_contains?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  pageTitle_not?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
+  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  shareImagesCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
   sys?: InputMaybe<SysFilter>;
 };
 
 export type CfPageBlogPostNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfPageBlogPostNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfPageBlogPostNestedFilter>>>;
-  author_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  content_contains?: InputMaybe<Scalars["String"]["input"]>;
-  content_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  content_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  author_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  content_contains?: InputMaybe<Scalars['String']['input']>;
+  content_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  content_not_contains?: InputMaybe<Scalars['String']['input']>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  featuredImage_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  publishedDate?: InputMaybe<Scalars["DateTime"]["input"]>;
-  publishedDate_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  publishedDate_gt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  publishedDate_gte?: InputMaybe<Scalars["DateTime"]["input"]>;
-  publishedDate_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
-  publishedDate_lt?: InputMaybe<Scalars["DateTime"]["input"]>;
-  publishedDate_lte?: InputMaybe<Scalars["DateTime"]["input"]>;
-  publishedDate_not?: InputMaybe<Scalars["DateTime"]["input"]>;
-  publishedDate_not_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
-  relatedBlogPostsCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  seoFields_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  shortDescription?: InputMaybe<Scalars["String"]["input"]>;
-  shortDescription_contains?: InputMaybe<Scalars["String"]["input"]>;
-  shortDescription_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  shortDescription_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  shortDescription_not?: InputMaybe<Scalars["String"]["input"]>;
-  shortDescription_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  shortDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  slug?: InputMaybe<Scalars["String"]["input"]>;
-  slug_contains?: InputMaybe<Scalars["String"]["input"]>;
-  slug_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  slug_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  slug_not?: InputMaybe<Scalars["String"]["input"]>;
-  slug_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  slug_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  featuredImage_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName?: InputMaybe<Scalars['String']['input']>;
+  internalName_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName_not?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  publishedDate?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedDate_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  publishedDate_gt?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedDate_gte?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedDate_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  publishedDate_lt?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedDate_lte?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedDate_not?: InputMaybe<Scalars['DateTime']['input']>;
+  publishedDate_not_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  relatedBlogPostsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  seoFields_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  shortDescription?: InputMaybe<Scalars['String']['input']>;
+  shortDescription_contains?: InputMaybe<Scalars['String']['input']>;
+  shortDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  shortDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  shortDescription_not?: InputMaybe<Scalars['String']['input']>;
+  shortDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
+  shortDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  slug?: InputMaybe<Scalars['String']['input']>;
+  slug_contains?: InputMaybe<Scalars['String']['input']>;
+  slug_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  slug_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  slug_not?: InputMaybe<Scalars['String']['input']>;
+  slug_not_contains?: InputMaybe<Scalars['String']['input']>;
+  slug_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars["String"]["input"]>;
-  title_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
-  title_not?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title?: InputMaybe<Scalars['String']['input']>;
+  title_contains?: InputMaybe<Scalars['String']['input']>;
+  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title_not?: InputMaybe<Scalars['String']['input']>;
+  title_not_contains?: InputMaybe<Scalars['String']['input']>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
 };
 
-export type AuthorFieldsFragment = {
-  __typename: "ComponentAuthor";
-  name?: string | null;
-  profession?: string | null;
-  sys: { __typename?: "Sys"; id: string };
-  avatar?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
-};
+export type AuthorFieldsFragment = { __typename: 'ComponentAuthor', name?: string | null, profession?: string | null, sys: { __typename?: 'Sys', id: string }, avatar?: (
+    { __typename?: 'Asset' }
+    & ImageFieldsFragment
+  ) | null };
 
-export type ComponentAlertFieldsFragment = {
-  __typename: "ComponentAlert";
-  internalName?: string | null;
-  title?: string | null;
-  type?: string | null;
-  severity?: string | null;
-  dismissible?: boolean | null;
-  audience?: string | null;
-  startAt?: any | null;
-  endAt?: any | null;
-  active?: boolean | null;
-  sys: { __typename?: "Sys"; id: string };
-  body?: { __typename?: "ComponentAlertBody"; json: any } | null;
-  link?: ({ __typename?: "ComponentButton" } & ButtonFieldsFragment) | null;
-};
+export type ComponentAlertFieldsFragment = { __typename: 'ComponentAlert', internalName?: string | null, title?: string | null, type?: string | null, severity?: string | null, dismissible?: boolean | null, audience?: string | null, startAt?: any | null, endAt?: any | null, active?: boolean | null, sys: { __typename?: 'Sys', id: string }, body?: { __typename?: 'ComponentAlertBody', json: any } | null, link?: (
+    { __typename?: 'ComponentButton' }
+    & ButtonFieldsFragment
+  ) | null };
 
 export type ActiveAlertsQueryVariables = Exact<{
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  now: Scalars["DateTime"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  audience?: InputMaybe<
-    Array<InputMaybe<Scalars["String"]["input"]>> | InputMaybe<Scalars["String"]["input"]>
-  >;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  now: Scalars['DateTime']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  audience?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>> | InputMaybe<Scalars['String']['input']>>;
 }>;
 
-export type ActiveAlertsQuery = {
-  __typename?: "Query";
-  componentAlertCollection?: {
-    __typename?: "ComponentAlertCollection";
-    items: Array<({ __typename?: "ComponentAlert" } & ComponentAlertFieldsFragment) | null>;
-  } | null;
-};
 
-export type FooterFieldsFragment = {
-  __typename: "Footer";
-  internalName?: string | null;
-  brand?: string | null;
-  title?: string | null;
-  badge?: string | null;
-  menuTitle?: string | null;
-  supportTitle?: string | null;
-  copyright?: string | null;
-  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
-  menuButtonsCollection?: {
-    __typename?: "FooterMenuButtonsCollection";
-    items: Array<({ __typename?: "ComponentButton" } & ButtonFieldsFragment) | null>;
-  } | null;
-  supportButtonsCollection?: {
-    __typename?: "FooterSupportButtonsCollection";
-    items: Array<({ __typename?: "ComponentButton" } & ButtonFieldsFragment) | null>;
-  } | null;
-};
+export type ActiveAlertsQuery = { __typename?: 'Query', componentAlertCollection?: { __typename?: 'ComponentAlertCollection', items: Array<(
+      { __typename?: 'ComponentAlert' }
+      & ComponentAlertFieldsFragment
+    ) | null> } | null };
 
-export type ButtonFieldsFragment = {
-  __typename: "ComponentButton";
-  label?: string | null;
-  url?: string | null;
-  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
-};
+export type FooterFieldsFragment = { __typename: 'Footer', internalName?: string | null, brand?: string | null, title?: string | null, badge?: string | null, menuTitle?: string | null, supportTitle?: string | null, copyright?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, menuButtonsCollection?: { __typename?: 'FooterMenuButtonsCollection', items: Array<(
+      { __typename?: 'ComponentButton' }
+      & ButtonFieldsFragment
+    ) | null> } | null, supportButtonsCollection?: { __typename?: 'FooterSupportButtonsCollection', items: Array<(
+      { __typename?: 'ComponentButton' }
+      & ButtonFieldsFragment
+    ) | null> } | null };
+
+export type ButtonFieldsFragment = { __typename: 'ComponentButton', label?: string | null, url?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string } };
 
 export type FooterQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
-export type FooterQuery = {
-  __typename?: "Query";
-  footerCollection?: {
-    __typename?: "FooterCollection";
-    items: Array<({ __typename?: "Footer" } & FooterFieldsFragment) | null>;
-  } | null;
-};
 
-export type ImageFieldsFragment = {
-  __typename: "Asset";
-  title?: string | null;
-  description?: string | null;
-  width?: number | null;
-  height?: number | null;
-  url?: string | null;
-  contentType?: string | null;
-  sys: { __typename?: "Sys"; id: string };
-};
+export type FooterQuery = { __typename?: 'Query', footerCollection?: { __typename?: 'FooterCollection', items: Array<(
+      { __typename?: 'Footer' }
+      & FooterFieldsFragment
+    ) | null> } | null };
 
-export type LandingMetadataFieldsFragment = {
-  __typename: "LandingMetadata";
-  internalName?: string | null;
-  title?: string | null;
-  description?: string | null;
-  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
-};
+export type ImageFieldsFragment = { __typename: 'Asset', title?: string | null, description?: string | null, width?: number | null, height?: number | null, url?: string | null, contentType?: string | null, sys: { __typename?: 'Sys', id: string } };
+
+export type LandingMetadataFieldsFragment = { __typename: 'LandingMetadata', internalName?: string | null, title?: string | null, description?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string } };
 
 export type LandingMetadataQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
-export type LandingMetadataQuery = {
-  __typename?: "Query";
-  landingMetadataCollection?: {
-    __typename?: "LandingMetadataCollection";
-    items: Array<({ __typename?: "LandingMetadata" } & LandingMetadataFieldsFragment) | null>;
-  } | null;
-};
 
-export type PageAboutFieldsFragment = {
-  __typename: "PageAbout";
-  pageTitle?: string | null;
-  pageDescription?: string | null;
-  internalName?: string | null;
-  title?: string | null;
-  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
-  description?: {
-    __typename?: "PageAboutDescription";
-    json: any;
-    links: {
-      __typename?: "PageAboutDescriptionLinks";
-      entries: {
-        __typename?: "PageAboutDescriptionEntries";
-        block: Array<
-          | { __typename?: "ComponentAlert" }
-          | { __typename?: "ComponentAuthor" }
-          | { __typename?: "ComponentButton" }
-          | { __typename?: "ComponentEmail" }
-          | { __typename?: "ComponentFaqQuestion" }
-          | { __typename?: "ComponentFeature" }
-          | { __typename?: "ComponentPartner" }
-          | ({ __typename?: "ComponentRichImage" } & RichImageFieldsFragment)
-          | { __typename?: "ComponentSeo" }
-          | { __typename?: "Footer" }
-          | { __typename?: "LandingMetadata" }
-          | { __typename?: "PageAbout" }
-          | { __typename?: "PageBlogPost" }
-          | { __typename?: "PageCookiePolicy" }
-          | { __typename?: "PageEmails" }
-          | { __typename?: "PageFaq" }
-          | { __typename?: "PageForceUpdate" }
-          | { __typename?: "PageHomeFeatures" }
-          | { __typename?: "PageHomeHero" }
-          | { __typename?: "PageHomeMission" }
-          | { __typename?: "PageHomePartners" }
-          | { __typename?: "PageLanding" }
-          | { __typename?: "PagePolicies" }
-          | { __typename?: "PageTermsAndConditions" }
-          | null
-        >;
-      };
-    };
-  } | null;
-  image?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
-};
+export type LandingMetadataQuery = { __typename?: 'Query', landingMetadataCollection?: { __typename?: 'LandingMetadataCollection', items: Array<(
+      { __typename?: 'LandingMetadata' }
+      & LandingMetadataFieldsFragment
+    ) | null> } | null };
+
+export type PageAboutFieldsFragment = { __typename: 'PageAbout', pageTitle?: string | null, pageDescription?: string | null, internalName?: string | null, title?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, description?: { __typename?: 'PageAboutDescription', json: any, links: { __typename?: 'PageAboutDescriptionLinks', entries: { __typename?: 'PageAboutDescriptionEntries', block: Array<
+          | { __typename?: 'ComponentAlert' }
+          | { __typename?: 'ComponentAuthor' }
+          | { __typename?: 'ComponentButton' }
+          | { __typename?: 'ComponentEmail' }
+          | { __typename?: 'ComponentFaqQuestion' }
+          | { __typename?: 'ComponentFeature' }
+          | { __typename?: 'ComponentPartner' }
+          | { __typename?: 'ComponentReleaseNote' }
+          | (
+            { __typename?: 'ComponentRichImage' }
+            & RichImageFieldsFragment
+          )
+          | { __typename?: 'ComponentSeo' }
+          | { __typename?: 'Footer' }
+          | { __typename?: 'LandingMetadata' }
+          | { __typename?: 'PageAbout' }
+          | { __typename?: 'PageBlogPost' }
+          | { __typename?: 'PageCookiePolicy' }
+          | { __typename?: 'PageEmails' }
+          | { __typename?: 'PageFaq' }
+          | { __typename?: 'PageForceUpdate' }
+          | { __typename?: 'PageHomeFeatures' }
+          | { __typename?: 'PageHomeHero' }
+          | { __typename?: 'PageHomeMission' }
+          | { __typename?: 'PageHomePartners' }
+          | { __typename?: 'PageLanding' }
+          | { __typename?: 'PagePolicies' }
+          | { __typename?: 'PageTermsAndConditions' }
+         | null> } } } | null, image?: (
+    { __typename?: 'Asset' }
+    & ImageFieldsFragment
+  ) | null };
 
 export type PageAboutQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
-export type PageAboutQuery = {
-  __typename?: "Query";
-  pageAboutCollection?: {
-    __typename?: "PageAboutCollection";
-    items: Array<({ __typename?: "PageAbout" } & PageAboutFieldsFragment) | null>;
-  } | null;
-};
+
+export type PageAboutQuery = { __typename?: 'Query', pageAboutCollection?: { __typename?: 'PageAboutCollection', items: Array<(
+      { __typename?: 'PageAbout' }
+      & PageAboutFieldsFragment
+    ) | null> } | null };
 
 export type PageBlogQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageBlogPostOrder>> | InputMaybe<PageBlogPostOrder>>;
   where?: InputMaybe<PageBlogPostFilter>;
 }>;
 
-export type PageBlogQuery = {
-  __typename?: "Query";
-  pageLandingCollection?: {
-    __typename?: "PageLandingCollection";
-    items: Array<({ __typename?: "PageLanding" } & PageLandingFieldsFragment) | null>;
-  } | null;
-  pageBlogPostCollection?: {
-    __typename?: "PageBlogPostCollection";
-    items: Array<({ __typename?: "PageBlogPost" } & PageBlogPostFieldsFragment) | null>;
-  } | null;
-};
+
+export type PageBlogQuery = { __typename?: 'Query', pageLandingCollection?: { __typename?: 'PageLandingCollection', items: Array<(
+      { __typename?: 'PageLanding' }
+      & PageLandingFieldsFragment
+    ) | null> } | null, pageBlogPostCollection?: { __typename?: 'PageBlogPostCollection', items: Array<(
+      { __typename?: 'PageBlogPost' }
+      & PageBlogPostFieldsFragment
+    ) | null> } | null };
 
 export type PageBlogDetailQueryVariables = Exact<{
-  slug: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  slug: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
-export type PageBlogDetailQuery = {
-  __typename?: "Query";
-  pageBlogPostCollection?: {
-    __typename?: "PageBlogPostCollection";
-    items: Array<({ __typename?: "PageBlogPost" } & PageBlogPostFieldsFragment) | null>;
-  } | null;
-  pageLandingCollection?: {
-    __typename?: "PageLandingCollection";
-    items: Array<({ __typename?: "PageLanding" } & PageLandingFieldsFragment) | null>;
-  } | null;
-};
 
-export type ReferencePageBlogPostFieldsFragment = {
-  __typename: "PageBlogPost";
-  slug?: string | null;
-  publishedDate?: any | null;
-  title?: string | null;
-  shortDescription?: string | null;
-  sys: { __typename?: "Sys"; id: string; spaceId: string };
-  author?: ({ __typename?: "ComponentAuthor" } & AuthorFieldsFragment) | null;
-  featuredImage?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
-};
+export type PageBlogDetailQuery = { __typename?: 'Query', pageBlogPostCollection?: { __typename?: 'PageBlogPostCollection', items: Array<(
+      { __typename?: 'PageBlogPost' }
+      & PageBlogPostFieldsFragment
+    ) | null> } | null, pageLandingCollection?: { __typename?: 'PageLandingCollection', items: Array<(
+      { __typename?: 'PageLanding' }
+      & PageLandingFieldsFragment
+    ) | null> } | null };
 
-export type PageBlogPostFieldsFragment = {
-  __typename: "PageBlogPost";
-  internalName?: string | null;
-  slug?: string | null;
-  publishedDate?: any | null;
-  title?: string | null;
-  shortDescription?: string | null;
-  sys: { __typename?: "Sys"; id: string; spaceId: string };
-  seoFields?: ({ __typename?: "ComponentSeo" } & SeoFieldsFragment) | null;
-  author?: ({ __typename?: "ComponentAuthor" } & AuthorFieldsFragment) | null;
-  featuredImage?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
-  content?: {
-    __typename?: "PageBlogPostContent";
-    json: any;
-    links: {
-      __typename?: "PageBlogPostContentLinks";
-      entries: {
-        __typename?: "PageBlogPostContentEntries";
-        block: Array<
-          | { __typename?: "ComponentAlert" }
-          | { __typename?: "ComponentAuthor" }
-          | { __typename?: "ComponentButton" }
-          | { __typename?: "ComponentEmail" }
-          | { __typename?: "ComponentFaqQuestion" }
-          | { __typename?: "ComponentFeature" }
-          | { __typename?: "ComponentPartner" }
-          | ({ __typename?: "ComponentRichImage" } & RichImageFieldsFragment)
-          | { __typename?: "ComponentSeo" }
-          | { __typename?: "Footer" }
-          | { __typename?: "LandingMetadata" }
-          | { __typename?: "PageAbout" }
-          | { __typename?: "PageBlogPost" }
-          | { __typename?: "PageCookiePolicy" }
-          | { __typename?: "PageEmails" }
-          | { __typename?: "PageFaq" }
-          | { __typename?: "PageForceUpdate" }
-          | { __typename?: "PageHomeFeatures" }
-          | { __typename?: "PageHomeHero" }
-          | { __typename?: "PageHomeMission" }
-          | { __typename?: "PageHomePartners" }
-          | { __typename?: "PageLanding" }
-          | { __typename?: "PagePolicies" }
-          | { __typename?: "PageTermsAndConditions" }
-          | null
-        >;
-      };
-    };
-  } | null;
-  relatedBlogPostsCollection?: {
-    __typename?: "PageBlogPostRelatedBlogPostsCollection";
-    items: Array<({ __typename?: "PageBlogPost" } & ReferencePageBlogPostFieldsFragment) | null>;
-  } | null;
-};
+export type ReferencePageBlogPostFieldsFragment = { __typename: 'PageBlogPost', slug?: string | null, publishedDate?: any | null, title?: string | null, shortDescription?: string | null, sys: { __typename?: 'Sys', id: string, spaceId: string }, author?: (
+    { __typename?: 'ComponentAuthor' }
+    & AuthorFieldsFragment
+  ) | null, featuredImage?: (
+    { __typename?: 'Asset' }
+    & ImageFieldsFragment
+  ) | null };
+
+export type PageBlogPostFieldsFragment = { __typename: 'PageBlogPost', internalName?: string | null, slug?: string | null, publishedDate?: any | null, title?: string | null, shortDescription?: string | null, sys: { __typename?: 'Sys', id: string, spaceId: string }, seoFields?: (
+    { __typename?: 'ComponentSeo' }
+    & SeoFieldsFragment
+  ) | null, author?: (
+    { __typename?: 'ComponentAuthor' }
+    & AuthorFieldsFragment
+  ) | null, featuredImage?: (
+    { __typename?: 'Asset' }
+    & ImageFieldsFragment
+  ) | null, content?: { __typename?: 'PageBlogPostContent', json: any, links: { __typename?: 'PageBlogPostContentLinks', entries: { __typename?: 'PageBlogPostContentEntries', block: Array<
+          | { __typename?: 'ComponentAlert' }
+          | { __typename?: 'ComponentAuthor' }
+          | { __typename?: 'ComponentButton' }
+          | { __typename?: 'ComponentEmail' }
+          | { __typename?: 'ComponentFaqQuestion' }
+          | { __typename?: 'ComponentFeature' }
+          | { __typename?: 'ComponentPartner' }
+          | { __typename?: 'ComponentReleaseNote' }
+          | (
+            { __typename?: 'ComponentRichImage' }
+            & RichImageFieldsFragment
+          )
+          | { __typename?: 'ComponentSeo' }
+          | { __typename?: 'Footer' }
+          | { __typename?: 'LandingMetadata' }
+          | { __typename?: 'PageAbout' }
+          | { __typename?: 'PageBlogPost' }
+          | { __typename?: 'PageCookiePolicy' }
+          | { __typename?: 'PageEmails' }
+          | { __typename?: 'PageFaq' }
+          | { __typename?: 'PageForceUpdate' }
+          | { __typename?: 'PageHomeFeatures' }
+          | { __typename?: 'PageHomeHero' }
+          | { __typename?: 'PageHomeMission' }
+          | { __typename?: 'PageHomePartners' }
+          | { __typename?: 'PageLanding' }
+          | { __typename?: 'PagePolicies' }
+          | { __typename?: 'PageTermsAndConditions' }
+         | null> } } } | null, relatedBlogPostsCollection?: { __typename?: 'PageBlogPostRelatedBlogPostsCollection', items: Array<(
+      { __typename?: 'PageBlogPost' }
+      & ReferencePageBlogPostFieldsFragment
+    ) | null> } | null };
 
 export type PageBlogPostQueryVariables = Exact<{
-  slug: Scalars["String"]["input"];
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  slug: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
-export type PageBlogPostQuery = {
-  __typename?: "Query";
-  pageBlogPostCollection?: {
-    __typename?: "PageBlogPostCollection";
-    items: Array<({ __typename?: "PageBlogPost" } & PageBlogPostFieldsFragment) | null>;
-  } | null;
-};
+
+export type PageBlogPostQuery = { __typename?: 'Query', pageBlogPostCollection?: { __typename?: 'PageBlogPostCollection', items: Array<(
+      { __typename?: 'PageBlogPost' }
+      & PageBlogPostFieldsFragment
+    ) | null> } | null };
 
 export type PageBlogPostCollectionQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Array<InputMaybe<PageBlogPostOrder>> | InputMaybe<PageBlogPostOrder>>;
   where?: InputMaybe<PageBlogPostFilter>;
 }>;
 
-export type PageBlogPostCollectionQuery = {
-  __typename?: "Query";
-  pageBlogPostCollection?: {
-    __typename?: "PageBlogPostCollection";
-    items: Array<({ __typename?: "PageBlogPost" } & PageBlogPostFieldsFragment) | null>;
-  } | null;
-};
 
-export type PageCookiePolicyFieldsFragment = {
-  __typename: "PageCookiePolicy";
-  pageTitle?: string | null;
-  pageDescription?: string | null;
-  internalName?: string | null;
-  title?: string | null;
-  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
-  content?: {
-    __typename?: "PageCookiePolicyContent";
-    json: any;
-    links: {
-      __typename?: "PageCookiePolicyContentLinks";
-      entries: {
-        __typename?: "PageCookiePolicyContentEntries";
-        block: Array<
-          | { __typename?: "ComponentAlert" }
-          | { __typename?: "ComponentAuthor" }
-          | { __typename?: "ComponentButton" }
-          | { __typename?: "ComponentEmail" }
-          | { __typename?: "ComponentFaqQuestion" }
-          | { __typename?: "ComponentFeature" }
-          | { __typename?: "ComponentPartner" }
-          | ({ __typename?: "ComponentRichImage" } & RichImageFieldsFragment)
-          | { __typename?: "ComponentSeo" }
-          | { __typename?: "Footer" }
-          | { __typename?: "LandingMetadata" }
-          | { __typename?: "PageAbout" }
-          | { __typename?: "PageBlogPost" }
-          | { __typename?: "PageCookiePolicy" }
-          | { __typename?: "PageEmails" }
-          | { __typename?: "PageFaq" }
-          | { __typename?: "PageForceUpdate" }
-          | { __typename?: "PageHomeFeatures" }
-          | { __typename?: "PageHomeHero" }
-          | { __typename?: "PageHomeMission" }
-          | { __typename?: "PageHomePartners" }
-          | { __typename?: "PageLanding" }
-          | { __typename?: "PagePolicies" }
-          | { __typename?: "PageTermsAndConditions" }
-          | null
-        >;
-      };
-    };
-  } | null;
-};
+export type PageBlogPostCollectionQuery = { __typename?: 'Query', pageBlogPostCollection?: { __typename?: 'PageBlogPostCollection', items: Array<(
+      { __typename?: 'PageBlogPost' }
+      & PageBlogPostFieldsFragment
+    ) | null> } | null };
+
+export type PageCookiePolicyFieldsFragment = { __typename: 'PageCookiePolicy', pageTitle?: string | null, pageDescription?: string | null, internalName?: string | null, title?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, content?: { __typename?: 'PageCookiePolicyContent', json: any, links: { __typename?: 'PageCookiePolicyContentLinks', entries: { __typename?: 'PageCookiePolicyContentEntries', block: Array<
+          | { __typename?: 'ComponentAlert' }
+          | { __typename?: 'ComponentAuthor' }
+          | { __typename?: 'ComponentButton' }
+          | { __typename?: 'ComponentEmail' }
+          | { __typename?: 'ComponentFaqQuestion' }
+          | { __typename?: 'ComponentFeature' }
+          | { __typename?: 'ComponentPartner' }
+          | { __typename?: 'ComponentReleaseNote' }
+          | (
+            { __typename?: 'ComponentRichImage' }
+            & RichImageFieldsFragment
+          )
+          | { __typename?: 'ComponentSeo' }
+          | { __typename?: 'Footer' }
+          | { __typename?: 'LandingMetadata' }
+          | { __typename?: 'PageAbout' }
+          | { __typename?: 'PageBlogPost' }
+          | { __typename?: 'PageCookiePolicy' }
+          | { __typename?: 'PageEmails' }
+          | { __typename?: 'PageFaq' }
+          | { __typename?: 'PageForceUpdate' }
+          | { __typename?: 'PageHomeFeatures' }
+          | { __typename?: 'PageHomeHero' }
+          | { __typename?: 'PageHomeMission' }
+          | { __typename?: 'PageHomePartners' }
+          | { __typename?: 'PageLanding' }
+          | { __typename?: 'PagePolicies' }
+          | { __typename?: 'PageTermsAndConditions' }
+         | null> } } } | null };
 
 export type PageCookiePolicyQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
-export type PageCookiePolicyQuery = {
-  __typename?: "Query";
-  pageCookiePolicyCollection?: {
-    __typename?: "PageCookiePolicyCollection";
-    items: Array<({ __typename?: "PageCookiePolicy" } & PageCookiePolicyFieldsFragment) | null>;
-  } | null;
-};
 
-export type ComponentEmailFieldsFragment = {
-  __typename: "ComponentEmail";
-  internalName?: string | null;
-  availableVariables?: string | null;
-  preview?: string | null;
-  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
-  content?: {
-    __typename?: "ComponentEmailContent";
-    json: any;
-    links: {
-      __typename?: "ComponentEmailContentLinks";
-      entries: {
-        __typename?: "ComponentEmailContentEntries";
-        block: Array<
-          | { __typename?: "ComponentAlert" }
-          | { __typename?: "ComponentAuthor" }
-          | ({ __typename?: "ComponentButton" } & ButtonFieldsFragment)
-          | { __typename?: "ComponentEmail" }
-          | { __typename?: "ComponentFaqQuestion" }
-          | { __typename?: "ComponentFeature" }
-          | { __typename?: "ComponentPartner" }
-          | { __typename?: "ComponentRichImage" }
-          | { __typename?: "ComponentSeo" }
-          | { __typename?: "Footer" }
-          | { __typename?: "LandingMetadata" }
-          | { __typename?: "PageAbout" }
-          | { __typename?: "PageBlogPost" }
-          | { __typename?: "PageCookiePolicy" }
-          | { __typename?: "PageEmails" }
-          | { __typename?: "PageFaq" }
-          | { __typename?: "PageForceUpdate" }
-          | { __typename?: "PageHomeFeatures" }
-          | { __typename?: "PageHomeHero" }
-          | { __typename?: "PageHomeMission" }
-          | { __typename?: "PageHomePartners" }
-          | { __typename?: "PageLanding" }
-          | { __typename?: "PagePolicies" }
-          | { __typename?: "PageTermsAndConditions" }
-          | null
-        >;
-      };
-    };
-  } | null;
-};
+export type PageCookiePolicyQuery = { __typename?: 'Query', pageCookiePolicyCollection?: { __typename?: 'PageCookiePolicyCollection', items: Array<(
+      { __typename?: 'PageCookiePolicy' }
+      & PageCookiePolicyFieldsFragment
+    ) | null> } | null };
+
+export type ComponentEmailFieldsFragment = { __typename: 'ComponentEmail', internalName?: string | null, availableVariables?: string | null, preview?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, content?: { __typename?: 'ComponentEmailContent', json: any, links: { __typename?: 'ComponentEmailContentLinks', entries: { __typename?: 'ComponentEmailContentEntries', block: Array<
+          | { __typename?: 'ComponentAlert' }
+          | { __typename?: 'ComponentAuthor' }
+          | (
+            { __typename?: 'ComponentButton' }
+            & ButtonFieldsFragment
+          )
+          | { __typename?: 'ComponentEmail' }
+          | { __typename?: 'ComponentFaqQuestion' }
+          | { __typename?: 'ComponentFeature' }
+          | { __typename?: 'ComponentPartner' }
+          | { __typename?: 'ComponentReleaseNote' }
+          | { __typename?: 'ComponentRichImage' }
+          | { __typename?: 'ComponentSeo' }
+          | { __typename?: 'Footer' }
+          | { __typename?: 'LandingMetadata' }
+          | { __typename?: 'PageAbout' }
+          | { __typename?: 'PageBlogPost' }
+          | { __typename?: 'PageCookiePolicy' }
+          | { __typename?: 'PageEmails' }
+          | { __typename?: 'PageFaq' }
+          | { __typename?: 'PageForceUpdate' }
+          | { __typename?: 'PageHomeFeatures' }
+          | { __typename?: 'PageHomeHero' }
+          | { __typename?: 'PageHomeMission' }
+          | { __typename?: 'PageHomePartners' }
+          | { __typename?: 'PageLanding' }
+          | { __typename?: 'PagePolicies' }
+          | { __typename?: 'PageTermsAndConditions' }
+         | null> } } } | null };
 
 export type ComponentEmailByNameQueryVariables = Exact<{
-  internalName: Scalars["String"]["input"];
+  internalName: Scalars['String']['input'];
 }>;
 
-export type ComponentEmailByNameQuery = {
-  __typename?: "Query";
-  componentEmailCollection?: {
-    __typename?: "ComponentEmailCollection";
-    items: Array<({ __typename?: "ComponentEmail" } & ComponentEmailFieldsFragment) | null>;
-  } | null;
-};
 
-export type FaqQuestionFieldsFragment = {
-  __typename: "ComponentFaqQuestion";
-  question?: string | null;
-  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
-  answer?: { __typename?: "ComponentFaqQuestionAnswer"; json: any } | null;
-};
+export type ComponentEmailByNameQuery = { __typename?: 'Query', componentEmailCollection?: { __typename?: 'ComponentEmailCollection', items: Array<(
+      { __typename?: 'ComponentEmail' }
+      & ComponentEmailFieldsFragment
+    ) | null> } | null };
 
-export type PageFaqFieldsFragment = {
-  __typename: "PageFaq";
-  pageTitle?: string | null;
-  pageDescription?: string | null;
-  internalName?: string | null;
-  title?: string | null;
-  intro?: string | null;
-  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
-  questionsCollection?: {
-    __typename?: "PageFaqQuestionsCollection";
-    items: Array<({ __typename?: "ComponentFaqQuestion" } & FaqQuestionFieldsFragment) | null>;
-  } | null;
-};
+export type FaqQuestionFieldsFragment = { __typename: 'ComponentFaqQuestion', question?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, answer?: { __typename?: 'ComponentFaqQuestionAnswer', json: any } | null };
+
+export type PageFaqFieldsFragment = { __typename: 'PageFaq', pageTitle?: string | null, pageDescription?: string | null, internalName?: string | null, title?: string | null, intro?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, questionsCollection?: { __typename?: 'PageFaqQuestionsCollection', items: Array<(
+      { __typename?: 'ComponentFaqQuestion' }
+      & FaqQuestionFieldsFragment
+    ) | null> } | null };
 
 export type PageFaqQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
-export type PageFaqQuery = {
-  __typename?: "Query";
-  pageFaqCollection?: {
-    __typename?: "PageFaqCollection";
-    items: Array<({ __typename?: "PageFaq" } & PageFaqFieldsFragment) | null>;
-  } | null;
-};
 
-export type PageForceUpdateFieldsFragment = {
-  __typename: "PageForceUpdate";
-  internalName?: string | null;
-  title?: string | null;
-  minVersion?: string | null;
-  effectiveAt?: any | null;
-  active?: boolean | null;
-  sys: { __typename?: "Sys"; id: string };
-  body?: { __typename?: "PageForceUpdateBody"; json: any } | null;
-  updateCta?: ({ __typename?: "ComponentButton" } & ButtonFieldsFragment) | null;
-};
+export type PageFaqQuery = { __typename?: 'Query', pageFaqCollection?: { __typename?: 'PageFaqCollection', items: Array<(
+      { __typename?: 'PageFaq' }
+      & PageFaqFieldsFragment
+    ) | null> } | null };
+
+export type PageForceUpdateFieldsFragment = { __typename: 'PageForceUpdate', internalName?: string | null, title?: string | null, minVersion?: string | null, effectiveAt?: any | null, active?: boolean | null, sys: { __typename?: 'Sys', id: string }, body?: { __typename?: 'PageForceUpdateBody', json: any } | null, updateCta?: (
+    { __typename?: 'ComponentButton' }
+    & ButtonFieldsFragment
+  ) | null };
 
 export type PageForceUpdateQueryVariables = Exact<{
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
-  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars['String']['input']>;
 }>;
 
-export type PageForceUpdateQuery = {
-  __typename?: "Query";
-  pageForceUpdateCollection?: {
-    __typename?: "PageForceUpdateCollection";
-    items: Array<({ __typename?: "PageForceUpdate" } & PageForceUpdateFieldsFragment) | null>;
-  } | null;
-};
+
+export type PageForceUpdateQuery = { __typename?: 'Query', pageForceUpdateCollection?: { __typename?: 'PageForceUpdateCollection', items: Array<(
+      { __typename?: 'PageForceUpdate' }
+      & PageForceUpdateFieldsFragment
+    ) | null> } | null };
 
 export type PageHomeQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
-export type PageHomeQuery = {
-  __typename?: "Query";
-  pageHomeHeroCollection?: {
-    __typename?: "PageHomeHeroCollection";
-    items: Array<({ __typename?: "PageHomeHero" } & PageHomeHeroFieldsFragment) | null>;
-  } | null;
-  pageHomeMissionCollection?: {
-    __typename?: "PageHomeMissionCollection";
-    items: Array<({ __typename?: "PageHomeMission" } & PageHomeMissionFieldsFragment) | null>;
-  } | null;
-  pageHomeFeaturesCollection?: {
-    __typename?: "PageHomeFeaturesCollection";
-    items: Array<({ __typename?: "PageHomeFeatures" } & PageHomeFeaturesFieldsFragment) | null>;
-  } | null;
-  pageHomePartnersCollection?: {
-    __typename?: "PageHomePartnersCollection";
-    items: Array<({ __typename?: "PageHomePartners" } & PageHomePartnersFieldsFragment) | null>;
-  } | null;
-  footerCollection?: {
-    __typename?: "FooterCollection";
-    items: Array<({ __typename?: "Footer" } & FooterFieldsFragment) | null>;
-  } | null;
-  landingMetadataCollection?: {
-    __typename?: "LandingMetadataCollection";
-    items: Array<({ __typename?: "LandingMetadata" } & LandingMetadataFieldsFragment) | null>;
-  } | null;
-};
 
-export type PageHomeFeaturesFieldsFragment = {
-  __typename: "PageHomeFeatures";
-  internalName?: string | null;
-  title?: string | null;
-  subtitle?: string | null;
-  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
-  featuresCollection?: {
-    __typename?: "PageHomeFeaturesFeaturesCollection";
-    items: Array<({ __typename?: "ComponentFeature" } & FeatureFieldsFragment) | null>;
-  } | null;
-  image?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
-};
+export type PageHomeQuery = { __typename?: 'Query', pageHomeHeroCollection?: { __typename?: 'PageHomeHeroCollection', items: Array<(
+      { __typename?: 'PageHomeHero' }
+      & PageHomeHeroFieldsFragment
+    ) | null> } | null, pageHomeMissionCollection?: { __typename?: 'PageHomeMissionCollection', items: Array<(
+      { __typename?: 'PageHomeMission' }
+      & PageHomeMissionFieldsFragment
+    ) | null> } | null, pageHomeFeaturesCollection?: { __typename?: 'PageHomeFeaturesCollection', items: Array<(
+      { __typename?: 'PageHomeFeatures' }
+      & PageHomeFeaturesFieldsFragment
+    ) | null> } | null, pageHomePartnersCollection?: { __typename?: 'PageHomePartnersCollection', items: Array<(
+      { __typename?: 'PageHomePartners' }
+      & PageHomePartnersFieldsFragment
+    ) | null> } | null, footerCollection?: { __typename?: 'FooterCollection', items: Array<(
+      { __typename?: 'Footer' }
+      & FooterFieldsFragment
+    ) | null> } | null, landingMetadataCollection?: { __typename?: 'LandingMetadataCollection', items: Array<(
+      { __typename?: 'LandingMetadata' }
+      & LandingMetadataFieldsFragment
+    ) | null> } | null };
 
-export type FeatureFieldsFragment = {
-  __typename: "ComponentFeature";
-  title?: string | null;
-  subtitle?: string | null;
-  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
-  icon?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
-};
+export type PageHomeFeaturesFieldsFragment = { __typename: 'PageHomeFeatures', internalName?: string | null, title?: string | null, subtitle?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, featuresCollection?: { __typename?: 'PageHomeFeaturesFeaturesCollection', items: Array<(
+      { __typename?: 'ComponentFeature' }
+      & FeatureFieldsFragment
+    ) | null> } | null, image?: (
+    { __typename?: 'Asset' }
+    & ImageFieldsFragment
+  ) | null };
+
+export type FeatureFieldsFragment = { __typename: 'ComponentFeature', title?: string | null, subtitle?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, icon?: (
+    { __typename?: 'Asset' }
+    & ImageFieldsFragment
+  ) | null };
 
 export type PageHomeFeaturesQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
-export type PageHomeFeaturesQuery = {
-  __typename?: "Query";
-  pageHomeFeaturesCollection?: {
-    __typename?: "PageHomeFeaturesCollection";
-    items: Array<({ __typename?: "PageHomeFeatures" } & PageHomeFeaturesFieldsFragment) | null>;
-  } | null;
-};
 
-export type PageHomeHeroFieldsFragment = {
-  __typename: "PageHomeHero";
-  internalName?: string | null;
-  badge?: string | null;
-  title?: string | null;
-  subtitle?: string | null;
-  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
-  buttonsCollection?: {
-    __typename?: "PageHomeHeroButtonsCollection";
-    items: Array<({ __typename?: "ComponentButton" } & ButtonFieldsFragment) | null>;
-  } | null;
-  image?: {
-    __typename?: "Asset";
-    url?: string | null;
-    title?: string | null;
-    sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
-  } | null;
-};
+export type PageHomeFeaturesQuery = { __typename?: 'Query', pageHomeFeaturesCollection?: { __typename?: 'PageHomeFeaturesCollection', items: Array<(
+      { __typename?: 'PageHomeFeatures' }
+      & PageHomeFeaturesFieldsFragment
+    ) | null> } | null };
+
+export type PageHomeHeroFieldsFragment = { __typename: 'PageHomeHero', internalName?: string | null, badge?: string | null, title?: string | null, subtitle?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, buttonsCollection?: { __typename?: 'PageHomeHeroButtonsCollection', items: Array<(
+      { __typename?: 'ComponentButton' }
+      & ButtonFieldsFragment
+    ) | null> } | null, image?: { __typename?: 'Asset', url?: string | null, title?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string } } | null };
 
 export type PageHomeHeroQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
-export type PageHomeHeroQuery = {
-  __typename?: "Query";
-  pageHomeHeroCollection?: {
-    __typename?: "PageHomeHeroCollection";
-    items: Array<({ __typename?: "PageHomeHero" } & PageHomeHeroFieldsFragment) | null>;
-  } | null;
-};
 
-export type PageHomeMissionFieldsFragment = {
-  __typename: "PageHomeMission";
-  internalName?: string | null;
-  title?: string | null;
-  subtitle?: string | null;
-  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
-  about?: {
-    __typename?: "PageHomeMissionAbout";
-    json: any;
-    links: {
-      __typename?: "PageHomeMissionAboutLinks";
-      entries: {
-        __typename?: "PageHomeMissionAboutEntries";
-        block: Array<
-          | { __typename?: "ComponentAlert" }
-          | { __typename?: "ComponentAuthor" }
-          | { __typename?: "ComponentButton" }
-          | { __typename?: "ComponentEmail" }
-          | { __typename?: "ComponentFaqQuestion" }
-          | { __typename?: "ComponentFeature" }
-          | { __typename?: "ComponentPartner" }
-          | ({ __typename?: "ComponentRichImage" } & RichImageFieldsFragment)
-          | { __typename?: "ComponentSeo" }
-          | { __typename?: "Footer" }
-          | { __typename?: "LandingMetadata" }
-          | { __typename?: "PageAbout" }
-          | { __typename?: "PageBlogPost" }
-          | { __typename?: "PageCookiePolicy" }
-          | { __typename?: "PageEmails" }
-          | { __typename?: "PageFaq" }
-          | { __typename?: "PageForceUpdate" }
-          | { __typename?: "PageHomeFeatures" }
-          | { __typename?: "PageHomeHero" }
-          | { __typename?: "PageHomeMission" }
-          | { __typename?: "PageHomePartners" }
-          | { __typename?: "PageLanding" }
-          | { __typename?: "PagePolicies" }
-          | { __typename?: "PageTermsAndConditions" }
-          | null
-        >;
-      };
-    };
-  } | null;
-  mission?: {
-    __typename?: "PageHomeMissionMission";
-    json: any;
-    links: {
-      __typename?: "PageHomeMissionMissionLinks";
-      entries: {
-        __typename?: "PageHomeMissionMissionEntries";
-        block: Array<
-          | { __typename?: "ComponentAlert" }
-          | { __typename?: "ComponentAuthor" }
-          | { __typename?: "ComponentButton" }
-          | { __typename?: "ComponentEmail" }
-          | { __typename?: "ComponentFaqQuestion" }
-          | { __typename?: "ComponentFeature" }
-          | { __typename?: "ComponentPartner" }
-          | ({ __typename?: "ComponentRichImage" } & RichImageFieldsFragment)
-          | { __typename?: "ComponentSeo" }
-          | { __typename?: "Footer" }
-          | { __typename?: "LandingMetadata" }
-          | { __typename?: "PageAbout" }
-          | { __typename?: "PageBlogPost" }
-          | { __typename?: "PageCookiePolicy" }
-          | { __typename?: "PageEmails" }
-          | { __typename?: "PageFaq" }
-          | { __typename?: "PageForceUpdate" }
-          | { __typename?: "PageHomeFeatures" }
-          | { __typename?: "PageHomeHero" }
-          | { __typename?: "PageHomeMission" }
-          | { __typename?: "PageHomePartners" }
-          | { __typename?: "PageLanding" }
-          | { __typename?: "PagePolicies" }
-          | { __typename?: "PageTermsAndConditions" }
-          | null
-        >;
-      };
-    };
-  } | null;
-  image?: {
-    __typename?: "Asset";
-    url?: string | null;
-    title?: string | null;
-    sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
-  } | null;
-  imagesCollection?: {
-    __typename?: "AssetCollection";
-    items: Array<({ __typename?: "Asset" } & ImageFieldsFragment) | null>;
-  } | null;
-};
+export type PageHomeHeroQuery = { __typename?: 'Query', pageHomeHeroCollection?: { __typename?: 'PageHomeHeroCollection', items: Array<(
+      { __typename?: 'PageHomeHero' }
+      & PageHomeHeroFieldsFragment
+    ) | null> } | null };
+
+export type PageHomeMissionFieldsFragment = { __typename: 'PageHomeMission', internalName?: string | null, title?: string | null, subtitle?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, about?: { __typename?: 'PageHomeMissionAbout', json: any, links: { __typename?: 'PageHomeMissionAboutLinks', entries: { __typename?: 'PageHomeMissionAboutEntries', block: Array<
+          | { __typename?: 'ComponentAlert' }
+          | { __typename?: 'ComponentAuthor' }
+          | { __typename?: 'ComponentButton' }
+          | { __typename?: 'ComponentEmail' }
+          | { __typename?: 'ComponentFaqQuestion' }
+          | { __typename?: 'ComponentFeature' }
+          | { __typename?: 'ComponentPartner' }
+          | { __typename?: 'ComponentReleaseNote' }
+          | (
+            { __typename?: 'ComponentRichImage' }
+            & RichImageFieldsFragment
+          )
+          | { __typename?: 'ComponentSeo' }
+          | { __typename?: 'Footer' }
+          | { __typename?: 'LandingMetadata' }
+          | { __typename?: 'PageAbout' }
+          | { __typename?: 'PageBlogPost' }
+          | { __typename?: 'PageCookiePolicy' }
+          | { __typename?: 'PageEmails' }
+          | { __typename?: 'PageFaq' }
+          | { __typename?: 'PageForceUpdate' }
+          | { __typename?: 'PageHomeFeatures' }
+          | { __typename?: 'PageHomeHero' }
+          | { __typename?: 'PageHomeMission' }
+          | { __typename?: 'PageHomePartners' }
+          | { __typename?: 'PageLanding' }
+          | { __typename?: 'PagePolicies' }
+          | { __typename?: 'PageTermsAndConditions' }
+         | null> } } } | null, mission?: { __typename?: 'PageHomeMissionMission', json: any, links: { __typename?: 'PageHomeMissionMissionLinks', entries: { __typename?: 'PageHomeMissionMissionEntries', block: Array<
+          | { __typename?: 'ComponentAlert' }
+          | { __typename?: 'ComponentAuthor' }
+          | { __typename?: 'ComponentButton' }
+          | { __typename?: 'ComponentEmail' }
+          | { __typename?: 'ComponentFaqQuestion' }
+          | { __typename?: 'ComponentFeature' }
+          | { __typename?: 'ComponentPartner' }
+          | { __typename?: 'ComponentReleaseNote' }
+          | (
+            { __typename?: 'ComponentRichImage' }
+            & RichImageFieldsFragment
+          )
+          | { __typename?: 'ComponentSeo' }
+          | { __typename?: 'Footer' }
+          | { __typename?: 'LandingMetadata' }
+          | { __typename?: 'PageAbout' }
+          | { __typename?: 'PageBlogPost' }
+          | { __typename?: 'PageCookiePolicy' }
+          | { __typename?: 'PageEmails' }
+          | { __typename?: 'PageFaq' }
+          | { __typename?: 'PageForceUpdate' }
+          | { __typename?: 'PageHomeFeatures' }
+          | { __typename?: 'PageHomeHero' }
+          | { __typename?: 'PageHomeMission' }
+          | { __typename?: 'PageHomePartners' }
+          | { __typename?: 'PageLanding' }
+          | { __typename?: 'PagePolicies' }
+          | { __typename?: 'PageTermsAndConditions' }
+         | null> } } } | null, image?: { __typename?: 'Asset', url?: string | null, title?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string } } | null, imagesCollection?: { __typename?: 'AssetCollection', items: Array<(
+      { __typename?: 'Asset' }
+      & ImageFieldsFragment
+    ) | null> } | null };
 
 export type PageHomeMissionQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
-export type PageHomeMissionQuery = {
-  __typename?: "Query";
-  pageHomeMissionCollection?: {
-    __typename?: "PageHomeMissionCollection";
-    items: Array<({ __typename?: "PageHomeMission" } & PageHomeMissionFieldsFragment) | null>;
-  } | null;
-};
 
-export type PageHomePartnersFieldsFragment = {
-  __typename: "PageHomePartners";
-  title?: string | null;
-  subtitle?: string | null;
-  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
-  partnersCollection?: {
-    __typename?: "PageHomePartnersPartnersCollection";
-    items: Array<({ __typename?: "ComponentPartner" } & PartnerFieldsFragment) | null>;
-  } | null;
-  imagesCollection?: {
-    __typename?: "AssetCollection";
-    items: Array<({ __typename?: "Asset" } & ImageFieldsFragment) | null>;
-  } | null;
-};
+export type PageHomeMissionQuery = { __typename?: 'Query', pageHomeMissionCollection?: { __typename?: 'PageHomeMissionCollection', items: Array<(
+      { __typename?: 'PageHomeMission' }
+      & PageHomeMissionFieldsFragment
+    ) | null> } | null };
 
-export type PartnerFieldsFragment = {
-  __typename: "ComponentPartner";
-  subtitle?: string | null;
-  url?: string | null;
-  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
-  logo?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
-};
+export type PageHomePartnersFieldsFragment = { __typename: 'PageHomePartners', title?: string | null, subtitle?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, partnersCollection?: { __typename?: 'PageHomePartnersPartnersCollection', items: Array<(
+      { __typename?: 'ComponentPartner' }
+      & PartnerFieldsFragment
+    ) | null> } | null, imagesCollection?: { __typename?: 'AssetCollection', items: Array<(
+      { __typename?: 'Asset' }
+      & ImageFieldsFragment
+    ) | null> } | null };
+
+export type PartnerFieldsFragment = { __typename: 'ComponentPartner', subtitle?: string | null, url?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, logo?: (
+    { __typename?: 'Asset' }
+    & ImageFieldsFragment
+  ) | null };
 
 export type PageHomePartnersQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
-export type PageHomePartnersQuery = {
-  __typename?: "Query";
-  pageHomePartnersCollection?: {
-    __typename?: "PageHomePartnersCollection";
-    items: Array<({ __typename?: "PageHomePartners" } & PageHomePartnersFieldsFragment) | null>;
-  } | null;
-};
 
-export type PageLandingFieldsFragment = {
-  __typename: "PageLanding";
-  internalName?: string | null;
-  sys: { __typename?: "Sys"; id: string; spaceId: string };
-  seoFields?: ({ __typename?: "ComponentSeo" } & SeoFieldsFragment) | null;
-  featuredBlogPost?: ({ __typename?: "PageBlogPost" } & ReferencePageBlogPostFieldsFragment) | null;
-};
+export type PageHomePartnersQuery = { __typename?: 'Query', pageHomePartnersCollection?: { __typename?: 'PageHomePartnersCollection', items: Array<(
+      { __typename?: 'PageHomePartners' }
+      & PageHomePartnersFieldsFragment
+    ) | null> } | null };
+
+export type PageLandingFieldsFragment = { __typename: 'PageLanding', internalName?: string | null, sys: { __typename?: 'Sys', id: string, spaceId: string }, seoFields?: (
+    { __typename?: 'ComponentSeo' }
+    & SeoFieldsFragment
+  ) | null, featuredBlogPost?: (
+    { __typename?: 'PageBlogPost' }
+    & ReferencePageBlogPostFieldsFragment
+  ) | null };
 
 export type PageLandingQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
-export type PageLandingQuery = {
-  __typename?: "Query";
-  pageLandingCollection?: {
-    __typename?: "PageLandingCollection";
-    items: Array<({ __typename?: "PageLanding" } & PageLandingFieldsFragment) | null>;
-  } | null;
-};
+
+export type PageLandingQuery = { __typename?: 'Query', pageLandingCollection?: { __typename?: 'PageLandingCollection', items: Array<(
+      { __typename?: 'PageLanding' }
+      & PageLandingFieldsFragment
+    ) | null> } | null };
 
 export type PageLandingCollectionQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
-export type PageLandingCollectionQuery = {
-  __typename?: "Query";
-  pageLandingCollection?: {
-    __typename?: "PageLandingCollection";
-    items: Array<({ __typename?: "PageLanding" } & PageLandingFieldsFragment) | null>;
-  } | null;
-};
 
-export type PagePoliciesFieldsFragment = {
-  __typename: "PagePolicies";
-  pageTitle?: string | null;
-  pageDescription?: string | null;
-  internalName?: string | null;
-  title?: string | null;
-  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
-  content?: {
-    __typename?: "PagePoliciesContent";
-    json: any;
-    links: {
-      __typename?: "PagePoliciesContentLinks";
-      entries: {
-        __typename?: "PagePoliciesContentEntries";
-        block: Array<
-          | { __typename?: "ComponentAlert" }
-          | { __typename?: "ComponentAuthor" }
-          | { __typename?: "ComponentButton" }
-          | { __typename?: "ComponentEmail" }
-          | { __typename?: "ComponentFaqQuestion" }
-          | { __typename?: "ComponentFeature" }
-          | { __typename?: "ComponentPartner" }
-          | ({ __typename?: "ComponentRichImage" } & RichImageFieldsFragment)
-          | { __typename?: "ComponentSeo" }
-          | { __typename?: "Footer" }
-          | { __typename?: "LandingMetadata" }
-          | { __typename?: "PageAbout" }
-          | { __typename?: "PageBlogPost" }
-          | { __typename?: "PageCookiePolicy" }
-          | { __typename?: "PageEmails" }
-          | { __typename?: "PageFaq" }
-          | { __typename?: "PageForceUpdate" }
-          | { __typename?: "PageHomeFeatures" }
-          | { __typename?: "PageHomeHero" }
-          | { __typename?: "PageHomeMission" }
-          | { __typename?: "PageHomePartners" }
-          | { __typename?: "PageLanding" }
-          | { __typename?: "PagePolicies" }
-          | { __typename?: "PageTermsAndConditions" }
-          | null
-        >;
-      };
-    };
-  } | null;
-};
+export type PageLandingCollectionQuery = { __typename?: 'Query', pageLandingCollection?: { __typename?: 'PageLandingCollection', items: Array<(
+      { __typename?: 'PageLanding' }
+      & PageLandingFieldsFragment
+    ) | null> } | null };
+
+export type PagePoliciesFieldsFragment = { __typename: 'PagePolicies', pageTitle?: string | null, pageDescription?: string | null, internalName?: string | null, title?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, content?: { __typename?: 'PagePoliciesContent', json: any, links: { __typename?: 'PagePoliciesContentLinks', entries: { __typename?: 'PagePoliciesContentEntries', block: Array<
+          | { __typename?: 'ComponentAlert' }
+          | { __typename?: 'ComponentAuthor' }
+          | { __typename?: 'ComponentButton' }
+          | { __typename?: 'ComponentEmail' }
+          | { __typename?: 'ComponentFaqQuestion' }
+          | { __typename?: 'ComponentFeature' }
+          | { __typename?: 'ComponentPartner' }
+          | { __typename?: 'ComponentReleaseNote' }
+          | (
+            { __typename?: 'ComponentRichImage' }
+            & RichImageFieldsFragment
+          )
+          | { __typename?: 'ComponentSeo' }
+          | { __typename?: 'Footer' }
+          | { __typename?: 'LandingMetadata' }
+          | { __typename?: 'PageAbout' }
+          | { __typename?: 'PageBlogPost' }
+          | { __typename?: 'PageCookiePolicy' }
+          | { __typename?: 'PageEmails' }
+          | { __typename?: 'PageFaq' }
+          | { __typename?: 'PageForceUpdate' }
+          | { __typename?: 'PageHomeFeatures' }
+          | { __typename?: 'PageHomeHero' }
+          | { __typename?: 'PageHomeMission' }
+          | { __typename?: 'PageHomePartners' }
+          | { __typename?: 'PageLanding' }
+          | { __typename?: 'PagePolicies' }
+          | { __typename?: 'PageTermsAndConditions' }
+         | null> } } } | null };
 
 export type PagePoliciesQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
-export type PagePoliciesQuery = {
-  __typename?: "Query";
-  pagePoliciesCollection?: {
-    __typename?: "PagePoliciesCollection";
-    items: Array<({ __typename?: "PagePolicies" } & PagePoliciesFieldsFragment) | null>;
-  } | null;
-};
 
-export type PageTermsAndConditionsFieldsFragment = {
-  __typename: "PageTermsAndConditions";
-  pageTitle?: string | null;
-  pageDescription?: string | null;
-  internalName?: string | null;
-  title?: string | null;
-  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
-  content?: {
-    __typename?: "PageTermsAndConditionsContent";
-    json: any;
-    links: {
-      __typename?: "PageTermsAndConditionsContentLinks";
-      entries: {
-        __typename?: "PageTermsAndConditionsContentEntries";
-        block: Array<
-          | { __typename?: "ComponentAlert" }
-          | { __typename?: "ComponentAuthor" }
-          | { __typename?: "ComponentButton" }
-          | { __typename?: "ComponentEmail" }
-          | { __typename?: "ComponentFaqQuestion" }
-          | { __typename?: "ComponentFeature" }
-          | { __typename?: "ComponentPartner" }
-          | ({ __typename?: "ComponentRichImage" } & RichImageFieldsFragment)
-          | { __typename?: "ComponentSeo" }
-          | { __typename?: "Footer" }
-          | { __typename?: "LandingMetadata" }
-          | { __typename?: "PageAbout" }
-          | { __typename?: "PageBlogPost" }
-          | { __typename?: "PageCookiePolicy" }
-          | { __typename?: "PageEmails" }
-          | { __typename?: "PageFaq" }
-          | { __typename?: "PageForceUpdate" }
-          | { __typename?: "PageHomeFeatures" }
-          | { __typename?: "PageHomeHero" }
-          | { __typename?: "PageHomeMission" }
-          | { __typename?: "PageHomePartners" }
-          | { __typename?: "PageLanding" }
-          | { __typename?: "PagePolicies" }
-          | { __typename?: "PageTermsAndConditions" }
-          | null
-        >;
-      };
-    };
-  } | null;
-};
+export type PagePoliciesQuery = { __typename?: 'Query', pagePoliciesCollection?: { __typename?: 'PagePoliciesCollection', items: Array<(
+      { __typename?: 'PagePolicies' }
+      & PagePoliciesFieldsFragment
+    ) | null> } | null };
+
+export type PageTermsAndConditionsFieldsFragment = { __typename: 'PageTermsAndConditions', pageTitle?: string | null, pageDescription?: string | null, internalName?: string | null, title?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, content?: { __typename?: 'PageTermsAndConditionsContent', json: any, links: { __typename?: 'PageTermsAndConditionsContentLinks', entries: { __typename?: 'PageTermsAndConditionsContentEntries', block: Array<
+          | { __typename?: 'ComponentAlert' }
+          | { __typename?: 'ComponentAuthor' }
+          | { __typename?: 'ComponentButton' }
+          | { __typename?: 'ComponentEmail' }
+          | { __typename?: 'ComponentFaqQuestion' }
+          | { __typename?: 'ComponentFeature' }
+          | { __typename?: 'ComponentPartner' }
+          | { __typename?: 'ComponentReleaseNote' }
+          | (
+            { __typename?: 'ComponentRichImage' }
+            & RichImageFieldsFragment
+          )
+          | { __typename?: 'ComponentSeo' }
+          | { __typename?: 'Footer' }
+          | { __typename?: 'LandingMetadata' }
+          | { __typename?: 'PageAbout' }
+          | { __typename?: 'PageBlogPost' }
+          | { __typename?: 'PageCookiePolicy' }
+          | { __typename?: 'PageEmails' }
+          | { __typename?: 'PageFaq' }
+          | { __typename?: 'PageForceUpdate' }
+          | { __typename?: 'PageHomeFeatures' }
+          | { __typename?: 'PageHomeHero' }
+          | { __typename?: 'PageHomeMission' }
+          | { __typename?: 'PageHomePartners' }
+          | { __typename?: 'PageLanding' }
+          | { __typename?: 'PagePolicies' }
+          | { __typename?: 'PageTermsAndConditions' }
+         | null> } } } | null };
 
 export type PageTermsAndConditionsQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars["String"]["input"]>;
-  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
 }>;
 
-export type PageTermsAndConditionsQuery = {
-  __typename?: "Query";
-  pageTermsAndConditionsCollection?: {
-    __typename?: "PageTermsAndConditionsCollection";
-    items: Array<
-      ({ __typename?: "PageTermsAndConditions" } & PageTermsAndConditionsFieldsFragment) | null
-    >;
-  } | null;
-};
 
-export type RichImageFieldsFragment = {
-  __typename: "ComponentRichImage";
-  internalName?: string | null;
-  caption?: string | null;
-  fullWidth?: boolean | null;
-  sys: { __typename?: "Sys"; id: string };
-  image?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
-};
+export type PageTermsAndConditionsQuery = { __typename?: 'Query', pageTermsAndConditionsCollection?: { __typename?: 'PageTermsAndConditionsCollection', items: Array<(
+      { __typename?: 'PageTermsAndConditions' }
+      & PageTermsAndConditionsFieldsFragment
+    ) | null> } | null };
 
-export type SeoFieldsFragment = {
-  __typename: "ComponentSeo";
-  pageTitle?: string | null;
-  pageDescription?: string | null;
-  canonicalUrl?: string | null;
-  nofollow?: boolean | null;
-  noindex?: boolean | null;
-  shareImagesCollection?: {
-    __typename?: "AssetCollection";
-    items: Array<({ __typename?: "Asset" } & ImageFieldsFragment) | null>;
-  } | null;
-};
+export type ComponentReleaseNoteFieldsFragment = { __typename: 'ComponentReleaseNote', slug?: string | null, title?: string | null, summary?: string | null, category?: string | null, surfaces?: string | null, publishedAt?: any | null, active?: boolean | null, sys: { __typename?: 'Sys', id: string }, body?: { __typename?: 'ComponentReleaseNoteBody', json: any } | null, media?: (
+    { __typename?: 'Asset' }
+    & ImageFieldsFragment
+  ) | null, cta?: (
+    { __typename?: 'ComponentButton' }
+    & ButtonFieldsFragment
+  ) | null, seoFields?: (
+    { __typename?: 'ComponentSeo' }
+    & SeoFieldsFragment
+  ) | null };
 
-export type SitemapPagesFieldsFragment = {
-  __typename?: "Query";
-  pageBlogPostCollection?: {
-    __typename?: "PageBlogPostCollection";
-    items: Array<{
-      __typename?: "PageBlogPost";
-      slug?: string | null;
-      sys: { __typename?: "Sys"; publishedAt?: any | null };
-    } | null>;
-  } | null;
-  pageLandingCollection?: {
-    __typename?: "PageLandingCollection";
-    items: Array<{
-      __typename?: "PageLanding";
-      sys: { __typename?: "Sys"; publishedAt?: any | null };
-    } | null>;
-  } | null;
-};
+export type ActiveReleaseNotesQueryVariables = Exact<{
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  now: Scalars['DateTime']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  surfaces?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>> | InputMaybe<Scalars['String']['input']>>;
+}>;
+
+
+export type ActiveReleaseNotesQuery = { __typename?: 'Query', componentReleaseNoteCollection?: { __typename?: 'ComponentReleaseNoteCollection', items: Array<(
+      { __typename?: 'ComponentReleaseNote' }
+      & ComponentReleaseNoteFieldsFragment
+    ) | null> } | null };
+
+export type AllReleaseNotesQueryVariables = Exact<{
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  now: Scalars['DateTime']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type AllReleaseNotesQuery = { __typename?: 'Query', componentReleaseNoteCollection?: { __typename?: 'ComponentReleaseNoteCollection', items: Array<(
+      { __typename?: 'ComponentReleaseNote' }
+      & ComponentReleaseNoteFieldsFragment
+    ) | null> } | null };
+
+export type ReleaseNoteBySlugQueryVariables = Exact<{
+  slug: Scalars['String']['input'];
+  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars['Boolean']['input']>;
+}>;
+
+
+export type ReleaseNoteBySlugQuery = { __typename?: 'Query', componentReleaseNoteCollection?: { __typename?: 'ComponentReleaseNoteCollection', items: Array<(
+      { __typename?: 'ComponentReleaseNote' }
+      & ComponentReleaseNoteFieldsFragment
+    ) | null> } | null };
+
+export type RichImageFieldsFragment = { __typename: 'ComponentRichImage', internalName?: string | null, caption?: string | null, fullWidth?: boolean | null, sys: { __typename?: 'Sys', id: string }, image?: (
+    { __typename?: 'Asset' }
+    & ImageFieldsFragment
+  ) | null };
+
+export type SeoFieldsFragment = { __typename: 'ComponentSeo', pageTitle?: string | null, pageDescription?: string | null, canonicalUrl?: string | null, nofollow?: boolean | null, noindex?: boolean | null, shareImagesCollection?: { __typename?: 'AssetCollection', items: Array<(
+      { __typename?: 'Asset' }
+      & ImageFieldsFragment
+    ) | null> } | null };
+
+export type SitemapPagesFieldsFragment = { __typename?: 'Query', pageBlogPostCollection?: { __typename?: 'PageBlogPostCollection', items: Array<{ __typename?: 'PageBlogPost', slug?: string | null, sys: { __typename?: 'Sys', publishedAt?: any | null } } | null> } | null, pageLandingCollection?: { __typename?: 'PageLandingCollection', items: Array<{ __typename?: 'PageLanding', sys: { __typename?: 'Sys', publishedAt?: any | null } } | null> } | null };
 
 export type SitemapPagesQueryVariables = Exact<{
-  locale: Scalars["String"]["input"];
+  locale: Scalars['String']['input'];
 }>;
 
-export type SitemapPagesQuery = { __typename?: "Query" } & SitemapPagesFieldsFragment;
+
+export type SitemapPagesQuery = (
+  { __typename?: 'Query' }
+  & SitemapPagesFieldsFragment
+);
 
 export const ButtonFieldsFragmentDoc = gql`
-  fragment ButtonFields on ComponentButton {
-    __typename
-    sys {
-      id
-      publishedAt
-      environmentId
-    }
-    label
-    url
+    fragment ButtonFields on ComponentButton {
+  __typename
+  sys {
+    id
+    publishedAt
+    environmentId
   }
-`;
+  label
+  url
+}
+    `;
 export const ComponentAlertFieldsFragmentDoc = gql`
-  fragment ComponentAlertFields on ComponentAlert {
-    __typename
-    sys {
-      id
-    }
-    internalName
-    title
-    body {
-      json
-    }
-    type
-    severity
-    dismissible
-    link {
-      ...ButtonFields
-    }
-    audience
-    startAt
-    endAt
-    active
+    fragment ComponentAlertFields on ComponentAlert {
+  __typename
+  sys {
+    id
   }
-  ${ButtonFieldsFragmentDoc}
-`;
+  internalName
+  title
+  body {
+    json
+  }
+  type
+  severity
+  dismissible
+  link {
+    ...ButtonFields
+  }
+  audience
+  startAt
+  endAt
+  active
+}
+    ${ButtonFieldsFragmentDoc}`;
 export const FooterFieldsFragmentDoc = gql`
-  fragment FooterFields on Footer {
-    __typename
-    sys {
-      id
-      publishedAt
-      environmentId
-    }
-    internalName
-    brand
-    title
-    badge
-    menuTitle
-    supportTitle
-    copyright
-    menuButtonsCollection {
-      items {
-        ...ButtonFields
-      }
-    }
-    supportButtonsCollection {
-      items {
-        ...ButtonFields
-      }
-    }
+    fragment FooterFields on Footer {
+  __typename
+  sys {
+    id
+    publishedAt
+    environmentId
   }
-  ${ButtonFieldsFragmentDoc}
-`;
-export const LandingMetadataFieldsFragmentDoc = gql`
-  fragment LandingMetadataFields on LandingMetadata {
-    __typename
-    sys {
-      id
-      publishedAt
-      environmentId
-    }
-    internalName
-    title
-    description
-  }
-`;
-export const ImageFieldsFragmentDoc = gql`
-  fragment ImageFields on Asset {
-    __typename
-    sys {
-      id
-    }
-    title
-    description
-    width
-    height
-    url
-    contentType
-  }
-`;
-export const RichImageFieldsFragmentDoc = gql`
-  fragment RichImageFields on ComponentRichImage {
-    __typename
-    internalName
-    sys {
-      id
-    }
-    image {
-      ...ImageFields
-    }
-    caption
-    fullWidth
-  }
-  ${ImageFieldsFragmentDoc}
-`;
-export const PageAboutFieldsFragmentDoc = gql`
-  fragment PageAboutFields on PageAbout {
-    __typename
-    sys {
-      id
-      publishedAt
-      environmentId
-    }
-    pageTitle
-    pageDescription
-    internalName
-    title
-    description {
-      json
-      links {
-        entries {
-          block {
-            ...RichImageFields
-          }
-        }
-      }
-    }
-    image {
-      ...ImageFields
-    }
-  }
-  ${RichImageFieldsFragmentDoc}
-  ${ImageFieldsFragmentDoc}
-`;
-export const SeoFieldsFragmentDoc = gql`
-  fragment SeoFields on ComponentSeo {
-    __typename
-    pageTitle
-    pageDescription
-    canonicalUrl
-    nofollow
-    noindex
-    shareImagesCollection(limit: 3, locale: $locale) {
-      items {
-        ...ImageFields
-      }
-    }
-  }
-  ${ImageFieldsFragmentDoc}
-`;
-export const AuthorFieldsFragmentDoc = gql`
-  fragment AuthorFields on ComponentAuthor {
-    __typename
-    sys {
-      id
-    }
-    name
-    profession
-    avatar {
-      ...ImageFields
-    }
-  }
-  ${ImageFieldsFragmentDoc}
-`;
-export const ReferencePageBlogPostFieldsFragmentDoc = gql`
-  fragment ReferencePageBlogPostFields on PageBlogPost {
-    __typename
-    sys {
-      id
-      spaceId
-    }
-    slug
-    author {
-      ...AuthorFields
-    }
-    publishedDate
-    title
-    shortDescription
-    featuredImage {
-      ...ImageFields
-    }
-  }
-  ${AuthorFieldsFragmentDoc}
-  ${ImageFieldsFragmentDoc}
-`;
-export const PageBlogPostFieldsFragmentDoc = gql`
-  fragment PageBlogPostFields on PageBlogPost {
-    __typename
-    sys {
-      id
-      spaceId
-    }
-    internalName
-    seoFields {
-      ...SeoFields
-    }
-    slug
-    author {
-      ...AuthorFields
-    }
-    publishedDate
-    title
-    shortDescription
-    featuredImage {
-      ...ImageFields
-    }
-    content {
-      json
-      links {
-        entries {
-          block {
-            ...RichImageFields
-          }
-        }
-      }
-    }
-    relatedBlogPostsCollection(limit: 2) {
-      items {
-        ...ReferencePageBlogPostFields
-      }
-    }
-  }
-  ${SeoFieldsFragmentDoc}
-  ${AuthorFieldsFragmentDoc}
-  ${ImageFieldsFragmentDoc}
-  ${RichImageFieldsFragmentDoc}
-  ${ReferencePageBlogPostFieldsFragmentDoc}
-`;
-export const PageCookiePolicyFieldsFragmentDoc = gql`
-  fragment PageCookiePolicyFields on PageCookiePolicy {
-    __typename
-    sys {
-      id
-      publishedAt
-      environmentId
-    }
-    pageTitle
-    pageDescription
-    internalName
-    title
-    content {
-      json
-      links {
-        entries {
-          block {
-            ...RichImageFields
-          }
-        }
-      }
-    }
-  }
-  ${RichImageFieldsFragmentDoc}
-`;
-export const ComponentEmailFieldsFragmentDoc = gql`
-  fragment ComponentEmailFields on ComponentEmail {
-    __typename
-    sys {
-      id
-      publishedAt
-      environmentId
-    }
-    internalName
-    availableVariables
-    preview
-    content {
-      json
-      links {
-        entries {
-          block {
-            ...ButtonFields
-          }
-        }
-      }
-    }
-  }
-  ${ButtonFieldsFragmentDoc}
-`;
-export const FaqQuestionFieldsFragmentDoc = gql`
-  fragment FaqQuestionFields on ComponentFaqQuestion {
-    __typename
-    sys {
-      id
-      publishedAt
-      environmentId
-    }
-    question
-    answer {
-      json
-    }
-  }
-`;
-export const PageFaqFieldsFragmentDoc = gql`
-  fragment PageFaqFields on PageFaq {
-    __typename
-    sys {
-      id
-      publishedAt
-      environmentId
-    }
-    pageTitle
-    pageDescription
-    internalName
-    title
-    intro
-    questionsCollection {
-      items {
-        ...FaqQuestionFields
-      }
-    }
-  }
-  ${FaqQuestionFieldsFragmentDoc}
-`;
-export const PageForceUpdateFieldsFragmentDoc = gql`
-  fragment PageForceUpdateFields on PageForceUpdate {
-    __typename
-    sys {
-      id
-    }
-    internalName
-    title
-    body {
-      json
-    }
-    updateCta {
+  internalName
+  brand
+  title
+  badge
+  menuTitle
+  supportTitle
+  copyright
+  menuButtonsCollection {
+    items {
       ...ButtonFields
     }
-    minVersion
-    effectiveAt
-    active
   }
-  ${ButtonFieldsFragmentDoc}
-`;
-export const FeatureFieldsFragmentDoc = gql`
-  fragment FeatureFields on ComponentFeature {
-    __typename
-    sys {
-      id
-      publishedAt
-      environmentId
-    }
-    title
-    subtitle
-    icon {
-      ...ImageFields
+  supportButtonsCollection {
+    items {
+      ...ButtonFields
     }
   }
-  ${ImageFieldsFragmentDoc}
-`;
-export const PageHomeFeaturesFieldsFragmentDoc = gql`
-  fragment PageHomeFeaturesFields on PageHomeFeatures {
-    __typename
-    sys {
-      id
-      publishedAt
-      environmentId
-    }
-    internalName
-    title
-    subtitle
-    featuresCollection {
-      items {
-        ...FeatureFields
-      }
-    }
-    image {
-      ...ImageFields
-    }
+}
+    ${ButtonFieldsFragmentDoc}`;
+export const LandingMetadataFieldsFragmentDoc = gql`
+    fragment LandingMetadataFields on LandingMetadata {
+  __typename
+  sys {
+    id
+    publishedAt
+    environmentId
   }
-  ${FeatureFieldsFragmentDoc}
-  ${ImageFieldsFragmentDoc}
-`;
-export const PageHomeHeroFieldsFragmentDoc = gql`
-  fragment PageHomeHeroFields on PageHomeHero {
-    __typename
-    sys {
-      id
-      publishedAt
-      environmentId
-    }
-    internalName
-    badge
-    title
-    subtitle
-    buttonsCollection {
-      items {
-        ...ButtonFields
-      }
-    }
-    image {
-      url
-      title
-      sys {
-        id
-        publishedAt
-        environmentId
-      }
-    }
+  internalName
+  title
+  description
+}
+    `;
+export const ImageFieldsFragmentDoc = gql`
+    fragment ImageFields on Asset {
+  __typename
+  sys {
+    id
   }
-  ${ButtonFieldsFragmentDoc}
-`;
-export const PageHomeMissionFieldsFragmentDoc = gql`
-  fragment PageHomeMissionFields on PageHomeMission {
-    __typename
-    sys {
-      id
-      publishedAt
-      environmentId
-    }
-    internalName
-    title
-    about {
-      json
-      links {
-        entries {
-          block {
-            ...RichImageFields
-          }
+  title
+  description
+  width
+  height
+  url
+  contentType
+}
+    `;
+export const RichImageFieldsFragmentDoc = gql`
+    fragment RichImageFields on ComponentRichImage {
+  __typename
+  internalName
+  sys {
+    id
+  }
+  image {
+    ...ImageFields
+  }
+  caption
+  fullWidth
+}
+    ${ImageFieldsFragmentDoc}`;
+export const PageAboutFieldsFragmentDoc = gql`
+    fragment PageAboutFields on PageAbout {
+  __typename
+  sys {
+    id
+    publishedAt
+    environmentId
+  }
+  pageTitle
+  pageDescription
+  internalName
+  title
+  description {
+    json
+    links {
+      entries {
+        block {
+          ...RichImageFields
         }
       }
     }
-    subtitle
-    mission {
-      json
-      links {
-        entries {
-          block {
-            ...RichImageFields
-          }
+  }
+  image {
+    ...ImageFields
+  }
+}
+    ${RichImageFieldsFragmentDoc}
+${ImageFieldsFragmentDoc}`;
+export const SeoFieldsFragmentDoc = gql`
+    fragment SeoFields on ComponentSeo {
+  __typename
+  pageTitle
+  pageDescription
+  canonicalUrl
+  nofollow
+  noindex
+  shareImagesCollection(limit: 3, locale: $locale) {
+    items {
+      ...ImageFields
+    }
+  }
+}
+    ${ImageFieldsFragmentDoc}`;
+export const AuthorFieldsFragmentDoc = gql`
+    fragment AuthorFields on ComponentAuthor {
+  __typename
+  sys {
+    id
+  }
+  name
+  profession
+  avatar {
+    ...ImageFields
+  }
+}
+    ${ImageFieldsFragmentDoc}`;
+export const ReferencePageBlogPostFieldsFragmentDoc = gql`
+    fragment ReferencePageBlogPostFields on PageBlogPost {
+  __typename
+  sys {
+    id
+    spaceId
+  }
+  slug
+  author {
+    ...AuthorFields
+  }
+  publishedDate
+  title
+  shortDescription
+  featuredImage {
+    ...ImageFields
+  }
+}
+    ${AuthorFieldsFragmentDoc}
+${ImageFieldsFragmentDoc}`;
+export const PageBlogPostFieldsFragmentDoc = gql`
+    fragment PageBlogPostFields on PageBlogPost {
+  __typename
+  sys {
+    id
+    spaceId
+  }
+  internalName
+  seoFields {
+    ...SeoFields
+  }
+  slug
+  author {
+    ...AuthorFields
+  }
+  publishedDate
+  title
+  shortDescription
+  featuredImage {
+    ...ImageFields
+  }
+  content {
+    json
+    links {
+      entries {
+        block {
+          ...RichImageFields
         }
       }
     }
-    image {
-      url
-      title
-      sys {
-        id
-        publishedAt
-        environmentId
-      }
-    }
-    imagesCollection {
-      items {
-        ...ImageFields
-      }
-    }
   }
-  ${RichImageFieldsFragmentDoc}
-  ${ImageFieldsFragmentDoc}
-`;
-export const PartnerFieldsFragmentDoc = gql`
-  fragment PartnerFields on ComponentPartner {
-    __typename
-    sys {
-      id
-      publishedAt
-      environmentId
-    }
-    logo {
-      ...ImageFields
-    }
-    subtitle
-    url
-  }
-  ${ImageFieldsFragmentDoc}
-`;
-export const PageHomePartnersFieldsFragmentDoc = gql`
-  fragment PageHomePartnersFields on PageHomePartners {
-    __typename
-    sys {
-      id
-      publishedAt
-      environmentId
-    }
-    title
-    subtitle
-    partnersCollection {
-      items {
-        ...PartnerFields
-      }
-    }
-    imagesCollection {
-      items {
-        ...ImageFields
-      }
-    }
-  }
-  ${PartnerFieldsFragmentDoc}
-  ${ImageFieldsFragmentDoc}
-`;
-export const PageLandingFieldsFragmentDoc = gql`
-  fragment PageLandingFields on PageLanding {
-    __typename
-    sys {
-      id
-      spaceId
-    }
-    internalName
-    seoFields {
-      ...SeoFields
-    }
-    featuredBlogPost {
+  relatedBlogPostsCollection(limit: 2) {
+    items {
       ...ReferencePageBlogPostFields
     }
   }
-  ${SeoFieldsFragmentDoc}
-  ${ReferencePageBlogPostFieldsFragmentDoc}
-`;
+}
+    ${SeoFieldsFragmentDoc}
+${AuthorFieldsFragmentDoc}
+${ImageFieldsFragmentDoc}
+${RichImageFieldsFragmentDoc}
+${ReferencePageBlogPostFieldsFragmentDoc}`;
+export const PageCookiePolicyFieldsFragmentDoc = gql`
+    fragment PageCookiePolicyFields on PageCookiePolicy {
+  __typename
+  sys {
+    id
+    publishedAt
+    environmentId
+  }
+  pageTitle
+  pageDescription
+  internalName
+  title
+  content {
+    json
+    links {
+      entries {
+        block {
+          ...RichImageFields
+        }
+      }
+    }
+  }
+}
+    ${RichImageFieldsFragmentDoc}`;
+export const ComponentEmailFieldsFragmentDoc = gql`
+    fragment ComponentEmailFields on ComponentEmail {
+  __typename
+  sys {
+    id
+    publishedAt
+    environmentId
+  }
+  internalName
+  availableVariables
+  preview
+  content {
+    json
+    links {
+      entries {
+        block {
+          ...ButtonFields
+        }
+      }
+    }
+  }
+}
+    ${ButtonFieldsFragmentDoc}`;
+export const FaqQuestionFieldsFragmentDoc = gql`
+    fragment FaqQuestionFields on ComponentFaqQuestion {
+  __typename
+  sys {
+    id
+    publishedAt
+    environmentId
+  }
+  question
+  answer {
+    json
+  }
+}
+    `;
+export const PageFaqFieldsFragmentDoc = gql`
+    fragment PageFaqFields on PageFaq {
+  __typename
+  sys {
+    id
+    publishedAt
+    environmentId
+  }
+  pageTitle
+  pageDescription
+  internalName
+  title
+  intro
+  questionsCollection {
+    items {
+      ...FaqQuestionFields
+    }
+  }
+}
+    ${FaqQuestionFieldsFragmentDoc}`;
+export const PageForceUpdateFieldsFragmentDoc = gql`
+    fragment PageForceUpdateFields on PageForceUpdate {
+  __typename
+  sys {
+    id
+  }
+  internalName
+  title
+  body {
+    json
+  }
+  updateCta {
+    ...ButtonFields
+  }
+  minVersion
+  effectiveAt
+  active
+}
+    ${ButtonFieldsFragmentDoc}`;
+export const FeatureFieldsFragmentDoc = gql`
+    fragment FeatureFields on ComponentFeature {
+  __typename
+  sys {
+    id
+    publishedAt
+    environmentId
+  }
+  title
+  subtitle
+  icon {
+    ...ImageFields
+  }
+}
+    ${ImageFieldsFragmentDoc}`;
+export const PageHomeFeaturesFieldsFragmentDoc = gql`
+    fragment PageHomeFeaturesFields on PageHomeFeatures {
+  __typename
+  sys {
+    id
+    publishedAt
+    environmentId
+  }
+  internalName
+  title
+  subtitle
+  featuresCollection {
+    items {
+      ...FeatureFields
+    }
+  }
+  image {
+    ...ImageFields
+  }
+}
+    ${FeatureFieldsFragmentDoc}
+${ImageFieldsFragmentDoc}`;
+export const PageHomeHeroFieldsFragmentDoc = gql`
+    fragment PageHomeHeroFields on PageHomeHero {
+  __typename
+  sys {
+    id
+    publishedAt
+    environmentId
+  }
+  internalName
+  badge
+  title
+  subtitle
+  buttonsCollection {
+    items {
+      ...ButtonFields
+    }
+  }
+  image {
+    url
+    title
+    sys {
+      id
+      publishedAt
+      environmentId
+    }
+  }
+}
+    ${ButtonFieldsFragmentDoc}`;
+export const PageHomeMissionFieldsFragmentDoc = gql`
+    fragment PageHomeMissionFields on PageHomeMission {
+  __typename
+  sys {
+    id
+    publishedAt
+    environmentId
+  }
+  internalName
+  title
+  about {
+    json
+    links {
+      entries {
+        block {
+          ...RichImageFields
+        }
+      }
+    }
+  }
+  subtitle
+  mission {
+    json
+    links {
+      entries {
+        block {
+          ...RichImageFields
+        }
+      }
+    }
+  }
+  image {
+    url
+    title
+    sys {
+      id
+      publishedAt
+      environmentId
+    }
+  }
+  imagesCollection {
+    items {
+      ...ImageFields
+    }
+  }
+}
+    ${RichImageFieldsFragmentDoc}
+${ImageFieldsFragmentDoc}`;
+export const PartnerFieldsFragmentDoc = gql`
+    fragment PartnerFields on ComponentPartner {
+  __typename
+  sys {
+    id
+    publishedAt
+    environmentId
+  }
+  logo {
+    ...ImageFields
+  }
+  subtitle
+  url
+}
+    ${ImageFieldsFragmentDoc}`;
+export const PageHomePartnersFieldsFragmentDoc = gql`
+    fragment PageHomePartnersFields on PageHomePartners {
+  __typename
+  sys {
+    id
+    publishedAt
+    environmentId
+  }
+  title
+  subtitle
+  partnersCollection {
+    items {
+      ...PartnerFields
+    }
+  }
+  imagesCollection {
+    items {
+      ...ImageFields
+    }
+  }
+}
+    ${PartnerFieldsFragmentDoc}
+${ImageFieldsFragmentDoc}`;
+export const PageLandingFieldsFragmentDoc = gql`
+    fragment PageLandingFields on PageLanding {
+  __typename
+  sys {
+    id
+    spaceId
+  }
+  internalName
+  seoFields {
+    ...SeoFields
+  }
+  featuredBlogPost {
+    ...ReferencePageBlogPostFields
+  }
+}
+    ${SeoFieldsFragmentDoc}
+${ReferencePageBlogPostFieldsFragmentDoc}`;
 export const PagePoliciesFieldsFragmentDoc = gql`
-  fragment PagePoliciesFields on PagePolicies {
-    __typename
-    sys {
-      id
-      publishedAt
-      environmentId
-    }
-    pageTitle
-    pageDescription
-    internalName
-    title
-    content {
-      json
-      links {
-        entries {
-          block {
-            ...RichImageFields
-          }
+    fragment PagePoliciesFields on PagePolicies {
+  __typename
+  sys {
+    id
+    publishedAt
+    environmentId
+  }
+  pageTitle
+  pageDescription
+  internalName
+  title
+  content {
+    json
+    links {
+      entries {
+        block {
+          ...RichImageFields
         }
       }
     }
   }
-  ${RichImageFieldsFragmentDoc}
-`;
+}
+    ${RichImageFieldsFragmentDoc}`;
 export const PageTermsAndConditionsFieldsFragmentDoc = gql`
-  fragment PageTermsAndConditionsFields on PageTermsAndConditions {
-    __typename
-    sys {
-      id
-      publishedAt
-      environmentId
-    }
-    pageTitle
-    pageDescription
-    internalName
-    title
-    content {
-      json
-      links {
-        entries {
-          block {
-            ...RichImageFields
-          }
+    fragment PageTermsAndConditionsFields on PageTermsAndConditions {
+  __typename
+  sys {
+    id
+    publishedAt
+    environmentId
+  }
+  pageTitle
+  pageDescription
+  internalName
+  title
+  content {
+    json
+    links {
+      entries {
+        block {
+          ...RichImageFields
         }
       }
     }
   }
-  ${RichImageFieldsFragmentDoc}
-`;
+}
+    ${RichImageFieldsFragmentDoc}`;
+export const ComponentReleaseNoteFieldsFragmentDoc = gql`
+    fragment ComponentReleaseNoteFields on ComponentReleaseNote {
+  __typename
+  sys {
+    id
+  }
+  slug
+  title
+  summary
+  body {
+    json
+  }
+  media {
+    ...ImageFields
+  }
+  category
+  surfaces
+  publishedAt
+  cta {
+    ...ButtonFields
+  }
+  seoFields {
+    ...SeoFields
+  }
+  active
+}
+    ${ImageFieldsFragmentDoc}
+${ButtonFieldsFragmentDoc}
+${SeoFieldsFragmentDoc}`;
 export const SitemapPagesFieldsFragmentDoc = gql`
-  fragment sitemapPagesFields on Query {
-    pageBlogPostCollection(limit: 100, locale: $locale) {
-      items {
-        slug
-        sys {
-          publishedAt
-        }
-      }
-    }
-    pageLandingCollection(limit: 1, locale: $locale) {
-      items {
-        sys {
-          publishedAt
-        }
+    fragment sitemapPagesFields on Query {
+  pageBlogPostCollection(limit: 100, locale: $locale) {
+    items {
+      slug
+      sys {
+        publishedAt
       }
     }
   }
-`;
+  pageLandingCollection(limit: 1, locale: $locale) {
+    items {
+      sys {
+        publishedAt
+      }
+    }
+  }
+}
+    `;
 export const ActiveAlertsDocument = gql`
-  query activeAlerts($preview: Boolean, $now: DateTime!, $locale: String, $audience: [String]) {
-    componentAlertCollection(
-      preview: $preview
-      locale: $locale
-      where: {
-        active: true
-        audience_in: $audience
-        startAt_lte: $now
-        OR: [{ endAt_gt: $now }, { endAt_exists: false }]
-      }
-    ) {
-      items {
-        ...ComponentAlertFields
-      }
+    query activeAlerts($preview: Boolean, $now: DateTime!, $locale: String, $audience: [String]) {
+  componentAlertCollection(
+    preview: $preview
+    locale: $locale
+    where: {active: true, audience_in: $audience, startAt_lte: $now, OR: [{endAt_gt: $now}, {endAt_exists: false}]}
+  ) {
+    items {
+      ...ComponentAlertFields
     }
   }
-  ${ComponentAlertFieldsFragmentDoc}
-`;
+}
+    ${ComponentAlertFieldsFragmentDoc}`;
 export const FooterDocument = gql`
-  query footer($locale: String, $preview: Boolean) {
-    footerCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...FooterFields
-      }
+    query footer($locale: String, $preview: Boolean) {
+  footerCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...FooterFields
     }
   }
-  ${FooterFieldsFragmentDoc}
-`;
+}
+    ${FooterFieldsFragmentDoc}`;
 export const LandingMetadataDocument = gql`
-  query landingMetadata($locale: String, $preview: Boolean) {
-    landingMetadataCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...LandingMetadataFields
-      }
+    query landingMetadata($locale: String, $preview: Boolean) {
+  landingMetadataCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...LandingMetadataFields
     }
   }
-  ${LandingMetadataFieldsFragmentDoc}
-`;
+}
+    ${LandingMetadataFieldsFragmentDoc}`;
 export const PageAboutDocument = gql`
-  query pageAbout($locale: String, $preview: Boolean) {
-    pageAboutCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...PageAboutFields
-      }
+    query pageAbout($locale: String, $preview: Boolean) {
+  pageAboutCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...PageAboutFields
     }
   }
-  ${PageAboutFieldsFragmentDoc}
-`;
+}
+    ${PageAboutFieldsFragmentDoc}`;
 export const PageBlogDocument = gql`
-  query pageBlog(
-    $locale: String
-    $preview: Boolean
-    $limit: Int
-    $order: [PageBlogPostOrder]
-    $where: PageBlogPostFilter
-  ) {
-    pageLandingCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...PageLandingFields
-      }
-    }
-    pageBlogPostCollection(
-      limit: $limit
-      locale: $locale
-      preview: $preview
-      order: $order
-      where: $where
-    ) {
-      items {
-        ...PageBlogPostFields
-      }
+    query pageBlog($locale: String, $preview: Boolean, $limit: Int, $order: [PageBlogPostOrder], $where: PageBlogPostFilter) {
+  pageLandingCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...PageLandingFields
     }
   }
-  ${PageLandingFieldsFragmentDoc}
-  ${PageBlogPostFieldsFragmentDoc}
-`;
+  pageBlogPostCollection(
+    limit: $limit
+    locale: $locale
+    preview: $preview
+    order: $order
+    where: $where
+  ) {
+    items {
+      ...PageBlogPostFields
+    }
+  }
+}
+    ${PageLandingFieldsFragmentDoc}
+${PageBlogPostFieldsFragmentDoc}`;
 export const PageBlogDetailDocument = gql`
-  query pageBlogDetail($slug: String!, $locale: String, $preview: Boolean) {
-    pageBlogPostCollection(limit: 1, where: { slug: $slug }, locale: $locale, preview: $preview) {
-      items {
-        ...PageBlogPostFields
-      }
-    }
-    pageLandingCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...PageLandingFields
-      }
-    }
-  }
-  ${PageBlogPostFieldsFragmentDoc}
-  ${PageLandingFieldsFragmentDoc}
-`;
-export const PageBlogPostDocument = gql`
-  query pageBlogPost($slug: String!, $locale: String, $preview: Boolean) {
-    pageBlogPostCollection(limit: 1, where: { slug: $slug }, locale: $locale, preview: $preview) {
-      items {
-        ...PageBlogPostFields
-      }
-    }
-  }
-  ${PageBlogPostFieldsFragmentDoc}
-`;
-export const PageBlogPostCollectionDocument = gql`
-  query pageBlogPostCollection(
-    $locale: String
-    $preview: Boolean
-    $limit: Int
-    $order: [PageBlogPostOrder]
-    $where: PageBlogPostFilter
+    query pageBlogDetail($slug: String!, $locale: String, $preview: Boolean) {
+  pageBlogPostCollection(
+    limit: 1
+    where: {slug: $slug}
+    locale: $locale
+    preview: $preview
   ) {
-    pageBlogPostCollection(
-      limit: $limit
-      locale: $locale
-      preview: $preview
-      order: $order
-      where: $where
-    ) {
-      items {
-        ...PageBlogPostFields
-      }
+    items {
+      ...PageBlogPostFields
     }
   }
-  ${PageBlogPostFieldsFragmentDoc}
-`;
+  pageLandingCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...PageLandingFields
+    }
+  }
+}
+    ${PageBlogPostFieldsFragmentDoc}
+${PageLandingFieldsFragmentDoc}`;
+export const PageBlogPostDocument = gql`
+    query pageBlogPost($slug: String!, $locale: String, $preview: Boolean) {
+  pageBlogPostCollection(
+    limit: 1
+    where: {slug: $slug}
+    locale: $locale
+    preview: $preview
+  ) {
+    items {
+      ...PageBlogPostFields
+    }
+  }
+}
+    ${PageBlogPostFieldsFragmentDoc}`;
+export const PageBlogPostCollectionDocument = gql`
+    query pageBlogPostCollection($locale: String, $preview: Boolean, $limit: Int, $order: [PageBlogPostOrder], $where: PageBlogPostFilter) {
+  pageBlogPostCollection(
+    limit: $limit
+    locale: $locale
+    preview: $preview
+    order: $order
+    where: $where
+  ) {
+    items {
+      ...PageBlogPostFields
+    }
+  }
+}
+    ${PageBlogPostFieldsFragmentDoc}`;
 export const PageCookiePolicyDocument = gql`
-  query pageCookiePolicy($locale: String, $preview: Boolean) {
-    pageCookiePolicyCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...PageCookiePolicyFields
-      }
+    query pageCookiePolicy($locale: String, $preview: Boolean) {
+  pageCookiePolicyCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...PageCookiePolicyFields
     }
   }
-  ${PageCookiePolicyFieldsFragmentDoc}
-`;
+}
+    ${PageCookiePolicyFieldsFragmentDoc}`;
 export const ComponentEmailByNameDocument = gql`
-  query componentEmailByName($internalName: String!) {
-    componentEmailCollection(limit: 1, where: { internalName: $internalName }) {
-      items {
-        ...ComponentEmailFields
-      }
+    query componentEmailByName($internalName: String!) {
+  componentEmailCollection(limit: 1, where: {internalName: $internalName}) {
+    items {
+      ...ComponentEmailFields
     }
   }
-  ${ComponentEmailFieldsFragmentDoc}
-`;
+}
+    ${ComponentEmailFieldsFragmentDoc}`;
 export const PageFaqDocument = gql`
-  query pageFaq($locale: String, $preview: Boolean) {
-    pageFaqCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...PageFaqFields
-      }
+    query pageFaq($locale: String, $preview: Boolean) {
+  pageFaqCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...PageFaqFields
     }
   }
-  ${PageFaqFieldsFragmentDoc}
-`;
+}
+    ${PageFaqFieldsFragmentDoc}`;
 export const PageForceUpdateDocument = gql`
-  query pageForceUpdate($preview: Boolean, $locale: String) {
-    pageForceUpdateCollection(
-      limit: 1
-      order: [sys_publishedAt_DESC]
-      preview: $preview
-      locale: $locale
-    ) {
-      items {
-        ...PageForceUpdateFields
-      }
+    query pageForceUpdate($preview: Boolean, $locale: String) {
+  pageForceUpdateCollection(
+    limit: 1
+    order: [sys_publishedAt_DESC]
+    preview: $preview
+    locale: $locale
+  ) {
+    items {
+      ...PageForceUpdateFields
     }
   }
-  ${PageForceUpdateFieldsFragmentDoc}
-`;
+}
+    ${PageForceUpdateFieldsFragmentDoc}`;
 export const PageHomeDocument = gql`
-  query pageHome($locale: String, $preview: Boolean) {
-    pageHomeHeroCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...PageHomeHeroFields
-      }
-    }
-    pageHomeMissionCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...PageHomeMissionFields
-      }
-    }
-    pageHomeFeaturesCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...PageHomeFeaturesFields
-      }
-    }
-    pageHomePartnersCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...PageHomePartnersFields
-      }
-    }
-    footerCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...FooterFields
-      }
-    }
-    landingMetadataCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...LandingMetadataFields
-      }
+    query pageHome($locale: String, $preview: Boolean) {
+  pageHomeHeroCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...PageHomeHeroFields
     }
   }
-  ${PageHomeHeroFieldsFragmentDoc}
-  ${PageHomeMissionFieldsFragmentDoc}
-  ${PageHomeFeaturesFieldsFragmentDoc}
-  ${PageHomePartnersFieldsFragmentDoc}
-  ${FooterFieldsFragmentDoc}
-  ${LandingMetadataFieldsFragmentDoc}
-`;
+  pageHomeMissionCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...PageHomeMissionFields
+    }
+  }
+  pageHomeFeaturesCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...PageHomeFeaturesFields
+    }
+  }
+  pageHomePartnersCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...PageHomePartnersFields
+    }
+  }
+  footerCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...FooterFields
+    }
+  }
+  landingMetadataCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...LandingMetadataFields
+    }
+  }
+}
+    ${PageHomeHeroFieldsFragmentDoc}
+${PageHomeMissionFieldsFragmentDoc}
+${PageHomeFeaturesFieldsFragmentDoc}
+${PageHomePartnersFieldsFragmentDoc}
+${FooterFieldsFragmentDoc}
+${LandingMetadataFieldsFragmentDoc}`;
 export const PageHomeFeaturesDocument = gql`
-  query pageHomeFeatures($locale: String, $preview: Boolean) {
-    pageHomeFeaturesCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...PageHomeFeaturesFields
-      }
+    query pageHomeFeatures($locale: String, $preview: Boolean) {
+  pageHomeFeaturesCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...PageHomeFeaturesFields
     }
   }
-  ${PageHomeFeaturesFieldsFragmentDoc}
-`;
+}
+    ${PageHomeFeaturesFieldsFragmentDoc}`;
 export const PageHomeHeroDocument = gql`
-  query pageHomeHero($locale: String, $preview: Boolean) {
-    pageHomeHeroCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...PageHomeHeroFields
-      }
+    query pageHomeHero($locale: String, $preview: Boolean) {
+  pageHomeHeroCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...PageHomeHeroFields
     }
   }
-  ${PageHomeHeroFieldsFragmentDoc}
-`;
+}
+    ${PageHomeHeroFieldsFragmentDoc}`;
 export const PageHomeMissionDocument = gql`
-  query pageHomeMission($locale: String, $preview: Boolean) {
-    pageHomeMissionCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...PageHomeMissionFields
-      }
+    query pageHomeMission($locale: String, $preview: Boolean) {
+  pageHomeMissionCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...PageHomeMissionFields
     }
   }
-  ${PageHomeMissionFieldsFragmentDoc}
-`;
+}
+    ${PageHomeMissionFieldsFragmentDoc}`;
 export const PageHomePartnersDocument = gql`
-  query pageHomePartners($locale: String, $preview: Boolean) {
-    pageHomePartnersCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...PageHomePartnersFields
-      }
+    query pageHomePartners($locale: String, $preview: Boolean) {
+  pageHomePartnersCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...PageHomePartnersFields
     }
   }
-  ${PageHomePartnersFieldsFragmentDoc}
-`;
+}
+    ${PageHomePartnersFieldsFragmentDoc}`;
 export const PageLandingDocument = gql`
-  query pageLanding($locale: String, $preview: Boolean) {
-    pageLandingCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...PageLandingFields
-      }
+    query pageLanding($locale: String, $preview: Boolean) {
+  pageLandingCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...PageLandingFields
     }
   }
-  ${PageLandingFieldsFragmentDoc}
-`;
+}
+    ${PageLandingFieldsFragmentDoc}`;
 export const PageLandingCollectionDocument = gql`
-  query pageLandingCollection($locale: String, $preview: Boolean) {
-    pageLandingCollection(limit: 100, locale: $locale, preview: $preview) {
-      items {
-        ...PageLandingFields
-      }
+    query pageLandingCollection($locale: String, $preview: Boolean) {
+  pageLandingCollection(limit: 100, locale: $locale, preview: $preview) {
+    items {
+      ...PageLandingFields
     }
   }
-  ${PageLandingFieldsFragmentDoc}
-`;
+}
+    ${PageLandingFieldsFragmentDoc}`;
 export const PagePoliciesDocument = gql`
-  query pagePolicies($locale: String, $preview: Boolean) {
-    pagePoliciesCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...PagePoliciesFields
-      }
+    query pagePolicies($locale: String, $preview: Boolean) {
+  pagePoliciesCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...PagePoliciesFields
     }
   }
-  ${PagePoliciesFieldsFragmentDoc}
-`;
+}
+    ${PagePoliciesFieldsFragmentDoc}`;
 export const PageTermsAndConditionsDocument = gql`
-  query pageTermsAndConditions($locale: String, $preview: Boolean) {
-    pageTermsAndConditionsCollection(limit: 1, locale: $locale, preview: $preview) {
-      items {
-        ...PageTermsAndConditionsFields
-      }
+    query pageTermsAndConditions($locale: String, $preview: Boolean) {
+  pageTermsAndConditionsCollection(limit: 1, locale: $locale, preview: $preview) {
+    items {
+      ...PageTermsAndConditionsFields
     }
   }
-  ${PageTermsAndConditionsFieldsFragmentDoc}
-`;
-export const SitemapPagesDocument = gql`
-  query sitemapPages($locale: String!) {
-    ...sitemapPagesFields
+}
+    ${PageTermsAndConditionsFieldsFragmentDoc}`;
+export const ActiveReleaseNotesDocument = gql`
+    query activeReleaseNotes($preview: Boolean, $now: DateTime!, $locale: String, $surfaces: [String]) {
+  componentReleaseNoteCollection(
+    preview: $preview
+    locale: $locale
+    order: [publishedAt_DESC]
+    where: {active: true, surfaces_in: $surfaces, publishedAt_lte: $now}
+  ) {
+    items {
+      ...ComponentReleaseNoteFields
+    }
   }
-  ${SitemapPagesFieldsFragmentDoc}
-`;
+}
+    ${ComponentReleaseNoteFieldsFragmentDoc}`;
+export const AllReleaseNotesDocument = gql`
+    query allReleaseNotes($preview: Boolean, $now: DateTime!, $locale: String) {
+  componentReleaseNoteCollection(
+    preview: $preview
+    locale: $locale
+    order: [publishedAt_DESC]
+    where: {active: true, publishedAt_lte: $now}
+  ) {
+    items {
+      ...ComponentReleaseNoteFields
+    }
+  }
+}
+    ${ComponentReleaseNoteFieldsFragmentDoc}`;
+export const ReleaseNoteBySlugDocument = gql`
+    query releaseNoteBySlug($slug: String!, $locale: String, $preview: Boolean) {
+  componentReleaseNoteCollection(
+    limit: 1
+    preview: $preview
+    locale: $locale
+    where: {slug: $slug, active: true}
+  ) {
+    items {
+      ...ComponentReleaseNoteFields
+    }
+  }
+}
+    ${ComponentReleaseNoteFieldsFragmentDoc}`;
+export const SitemapPagesDocument = gql`
+    query sitemapPages($locale: String!) {
+  ...sitemapPagesFields
+}
+    ${SitemapPagesFieldsFragmentDoc}`;
 
-export type SdkFunctionWrapper = <T>(
-  action: (requestHeaders?: Record<string, string>) => Promise<T>,
-  operationName: string,
-  operationType?: string,
-  variables?: any,
-) => Promise<T>;
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string, variables?: any) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType, _variables) =>
-  action();
+
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType, _variables) => action();
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    activeAlerts(
-      variables: ActiveAlertsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<ActiveAlertsQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<ActiveAlertsQuery>({
-            document: ActiveAlertsDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "activeAlerts",
-        "query",
-        variables,
-      );
+    activeAlerts(variables: ActiveAlertsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<ActiveAlertsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ActiveAlertsQuery>({ document: ActiveAlertsDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'activeAlerts', 'query', variables);
     },
-    footer(
-      variables?: FooterQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<FooterQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<FooterQuery>({
-            document: FooterDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "footer",
-        "query",
-        variables,
-      );
+    footer(variables?: FooterQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<FooterQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<FooterQuery>({ document: FooterDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'footer', 'query', variables);
     },
-    landingMetadata(
-      variables?: LandingMetadataQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<LandingMetadataQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<LandingMetadataQuery>({
-            document: LandingMetadataDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "landingMetadata",
-        "query",
-        variables,
-      );
+    landingMetadata(variables?: LandingMetadataQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<LandingMetadataQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<LandingMetadataQuery>({ document: LandingMetadataDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'landingMetadata', 'query', variables);
     },
-    pageAbout(
-      variables?: PageAboutQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<PageAboutQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<PageAboutQuery>({
-            document: PageAboutDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "pageAbout",
-        "query",
-        variables,
-      );
+    pageAbout(variables?: PageAboutQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageAboutQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PageAboutQuery>({ document: PageAboutDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageAbout', 'query', variables);
     },
-    pageBlog(
-      variables?: PageBlogQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<PageBlogQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<PageBlogQuery>({
-            document: PageBlogDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "pageBlog",
-        "query",
-        variables,
-      );
+    pageBlog(variables?: PageBlogQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageBlogQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PageBlogQuery>({ document: PageBlogDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageBlog', 'query', variables);
     },
-    pageBlogDetail(
-      variables: PageBlogDetailQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<PageBlogDetailQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<PageBlogDetailQuery>({
-            document: PageBlogDetailDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "pageBlogDetail",
-        "query",
-        variables,
-      );
+    pageBlogDetail(variables: PageBlogDetailQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageBlogDetailQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PageBlogDetailQuery>({ document: PageBlogDetailDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageBlogDetail', 'query', variables);
     },
-    pageBlogPost(
-      variables: PageBlogPostQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<PageBlogPostQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<PageBlogPostQuery>({
-            document: PageBlogPostDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "pageBlogPost",
-        "query",
-        variables,
-      );
+    pageBlogPost(variables: PageBlogPostQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageBlogPostQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PageBlogPostQuery>({ document: PageBlogPostDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageBlogPost', 'query', variables);
     },
-    pageBlogPostCollection(
-      variables?: PageBlogPostCollectionQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<PageBlogPostCollectionQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<PageBlogPostCollectionQuery>({
-            document: PageBlogPostCollectionDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "pageBlogPostCollection",
-        "query",
-        variables,
-      );
+    pageBlogPostCollection(variables?: PageBlogPostCollectionQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageBlogPostCollectionQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PageBlogPostCollectionQuery>({ document: PageBlogPostCollectionDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageBlogPostCollection', 'query', variables);
     },
-    pageCookiePolicy(
-      variables?: PageCookiePolicyQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<PageCookiePolicyQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<PageCookiePolicyQuery>({
-            document: PageCookiePolicyDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "pageCookiePolicy",
-        "query",
-        variables,
-      );
+    pageCookiePolicy(variables?: PageCookiePolicyQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageCookiePolicyQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PageCookiePolicyQuery>({ document: PageCookiePolicyDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageCookiePolicy', 'query', variables);
     },
-    componentEmailByName(
-      variables: ComponentEmailByNameQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<ComponentEmailByNameQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<ComponentEmailByNameQuery>({
-            document: ComponentEmailByNameDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "componentEmailByName",
-        "query",
-        variables,
-      );
+    componentEmailByName(variables: ComponentEmailByNameQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<ComponentEmailByNameQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ComponentEmailByNameQuery>({ document: ComponentEmailByNameDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'componentEmailByName', 'query', variables);
     },
-    pageFaq(
-      variables?: PageFaqQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<PageFaqQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<PageFaqQuery>({
-            document: PageFaqDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "pageFaq",
-        "query",
-        variables,
-      );
+    pageFaq(variables?: PageFaqQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageFaqQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PageFaqQuery>({ document: PageFaqDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageFaq', 'query', variables);
     },
-    pageForceUpdate(
-      variables?: PageForceUpdateQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<PageForceUpdateQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<PageForceUpdateQuery>({
-            document: PageForceUpdateDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "pageForceUpdate",
-        "query",
-        variables,
-      );
+    pageForceUpdate(variables?: PageForceUpdateQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageForceUpdateQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PageForceUpdateQuery>({ document: PageForceUpdateDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageForceUpdate', 'query', variables);
     },
-    pageHome(
-      variables?: PageHomeQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<PageHomeQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<PageHomeQuery>({
-            document: PageHomeDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "pageHome",
-        "query",
-        variables,
-      );
+    pageHome(variables?: PageHomeQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageHomeQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PageHomeQuery>({ document: PageHomeDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageHome', 'query', variables);
     },
-    pageHomeFeatures(
-      variables?: PageHomeFeaturesQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<PageHomeFeaturesQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<PageHomeFeaturesQuery>({
-            document: PageHomeFeaturesDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "pageHomeFeatures",
-        "query",
-        variables,
-      );
+    pageHomeFeatures(variables?: PageHomeFeaturesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageHomeFeaturesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PageHomeFeaturesQuery>({ document: PageHomeFeaturesDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageHomeFeatures', 'query', variables);
     },
-    pageHomeHero(
-      variables?: PageHomeHeroQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<PageHomeHeroQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<PageHomeHeroQuery>({
-            document: PageHomeHeroDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "pageHomeHero",
-        "query",
-        variables,
-      );
+    pageHomeHero(variables?: PageHomeHeroQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageHomeHeroQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PageHomeHeroQuery>({ document: PageHomeHeroDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageHomeHero', 'query', variables);
     },
-    pageHomeMission(
-      variables?: PageHomeMissionQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<PageHomeMissionQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<PageHomeMissionQuery>({
-            document: PageHomeMissionDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "pageHomeMission",
-        "query",
-        variables,
-      );
+    pageHomeMission(variables?: PageHomeMissionQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageHomeMissionQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PageHomeMissionQuery>({ document: PageHomeMissionDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageHomeMission', 'query', variables);
     },
-    pageHomePartners(
-      variables?: PageHomePartnersQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<PageHomePartnersQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<PageHomePartnersQuery>({
-            document: PageHomePartnersDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "pageHomePartners",
-        "query",
-        variables,
-      );
+    pageHomePartners(variables?: PageHomePartnersQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageHomePartnersQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PageHomePartnersQuery>({ document: PageHomePartnersDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageHomePartners', 'query', variables);
     },
-    pageLanding(
-      variables?: PageLandingQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<PageLandingQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<PageLandingQuery>({
-            document: PageLandingDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "pageLanding",
-        "query",
-        variables,
-      );
+    pageLanding(variables?: PageLandingQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageLandingQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PageLandingQuery>({ document: PageLandingDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageLanding', 'query', variables);
     },
-    pageLandingCollection(
-      variables?: PageLandingCollectionQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<PageLandingCollectionQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<PageLandingCollectionQuery>({
-            document: PageLandingCollectionDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "pageLandingCollection",
-        "query",
-        variables,
-      );
+    pageLandingCollection(variables?: PageLandingCollectionQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageLandingCollectionQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PageLandingCollectionQuery>({ document: PageLandingCollectionDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageLandingCollection', 'query', variables);
     },
-    pagePolicies(
-      variables?: PagePoliciesQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<PagePoliciesQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<PagePoliciesQuery>({
-            document: PagePoliciesDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "pagePolicies",
-        "query",
-        variables,
-      );
+    pagePolicies(variables?: PagePoliciesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PagePoliciesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PagePoliciesQuery>({ document: PagePoliciesDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pagePolicies', 'query', variables);
     },
-    pageTermsAndConditions(
-      variables?: PageTermsAndConditionsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<PageTermsAndConditionsQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<PageTermsAndConditionsQuery>({
-            document: PageTermsAndConditionsDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "pageTermsAndConditions",
-        "query",
-        variables,
-      );
+    pageTermsAndConditions(variables?: PageTermsAndConditionsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageTermsAndConditionsQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PageTermsAndConditionsQuery>({ document: PageTermsAndConditionsDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageTermsAndConditions', 'query', variables);
     },
-    sitemapPages(
-      variables: SitemapPagesQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-      signal?: RequestInit["signal"],
-    ): Promise<SitemapPagesQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<SitemapPagesQuery>({
-            document: SitemapPagesDocument,
-            variables,
-            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
-            signal,
-          }),
-        "sitemapPages",
-        "query",
-        variables,
-      );
+    activeReleaseNotes(variables: ActiveReleaseNotesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<ActiveReleaseNotesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ActiveReleaseNotesQuery>({ document: ActiveReleaseNotesDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'activeReleaseNotes', 'query', variables);
     },
+    allReleaseNotes(variables: AllReleaseNotesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<AllReleaseNotesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<AllReleaseNotesQuery>({ document: AllReleaseNotesDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'allReleaseNotes', 'query', variables);
+    },
+    releaseNoteBySlug(variables: ReleaseNoteBySlugQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<ReleaseNoteBySlugQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ReleaseNoteBySlugQuery>({ document: ReleaseNoteBySlugDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'releaseNoteBySlug', 'query', variables);
+    },
+    sitemapPages(variables: SitemapPagesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<SitemapPagesQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<SitemapPagesQuery>({ document: SitemapPagesDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'sitemapPages', 'query', variables);
+    }
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;

--- a/packages/cms/src/lib/__generated/sdk.ts
+++ b/packages/cms/src/lib/__generated/sdk.ts
@@ -1,192 +1,188 @@
-import { GraphQLClient, RequestOptions } from 'graphql-request';
-import gql from 'graphql-tag';
+import { GraphQLClient, RequestOptions } from "graphql-request";
+import gql from "graphql-tag";
+
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
-export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
-type GraphQLClientRequestHeaders = RequestOptions['requestHeaders'];
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = {
+  [_ in K]?: never;
+};
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+type GraphQLClientRequestHeaders = RequestOptions["requestHeaders"];
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string; }
-  String: { input: string; output: string; }
-  Boolean: { input: boolean; output: boolean; }
-  Int: { input: number; output: number; }
-  Float: { input: number; output: number; }
-  DateTime: { input: any; output: any; }
-  Dimension: { input: any; output: any; }
-  HexColor: { input: any; output: any; }
-  JSON: { input: any; output: any; }
-  Quality: { input: any; output: any; }
+  ID: { input: string; output: string };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+  DateTime: { input: any; output: any };
+  Dimension: { input: any; output: any };
+  HexColor: { input: any; output: any };
+  JSON: { input: any; output: any };
+  Quality: { input: any; output: any };
 };
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type Asset = {
-  __typename?: 'Asset';
-  contentType?: Maybe<Scalars['String']['output']>;
+  __typename?: "Asset";
+  contentType?: Maybe<Scalars["String"]["output"]>;
   contentfulMetadata: ContentfulMetadata;
-  description?: Maybe<Scalars['String']['output']>;
-  fileName?: Maybe<Scalars['String']['output']>;
-  height?: Maybe<Scalars['Int']['output']>;
+  description?: Maybe<Scalars["String"]["output"]>;
+  fileName?: Maybe<Scalars["String"]["output"]>;
+  height?: Maybe<Scalars["Int"]["output"]>;
   linkedFrom?: Maybe<AssetLinkingCollections>;
-  size?: Maybe<Scalars['Int']['output']>;
+  size?: Maybe<Scalars["Int"]["output"]>;
   sys: Sys;
-  title?: Maybe<Scalars['String']['output']>;
-  url?: Maybe<Scalars['String']['output']>;
-  width?: Maybe<Scalars['Int']['output']>;
+  title?: Maybe<Scalars["String"]["output"]>;
+  url?: Maybe<Scalars["String"]["output"]>;
+  width?: Maybe<Scalars["Int"]["output"]>;
 };
-
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type AssetContentTypeArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type AssetDescriptionArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type AssetFileNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type AssetHeightArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type AssetLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type AssetSizeArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type AssetTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type AssetUrlArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   transform?: InputMaybe<ImageTransformOptions>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** Represents a binary file in a space. An asset can be any file type. */
 export type AssetWidthArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type AssetCollection = {
-  __typename?: 'AssetCollection';
+  __typename?: "AssetCollection";
   items: Array<Maybe<Asset>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type AssetCursorCollection = {
-  __typename?: 'AssetCursorCollection';
+  __typename?: "AssetCursorCollection";
   items: Array<Maybe<Asset>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export type AssetFilter = {
   AND?: InputMaybe<Array<InputMaybe<AssetFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<AssetFilter>>>;
-  contentType?: InputMaybe<Scalars['String']['input']>;
-  contentType_contains?: InputMaybe<Scalars['String']['input']>;
-  contentType_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  contentType_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  contentType_not?: InputMaybe<Scalars['String']['input']>;
-  contentType_not_contains?: InputMaybe<Scalars['String']['input']>;
-  contentType_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  contentType?: InputMaybe<Scalars["String"]["input"]>;
+  contentType_contains?: InputMaybe<Scalars["String"]["input"]>;
+  contentType_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  contentType_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  contentType_not?: InputMaybe<Scalars["String"]["input"]>;
+  contentType_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  contentType_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  description?: InputMaybe<Scalars['String']['input']>;
-  description_contains?: InputMaybe<Scalars['String']['input']>;
-  description_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  description_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  description_not?: InputMaybe<Scalars['String']['input']>;
-  description_not_contains?: InputMaybe<Scalars['String']['input']>;
-  description_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  fileName?: InputMaybe<Scalars['String']['input']>;
-  fileName_contains?: InputMaybe<Scalars['String']['input']>;
-  fileName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  fileName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  fileName_not?: InputMaybe<Scalars['String']['input']>;
-  fileName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  fileName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  height?: InputMaybe<Scalars['Int']['input']>;
-  height_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  height_gt?: InputMaybe<Scalars['Int']['input']>;
-  height_gte?: InputMaybe<Scalars['Int']['input']>;
-  height_in?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
-  height_lt?: InputMaybe<Scalars['Int']['input']>;
-  height_lte?: InputMaybe<Scalars['Int']['input']>;
-  height_not?: InputMaybe<Scalars['Int']['input']>;
-  height_not_in?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
-  size?: InputMaybe<Scalars['Int']['input']>;
-  size_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  size_gt?: InputMaybe<Scalars['Int']['input']>;
-  size_gte?: InputMaybe<Scalars['Int']['input']>;
-  size_in?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
-  size_lt?: InputMaybe<Scalars['Int']['input']>;
-  size_lte?: InputMaybe<Scalars['Int']['input']>;
-  size_not?: InputMaybe<Scalars['Int']['input']>;
-  size_not_in?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
+  description?: InputMaybe<Scalars["String"]["input"]>;
+  description_contains?: InputMaybe<Scalars["String"]["input"]>;
+  description_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  description_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  description_not?: InputMaybe<Scalars["String"]["input"]>;
+  description_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  description_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  fileName?: InputMaybe<Scalars["String"]["input"]>;
+  fileName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  fileName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  fileName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  fileName_not?: InputMaybe<Scalars["String"]["input"]>;
+  fileName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  fileName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  height?: InputMaybe<Scalars["Int"]["input"]>;
+  height_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  height_gt?: InputMaybe<Scalars["Int"]["input"]>;
+  height_gte?: InputMaybe<Scalars["Int"]["input"]>;
+  height_in?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  height_lt?: InputMaybe<Scalars["Int"]["input"]>;
+  height_lte?: InputMaybe<Scalars["Int"]["input"]>;
+  height_not?: InputMaybe<Scalars["Int"]["input"]>;
+  height_not_in?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  size?: InputMaybe<Scalars["Int"]["input"]>;
+  size_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  size_gt?: InputMaybe<Scalars["Int"]["input"]>;
+  size_gte?: InputMaybe<Scalars["Int"]["input"]>;
+  size_in?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  size_lt?: InputMaybe<Scalars["Int"]["input"]>;
+  size_lte?: InputMaybe<Scalars["Int"]["input"]>;
+  size_not?: InputMaybe<Scalars["Int"]["input"]>;
+  size_not_in?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  url?: InputMaybe<Scalars['String']['input']>;
-  url_contains?: InputMaybe<Scalars['String']['input']>;
-  url_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  url_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  url_not?: InputMaybe<Scalars['String']['input']>;
-  url_not_contains?: InputMaybe<Scalars['String']['input']>;
-  url_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  width?: InputMaybe<Scalars['Int']['input']>;
-  width_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  width_gt?: InputMaybe<Scalars['Int']['input']>;
-  width_gte?: InputMaybe<Scalars['Int']['input']>;
-  width_in?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
-  width_lt?: InputMaybe<Scalars['Int']['input']>;
-  width_lte?: InputMaybe<Scalars['Int']['input']>;
-  width_not?: InputMaybe<Scalars['Int']['input']>;
-  width_not_in?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  url?: InputMaybe<Scalars["String"]["input"]>;
+  url_contains?: InputMaybe<Scalars["String"]["input"]>;
+  url_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  url_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  url_not?: InputMaybe<Scalars["String"]["input"]>;
+  url_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  url_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  width?: InputMaybe<Scalars["Int"]["input"]>;
+  width_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  width_gt?: InputMaybe<Scalars["Int"]["input"]>;
+  width_gte?: InputMaybe<Scalars["Int"]["input"]>;
+  width_in?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
+  width_lt?: InputMaybe<Scalars["Int"]["input"]>;
+  width_lte?: InputMaybe<Scalars["Int"]["input"]>;
+  width_not?: InputMaybe<Scalars["Int"]["input"]>;
+  width_not_in?: InputMaybe<Array<InputMaybe<Scalars["Int"]["input"]>>>;
 };
 
 export type AssetLinkingCollections = {
-  __typename?: 'AssetLinkingCollections';
+  __typename?: "AssetLinkingCollections";
   componentAuthorCollection?: Maybe<ComponentAuthorCollection>;
   componentAuthorCursorCollection?: Maybe<ComponentAuthorCursorCollection>;
   componentFeatureCollection?: Maybe<ComponentFeatureCollection>;
@@ -215,815 +211,769 @@ export type AssetLinkingCollections = {
   pageHomePartnersCursorCollection?: Maybe<PageHomePartnersCursorCollection>;
 };
 
-
 export type AssetLinkingCollectionsComponentAuthorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsComponentAuthorCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsComponentFeatureCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsComponentFeatureCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsComponentPartnerCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsComponentPartnerCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsComponentReleaseNoteCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsComponentReleaseNoteCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsComponentRichImageCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsComponentRichImageCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsComponentSeoCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsComponentSeoCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsPageAboutCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsPageAboutCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsPageBlogPostCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsPageBlogPostCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsPageHomeFeaturesCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsPageHomeFeaturesCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsPageHomeHeroCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsPageHomeHeroCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsPageHomeMissionCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsPageHomeMissionCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type AssetLinkingCollectionsPageHomePartnersCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type AssetLinkingCollectionsPageHomePartnersCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum AssetOrder {
-  ContentTypeAsc = 'contentType_ASC',
-  ContentTypeDesc = 'contentType_DESC',
-  FileNameAsc = 'fileName_ASC',
-  FileNameDesc = 'fileName_DESC',
-  HeightAsc = 'height_ASC',
-  HeightDesc = 'height_DESC',
-  SizeAsc = 'size_ASC',
-  SizeDesc = 'size_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  UrlAsc = 'url_ASC',
-  UrlDesc = 'url_DESC',
-  WidthAsc = 'width_ASC',
-  WidthDesc = 'width_DESC'
+  ContentTypeAsc = "contentType_ASC",
+  ContentTypeDesc = "contentType_DESC",
+  FileNameAsc = "fileName_ASC",
+  FileNameDesc = "fileName_DESC",
+  HeightAsc = "height_ASC",
+  HeightDesc = "height_DESC",
+  SizeAsc = "size_ASC",
+  SizeDesc = "size_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  UrlAsc = "url_ASC",
+  UrlDesc = "url_DESC",
+  WidthAsc = "width_ASC",
+  WidthDesc = "width_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
-export type ComponentAlert = Entry & _Node & {
-  __typename?: 'ComponentAlert';
-  _id: Scalars['ID']['output'];
-  active?: Maybe<Scalars['Boolean']['output']>;
-  audience?: Maybe<Scalars['String']['output']>;
-  body?: Maybe<ComponentAlertBody>;
-  contentfulMetadata: ContentfulMetadata;
-  dismissible?: Maybe<Scalars['Boolean']['output']>;
-  endAt?: Maybe<Scalars['DateTime']['output']>;
-  internalName?: Maybe<Scalars['String']['output']>;
-  link?: Maybe<ComponentButton>;
-  linkedFrom?: Maybe<ComponentAlertLinkingCollections>;
-  severity?: Maybe<Scalars['String']['output']>;
-  startAt?: Maybe<Scalars['DateTime']['output']>;
-  sys: Sys;
-  title?: Maybe<Scalars['String']['output']>;
-  type?: Maybe<Scalars['String']['output']>;
-};
-
+export type ComponentAlert = Entry &
+  _Node & {
+    __typename?: "ComponentAlert";
+    _id: Scalars["ID"]["output"];
+    active?: Maybe<Scalars["Boolean"]["output"]>;
+    audience?: Maybe<Scalars["String"]["output"]>;
+    body?: Maybe<ComponentAlertBody>;
+    contentfulMetadata: ContentfulMetadata;
+    dismissible?: Maybe<Scalars["Boolean"]["output"]>;
+    endAt?: Maybe<Scalars["DateTime"]["output"]>;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    link?: Maybe<ComponentButton>;
+    linkedFrom?: Maybe<ComponentAlertLinkingCollections>;
+    severity?: Maybe<Scalars["String"]["output"]>;
+    startAt?: Maybe<Scalars["DateTime"]["output"]>;
+    sys: Sys;
+    title?: Maybe<Scalars["String"]["output"]>;
+    type?: Maybe<Scalars["String"]["output"]>;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertActiveArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertAudienceArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertBodyArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertDismissibleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertEndAtArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertLinkArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
 
-
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertSeverityArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertStartAtArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAlert) */
 export type ComponentAlertTypeArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type ComponentAlertBody = {
-  __typename?: 'ComponentAlertBody';
-  json: Scalars['JSON']['output'];
+  __typename?: "ComponentAlertBody";
+  json: Scalars["JSON"]["output"];
   links: ComponentAlertBodyLinks;
 };
 
 export type ComponentAlertBodyAssets = {
-  __typename?: 'ComponentAlertBodyAssets';
+  __typename?: "ComponentAlertBodyAssets";
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type ComponentAlertBodyEntries = {
-  __typename?: 'ComponentAlertBodyEntries';
+  __typename?: "ComponentAlertBodyEntries";
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type ComponentAlertBodyLinks = {
-  __typename?: 'ComponentAlertBodyLinks';
+  __typename?: "ComponentAlertBodyLinks";
   assets: ComponentAlertBodyAssets;
   entries: ComponentAlertBodyEntries;
   resources: ComponentAlertBodyResources;
 };
 
 export type ComponentAlertBodyResources = {
-  __typename?: 'ComponentAlertBodyResources';
+  __typename?: "ComponentAlertBodyResources";
   block: Array<ComponentAlertBodyResourcesBlock>;
   hyperlink: Array<ComponentAlertBodyResourcesHyperlink>;
   inline: Array<ComponentAlertBodyResourcesInline>;
 };
 
 export type ComponentAlertBodyResourcesBlock = ResourceLink & {
-  __typename?: 'ComponentAlertBodyResourcesBlock';
+  __typename?: "ComponentAlertBodyResourcesBlock";
   sys: ResourceSys;
 };
 
 export type ComponentAlertBodyResourcesHyperlink = ResourceLink & {
-  __typename?: 'ComponentAlertBodyResourcesHyperlink';
+  __typename?: "ComponentAlertBodyResourcesHyperlink";
   sys: ResourceSys;
 };
 
 export type ComponentAlertBodyResourcesInline = ResourceLink & {
-  __typename?: 'ComponentAlertBodyResourcesInline';
+  __typename?: "ComponentAlertBodyResourcesInline";
   sys: ResourceSys;
 };
 
 export type ComponentAlertCollection = {
-  __typename?: 'ComponentAlertCollection';
+  __typename?: "ComponentAlertCollection";
   items: Array<Maybe<ComponentAlert>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type ComponentAlertCursorCollection = {
-  __typename?: 'ComponentAlertCursorCollection';
+  __typename?: "ComponentAlertCursorCollection";
   items: Array<Maybe<ComponentAlert>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export type ComponentAlertFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentAlertFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentAlertFilter>>>;
-  active?: InputMaybe<Scalars['Boolean']['input']>;
-  active_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  active_not?: InputMaybe<Scalars['Boolean']['input']>;
-  audience?: InputMaybe<Scalars['String']['input']>;
-  audience_contains?: InputMaybe<Scalars['String']['input']>;
-  audience_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  audience_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  audience_not?: InputMaybe<Scalars['String']['input']>;
-  audience_not_contains?: InputMaybe<Scalars['String']['input']>;
-  audience_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  body_contains?: InputMaybe<Scalars['String']['input']>;
-  body_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  body_not_contains?: InputMaybe<Scalars['String']['input']>;
+  active?: InputMaybe<Scalars["Boolean"]["input"]>;
+  active_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  active_not?: InputMaybe<Scalars["Boolean"]["input"]>;
+  audience?: InputMaybe<Scalars["String"]["input"]>;
+  audience_contains?: InputMaybe<Scalars["String"]["input"]>;
+  audience_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  audience_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  audience_not?: InputMaybe<Scalars["String"]["input"]>;
+  audience_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  audience_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  body_contains?: InputMaybe<Scalars["String"]["input"]>;
+  body_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  body_not_contains?: InputMaybe<Scalars["String"]["input"]>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  dismissible?: InputMaybe<Scalars['Boolean']['input']>;
-  dismissible_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  dismissible_not?: InputMaybe<Scalars['Boolean']['input']>;
-  endAt?: InputMaybe<Scalars['DateTime']['input']>;
-  endAt_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  endAt_gt?: InputMaybe<Scalars['DateTime']['input']>;
-  endAt_gte?: InputMaybe<Scalars['DateTime']['input']>;
-  endAt_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
-  endAt_lt?: InputMaybe<Scalars['DateTime']['input']>;
-  endAt_lte?: InputMaybe<Scalars['DateTime']['input']>;
-  endAt_not?: InputMaybe<Scalars['DateTime']['input']>;
-  endAt_not_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  dismissible?: InputMaybe<Scalars["Boolean"]["input"]>;
+  dismissible_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  dismissible_not?: InputMaybe<Scalars["Boolean"]["input"]>;
+  endAt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  endAt_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  endAt_gt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  endAt_gte?: InputMaybe<Scalars["DateTime"]["input"]>;
+  endAt_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
+  endAt_lt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  endAt_lte?: InputMaybe<Scalars["DateTime"]["input"]>;
+  endAt_not?: InputMaybe<Scalars["DateTime"]["input"]>;
+  endAt_not_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   link?: InputMaybe<CfComponentButtonNestedFilter>;
-  link_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  severity?: InputMaybe<Scalars['String']['input']>;
-  severity_contains?: InputMaybe<Scalars['String']['input']>;
-  severity_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  severity_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  severity_not?: InputMaybe<Scalars['String']['input']>;
-  severity_not_contains?: InputMaybe<Scalars['String']['input']>;
-  severity_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  startAt?: InputMaybe<Scalars['DateTime']['input']>;
-  startAt_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  startAt_gt?: InputMaybe<Scalars['DateTime']['input']>;
-  startAt_gte?: InputMaybe<Scalars['DateTime']['input']>;
-  startAt_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
-  startAt_lt?: InputMaybe<Scalars['DateTime']['input']>;
-  startAt_lte?: InputMaybe<Scalars['DateTime']['input']>;
-  startAt_not?: InputMaybe<Scalars['DateTime']['input']>;
-  startAt_not_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  link_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  severity?: InputMaybe<Scalars["String"]["input"]>;
+  severity_contains?: InputMaybe<Scalars["String"]["input"]>;
+  severity_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  severity_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  severity_not?: InputMaybe<Scalars["String"]["input"]>;
+  severity_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  severity_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  startAt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  startAt_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  startAt_gt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  startAt_gte?: InputMaybe<Scalars["DateTime"]["input"]>;
+  startAt_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
+  startAt_lt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  startAt_lte?: InputMaybe<Scalars["DateTime"]["input"]>;
+  startAt_not?: InputMaybe<Scalars["DateTime"]["input"]>;
+  startAt_not_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  type?: InputMaybe<Scalars['String']['input']>;
-  type_contains?: InputMaybe<Scalars['String']['input']>;
-  type_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  type_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  type_not?: InputMaybe<Scalars['String']['input']>;
-  type_not_contains?: InputMaybe<Scalars['String']['input']>;
-  type_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  type?: InputMaybe<Scalars["String"]["input"]>;
+  type_contains?: InputMaybe<Scalars["String"]["input"]>;
+  type_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  type_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  type_not?: InputMaybe<Scalars["String"]["input"]>;
+  type_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  type_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type ComponentAlertLinkingCollections = {
-  __typename?: 'ComponentAlertLinkingCollections';
+  __typename?: "ComponentAlertLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
-
 export type ComponentAlertLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type ComponentAlertLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum ComponentAlertOrder {
-  ActiveAsc = 'active_ASC',
-  ActiveDesc = 'active_DESC',
-  AudienceAsc = 'audience_ASC',
-  AudienceDesc = 'audience_DESC',
-  DismissibleAsc = 'dismissible_ASC',
-  DismissibleDesc = 'dismissible_DESC',
-  EndAtAsc = 'endAt_ASC',
-  EndAtDesc = 'endAt_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SeverityAsc = 'severity_ASC',
-  SeverityDesc = 'severity_DESC',
-  StartAtAsc = 'startAt_ASC',
-  StartAtDesc = 'startAt_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC',
-  TypeAsc = 'type_ASC',
-  TypeDesc = 'type_DESC'
+  ActiveAsc = "active_ASC",
+  ActiveDesc = "active_DESC",
+  AudienceAsc = "audience_ASC",
+  AudienceDesc = "audience_DESC",
+  DismissibleAsc = "dismissible_ASC",
+  DismissibleDesc = "dismissible_DESC",
+  EndAtAsc = "endAt_ASC",
+  EndAtDesc = "endAt_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SeverityAsc = "severity_ASC",
+  SeverityDesc = "severity_DESC",
+  StartAtAsc = "startAt_ASC",
+  StartAtDesc = "startAt_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
+  TypeAsc = "type_ASC",
+  TypeDesc = "type_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAuthor) */
-export type ComponentAuthor = Entry & _Node & {
-  __typename?: 'ComponentAuthor';
-  _id: Scalars['ID']['output'];
-  avatar?: Maybe<Asset>;
-  contentfulMetadata: ContentfulMetadata;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<ComponentAuthorLinkingCollections>;
-  name?: Maybe<Scalars['String']['output']>;
-  profession?: Maybe<Scalars['String']['output']>;
-  sys: Sys;
-};
-
+export type ComponentAuthor = Entry &
+  _Node & {
+    __typename?: "ComponentAuthor";
+    _id: Scalars["ID"]["output"];
+    avatar?: Maybe<Asset>;
+    contentfulMetadata: ContentfulMetadata;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<ComponentAuthorLinkingCollections>;
+    name?: Maybe<Scalars["String"]["output"]>;
+    profession?: Maybe<Scalars["String"]["output"]>;
+    sys: Sys;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAuthor) */
 export type ComponentAuthorAvatarArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAuthor) */
 export type ComponentAuthorInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAuthor) */
 export type ComponentAuthorLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAuthor) */
 export type ComponentAuthorNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentAuthor) */
 export type ComponentAuthorProfessionArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type ComponentAuthorCollection = {
-  __typename?: 'ComponentAuthorCollection';
+  __typename?: "ComponentAuthorCollection";
   items: Array<Maybe<ComponentAuthor>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type ComponentAuthorCursorCollection = {
-  __typename?: 'ComponentAuthorCursorCollection';
+  __typename?: "ComponentAuthorCursorCollection";
   items: Array<Maybe<ComponentAuthor>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export type ComponentAuthorFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentAuthorFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentAuthorFilter>>>;
-  avatar_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  avatar_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  name?: InputMaybe<Scalars['String']['input']>;
-  name_contains?: InputMaybe<Scalars['String']['input']>;
-  name_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  name_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  name_not?: InputMaybe<Scalars['String']['input']>;
-  name_not_contains?: InputMaybe<Scalars['String']['input']>;
-  name_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  profession?: InputMaybe<Scalars['String']['input']>;
-  profession_contains?: InputMaybe<Scalars['String']['input']>;
-  profession_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  profession_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  profession_not?: InputMaybe<Scalars['String']['input']>;
-  profession_not_contains?: InputMaybe<Scalars['String']['input']>;
-  profession_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  name?: InputMaybe<Scalars["String"]["input"]>;
+  name_contains?: InputMaybe<Scalars["String"]["input"]>;
+  name_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  name_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  name_not?: InputMaybe<Scalars["String"]["input"]>;
+  name_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  name_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  profession?: InputMaybe<Scalars["String"]["input"]>;
+  profession_contains?: InputMaybe<Scalars["String"]["input"]>;
+  profession_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  profession_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  profession_not?: InputMaybe<Scalars["String"]["input"]>;
+  profession_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  profession_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
 };
 
 export type ComponentAuthorLinkingCollections = {
-  __typename?: 'ComponentAuthorLinkingCollections';
+  __typename?: "ComponentAuthorLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
   pageBlogPostCollection?: Maybe<PageBlogPostCollection>;
   pageBlogPostCursorCollection?: Maybe<PageBlogPostCursorCollection>;
 };
 
-
 export type ComponentAuthorLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentAuthorLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentAuthorLinkingCollectionsPageBlogPostCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentAuthorLinkingCollectionsPageBlogPostCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentAuthorLinkingCollectionsPageBlogPostCollectionOrder>>
+  >;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type ComponentAuthorLinkingCollectionsPageBlogPostCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentAuthorLinkingCollectionsPageBlogPostCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentAuthorLinkingCollectionsPageBlogPostCursorCollectionOrder>>
+  >;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum ComponentAuthorLinkingCollectionsPageBlogPostCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PublishedDateAsc = 'publishedDate_ASC',
-  PublishedDateDesc = 'publishedDate_DESC',
-  SlugAsc = 'slug_ASC',
-  SlugDesc = 'slug_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PublishedDateAsc = "publishedDate_ASC",
+  PublishedDateDesc = "publishedDate_DESC",
+  SlugAsc = "slug_ASC",
+  SlugDesc = "slug_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentAuthorLinkingCollectionsPageBlogPostCursorCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PublishedDateAsc = 'publishedDate_ASC',
-  PublishedDateDesc = 'publishedDate_DESC',
-  SlugAsc = 'slug_ASC',
-  SlugDesc = 'slug_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PublishedDateAsc = "publishedDate_ASC",
+  PublishedDateDesc = "publishedDate_DESC",
+  SlugAsc = "slug_ASC",
+  SlugDesc = "slug_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentAuthorOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  NameAsc = 'name_ASC',
-  NameDesc = 'name_DESC',
-  ProfessionAsc = 'profession_ASC',
-  ProfessionDesc = 'profession_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  NameAsc = "name_ASC",
+  NameDesc = "name_DESC",
+  ProfessionAsc = "profession_ASC",
+  ProfessionDesc = "profession_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentButton) */
-export type ComponentButton = Entry & _Node & {
-  __typename?: 'ComponentButton';
-  _id: Scalars['ID']['output'];
-  contentfulMetadata: ContentfulMetadata;
-  internalName?: Maybe<Scalars['String']['output']>;
-  label?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<ComponentButtonLinkingCollections>;
-  sys: Sys;
-  url?: Maybe<Scalars['String']['output']>;
-};
-
+export type ComponentButton = Entry &
+  _Node & {
+    __typename?: "ComponentButton";
+    _id: Scalars["ID"]["output"];
+    contentfulMetadata: ContentfulMetadata;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    label?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<ComponentButtonLinkingCollections>;
+    sys: Sys;
+    url?: Maybe<Scalars["String"]["output"]>;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentButton) */
 export type ComponentButtonInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentButton) */
 export type ComponentButtonLabelArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentButton) */
 export type ComponentButtonLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentButton) */
 export type ComponentButtonUrlArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type ComponentButtonCollection = {
-  __typename?: 'ComponentButtonCollection';
+  __typename?: "ComponentButtonCollection";
   items: Array<Maybe<ComponentButton>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type ComponentButtonCursorCollection = {
-  __typename?: 'ComponentButtonCursorCollection';
+  __typename?: "ComponentButtonCursorCollection";
   items: Array<Maybe<ComponentButton>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
@@ -1031,32 +981,32 @@ export type ComponentButtonFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentButtonFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentButtonFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  label?: InputMaybe<Scalars['String']['input']>;
-  label_contains?: InputMaybe<Scalars['String']['input']>;
-  label_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  label_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  label_not?: InputMaybe<Scalars['String']['input']>;
-  label_not_contains?: InputMaybe<Scalars['String']['input']>;
-  label_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  label?: InputMaybe<Scalars["String"]["input"]>;
+  label_contains?: InputMaybe<Scalars["String"]["input"]>;
+  label_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  label_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  label_not?: InputMaybe<Scalars["String"]["input"]>;
+  label_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  label_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  url?: InputMaybe<Scalars['String']['input']>;
-  url_contains?: InputMaybe<Scalars['String']['input']>;
-  url_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  url_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  url_not?: InputMaybe<Scalars['String']['input']>;
-  url_not_contains?: InputMaybe<Scalars['String']['input']>;
-  url_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  url?: InputMaybe<Scalars["String"]["input"]>;
+  url_contains?: InputMaybe<Scalars["String"]["input"]>;
+  url_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  url_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  url_not?: InputMaybe<Scalars["String"]["input"]>;
+  url_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  url_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type ComponentButtonLinkingCollections = {
-  __typename?: 'ComponentButtonLinkingCollections';
+  __typename?: "ComponentButtonLinkingCollections";
   componentAlertCollection?: Maybe<ComponentAlertCollection>;
   componentAlertCursorCollection?: Maybe<ComponentAlertCursorCollection>;
   componentReleaseNoteCollection?: Maybe<ComponentReleaseNoteCollection>;
@@ -1071,910 +1021,903 @@ export type ComponentButtonLinkingCollections = {
   pageHomeHeroCursorCollection?: Maybe<PageHomeHeroCursorCollection>;
 };
 
-
 export type ComponentButtonLinkingCollectionsComponentAlertCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsComponentAlertCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentButtonLinkingCollectionsComponentAlertCollectionOrder>>
+  >;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentButtonLinkingCollectionsComponentAlertCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsComponentAlertCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentButtonLinkingCollectionsComponentAlertCursorCollectionOrder>>
+  >;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentButtonLinkingCollectionsComponentReleaseNoteCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsComponentReleaseNoteCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentButtonLinkingCollectionsComponentReleaseNoteCollectionOrder>>
+  >;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentButtonLinkingCollectionsComponentReleaseNoteCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsComponentReleaseNoteCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentButtonLinkingCollectionsComponentReleaseNoteCursorCollectionOrder>>
+  >;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentButtonLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentButtonLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentButtonLinkingCollectionsFooterCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsFooterCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentButtonLinkingCollectionsFooterCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsFooterCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentButtonLinkingCollectionsFooterCursorCollectionOrder>>
+  >;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentButtonLinkingCollectionsPageForceUpdateCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsPageForceUpdateCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentButtonLinkingCollectionsPageForceUpdateCollectionOrder>>
+  >;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentButtonLinkingCollectionsPageForceUpdateCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsPageForceUpdateCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentButtonLinkingCollectionsPageForceUpdateCursorCollectionOrder>>
+  >;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentButtonLinkingCollectionsPageHomeHeroCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsPageHomeHeroCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentButtonLinkingCollectionsPageHomeHeroCollectionOrder>>
+  >;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type ComponentButtonLinkingCollectionsPageHomeHeroCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentButtonLinkingCollectionsPageHomeHeroCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentButtonLinkingCollectionsPageHomeHeroCursorCollectionOrder>>
+  >;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum ComponentButtonLinkingCollectionsComponentAlertCollectionOrder {
-  ActiveAsc = 'active_ASC',
-  ActiveDesc = 'active_DESC',
-  AudienceAsc = 'audience_ASC',
-  AudienceDesc = 'audience_DESC',
-  DismissibleAsc = 'dismissible_ASC',
-  DismissibleDesc = 'dismissible_DESC',
-  EndAtAsc = 'endAt_ASC',
-  EndAtDesc = 'endAt_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SeverityAsc = 'severity_ASC',
-  SeverityDesc = 'severity_DESC',
-  StartAtAsc = 'startAt_ASC',
-  StartAtDesc = 'startAt_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC',
-  TypeAsc = 'type_ASC',
-  TypeDesc = 'type_DESC'
+  ActiveAsc = "active_ASC",
+  ActiveDesc = "active_DESC",
+  AudienceAsc = "audience_ASC",
+  AudienceDesc = "audience_DESC",
+  DismissibleAsc = "dismissible_ASC",
+  DismissibleDesc = "dismissible_DESC",
+  EndAtAsc = "endAt_ASC",
+  EndAtDesc = "endAt_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SeverityAsc = "severity_ASC",
+  SeverityDesc = "severity_DESC",
+  StartAtAsc = "startAt_ASC",
+  StartAtDesc = "startAt_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
+  TypeAsc = "type_ASC",
+  TypeDesc = "type_DESC",
 }
 
 export enum ComponentButtonLinkingCollectionsComponentAlertCursorCollectionOrder {
-  ActiveAsc = 'active_ASC',
-  ActiveDesc = 'active_DESC',
-  AudienceAsc = 'audience_ASC',
-  AudienceDesc = 'audience_DESC',
-  DismissibleAsc = 'dismissible_ASC',
-  DismissibleDesc = 'dismissible_DESC',
-  EndAtAsc = 'endAt_ASC',
-  EndAtDesc = 'endAt_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SeverityAsc = 'severity_ASC',
-  SeverityDesc = 'severity_DESC',
-  StartAtAsc = 'startAt_ASC',
-  StartAtDesc = 'startAt_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC',
-  TypeAsc = 'type_ASC',
-  TypeDesc = 'type_DESC'
+  ActiveAsc = "active_ASC",
+  ActiveDesc = "active_DESC",
+  AudienceAsc = "audience_ASC",
+  AudienceDesc = "audience_DESC",
+  DismissibleAsc = "dismissible_ASC",
+  DismissibleDesc = "dismissible_DESC",
+  EndAtAsc = "endAt_ASC",
+  EndAtDesc = "endAt_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SeverityAsc = "severity_ASC",
+  SeverityDesc = "severity_DESC",
+  StartAtAsc = "startAt_ASC",
+  StartAtDesc = "startAt_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
+  TypeAsc = "type_ASC",
+  TypeDesc = "type_DESC",
 }
 
 export enum ComponentButtonLinkingCollectionsComponentReleaseNoteCollectionOrder {
-  ActiveAsc = 'active_ASC',
-  ActiveDesc = 'active_DESC',
-  CategoryAsc = 'category_ASC',
-  CategoryDesc = 'category_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PublishedAtAsc = 'publishedAt_ASC',
-  PublishedAtDesc = 'publishedAt_DESC',
-  SlugAsc = 'slug_ASC',
-  SlugDesc = 'slug_DESC',
-  SummaryAsc = 'summary_ASC',
-  SummaryDesc = 'summary_DESC',
-  SurfacesAsc = 'surfaces_ASC',
-  SurfacesDesc = 'surfaces_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  ActiveAsc = "active_ASC",
+  ActiveDesc = "active_DESC",
+  CategoryAsc = "category_ASC",
+  CategoryDesc = "category_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PublishedAtAsc = "publishedAt_ASC",
+  PublishedAtDesc = "publishedAt_DESC",
+  SlugAsc = "slug_ASC",
+  SlugDesc = "slug_DESC",
+  SummaryAsc = "summary_ASC",
+  SummaryDesc = "summary_DESC",
+  SurfacesAsc = "surfaces_ASC",
+  SurfacesDesc = "surfaces_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentButtonLinkingCollectionsComponentReleaseNoteCursorCollectionOrder {
-  ActiveAsc = 'active_ASC',
-  ActiveDesc = 'active_DESC',
-  CategoryAsc = 'category_ASC',
-  CategoryDesc = 'category_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PublishedAtAsc = 'publishedAt_ASC',
-  PublishedAtDesc = 'publishedAt_DESC',
-  SlugAsc = 'slug_ASC',
-  SlugDesc = 'slug_DESC',
-  SummaryAsc = 'summary_ASC',
-  SummaryDesc = 'summary_DESC',
-  SurfacesAsc = 'surfaces_ASC',
-  SurfacesDesc = 'surfaces_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  ActiveAsc = "active_ASC",
+  ActiveDesc = "active_DESC",
+  CategoryAsc = "category_ASC",
+  CategoryDesc = "category_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PublishedAtAsc = "publishedAt_ASC",
+  PublishedAtDesc = "publishedAt_DESC",
+  SlugAsc = "slug_ASC",
+  SlugDesc = "slug_DESC",
+  SummaryAsc = "summary_ASC",
+  SummaryDesc = "summary_DESC",
+  SurfacesAsc = "surfaces_ASC",
+  SurfacesDesc = "surfaces_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentButtonLinkingCollectionsFooterCollectionOrder {
-  BadgeAsc = 'badge_ASC',
-  BadgeDesc = 'badge_DESC',
-  BrandAsc = 'brand_ASC',
-  BrandDesc = 'brand_DESC',
-  CopyrightAsc = 'copyright_ASC',
-  CopyrightDesc = 'copyright_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  MenuTitleAsc = 'menuTitle_ASC',
-  MenuTitleDesc = 'menuTitle_DESC',
-  SupportTitleAsc = 'supportTitle_ASC',
-  SupportTitleDesc = 'supportTitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  BadgeAsc = "badge_ASC",
+  BadgeDesc = "badge_DESC",
+  BrandAsc = "brand_ASC",
+  BrandDesc = "brand_DESC",
+  CopyrightAsc = "copyright_ASC",
+  CopyrightDesc = "copyright_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  MenuTitleAsc = "menuTitle_ASC",
+  MenuTitleDesc = "menuTitle_DESC",
+  SupportTitleAsc = "supportTitle_ASC",
+  SupportTitleDesc = "supportTitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentButtonLinkingCollectionsFooterCursorCollectionOrder {
-  BadgeAsc = 'badge_ASC',
-  BadgeDesc = 'badge_DESC',
-  BrandAsc = 'brand_ASC',
-  BrandDesc = 'brand_DESC',
-  CopyrightAsc = 'copyright_ASC',
-  CopyrightDesc = 'copyright_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  MenuTitleAsc = 'menuTitle_ASC',
-  MenuTitleDesc = 'menuTitle_DESC',
-  SupportTitleAsc = 'supportTitle_ASC',
-  SupportTitleDesc = 'supportTitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  BadgeAsc = "badge_ASC",
+  BadgeDesc = "badge_DESC",
+  BrandAsc = "brand_ASC",
+  BrandDesc = "brand_DESC",
+  CopyrightAsc = "copyright_ASC",
+  CopyrightDesc = "copyright_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  MenuTitleAsc = "menuTitle_ASC",
+  MenuTitleDesc = "menuTitle_DESC",
+  SupportTitleAsc = "supportTitle_ASC",
+  SupportTitleDesc = "supportTitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentButtonLinkingCollectionsPageForceUpdateCollectionOrder {
-  ActiveAsc = 'active_ASC',
-  ActiveDesc = 'active_DESC',
-  EffectiveAtAsc = 'effectiveAt_ASC',
-  EffectiveAtDesc = 'effectiveAt_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  MinVersionAsc = 'minVersion_ASC',
-  MinVersionDesc = 'minVersion_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  ActiveAsc = "active_ASC",
+  ActiveDesc = "active_DESC",
+  EffectiveAtAsc = "effectiveAt_ASC",
+  EffectiveAtDesc = "effectiveAt_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  MinVersionAsc = "minVersion_ASC",
+  MinVersionDesc = "minVersion_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentButtonLinkingCollectionsPageForceUpdateCursorCollectionOrder {
-  ActiveAsc = 'active_ASC',
-  ActiveDesc = 'active_DESC',
-  EffectiveAtAsc = 'effectiveAt_ASC',
-  EffectiveAtDesc = 'effectiveAt_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  MinVersionAsc = 'minVersion_ASC',
-  MinVersionDesc = 'minVersion_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  ActiveAsc = "active_ASC",
+  ActiveDesc = "active_DESC",
+  EffectiveAtAsc = "effectiveAt_ASC",
+  EffectiveAtDesc = "effectiveAt_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  MinVersionAsc = "minVersion_ASC",
+  MinVersionDesc = "minVersion_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentButtonLinkingCollectionsPageHomeHeroCollectionOrder {
-  BadgeAsc = 'badge_ASC',
-  BadgeDesc = 'badge_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SubtitleAsc = 'subtitle_ASC',
-  SubtitleDesc = 'subtitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  BadgeAsc = "badge_ASC",
+  BadgeDesc = "badge_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SubtitleAsc = "subtitle_ASC",
+  SubtitleDesc = "subtitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentButtonLinkingCollectionsPageHomeHeroCursorCollectionOrder {
-  BadgeAsc = 'badge_ASC',
-  BadgeDesc = 'badge_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SubtitleAsc = 'subtitle_ASC',
-  SubtitleDesc = 'subtitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  BadgeAsc = "badge_ASC",
+  BadgeDesc = "badge_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SubtitleAsc = "subtitle_ASC",
+  SubtitleDesc = "subtitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentButtonOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  LabelAsc = 'label_ASC',
-  LabelDesc = 'label_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  UrlAsc = 'url_ASC',
-  UrlDesc = 'url_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  LabelAsc = "label_ASC",
+  LabelDesc = "label_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  UrlAsc = "url_ASC",
+  UrlDesc = "url_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentEmail) */
-export type ComponentEmail = Entry & _Node & {
-  __typename?: 'ComponentEmail';
-  _id: Scalars['ID']['output'];
-  availableVariables?: Maybe<Scalars['String']['output']>;
-  content?: Maybe<ComponentEmailContent>;
-  contentfulMetadata: ContentfulMetadata;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<ComponentEmailLinkingCollections>;
-  preview?: Maybe<Scalars['String']['output']>;
-  sys: Sys;
-};
-
+export type ComponentEmail = Entry &
+  _Node & {
+    __typename?: "ComponentEmail";
+    _id: Scalars["ID"]["output"];
+    availableVariables?: Maybe<Scalars["String"]["output"]>;
+    content?: Maybe<ComponentEmailContent>;
+    contentfulMetadata: ContentfulMetadata;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<ComponentEmailLinkingCollections>;
+    preview?: Maybe<Scalars["String"]["output"]>;
+    sys: Sys;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentEmail) */
 export type ComponentEmailAvailableVariablesArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentEmail) */
 export type ComponentEmailContentArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentEmail) */
 export type ComponentEmailInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentEmail) */
 export type ComponentEmailLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentEmail) */
 export type ComponentEmailPreviewArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type ComponentEmailCollection = {
-  __typename?: 'ComponentEmailCollection';
+  __typename?: "ComponentEmailCollection";
   items: Array<Maybe<ComponentEmail>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type ComponentEmailContent = {
-  __typename?: 'ComponentEmailContent';
-  json: Scalars['JSON']['output'];
+  __typename?: "ComponentEmailContent";
+  json: Scalars["JSON"]["output"];
   links: ComponentEmailContentLinks;
 };
 
 export type ComponentEmailContentAssets = {
-  __typename?: 'ComponentEmailContentAssets';
+  __typename?: "ComponentEmailContentAssets";
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type ComponentEmailContentEntries = {
-  __typename?: 'ComponentEmailContentEntries';
+  __typename?: "ComponentEmailContentEntries";
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type ComponentEmailContentLinks = {
-  __typename?: 'ComponentEmailContentLinks';
+  __typename?: "ComponentEmailContentLinks";
   assets: ComponentEmailContentAssets;
   entries: ComponentEmailContentEntries;
   resources: ComponentEmailContentResources;
 };
 
 export type ComponentEmailContentResources = {
-  __typename?: 'ComponentEmailContentResources';
+  __typename?: "ComponentEmailContentResources";
   block: Array<ComponentEmailContentResourcesBlock>;
   hyperlink: Array<ComponentEmailContentResourcesHyperlink>;
   inline: Array<ComponentEmailContentResourcesInline>;
 };
 
 export type ComponentEmailContentResourcesBlock = ResourceLink & {
-  __typename?: 'ComponentEmailContentResourcesBlock';
+  __typename?: "ComponentEmailContentResourcesBlock";
   sys: ResourceSys;
 };
 
 export type ComponentEmailContentResourcesHyperlink = ResourceLink & {
-  __typename?: 'ComponentEmailContentResourcesHyperlink';
+  __typename?: "ComponentEmailContentResourcesHyperlink";
   sys: ResourceSys;
 };
 
 export type ComponentEmailContentResourcesInline = ResourceLink & {
-  __typename?: 'ComponentEmailContentResourcesInline';
+  __typename?: "ComponentEmailContentResourcesInline";
   sys: ResourceSys;
 };
 
 export type ComponentEmailCursorCollection = {
-  __typename?: 'ComponentEmailCursorCollection';
+  __typename?: "ComponentEmailCursorCollection";
   items: Array<Maybe<ComponentEmail>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export type ComponentEmailFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentEmailFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentEmailFilter>>>;
-  availableVariables?: InputMaybe<Scalars['String']['input']>;
-  availableVariables_contains?: InputMaybe<Scalars['String']['input']>;
-  availableVariables_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  availableVariables_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  availableVariables_not?: InputMaybe<Scalars['String']['input']>;
-  availableVariables_not_contains?: InputMaybe<Scalars['String']['input']>;
-  availableVariables_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  content_contains?: InputMaybe<Scalars['String']['input']>;
-  content_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  content_not_contains?: InputMaybe<Scalars['String']['input']>;
+  availableVariables?: InputMaybe<Scalars["String"]["input"]>;
+  availableVariables_contains?: InputMaybe<Scalars["String"]["input"]>;
+  availableVariables_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  availableVariables_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  availableVariables_not?: InputMaybe<Scalars["String"]["input"]>;
+  availableVariables_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  availableVariables_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  content_contains?: InputMaybe<Scalars["String"]["input"]>;
+  content_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  content_not_contains?: InputMaybe<Scalars["String"]["input"]>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  preview?: InputMaybe<Scalars['String']['input']>;
-  preview_contains?: InputMaybe<Scalars['String']['input']>;
-  preview_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  preview_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  preview_not?: InputMaybe<Scalars['String']['input']>;
-  preview_not_contains?: InputMaybe<Scalars['String']['input']>;
-  preview_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  preview?: InputMaybe<Scalars["String"]["input"]>;
+  preview_contains?: InputMaybe<Scalars["String"]["input"]>;
+  preview_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  preview_not?: InputMaybe<Scalars["String"]["input"]>;
+  preview_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  preview_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
 };
 
 export type ComponentEmailLinkingCollections = {
-  __typename?: 'ComponentEmailLinkingCollections';
+  __typename?: "ComponentEmailLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
   pageEmailsCollection?: Maybe<PageEmailsCollection>;
   pageEmailsCursorCollection?: Maybe<PageEmailsCursorCollection>;
 };
 
-
 export type ComponentEmailLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentEmailLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentEmailLinkingCollectionsPageEmailsCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentEmailLinkingCollectionsPageEmailsCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type ComponentEmailLinkingCollectionsPageEmailsCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentEmailLinkingCollectionsPageEmailsCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentEmailLinkingCollectionsPageEmailsCursorCollectionOrder>>
+  >;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum ComponentEmailLinkingCollectionsPageEmailsCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
 }
 
 export enum ComponentEmailLinkingCollectionsPageEmailsCursorCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
 }
 
 export enum ComponentEmailOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PreviewAsc = 'preview_ASC',
-  PreviewDesc = 'preview_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PreviewAsc = "preview_ASC",
+  PreviewDesc = "preview_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFaqQuestion) */
-export type ComponentFaqQuestion = Entry & _Node & {
-  __typename?: 'ComponentFaqQuestion';
-  _id: Scalars['ID']['output'];
-  answer?: Maybe<ComponentFaqQuestionAnswer>;
-  contentfulMetadata: ContentfulMetadata;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<ComponentFaqQuestionLinkingCollections>;
-  question?: Maybe<Scalars['String']['output']>;
-  sys: Sys;
-};
-
+export type ComponentFaqQuestion = Entry &
+  _Node & {
+    __typename?: "ComponentFaqQuestion";
+    _id: Scalars["ID"]["output"];
+    answer?: Maybe<ComponentFaqQuestionAnswer>;
+    contentfulMetadata: ContentfulMetadata;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<ComponentFaqQuestionLinkingCollections>;
+    question?: Maybe<Scalars["String"]["output"]>;
+    sys: Sys;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFaqQuestion) */
 export type ComponentFaqQuestionAnswerArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFaqQuestion) */
 export type ComponentFaqQuestionInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFaqQuestion) */
 export type ComponentFaqQuestionLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFaqQuestion) */
 export type ComponentFaqQuestionQuestionArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type ComponentFaqQuestionAnswer = {
-  __typename?: 'ComponentFaqQuestionAnswer';
-  json: Scalars['JSON']['output'];
+  __typename?: "ComponentFaqQuestionAnswer";
+  json: Scalars["JSON"]["output"];
   links: ComponentFaqQuestionAnswerLinks;
 };
 
 export type ComponentFaqQuestionAnswerAssets = {
-  __typename?: 'ComponentFaqQuestionAnswerAssets';
+  __typename?: "ComponentFaqQuestionAnswerAssets";
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type ComponentFaqQuestionAnswerEntries = {
-  __typename?: 'ComponentFaqQuestionAnswerEntries';
+  __typename?: "ComponentFaqQuestionAnswerEntries";
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type ComponentFaqQuestionAnswerLinks = {
-  __typename?: 'ComponentFaqQuestionAnswerLinks';
+  __typename?: "ComponentFaqQuestionAnswerLinks";
   assets: ComponentFaqQuestionAnswerAssets;
   entries: ComponentFaqQuestionAnswerEntries;
   resources: ComponentFaqQuestionAnswerResources;
 };
 
 export type ComponentFaqQuestionAnswerResources = {
-  __typename?: 'ComponentFaqQuestionAnswerResources';
+  __typename?: "ComponentFaqQuestionAnswerResources";
   block: Array<ComponentFaqQuestionAnswerResourcesBlock>;
   hyperlink: Array<ComponentFaqQuestionAnswerResourcesHyperlink>;
   inline: Array<ComponentFaqQuestionAnswerResourcesInline>;
 };
 
 export type ComponentFaqQuestionAnswerResourcesBlock = ResourceLink & {
-  __typename?: 'ComponentFaqQuestionAnswerResourcesBlock';
+  __typename?: "ComponentFaqQuestionAnswerResourcesBlock";
   sys: ResourceSys;
 };
 
 export type ComponentFaqQuestionAnswerResourcesHyperlink = ResourceLink & {
-  __typename?: 'ComponentFaqQuestionAnswerResourcesHyperlink';
+  __typename?: "ComponentFaqQuestionAnswerResourcesHyperlink";
   sys: ResourceSys;
 };
 
 export type ComponentFaqQuestionAnswerResourcesInline = ResourceLink & {
-  __typename?: 'ComponentFaqQuestionAnswerResourcesInline';
+  __typename?: "ComponentFaqQuestionAnswerResourcesInline";
   sys: ResourceSys;
 };
 
 export type ComponentFaqQuestionCollection = {
-  __typename?: 'ComponentFaqQuestionCollection';
+  __typename?: "ComponentFaqQuestionCollection";
   items: Array<Maybe<ComponentFaqQuestion>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type ComponentFaqQuestionCursorCollection = {
-  __typename?: 'ComponentFaqQuestionCursorCollection';
+  __typename?: "ComponentFaqQuestionCursorCollection";
   items: Array<Maybe<ComponentFaqQuestion>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export type ComponentFaqQuestionFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentFaqQuestionFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentFaqQuestionFilter>>>;
-  answer_contains?: InputMaybe<Scalars['String']['input']>;
-  answer_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  answer_not_contains?: InputMaybe<Scalars['String']['input']>;
+  answer_contains?: InputMaybe<Scalars["String"]["input"]>;
+  answer_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  answer_not_contains?: InputMaybe<Scalars["String"]["input"]>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  question?: InputMaybe<Scalars['String']['input']>;
-  question_contains?: InputMaybe<Scalars['String']['input']>;
-  question_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  question_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  question_not?: InputMaybe<Scalars['String']['input']>;
-  question_not_contains?: InputMaybe<Scalars['String']['input']>;
-  question_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  question?: InputMaybe<Scalars["String"]["input"]>;
+  question_contains?: InputMaybe<Scalars["String"]["input"]>;
+  question_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  question_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  question_not?: InputMaybe<Scalars["String"]["input"]>;
+  question_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  question_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
 };
 
 export type ComponentFaqQuestionLinkingCollections = {
-  __typename?: 'ComponentFaqQuestionLinkingCollections';
+  __typename?: "ComponentFaqQuestionLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
   pageFaqCollection?: Maybe<PageFaqCollection>;
   pageFaqCursorCollection?: Maybe<PageFaqCursorCollection>;
 };
 
-
 export type ComponentFaqQuestionLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentFaqQuestionLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentFaqQuestionLinkingCollectionsPageFaqCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentFaqQuestionLinkingCollectionsPageFaqCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentFaqQuestionLinkingCollectionsPageFaqCollectionOrder>>
+  >;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type ComponentFaqQuestionLinkingCollectionsPageFaqCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentFaqQuestionLinkingCollectionsPageFaqCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentFaqQuestionLinkingCollectionsPageFaqCursorCollectionOrder>>
+  >;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum ComponentFaqQuestionLinkingCollectionsPageFaqCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  IntroAsc = 'intro_ASC',
-  IntroDesc = 'intro_DESC',
-  PageDescriptionAsc = 'pageDescription_ASC',
-  PageDescriptionDesc = 'pageDescription_DESC',
-  PageTitleAsc = 'pageTitle_ASC',
-  PageTitleDesc = 'pageTitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  IntroAsc = "intro_ASC",
+  IntroDesc = "intro_DESC",
+  PageDescriptionAsc = "pageDescription_ASC",
+  PageDescriptionDesc = "pageDescription_DESC",
+  PageTitleAsc = "pageTitle_ASC",
+  PageTitleDesc = "pageTitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentFaqQuestionLinkingCollectionsPageFaqCursorCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  IntroAsc = 'intro_ASC',
-  IntroDesc = 'intro_DESC',
-  PageDescriptionAsc = 'pageDescription_ASC',
-  PageDescriptionDesc = 'pageDescription_DESC',
-  PageTitleAsc = 'pageTitle_ASC',
-  PageTitleDesc = 'pageTitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  IntroAsc = "intro_ASC",
+  IntroDesc = "intro_DESC",
+  PageDescriptionAsc = "pageDescription_ASC",
+  PageDescriptionDesc = "pageDescription_DESC",
+  PageTitleAsc = "pageTitle_ASC",
+  PageTitleDesc = "pageTitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentFaqQuestionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  QuestionAsc = 'question_ASC',
-  QuestionDesc = 'question_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  QuestionAsc = "question_ASC",
+  QuestionDesc = "question_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFeature) */
-export type ComponentFeature = Entry & _Node & {
-  __typename?: 'ComponentFeature';
-  _id: Scalars['ID']['output'];
-  contentfulMetadata: ContentfulMetadata;
-  icon?: Maybe<Asset>;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<ComponentFeatureLinkingCollections>;
-  subtitle?: Maybe<Scalars['String']['output']>;
-  sys: Sys;
-  title?: Maybe<Scalars['String']['output']>;
-};
-
+export type ComponentFeature = Entry &
+  _Node & {
+    __typename?: "ComponentFeature";
+    _id: Scalars["ID"]["output"];
+    contentfulMetadata: ContentfulMetadata;
+    icon?: Maybe<Asset>;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<ComponentFeatureLinkingCollections>;
+    subtitle?: Maybe<Scalars["String"]["output"]>;
+    sys: Sys;
+    title?: Maybe<Scalars["String"]["output"]>;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFeature) */
 export type ComponentFeatureIconArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFeature) */
 export type ComponentFeatureInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFeature) */
 export type ComponentFeatureLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFeature) */
 export type ComponentFeatureSubtitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentFeature) */
 export type ComponentFeatureTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type ComponentFeatureCollection = {
-  __typename?: 'ComponentFeatureCollection';
+  __typename?: "ComponentFeatureCollection";
   items: Array<Maybe<ComponentFeature>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type ComponentFeatureCursorCollection = {
-  __typename?: 'ComponentFeatureCursorCollection';
+  __typename?: "ComponentFeatureCursorCollection";
   items: Array<Maybe<ComponentFeature>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
@@ -1982,190 +1925,186 @@ export type ComponentFeatureFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentFeatureFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentFeatureFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  icon_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  subtitle?: InputMaybe<Scalars['String']['input']>;
-  subtitle_contains?: InputMaybe<Scalars['String']['input']>;
-  subtitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  subtitle_not?: InputMaybe<Scalars['String']['input']>;
-  subtitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  icon_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  subtitle?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_contains?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  subtitle_not?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type ComponentFeatureLinkingCollections = {
-  __typename?: 'ComponentFeatureLinkingCollections';
+  __typename?: "ComponentFeatureLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
   pageHomeFeaturesCollection?: Maybe<PageHomeFeaturesCollection>;
   pageHomeFeaturesCursorCollection?: Maybe<PageHomeFeaturesCursorCollection>;
 };
 
-
 export type ComponentFeatureLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentFeatureLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentFeatureLinkingCollectionsPageHomeFeaturesCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentFeatureLinkingCollectionsPageHomeFeaturesCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentFeatureLinkingCollectionsPageHomeFeaturesCollectionOrder>>
+  >;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type ComponentFeatureLinkingCollectionsPageHomeFeaturesCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentFeatureLinkingCollectionsPageHomeFeaturesCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentFeatureLinkingCollectionsPageHomeFeaturesCursorCollectionOrder>>
+  >;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum ComponentFeatureLinkingCollectionsPageHomeFeaturesCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SubtitleAsc = 'subtitle_ASC',
-  SubtitleDesc = 'subtitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SubtitleAsc = "subtitle_ASC",
+  SubtitleDesc = "subtitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentFeatureLinkingCollectionsPageHomeFeaturesCursorCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SubtitleAsc = 'subtitle_ASC',
-  SubtitleDesc = 'subtitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SubtitleAsc = "subtitle_ASC",
+  SubtitleDesc = "subtitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentFeatureOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SubtitleAsc = 'subtitle_ASC',
-  SubtitleDesc = 'subtitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SubtitleAsc = "subtitle_ASC",
+  SubtitleDesc = "subtitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentPartner) */
-export type ComponentPartner = Entry & _Node & {
-  __typename?: 'ComponentPartner';
-  _id: Scalars['ID']['output'];
-  contentfulMetadata: ContentfulMetadata;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<ComponentPartnerLinkingCollections>;
-  logo?: Maybe<Asset>;
-  subtitle?: Maybe<Scalars['String']['output']>;
-  sys: Sys;
-  url?: Maybe<Scalars['String']['output']>;
-};
-
+export type ComponentPartner = Entry &
+  _Node & {
+    __typename?: "ComponentPartner";
+    _id: Scalars["ID"]["output"];
+    contentfulMetadata: ContentfulMetadata;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<ComponentPartnerLinkingCollections>;
+    logo?: Maybe<Asset>;
+    subtitle?: Maybe<Scalars["String"]["output"]>;
+    sys: Sys;
+    url?: Maybe<Scalars["String"]["output"]>;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentPartner) */
 export type ComponentPartnerInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentPartner) */
 export type ComponentPartnerLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentPartner) */
 export type ComponentPartnerLogoArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentPartner) */
 export type ComponentPartnerSubtitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentPartner) */
 export type ComponentPartnerUrlArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type ComponentPartnerCollection = {
-  __typename?: 'ComponentPartnerCollection';
+  __typename?: "ComponentPartnerCollection";
   items: Array<Maybe<ComponentPartner>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type ComponentPartnerCursorCollection = {
-  __typename?: 'ComponentPartnerCursorCollection';
+  __typename?: "ComponentPartnerCursorCollection";
   items: Array<Maybe<ComponentPartner>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
@@ -2173,705 +2112,677 @@ export type ComponentPartnerFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentPartnerFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentPartnerFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  logo_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  subtitle?: InputMaybe<Scalars['String']['input']>;
-  subtitle_contains?: InputMaybe<Scalars['String']['input']>;
-  subtitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  subtitle_not?: InputMaybe<Scalars['String']['input']>;
-  subtitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  logo_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  subtitle?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_contains?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  subtitle_not?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  url?: InputMaybe<Scalars['String']['input']>;
-  url_contains?: InputMaybe<Scalars['String']['input']>;
-  url_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  url_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  url_not?: InputMaybe<Scalars['String']['input']>;
-  url_not_contains?: InputMaybe<Scalars['String']['input']>;
-  url_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  url?: InputMaybe<Scalars["String"]["input"]>;
+  url_contains?: InputMaybe<Scalars["String"]["input"]>;
+  url_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  url_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  url_not?: InputMaybe<Scalars["String"]["input"]>;
+  url_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  url_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type ComponentPartnerLinkingCollections = {
-  __typename?: 'ComponentPartnerLinkingCollections';
+  __typename?: "ComponentPartnerLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
   pageHomePartnersCollection?: Maybe<PageHomePartnersCollection>;
   pageHomePartnersCursorCollection?: Maybe<PageHomePartnersCursorCollection>;
 };
 
-
 export type ComponentPartnerLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentPartnerLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentPartnerLinkingCollectionsPageHomePartnersCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentPartnerLinkingCollectionsPageHomePartnersCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentPartnerLinkingCollectionsPageHomePartnersCollectionOrder>>
+  >;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type ComponentPartnerLinkingCollectionsPageHomePartnersCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentPartnerLinkingCollectionsPageHomePartnersCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentPartnerLinkingCollectionsPageHomePartnersCursorCollectionOrder>>
+  >;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum ComponentPartnerLinkingCollectionsPageHomePartnersCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SubtitleAsc = 'subtitle_ASC',
-  SubtitleDesc = 'subtitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SubtitleAsc = "subtitle_ASC",
+  SubtitleDesc = "subtitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentPartnerLinkingCollectionsPageHomePartnersCursorCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SubtitleAsc = 'subtitle_ASC',
-  SubtitleDesc = 'subtitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SubtitleAsc = "subtitle_ASC",
+  SubtitleDesc = "subtitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentPartnerOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SubtitleAsc = 'subtitle_ASC',
-  SubtitleDesc = 'subtitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  UrlAsc = 'url_ASC',
-  UrlDesc = 'url_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SubtitleAsc = "subtitle_ASC",
+  SubtitleDesc = "subtitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  UrlAsc = "url_ASC",
+  UrlDesc = "url_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
-export type ComponentReleaseNote = Entry & _Node & {
-  __typename?: 'ComponentReleaseNote';
-  _id: Scalars['ID']['output'];
-  active?: Maybe<Scalars['Boolean']['output']>;
-  body?: Maybe<ComponentReleaseNoteBody>;
-  category?: Maybe<Scalars['String']['output']>;
-  contentfulMetadata: ContentfulMetadata;
-  cta?: Maybe<ComponentButton>;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<ComponentReleaseNoteLinkingCollections>;
-  media?: Maybe<Asset>;
-  publishedAt?: Maybe<Scalars['DateTime']['output']>;
-  seoFields?: Maybe<ComponentSeo>;
-  slug?: Maybe<Scalars['String']['output']>;
-  summary?: Maybe<Scalars['String']['output']>;
-  surfaces?: Maybe<Scalars['String']['output']>;
-  sys: Sys;
-  title?: Maybe<Scalars['String']['output']>;
-};
-
+export type ComponentReleaseNote = Entry &
+  _Node & {
+    __typename?: "ComponentReleaseNote";
+    _id: Scalars["ID"]["output"];
+    active?: Maybe<Scalars["Boolean"]["output"]>;
+    body?: Maybe<ComponentReleaseNoteBody>;
+    category?: Maybe<Scalars["String"]["output"]>;
+    contentfulMetadata: ContentfulMetadata;
+    cta?: Maybe<ComponentButton>;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<ComponentReleaseNoteLinkingCollections>;
+    media?: Maybe<Asset>;
+    publishedAt?: Maybe<Scalars["DateTime"]["output"]>;
+    seoFields?: Maybe<ComponentSeo>;
+    slug?: Maybe<Scalars["String"]["output"]>;
+    summary?: Maybe<Scalars["String"]["output"]>;
+    surfaces?: Maybe<Scalars["String"]["output"]>;
+    sys: Sys;
+    title?: Maybe<Scalars["String"]["output"]>;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
 export type ComponentReleaseNoteActiveArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
 export type ComponentReleaseNoteBodyArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
 export type ComponentReleaseNoteCategoryArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
 export type ComponentReleaseNoteCtaArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
 
-
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
 export type ComponentReleaseNoteInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
 export type ComponentReleaseNoteLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
 export type ComponentReleaseNoteMediaArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
 export type ComponentReleaseNotePublishedAtArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
 export type ComponentReleaseNoteSeoFieldsArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentSeoFilter>;
 };
 
-
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
 export type ComponentReleaseNoteSlugArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
 export type ComponentReleaseNoteSummaryArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
 export type ComponentReleaseNoteSurfacesArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentReleaseNote) */
 export type ComponentReleaseNoteTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type ComponentReleaseNoteBody = {
-  __typename?: 'ComponentReleaseNoteBody';
-  json: Scalars['JSON']['output'];
+  __typename?: "ComponentReleaseNoteBody";
+  json: Scalars["JSON"]["output"];
   links: ComponentReleaseNoteBodyLinks;
 };
 
 export type ComponentReleaseNoteBodyAssets = {
-  __typename?: 'ComponentReleaseNoteBodyAssets';
+  __typename?: "ComponentReleaseNoteBodyAssets";
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type ComponentReleaseNoteBodyEntries = {
-  __typename?: 'ComponentReleaseNoteBodyEntries';
+  __typename?: "ComponentReleaseNoteBodyEntries";
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type ComponentReleaseNoteBodyLinks = {
-  __typename?: 'ComponentReleaseNoteBodyLinks';
+  __typename?: "ComponentReleaseNoteBodyLinks";
   assets: ComponentReleaseNoteBodyAssets;
   entries: ComponentReleaseNoteBodyEntries;
   resources: ComponentReleaseNoteBodyResources;
 };
 
 export type ComponentReleaseNoteBodyResources = {
-  __typename?: 'ComponentReleaseNoteBodyResources';
+  __typename?: "ComponentReleaseNoteBodyResources";
   block: Array<ComponentReleaseNoteBodyResourcesBlock>;
   hyperlink: Array<ComponentReleaseNoteBodyResourcesHyperlink>;
   inline: Array<ComponentReleaseNoteBodyResourcesInline>;
 };
 
 export type ComponentReleaseNoteBodyResourcesBlock = ResourceLink & {
-  __typename?: 'ComponentReleaseNoteBodyResourcesBlock';
+  __typename?: "ComponentReleaseNoteBodyResourcesBlock";
   sys: ResourceSys;
 };
 
 export type ComponentReleaseNoteBodyResourcesHyperlink = ResourceLink & {
-  __typename?: 'ComponentReleaseNoteBodyResourcesHyperlink';
+  __typename?: "ComponentReleaseNoteBodyResourcesHyperlink";
   sys: ResourceSys;
 };
 
 export type ComponentReleaseNoteBodyResourcesInline = ResourceLink & {
-  __typename?: 'ComponentReleaseNoteBodyResourcesInline';
+  __typename?: "ComponentReleaseNoteBodyResourcesInline";
   sys: ResourceSys;
 };
 
 export type ComponentReleaseNoteCollection = {
-  __typename?: 'ComponentReleaseNoteCollection';
+  __typename?: "ComponentReleaseNoteCollection";
   items: Array<Maybe<ComponentReleaseNote>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type ComponentReleaseNoteCursorCollection = {
-  __typename?: 'ComponentReleaseNoteCursorCollection';
+  __typename?: "ComponentReleaseNoteCursorCollection";
   items: Array<Maybe<ComponentReleaseNote>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export type ComponentReleaseNoteFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentReleaseNoteFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentReleaseNoteFilter>>>;
-  active?: InputMaybe<Scalars['Boolean']['input']>;
-  active_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  active_not?: InputMaybe<Scalars['Boolean']['input']>;
-  body_contains?: InputMaybe<Scalars['String']['input']>;
-  body_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  body_not_contains?: InputMaybe<Scalars['String']['input']>;
-  category?: InputMaybe<Scalars['String']['input']>;
-  category_contains?: InputMaybe<Scalars['String']['input']>;
-  category_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  category_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  category_not?: InputMaybe<Scalars['String']['input']>;
-  category_not_contains?: InputMaybe<Scalars['String']['input']>;
-  category_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  active?: InputMaybe<Scalars["Boolean"]["input"]>;
+  active_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  active_not?: InputMaybe<Scalars["Boolean"]["input"]>;
+  body_contains?: InputMaybe<Scalars["String"]["input"]>;
+  body_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  body_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  category?: InputMaybe<Scalars["String"]["input"]>;
+  category_contains?: InputMaybe<Scalars["String"]["input"]>;
+  category_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  category_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  category_not?: InputMaybe<Scalars["String"]["input"]>;
+  category_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  category_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
   cta?: InputMaybe<CfComponentButtonNestedFilter>;
-  cta_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  media_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  publishedAt?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedAt_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  publishedAt_gt?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedAt_gte?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedAt_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
-  publishedAt_lt?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedAt_lte?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedAt_not?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedAt_not_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  cta_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  media_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  publishedAt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedAt_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  publishedAt_gt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedAt_gte?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedAt_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
+  publishedAt_lt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedAt_lte?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedAt_not?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedAt_not_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
   seoFields?: InputMaybe<CfComponentSeoNestedFilter>;
-  seoFields_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  slug?: InputMaybe<Scalars['String']['input']>;
-  slug_contains?: InputMaybe<Scalars['String']['input']>;
-  slug_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  slug_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  slug_not?: InputMaybe<Scalars['String']['input']>;
-  slug_not_contains?: InputMaybe<Scalars['String']['input']>;
-  slug_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  summary?: InputMaybe<Scalars['String']['input']>;
-  summary_contains?: InputMaybe<Scalars['String']['input']>;
-  summary_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  summary_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  summary_not?: InputMaybe<Scalars['String']['input']>;
-  summary_not_contains?: InputMaybe<Scalars['String']['input']>;
-  summary_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  surfaces?: InputMaybe<Scalars['String']['input']>;
-  surfaces_contains?: InputMaybe<Scalars['String']['input']>;
-  surfaces_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  surfaces_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  surfaces_not?: InputMaybe<Scalars['String']['input']>;
-  surfaces_not_contains?: InputMaybe<Scalars['String']['input']>;
-  surfaces_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  seoFields_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  slug?: InputMaybe<Scalars["String"]["input"]>;
+  slug_contains?: InputMaybe<Scalars["String"]["input"]>;
+  slug_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  slug_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  slug_not?: InputMaybe<Scalars["String"]["input"]>;
+  slug_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  slug_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  summary?: InputMaybe<Scalars["String"]["input"]>;
+  summary_contains?: InputMaybe<Scalars["String"]["input"]>;
+  summary_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  summary_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  summary_not?: InputMaybe<Scalars["String"]["input"]>;
+  summary_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  summary_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  surfaces?: InputMaybe<Scalars["String"]["input"]>;
+  surfaces_contains?: InputMaybe<Scalars["String"]["input"]>;
+  surfaces_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  surfaces_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  surfaces_not?: InputMaybe<Scalars["String"]["input"]>;
+  surfaces_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  surfaces_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type ComponentReleaseNoteLinkingCollections = {
-  __typename?: 'ComponentReleaseNoteLinkingCollections';
+  __typename?: "ComponentReleaseNoteLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
-
 export type ComponentReleaseNoteLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type ComponentReleaseNoteLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum ComponentReleaseNoteOrder {
-  ActiveAsc = 'active_ASC',
-  ActiveDesc = 'active_DESC',
-  CategoryAsc = 'category_ASC',
-  CategoryDesc = 'category_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PublishedAtAsc = 'publishedAt_ASC',
-  PublishedAtDesc = 'publishedAt_DESC',
-  SlugAsc = 'slug_ASC',
-  SlugDesc = 'slug_DESC',
-  SummaryAsc = 'summary_ASC',
-  SummaryDesc = 'summary_DESC',
-  SurfacesAsc = 'surfaces_ASC',
-  SurfacesDesc = 'surfaces_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  ActiveAsc = "active_ASC",
+  ActiveDesc = "active_DESC",
+  CategoryAsc = "category_ASC",
+  CategoryDesc = "category_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PublishedAtAsc = "publishedAt_ASC",
+  PublishedAtDesc = "publishedAt_DESC",
+  SlugAsc = "slug_ASC",
+  SlugDesc = "slug_DESC",
+  SummaryAsc = "summary_ASC",
+  SummaryDesc = "summary_DESC",
+  SurfacesAsc = "surfaces_ASC",
+  SurfacesDesc = "surfaces_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentRichImage) */
-export type ComponentRichImage = Entry & _Node & {
-  __typename?: 'ComponentRichImage';
-  _id: Scalars['ID']['output'];
-  caption?: Maybe<Scalars['String']['output']>;
-  contentfulMetadata: ContentfulMetadata;
-  fullWidth?: Maybe<Scalars['Boolean']['output']>;
-  image?: Maybe<Asset>;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<ComponentRichImageLinkingCollections>;
-  sys: Sys;
-};
-
+export type ComponentRichImage = Entry &
+  _Node & {
+    __typename?: "ComponentRichImage";
+    _id: Scalars["ID"]["output"];
+    caption?: Maybe<Scalars["String"]["output"]>;
+    contentfulMetadata: ContentfulMetadata;
+    fullWidth?: Maybe<Scalars["Boolean"]["output"]>;
+    image?: Maybe<Asset>;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<ComponentRichImageLinkingCollections>;
+    sys: Sys;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentRichImage) */
 export type ComponentRichImageCaptionArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentRichImage) */
 export type ComponentRichImageFullWidthArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentRichImage) */
 export type ComponentRichImageImageArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentRichImage) */
 export type ComponentRichImageInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentRichImage) */
 export type ComponentRichImageLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type ComponentRichImageCollection = {
-  __typename?: 'ComponentRichImageCollection';
+  __typename?: "ComponentRichImageCollection";
   items: Array<Maybe<ComponentRichImage>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type ComponentRichImageCursorCollection = {
-  __typename?: 'ComponentRichImageCursorCollection';
+  __typename?: "ComponentRichImageCursorCollection";
   items: Array<Maybe<ComponentRichImage>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export type ComponentRichImageFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentRichImageFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentRichImageFilter>>>;
-  caption?: InputMaybe<Scalars['String']['input']>;
-  caption_contains?: InputMaybe<Scalars['String']['input']>;
-  caption_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  caption_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  caption_not?: InputMaybe<Scalars['String']['input']>;
-  caption_not_contains?: InputMaybe<Scalars['String']['input']>;
-  caption_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  caption?: InputMaybe<Scalars["String"]["input"]>;
+  caption_contains?: InputMaybe<Scalars["String"]["input"]>;
+  caption_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  caption_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  caption_not?: InputMaybe<Scalars["String"]["input"]>;
+  caption_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  caption_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  fullWidth?: InputMaybe<Scalars['Boolean']['input']>;
-  fullWidth_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  fullWidth_not?: InputMaybe<Scalars['Boolean']['input']>;
-  image_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  fullWidth?: InputMaybe<Scalars["Boolean"]["input"]>;
+  fullWidth_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  fullWidth_not?: InputMaybe<Scalars["Boolean"]["input"]>;
+  image_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
 };
 
 export type ComponentRichImageLinkingCollections = {
-  __typename?: 'ComponentRichImageLinkingCollections';
+  __typename?: "ComponentRichImageLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
-
 export type ComponentRichImageLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type ComponentRichImageLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum ComponentRichImageOrder {
-  CaptionAsc = 'caption_ASC',
-  CaptionDesc = 'caption_DESC',
-  FullWidthAsc = 'fullWidth_ASC',
-  FullWidthDesc = 'fullWidth_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  CaptionAsc = "caption_ASC",
+  CaptionDesc = "caption_DESC",
+  FullWidthAsc = "fullWidth_ASC",
+  FullWidthDesc = "fullWidth_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
-export type ComponentSeo = Entry & _Node & {
-  __typename?: 'ComponentSeo';
-  _id: Scalars['ID']['output'];
-  canonicalUrl?: Maybe<Scalars['String']['output']>;
-  contentfulMetadata: ContentfulMetadata;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<ComponentSeoLinkingCollections>;
-  nofollow?: Maybe<Scalars['Boolean']['output']>;
-  noindex?: Maybe<Scalars['Boolean']['output']>;
-  pageDescription?: Maybe<Scalars['String']['output']>;
-  pageTitle?: Maybe<Scalars['String']['output']>;
-  shareImagesCollection?: Maybe<AssetCollection>;
-  shareImagesCursorCollection?: Maybe<AssetCursorCollection>;
-  sys: Sys;
-};
-
+export type ComponentSeo = Entry &
+  _Node & {
+    __typename?: "ComponentSeo";
+    _id: Scalars["ID"]["output"];
+    canonicalUrl?: Maybe<Scalars["String"]["output"]>;
+    contentfulMetadata: ContentfulMetadata;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<ComponentSeoLinkingCollections>;
+    nofollow?: Maybe<Scalars["Boolean"]["output"]>;
+    noindex?: Maybe<Scalars["Boolean"]["output"]>;
+    pageDescription?: Maybe<Scalars["String"]["output"]>;
+    pageTitle?: Maybe<Scalars["String"]["output"]>;
+    shareImagesCollection?: Maybe<AssetCollection>;
+    shareImagesCursorCollection?: Maybe<AssetCursorCollection>;
+    sys: Sys;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
 export type ComponentSeoCanonicalUrlArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
 export type ComponentSeoInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
 export type ComponentSeoLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
 export type ComponentSeoNofollowArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
 export type ComponentSeoNoindexArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
 export type ComponentSeoPageDescriptionArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
 export type ComponentSeoPageTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
 export type ComponentSeoShareImagesCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/componentSeo) */
 export type ComponentSeoShareImagesCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type ComponentSeoCollection = {
-  __typename?: 'ComponentSeoCollection';
+  __typename?: "ComponentSeoCollection";
   items: Array<Maybe<ComponentSeo>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type ComponentSeoCursorCollection = {
-  __typename?: 'ComponentSeoCursorCollection';
+  __typename?: "ComponentSeoCursorCollection";
   items: Array<Maybe<ComponentSeo>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export type ComponentSeoFilter = {
   AND?: InputMaybe<Array<InputMaybe<ComponentSeoFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<ComponentSeoFilter>>>;
-  canonicalUrl?: InputMaybe<Scalars['String']['input']>;
-  canonicalUrl_contains?: InputMaybe<Scalars['String']['input']>;
-  canonicalUrl_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  canonicalUrl_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  canonicalUrl_not?: InputMaybe<Scalars['String']['input']>;
-  canonicalUrl_not_contains?: InputMaybe<Scalars['String']['input']>;
-  canonicalUrl_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  canonicalUrl?: InputMaybe<Scalars["String"]["input"]>;
+  canonicalUrl_contains?: InputMaybe<Scalars["String"]["input"]>;
+  canonicalUrl_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  canonicalUrl_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  canonicalUrl_not?: InputMaybe<Scalars["String"]["input"]>;
+  canonicalUrl_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  canonicalUrl_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  nofollow?: InputMaybe<Scalars['Boolean']['input']>;
-  nofollow_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  nofollow_not?: InputMaybe<Scalars['Boolean']['input']>;
-  noindex?: InputMaybe<Scalars['Boolean']['input']>;
-  noindex_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  noindex_not?: InputMaybe<Scalars['Boolean']['input']>;
-  pageDescription?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_contains?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageDescription_not?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageTitle?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_contains?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageTitle_not?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  shareImagesCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  nofollow?: InputMaybe<Scalars["Boolean"]["input"]>;
+  nofollow_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  nofollow_not?: InputMaybe<Scalars["Boolean"]["input"]>;
+  noindex?: InputMaybe<Scalars["Boolean"]["input"]>;
+  noindex_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  noindex_not?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageDescription?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageDescription_not?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageTitle?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageTitle_not?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  shareImagesCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
   sys?: InputMaybe<SysFilter>;
 };
 
 export type ComponentSeoLinkingCollections = {
-  __typename?: 'ComponentSeoLinkingCollections';
+  __typename?: "ComponentSeoLinkingCollections";
   componentReleaseNoteCollection?: Maybe<ComponentReleaseNoteCollection>;
   componentReleaseNoteCursorCollection?: Maybe<ComponentReleaseNoteCursorCollection>;
   entryCollection?: Maybe<EntryCollection>;
@@ -2882,257 +2793,257 @@ export type ComponentSeoLinkingCollections = {
   pageLandingCursorCollection?: Maybe<PageLandingCursorCollection>;
 };
 
-
 export type ComponentSeoLinkingCollectionsComponentReleaseNoteCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentSeoLinkingCollectionsComponentReleaseNoteCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentSeoLinkingCollectionsComponentReleaseNoteCollectionOrder>>
+  >;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentSeoLinkingCollectionsComponentReleaseNoteCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentSeoLinkingCollectionsComponentReleaseNoteCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentSeoLinkingCollectionsComponentReleaseNoteCursorCollectionOrder>>
+  >;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentSeoLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentSeoLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentSeoLinkingCollectionsPageBlogPostCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentSeoLinkingCollectionsPageBlogPostCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentSeoLinkingCollectionsPageBlogPostCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentSeoLinkingCollectionsPageBlogPostCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentSeoLinkingCollectionsPageBlogPostCursorCollectionOrder>>
+  >;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type ComponentSeoLinkingCollectionsPageLandingCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentSeoLinkingCollectionsPageLandingCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type ComponentSeoLinkingCollectionsPageLandingCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<ComponentSeoLinkingCollectionsPageLandingCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<ComponentSeoLinkingCollectionsPageLandingCursorCollectionOrder>>
+  >;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum ComponentSeoLinkingCollectionsComponentReleaseNoteCollectionOrder {
-  ActiveAsc = 'active_ASC',
-  ActiveDesc = 'active_DESC',
-  CategoryAsc = 'category_ASC',
-  CategoryDesc = 'category_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PublishedAtAsc = 'publishedAt_ASC',
-  PublishedAtDesc = 'publishedAt_DESC',
-  SlugAsc = 'slug_ASC',
-  SlugDesc = 'slug_DESC',
-  SummaryAsc = 'summary_ASC',
-  SummaryDesc = 'summary_DESC',
-  SurfacesAsc = 'surfaces_ASC',
-  SurfacesDesc = 'surfaces_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  ActiveAsc = "active_ASC",
+  ActiveDesc = "active_DESC",
+  CategoryAsc = "category_ASC",
+  CategoryDesc = "category_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PublishedAtAsc = "publishedAt_ASC",
+  PublishedAtDesc = "publishedAt_DESC",
+  SlugAsc = "slug_ASC",
+  SlugDesc = "slug_DESC",
+  SummaryAsc = "summary_ASC",
+  SummaryDesc = "summary_DESC",
+  SurfacesAsc = "surfaces_ASC",
+  SurfacesDesc = "surfaces_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentSeoLinkingCollectionsComponentReleaseNoteCursorCollectionOrder {
-  ActiveAsc = 'active_ASC',
-  ActiveDesc = 'active_DESC',
-  CategoryAsc = 'category_ASC',
-  CategoryDesc = 'category_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PublishedAtAsc = 'publishedAt_ASC',
-  PublishedAtDesc = 'publishedAt_DESC',
-  SlugAsc = 'slug_ASC',
-  SlugDesc = 'slug_DESC',
-  SummaryAsc = 'summary_ASC',
-  SummaryDesc = 'summary_DESC',
-  SurfacesAsc = 'surfaces_ASC',
-  SurfacesDesc = 'surfaces_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  ActiveAsc = "active_ASC",
+  ActiveDesc = "active_DESC",
+  CategoryAsc = "category_ASC",
+  CategoryDesc = "category_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PublishedAtAsc = "publishedAt_ASC",
+  PublishedAtDesc = "publishedAt_DESC",
+  SlugAsc = "slug_ASC",
+  SlugDesc = "slug_DESC",
+  SummaryAsc = "summary_ASC",
+  SummaryDesc = "summary_DESC",
+  SurfacesAsc = "surfaces_ASC",
+  SurfacesDesc = "surfaces_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentSeoLinkingCollectionsPageBlogPostCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PublishedDateAsc = 'publishedDate_ASC',
-  PublishedDateDesc = 'publishedDate_DESC',
-  SlugAsc = 'slug_ASC',
-  SlugDesc = 'slug_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PublishedDateAsc = "publishedDate_ASC",
+  PublishedDateDesc = "publishedDate_DESC",
+  SlugAsc = "slug_ASC",
+  SlugDesc = "slug_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentSeoLinkingCollectionsPageBlogPostCursorCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PublishedDateAsc = 'publishedDate_ASC',
-  PublishedDateDesc = 'publishedDate_DESC',
-  SlugAsc = 'slug_ASC',
-  SlugDesc = 'slug_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PublishedDateAsc = "publishedDate_ASC",
+  PublishedDateDesc = "publishedDate_DESC",
+  SlugAsc = "slug_ASC",
+  SlugDesc = "slug_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum ComponentSeoLinkingCollectionsPageLandingCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
 }
 
 export enum ComponentSeoLinkingCollectionsPageLandingCursorCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
 }
 
 export enum ComponentSeoOrder {
-  CanonicalUrlAsc = 'canonicalUrl_ASC',
-  CanonicalUrlDesc = 'canonicalUrl_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  NofollowAsc = 'nofollow_ASC',
-  NofollowDesc = 'nofollow_DESC',
-  NoindexAsc = 'noindex_ASC',
-  NoindexDesc = 'noindex_DESC',
-  PageTitleAsc = 'pageTitle_ASC',
-  PageTitleDesc = 'pageTitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  CanonicalUrlAsc = "canonicalUrl_ASC",
+  CanonicalUrlDesc = "canonicalUrl_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  NofollowAsc = "nofollow_ASC",
+  NofollowDesc = "nofollow_DESC",
+  NoindexAsc = "noindex_ASC",
+  NoindexDesc = "noindex_DESC",
+  PageTitleAsc = "pageTitle_ASC",
+  PageTitleDesc = "pageTitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
 }
 
 export type ContentfulMetadata = {
-  __typename?: 'ContentfulMetadata';
+  __typename?: "ContentfulMetadata";
   concepts: Array<Maybe<TaxonomyConcept>>;
   tags: Array<Maybe<ContentfulTag>>;
 };
 
 export type ContentfulMetadataConceptsDescendantsFilter = {
-  id_contains_all?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  id_contains_none?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  id_contains_some?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  id_contains_all?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  id_contains_none?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  id_contains_some?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type ContentfulMetadataConceptsFilter = {
   descendants?: InputMaybe<ContentfulMetadataConceptsDescendantsFilter>;
-  id_contains_all?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  id_contains_none?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  id_contains_some?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  id_contains_all?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  id_contains_none?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  id_contains_some?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type ContentfulMetadataFilter = {
   concepts?: InputMaybe<ContentfulMetadataConceptsFilter>;
-  concepts_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  concepts_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
   tags?: InputMaybe<ContentfulMetadataTagsFilter>;
-  tags_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  tags_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type ContentfulMetadataTagsFilter = {
-  id_contains_all?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  id_contains_none?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  id_contains_some?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  id_contains_all?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  id_contains_none?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  id_contains_some?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 /**
@@ -3140,15 +3051,15 @@ export type ContentfulMetadataTagsFilter = {
  *       Find out more here: https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/content-tags
  */
 export type ContentfulTag = {
-  __typename?: 'ContentfulTag';
-  id?: Maybe<Scalars['String']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
+  __typename?: "ContentfulTag";
+  id?: Maybe<Scalars["String"]["output"]>;
+  name?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type CursorPages = {
-  __typename?: 'CursorPages';
-  next?: Maybe<Scalars['String']['output']>;
-  prev?: Maybe<Scalars['String']['output']>;
+  __typename?: "CursorPages";
+  next?: Maybe<Scalars["String"]["output"]>;
+  prev?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type Entry = {
@@ -3157,17 +3068,17 @@ export type Entry = {
 };
 
 export type EntryCollection = {
-  __typename?: 'EntryCollection';
+  __typename?: "EntryCollection";
   items: Array<Maybe<Entry>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type EntryCursorCollection = {
-  __typename?: 'EntryCursorCollection';
+  __typename?: "EntryCursorCollection";
   items: Array<Maybe<Entry>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
@@ -3179,428 +3090,415 @@ export type EntryFilter = {
 };
 
 export enum EntryOrder {
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
-export type Footer = Entry & _Node & {
-  __typename?: 'Footer';
-  _id: Scalars['ID']['output'];
-  badge?: Maybe<Scalars['String']['output']>;
-  brand?: Maybe<Scalars['String']['output']>;
-  contentfulMetadata: ContentfulMetadata;
-  copyright?: Maybe<Scalars['String']['output']>;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<FooterLinkingCollections>;
-  menuButtonsCollection?: Maybe<FooterMenuButtonsCollection>;
-  menuButtonsCursorCollection?: Maybe<FooterMenuButtonsCursorCollection>;
-  menuTitle?: Maybe<Scalars['String']['output']>;
-  supportButtonsCollection?: Maybe<FooterSupportButtonsCollection>;
-  supportButtonsCursorCollection?: Maybe<FooterSupportButtonsCursorCollection>;
-  supportTitle?: Maybe<Scalars['String']['output']>;
-  sys: Sys;
-  title?: Maybe<Scalars['String']['output']>;
-};
-
+export type Footer = Entry &
+  _Node & {
+    __typename?: "Footer";
+    _id: Scalars["ID"]["output"];
+    badge?: Maybe<Scalars["String"]["output"]>;
+    brand?: Maybe<Scalars["String"]["output"]>;
+    contentfulMetadata: ContentfulMetadata;
+    copyright?: Maybe<Scalars["String"]["output"]>;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<FooterLinkingCollections>;
+    menuButtonsCollection?: Maybe<FooterMenuButtonsCollection>;
+    menuButtonsCursorCollection?: Maybe<FooterMenuButtonsCursorCollection>;
+    menuTitle?: Maybe<Scalars["String"]["output"]>;
+    supportButtonsCollection?: Maybe<FooterSupportButtonsCollection>;
+    supportButtonsCursorCollection?: Maybe<FooterSupportButtonsCursorCollection>;
+    supportTitle?: Maybe<Scalars["String"]["output"]>;
+    sys: Sys;
+    title?: Maybe<Scalars["String"]["output"]>;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterBadgeArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterBrandArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterCopyrightArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterMenuButtonsCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<FooterMenuButtonsCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterMenuButtonsCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<FooterMenuButtonsCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterMenuTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterSupportButtonsCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<FooterSupportButtonsCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterSupportButtonsCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<FooterSupportButtonsCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
 
-
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterSupportTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/footer) */
 export type FooterTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type FooterCollection = {
-  __typename?: 'FooterCollection';
+  __typename?: "FooterCollection";
   items: Array<Maybe<Footer>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type FooterCursorCollection = {
-  __typename?: 'FooterCursorCollection';
+  __typename?: "FooterCursorCollection";
   items: Array<Maybe<Footer>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export type FooterFilter = {
   AND?: InputMaybe<Array<InputMaybe<FooterFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<FooterFilter>>>;
-  badge?: InputMaybe<Scalars['String']['input']>;
-  badge_contains?: InputMaybe<Scalars['String']['input']>;
-  badge_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  badge_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  badge_not?: InputMaybe<Scalars['String']['input']>;
-  badge_not_contains?: InputMaybe<Scalars['String']['input']>;
-  badge_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  brand?: InputMaybe<Scalars['String']['input']>;
-  brand_contains?: InputMaybe<Scalars['String']['input']>;
-  brand_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  brand_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  brand_not?: InputMaybe<Scalars['String']['input']>;
-  brand_not_contains?: InputMaybe<Scalars['String']['input']>;
-  brand_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  badge?: InputMaybe<Scalars["String"]["input"]>;
+  badge_contains?: InputMaybe<Scalars["String"]["input"]>;
+  badge_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  badge_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  badge_not?: InputMaybe<Scalars["String"]["input"]>;
+  badge_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  badge_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  brand?: InputMaybe<Scalars["String"]["input"]>;
+  brand_contains?: InputMaybe<Scalars["String"]["input"]>;
+  brand_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  brand_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  brand_not?: InputMaybe<Scalars["String"]["input"]>;
+  brand_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  brand_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  copyright?: InputMaybe<Scalars['String']['input']>;
-  copyright_contains?: InputMaybe<Scalars['String']['input']>;
-  copyright_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  copyright_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  copyright_not?: InputMaybe<Scalars['String']['input']>;
-  copyright_not_contains?: InputMaybe<Scalars['String']['input']>;
-  copyright_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  copyright?: InputMaybe<Scalars["String"]["input"]>;
+  copyright_contains?: InputMaybe<Scalars["String"]["input"]>;
+  copyright_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  copyright_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  copyright_not?: InputMaybe<Scalars["String"]["input"]>;
+  copyright_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  copyright_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   menuButtons?: InputMaybe<CfComponentButtonNestedFilter>;
-  menuButtonsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  menuTitle?: InputMaybe<Scalars['String']['input']>;
-  menuTitle_contains?: InputMaybe<Scalars['String']['input']>;
-  menuTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  menuTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  menuTitle_not?: InputMaybe<Scalars['String']['input']>;
-  menuTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  menuTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  menuButtonsCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  menuTitle?: InputMaybe<Scalars["String"]["input"]>;
+  menuTitle_contains?: InputMaybe<Scalars["String"]["input"]>;
+  menuTitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  menuTitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  menuTitle_not?: InputMaybe<Scalars["String"]["input"]>;
+  menuTitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  menuTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   supportButtons?: InputMaybe<CfComponentButtonNestedFilter>;
-  supportButtonsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  supportTitle?: InputMaybe<Scalars['String']['input']>;
-  supportTitle_contains?: InputMaybe<Scalars['String']['input']>;
-  supportTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  supportTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  supportTitle_not?: InputMaybe<Scalars['String']['input']>;
-  supportTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  supportTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  supportButtonsCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  supportTitle?: InputMaybe<Scalars["String"]["input"]>;
+  supportTitle_contains?: InputMaybe<Scalars["String"]["input"]>;
+  supportTitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  supportTitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  supportTitle_not?: InputMaybe<Scalars["String"]["input"]>;
+  supportTitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  supportTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type FooterLinkingCollections = {
-  __typename?: 'FooterLinkingCollections';
+  __typename?: "FooterLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
-
 export type FooterLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type FooterLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type FooterMenuButtonsCollection = {
-  __typename?: 'FooterMenuButtonsCollection';
+  __typename?: "FooterMenuButtonsCollection";
   items: Array<Maybe<ComponentButton>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export enum FooterMenuButtonsCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  LabelAsc = 'label_ASC',
-  LabelDesc = 'label_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  UrlAsc = 'url_ASC',
-  UrlDesc = 'url_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  LabelAsc = "label_ASC",
+  LabelDesc = "label_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  UrlAsc = "url_ASC",
+  UrlDesc = "url_DESC",
 }
 
 export type FooterMenuButtonsCursorCollection = {
-  __typename?: 'FooterMenuButtonsCursorCollection';
+  __typename?: "FooterMenuButtonsCursorCollection";
   items: Array<Maybe<ComponentButton>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export enum FooterMenuButtonsCursorCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  LabelAsc = 'label_ASC',
-  LabelDesc = 'label_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  UrlAsc = 'url_ASC',
-  UrlDesc = 'url_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  LabelAsc = "label_ASC",
+  LabelDesc = "label_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  UrlAsc = "url_ASC",
+  UrlDesc = "url_DESC",
 }
 
 export enum FooterOrder {
-  BadgeAsc = 'badge_ASC',
-  BadgeDesc = 'badge_DESC',
-  BrandAsc = 'brand_ASC',
-  BrandDesc = 'brand_DESC',
-  CopyrightAsc = 'copyright_ASC',
-  CopyrightDesc = 'copyright_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  MenuTitleAsc = 'menuTitle_ASC',
-  MenuTitleDesc = 'menuTitle_DESC',
-  SupportTitleAsc = 'supportTitle_ASC',
-  SupportTitleDesc = 'supportTitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  BadgeAsc = "badge_ASC",
+  BadgeDesc = "badge_DESC",
+  BrandAsc = "brand_ASC",
+  BrandDesc = "brand_DESC",
+  CopyrightAsc = "copyright_ASC",
+  CopyrightDesc = "copyright_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  MenuTitleAsc = "menuTitle_ASC",
+  MenuTitleDesc = "menuTitle_DESC",
+  SupportTitleAsc = "supportTitle_ASC",
+  SupportTitleDesc = "supportTitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export type FooterSupportButtonsCollection = {
-  __typename?: 'FooterSupportButtonsCollection';
+  __typename?: "FooterSupportButtonsCollection";
   items: Array<Maybe<ComponentButton>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export enum FooterSupportButtonsCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  LabelAsc = 'label_ASC',
-  LabelDesc = 'label_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  UrlAsc = 'url_ASC',
-  UrlDesc = 'url_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  LabelAsc = "label_ASC",
+  LabelDesc = "label_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  UrlAsc = "url_ASC",
+  UrlDesc = "url_DESC",
 }
 
 export type FooterSupportButtonsCursorCollection = {
-  __typename?: 'FooterSupportButtonsCursorCollection';
+  __typename?: "FooterSupportButtonsCursorCollection";
   items: Array<Maybe<ComponentButton>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export enum FooterSupportButtonsCursorCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  LabelAsc = 'label_ASC',
-  LabelDesc = 'label_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  UrlAsc = 'url_ASC',
-  UrlDesc = 'url_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  LabelAsc = "label_ASC",
+  LabelDesc = "label_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  UrlAsc = "url_ASC",
+  UrlDesc = "url_DESC",
 }
 
 export enum ImageFormat {
   /** AVIF image format. */
-  Avif = 'AVIF',
+  Avif = "AVIF",
   /** JPG image format. */
-  Jpg = 'JPG',
+  Jpg = "JPG",
   /**
    * Progressive JPG format stores multiple passes of an image in progressively higher detail.
    *         When a progressive image is loading, the viewer will first see a lower quality pixelated version which
    *         will gradually improve in detail, until the image is fully downloaded. This is to display an image as
    *         early as possible to make the layout look as designed.
    */
-  JpgProgressive = 'JPG_PROGRESSIVE',
+  JpgProgressive = "JPG_PROGRESSIVE",
   /** PNG image format */
-  Png = 'PNG',
+  Png = "PNG",
   /**
    * 8-bit PNG images support up to 256 colors and weigh less than the standard 24-bit PNG equivalent.
    *         The 8-bit PNG format is mostly used for simple images, such as icons or logos.
    */
-  Png8 = 'PNG8',
+  Png8 = "PNG8",
   /** WebP image format. */
-  Webp = 'WEBP'
+  Webp = "WEBP",
 }
 
 export enum ImageResizeFocus {
   /** Focus the resizing on the bottom. */
-  Bottom = 'BOTTOM',
+  Bottom = "BOTTOM",
   /** Focus the resizing on the bottom left. */
-  BottomLeft = 'BOTTOM_LEFT',
+  BottomLeft = "BOTTOM_LEFT",
   /** Focus the resizing on the bottom right. */
-  BottomRight = 'BOTTOM_RIGHT',
+  BottomRight = "BOTTOM_RIGHT",
   /** Focus the resizing on the center. */
-  Center = 'CENTER',
+  Center = "CENTER",
   /** Focus the resizing on the largest face. */
-  Face = 'FACE',
+  Face = "FACE",
   /** Focus the resizing on the area containing all the faces. */
-  Faces = 'FACES',
+  Faces = "FACES",
   /** Focus the resizing on the left. */
-  Left = 'LEFT',
+  Left = "LEFT",
   /** Focus the resizing on the right. */
-  Right = 'RIGHT',
+  Right = "RIGHT",
   /** Focus the resizing on the top. */
-  Top = 'TOP',
+  Top = "TOP",
   /** Focus the resizing on the top left. */
-  TopLeft = 'TOP_LEFT',
+  TopLeft = "TOP_LEFT",
   /** Focus the resizing on the top right. */
-  TopRight = 'TOP_RIGHT'
+  TopRight = "TOP_RIGHT",
 }
 
 export enum ImageResizeStrategy {
   /** Crops a part of the original image to fit into the specified dimensions. */
-  Crop = 'CROP',
+  Crop = "CROP",
   /** Resizes the image to the specified dimensions, cropping the image if needed. */
-  Fill = 'FILL',
+  Fill = "FILL",
   /** Resizes the image to fit into the specified dimensions. */
-  Fit = 'FIT',
+  Fit = "FIT",
   /**
    * Resizes the image to the specified dimensions, padding the image if needed.
    *         Uses desired background color as padding color.
    */
-  Pad = 'PAD',
+  Pad = "PAD",
   /** Resizes the image to the specified dimensions, changing the original aspect ratio if needed. */
-  Scale = 'SCALE',
+  Scale = "SCALE",
   /** Creates a thumbnail from the image. */
-  Thumb = 'THUMB'
+  Thumb = "THUMB",
 }
 
 export type ImageTransformOptions = {
@@ -3608,82 +3506,79 @@ export type ImageTransformOptions = {
    * Desired background color, used with corner radius or `PAD` resize strategy.
    *         Defaults to transparent (for `PNG`, `PNG8` and `WEBP`) or white (for `JPG` and `JPG_PROGRESSIVE`).
    */
-  backgroundColor?: InputMaybe<Scalars['HexColor']['input']>;
+  backgroundColor?: InputMaybe<Scalars["HexColor"]["input"]>;
   /**
    * Desired corner radius in pixels.
    *         Results in an image with rounded corners (pass `-1` for a full circle/ellipse).
    *         Defaults to `0`. Uses desired background color as padding color,
    *         unless the format is `JPG` or `JPG_PROGRESSIVE` and resize strategy is `PAD`, then defaults to white.
    */
-  cornerRadius?: InputMaybe<Scalars['Int']['input']>;
+  cornerRadius?: InputMaybe<Scalars["Int"]["input"]>;
   /** Desired image format. Defaults to the original image format. */
   format?: InputMaybe<ImageFormat>;
   /** Desired height in pixels. Defaults to the original image height. */
-  height?: InputMaybe<Scalars['Dimension']['input']>;
+  height?: InputMaybe<Scalars["Dimension"]["input"]>;
   /**
    * Desired quality of the image in percents.
    *         Used for `PNG8`, `JPG`, `JPG_PROGRESSIVE` and `WEBP` formats.
    */
-  quality?: InputMaybe<Scalars['Quality']['input']>;
+  quality?: InputMaybe<Scalars["Quality"]["input"]>;
   /** Desired resize focus area. Defaults to `CENTER`. */
   resizeFocus?: InputMaybe<ImageResizeFocus>;
   /** Desired resize strategy. Defaults to `FIT`. */
   resizeStrategy?: InputMaybe<ImageResizeStrategy>;
   /** Desired width in pixels. Defaults to the original image width. */
-  width?: InputMaybe<Scalars['Dimension']['input']>;
+  width?: InputMaybe<Scalars["Dimension"]["input"]>;
 };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/landingMetadata) */
-export type LandingMetadata = Entry & _Node & {
-  __typename?: 'LandingMetadata';
-  _id: Scalars['ID']['output'];
-  contentfulMetadata: ContentfulMetadata;
-  description?: Maybe<Scalars['String']['output']>;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<LandingMetadataLinkingCollections>;
-  sys: Sys;
-  title?: Maybe<Scalars['String']['output']>;
-};
-
+export type LandingMetadata = Entry &
+  _Node & {
+    __typename?: "LandingMetadata";
+    _id: Scalars["ID"]["output"];
+    contentfulMetadata: ContentfulMetadata;
+    description?: Maybe<Scalars["String"]["output"]>;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<LandingMetadataLinkingCollections>;
+    sys: Sys;
+    title?: Maybe<Scalars["String"]["output"]>;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/landingMetadata) */
 export type LandingMetadataDescriptionArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/landingMetadata) */
 export type LandingMetadataInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/landingMetadata) */
 export type LandingMetadataLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/landingMetadata) */
 export type LandingMetadataTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type LandingMetadataCollection = {
-  __typename?: 'LandingMetadataCollection';
+  __typename?: "LandingMetadataCollection";
   items: Array<Maybe<LandingMetadata>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type LandingMetadataCursorCollection = {
-  __typename?: 'LandingMetadataCursorCollection';
+  __typename?: "LandingMetadataCursorCollection";
   items: Array<Maybe<LandingMetadata>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
@@ -3691,196 +3586,188 @@ export type LandingMetadataFilter = {
   AND?: InputMaybe<Array<InputMaybe<LandingMetadataFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<LandingMetadataFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  description?: InputMaybe<Scalars['String']['input']>;
-  description_contains?: InputMaybe<Scalars['String']['input']>;
-  description_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  description_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  description_not?: InputMaybe<Scalars['String']['input']>;
-  description_not_contains?: InputMaybe<Scalars['String']['input']>;
-  description_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  description?: InputMaybe<Scalars["String"]["input"]>;
+  description_contains?: InputMaybe<Scalars["String"]["input"]>;
+  description_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  description_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  description_not?: InputMaybe<Scalars["String"]["input"]>;
+  description_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  description_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type LandingMetadataLinkingCollections = {
-  __typename?: 'LandingMetadataLinkingCollections';
+  __typename?: "LandingMetadataLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
-
 export type LandingMetadataLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type LandingMetadataLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum LandingMetadataOrder {
-  DescriptionAsc = 'description_ASC',
-  DescriptionDesc = 'description_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  DescriptionAsc = "description_ASC",
+  DescriptionDesc = "description_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageAbout) */
-export type PageAbout = Entry & _Node & {
-  __typename?: 'PageAbout';
-  _id: Scalars['ID']['output'];
-  contentfulMetadata: ContentfulMetadata;
-  description?: Maybe<PageAboutDescription>;
-  image?: Maybe<Asset>;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<PageAboutLinkingCollections>;
-  pageDescription?: Maybe<Scalars['String']['output']>;
-  pageTitle?: Maybe<Scalars['String']['output']>;
-  sys: Sys;
-  title?: Maybe<Scalars['String']['output']>;
-};
-
+export type PageAbout = Entry &
+  _Node & {
+    __typename?: "PageAbout";
+    _id: Scalars["ID"]["output"];
+    contentfulMetadata: ContentfulMetadata;
+    description?: Maybe<PageAboutDescription>;
+    image?: Maybe<Asset>;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<PageAboutLinkingCollections>;
+    pageDescription?: Maybe<Scalars["String"]["output"]>;
+    pageTitle?: Maybe<Scalars["String"]["output"]>;
+    sys: Sys;
+    title?: Maybe<Scalars["String"]["output"]>;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageAbout) */
 export type PageAboutDescriptionArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageAbout) */
 export type PageAboutImageArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageAbout) */
 export type PageAboutInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageAbout) */
 export type PageAboutLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageAbout) */
 export type PageAboutPageDescriptionArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageAbout) */
 export type PageAboutPageTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageAbout) */
 export type PageAboutTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type PageAboutCollection = {
-  __typename?: 'PageAboutCollection';
+  __typename?: "PageAboutCollection";
   items: Array<Maybe<PageAbout>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type PageAboutCursorCollection = {
-  __typename?: 'PageAboutCursorCollection';
+  __typename?: "PageAboutCursorCollection";
   items: Array<Maybe<PageAbout>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export type PageAboutDescription = {
-  __typename?: 'PageAboutDescription';
-  json: Scalars['JSON']['output'];
+  __typename?: "PageAboutDescription";
+  json: Scalars["JSON"]["output"];
   links: PageAboutDescriptionLinks;
 };
 
 export type PageAboutDescriptionAssets = {
-  __typename?: 'PageAboutDescriptionAssets';
+  __typename?: "PageAboutDescriptionAssets";
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type PageAboutDescriptionEntries = {
-  __typename?: 'PageAboutDescriptionEntries';
+  __typename?: "PageAboutDescriptionEntries";
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type PageAboutDescriptionLinks = {
-  __typename?: 'PageAboutDescriptionLinks';
+  __typename?: "PageAboutDescriptionLinks";
   assets: PageAboutDescriptionAssets;
   entries: PageAboutDescriptionEntries;
   resources: PageAboutDescriptionResources;
 };
 
 export type PageAboutDescriptionResources = {
-  __typename?: 'PageAboutDescriptionResources';
+  __typename?: "PageAboutDescriptionResources";
   block: Array<PageAboutDescriptionResourcesBlock>;
   hyperlink: Array<PageAboutDescriptionResourcesHyperlink>;
   inline: Array<PageAboutDescriptionResourcesInline>;
 };
 
 export type PageAboutDescriptionResourcesBlock = ResourceLink & {
-  __typename?: 'PageAboutDescriptionResourcesBlock';
+  __typename?: "PageAboutDescriptionResourcesBlock";
   sys: ResourceSys;
 };
 
 export type PageAboutDescriptionResourcesHyperlink = ResourceLink & {
-  __typename?: 'PageAboutDescriptionResourcesHyperlink';
+  __typename?: "PageAboutDescriptionResourcesHyperlink";
   sys: ResourceSys;
 };
 
 export type PageAboutDescriptionResourcesInline = ResourceLink & {
-  __typename?: 'PageAboutDescriptionResourcesInline';
+  __typename?: "PageAboutDescriptionResourcesInline";
   sys: ResourceSys;
 };
 
@@ -3888,264 +3775,251 @@ export type PageAboutFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageAboutFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageAboutFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  description_contains?: InputMaybe<Scalars['String']['input']>;
-  description_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  description_not_contains?: InputMaybe<Scalars['String']['input']>;
-  image_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageDescription?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_contains?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageDescription_not?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageTitle?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_contains?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageTitle_not?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  description_contains?: InputMaybe<Scalars["String"]["input"]>;
+  description_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  description_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  image_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageDescription?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageDescription_not?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageTitle?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageTitle_not?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type PageAboutLinkingCollections = {
-  __typename?: 'PageAboutLinkingCollections';
+  __typename?: "PageAboutLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
-
 export type PageAboutLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type PageAboutLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum PageAboutOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PageDescriptionAsc = 'pageDescription_ASC',
-  PageDescriptionDesc = 'pageDescription_DESC',
-  PageTitleAsc = 'pageTitle_ASC',
-  PageTitleDesc = 'pageTitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PageDescriptionAsc = "pageDescription_ASC",
+  PageDescriptionDesc = "pageDescription_DESC",
+  PageTitleAsc = "pageTitle_ASC",
+  PageTitleDesc = "pageTitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
-export type PageBlogPost = Entry & _Node & {
-  __typename?: 'PageBlogPost';
-  _id: Scalars['ID']['output'];
-  author?: Maybe<ComponentAuthor>;
-  content?: Maybe<PageBlogPostContent>;
-  contentfulMetadata: ContentfulMetadata;
-  featuredImage?: Maybe<Asset>;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<PageBlogPostLinkingCollections>;
-  publishedDate?: Maybe<Scalars['DateTime']['output']>;
-  relatedBlogPostsCollection?: Maybe<PageBlogPostRelatedBlogPostsCollection>;
-  relatedBlogPostsCursorCollection?: Maybe<PageBlogPostRelatedBlogPostsCursorCollection>;
-  seoFields?: Maybe<ComponentSeo>;
-  shortDescription?: Maybe<Scalars['String']['output']>;
-  slug?: Maybe<Scalars['String']['output']>;
-  sys: Sys;
-  title?: Maybe<Scalars['String']['output']>;
-};
-
+export type PageBlogPost = Entry &
+  _Node & {
+    __typename?: "PageBlogPost";
+    _id: Scalars["ID"]["output"];
+    author?: Maybe<ComponentAuthor>;
+    content?: Maybe<PageBlogPostContent>;
+    contentfulMetadata: ContentfulMetadata;
+    featuredImage?: Maybe<Asset>;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<PageBlogPostLinkingCollections>;
+    publishedDate?: Maybe<Scalars["DateTime"]["output"]>;
+    relatedBlogPostsCollection?: Maybe<PageBlogPostRelatedBlogPostsCollection>;
+    relatedBlogPostsCursorCollection?: Maybe<PageBlogPostRelatedBlogPostsCursorCollection>;
+    seoFields?: Maybe<ComponentSeo>;
+    shortDescription?: Maybe<Scalars["String"]["output"]>;
+    slug?: Maybe<Scalars["String"]["output"]>;
+    sys: Sys;
+    title?: Maybe<Scalars["String"]["output"]>;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostAuthorArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentAuthorFilter>;
 };
 
-
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostContentArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostFeaturedImageArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostPublishedDateArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostRelatedBlogPostsCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageBlogPostRelatedBlogPostsCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageBlogPostFilter>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostRelatedBlogPostsCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageBlogPostRelatedBlogPostsCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageBlogPostFilter>;
 };
 
-
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostSeoFieldsArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentSeoFilter>;
 };
 
-
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostShortDescriptionArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostSlugArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageBlogPost) */
 export type PageBlogPostTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type PageBlogPostCollection = {
-  __typename?: 'PageBlogPostCollection';
+  __typename?: "PageBlogPostCollection";
   items: Array<Maybe<PageBlogPost>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type PageBlogPostContent = {
-  __typename?: 'PageBlogPostContent';
-  json: Scalars['JSON']['output'];
+  __typename?: "PageBlogPostContent";
+  json: Scalars["JSON"]["output"];
   links: PageBlogPostContentLinks;
 };
 
 export type PageBlogPostContentAssets = {
-  __typename?: 'PageBlogPostContentAssets';
+  __typename?: "PageBlogPostContentAssets";
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type PageBlogPostContentEntries = {
-  __typename?: 'PageBlogPostContentEntries';
+  __typename?: "PageBlogPostContentEntries";
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type PageBlogPostContentLinks = {
-  __typename?: 'PageBlogPostContentLinks';
+  __typename?: "PageBlogPostContentLinks";
   assets: PageBlogPostContentAssets;
   entries: PageBlogPostContentEntries;
   resources: PageBlogPostContentResources;
 };
 
 export type PageBlogPostContentResources = {
-  __typename?: 'PageBlogPostContentResources';
+  __typename?: "PageBlogPostContentResources";
   block: Array<PageBlogPostContentResourcesBlock>;
   hyperlink: Array<PageBlogPostContentResourcesHyperlink>;
   inline: Array<PageBlogPostContentResourcesInline>;
 };
 
 export type PageBlogPostContentResourcesBlock = ResourceLink & {
-  __typename?: 'PageBlogPostContentResourcesBlock';
+  __typename?: "PageBlogPostContentResourcesBlock";
   sys: ResourceSys;
 };
 
 export type PageBlogPostContentResourcesHyperlink = ResourceLink & {
-  __typename?: 'PageBlogPostContentResourcesHyperlink';
+  __typename?: "PageBlogPostContentResourcesHyperlink";
   sys: ResourceSys;
 };
 
 export type PageBlogPostContentResourcesInline = ResourceLink & {
-  __typename?: 'PageBlogPostContentResourcesInline';
+  __typename?: "PageBlogPostContentResourcesInline";
   sys: ResourceSys;
 };
 
 export type PageBlogPostCursorCollection = {
-  __typename?: 'PageBlogPostCursorCollection';
+  __typename?: "PageBlogPostCursorCollection";
   items: Array<Maybe<PageBlogPost>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
@@ -4153,58 +4027,58 @@ export type PageBlogPostFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageBlogPostFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageBlogPostFilter>>>;
   author?: InputMaybe<CfComponentAuthorNestedFilter>;
-  author_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  content_contains?: InputMaybe<Scalars['String']['input']>;
-  content_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  content_not_contains?: InputMaybe<Scalars['String']['input']>;
+  author_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  content_contains?: InputMaybe<Scalars["String"]["input"]>;
+  content_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  content_not_contains?: InputMaybe<Scalars["String"]["input"]>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  featuredImage_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  publishedDate?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedDate_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  publishedDate_gt?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedDate_gte?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedDate_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
-  publishedDate_lt?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedDate_lte?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedDate_not?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedDate_not_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
+  featuredImage_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  publishedDate?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedDate_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  publishedDate_gt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedDate_gte?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedDate_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
+  publishedDate_lt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedDate_lte?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedDate_not?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedDate_not_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
   relatedBlogPosts?: InputMaybe<CfPageBlogPostNestedFilter>;
-  relatedBlogPostsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  relatedBlogPostsCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
   seoFields?: InputMaybe<CfComponentSeoNestedFilter>;
-  seoFields_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  shortDescription?: InputMaybe<Scalars['String']['input']>;
-  shortDescription_contains?: InputMaybe<Scalars['String']['input']>;
-  shortDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  shortDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  shortDescription_not?: InputMaybe<Scalars['String']['input']>;
-  shortDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
-  shortDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  slug?: InputMaybe<Scalars['String']['input']>;
-  slug_contains?: InputMaybe<Scalars['String']['input']>;
-  slug_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  slug_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  slug_not?: InputMaybe<Scalars['String']['input']>;
-  slug_not_contains?: InputMaybe<Scalars['String']['input']>;
-  slug_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  seoFields_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  shortDescription?: InputMaybe<Scalars["String"]["input"]>;
+  shortDescription_contains?: InputMaybe<Scalars["String"]["input"]>;
+  shortDescription_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  shortDescription_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  shortDescription_not?: InputMaybe<Scalars["String"]["input"]>;
+  shortDescription_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  shortDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  slug?: InputMaybe<Scalars["String"]["input"]>;
+  slug_contains?: InputMaybe<Scalars["String"]["input"]>;
+  slug_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  slug_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  slug_not?: InputMaybe<Scalars["String"]["input"]>;
+  slug_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  slug_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type PageBlogPostLinkingCollections = {
-  __typename?: 'PageBlogPostLinkingCollections';
+  __typename?: "PageBlogPostLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
   pageBlogPostCollection?: Maybe<PageBlogPostCollection>;
@@ -4213,511 +4087,499 @@ export type PageBlogPostLinkingCollections = {
   pageLandingCursorCollection?: Maybe<PageLandingCursorCollection>;
 };
 
-
 export type PageBlogPostLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type PageBlogPostLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type PageBlogPostLinkingCollectionsPageBlogPostCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageBlogPostLinkingCollectionsPageBlogPostCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type PageBlogPostLinkingCollectionsPageBlogPostCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<PageBlogPostLinkingCollectionsPageBlogPostCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<PageBlogPostLinkingCollectionsPageBlogPostCursorCollectionOrder>>
+  >;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type PageBlogPostLinkingCollectionsPageLandingCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageBlogPostLinkingCollectionsPageLandingCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type PageBlogPostLinkingCollectionsPageLandingCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  order?: InputMaybe<Array<InputMaybe<PageBlogPostLinkingCollectionsPageLandingCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  order?: InputMaybe<
+    Array<InputMaybe<PageBlogPostLinkingCollectionsPageLandingCursorCollectionOrder>>
+  >;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum PageBlogPostLinkingCollectionsPageBlogPostCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PublishedDateAsc = 'publishedDate_ASC',
-  PublishedDateDesc = 'publishedDate_DESC',
-  SlugAsc = 'slug_ASC',
-  SlugDesc = 'slug_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PublishedDateAsc = "publishedDate_ASC",
+  PublishedDateDesc = "publishedDate_DESC",
+  SlugAsc = "slug_ASC",
+  SlugDesc = "slug_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum PageBlogPostLinkingCollectionsPageBlogPostCursorCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PublishedDateAsc = 'publishedDate_ASC',
-  PublishedDateDesc = 'publishedDate_DESC',
-  SlugAsc = 'slug_ASC',
-  SlugDesc = 'slug_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PublishedDateAsc = "publishedDate_ASC",
+  PublishedDateDesc = "publishedDate_DESC",
+  SlugAsc = "slug_ASC",
+  SlugDesc = "slug_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export enum PageBlogPostLinkingCollectionsPageLandingCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
 }
 
 export enum PageBlogPostLinkingCollectionsPageLandingCursorCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
 }
 
 export enum PageBlogPostOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PublishedDateAsc = 'publishedDate_ASC',
-  PublishedDateDesc = 'publishedDate_DESC',
-  SlugAsc = 'slug_ASC',
-  SlugDesc = 'slug_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PublishedDateAsc = "publishedDate_ASC",
+  PublishedDateDesc = "publishedDate_DESC",
+  SlugAsc = "slug_ASC",
+  SlugDesc = "slug_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export type PageBlogPostRelatedBlogPostsCollection = {
-  __typename?: 'PageBlogPostRelatedBlogPostsCollection';
+  __typename?: "PageBlogPostRelatedBlogPostsCollection";
   items: Array<Maybe<PageBlogPost>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export enum PageBlogPostRelatedBlogPostsCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PublishedDateAsc = 'publishedDate_ASC',
-  PublishedDateDesc = 'publishedDate_DESC',
-  SlugAsc = 'slug_ASC',
-  SlugDesc = 'slug_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PublishedDateAsc = "publishedDate_ASC",
+  PublishedDateDesc = "publishedDate_DESC",
+  SlugAsc = "slug_ASC",
+  SlugDesc = "slug_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export type PageBlogPostRelatedBlogPostsCursorCollection = {
-  __typename?: 'PageBlogPostRelatedBlogPostsCursorCollection';
+  __typename?: "PageBlogPostRelatedBlogPostsCursorCollection";
   items: Array<Maybe<PageBlogPost>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export enum PageBlogPostRelatedBlogPostsCursorCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PublishedDateAsc = 'publishedDate_ASC',
-  PublishedDateDesc = 'publishedDate_DESC',
-  SlugAsc = 'slug_ASC',
-  SlugDesc = 'slug_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PublishedDateAsc = "publishedDate_ASC",
+  PublishedDateDesc = "publishedDate_DESC",
+  SlugAsc = "slug_ASC",
+  SlugDesc = "slug_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageCookiePolicy) */
-export type PageCookiePolicy = Entry & _Node & {
-  __typename?: 'PageCookiePolicy';
-  _id: Scalars['ID']['output'];
-  content?: Maybe<PageCookiePolicyContent>;
-  contentfulMetadata: ContentfulMetadata;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<PageCookiePolicyLinkingCollections>;
-  pageDescription?: Maybe<Scalars['String']['output']>;
-  pageTitle?: Maybe<Scalars['String']['output']>;
-  sys: Sys;
-  title?: Maybe<Scalars['String']['output']>;
-};
-
+export type PageCookiePolicy = Entry &
+  _Node & {
+    __typename?: "PageCookiePolicy";
+    _id: Scalars["ID"]["output"];
+    content?: Maybe<PageCookiePolicyContent>;
+    contentfulMetadata: ContentfulMetadata;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<PageCookiePolicyLinkingCollections>;
+    pageDescription?: Maybe<Scalars["String"]["output"]>;
+    pageTitle?: Maybe<Scalars["String"]["output"]>;
+    sys: Sys;
+    title?: Maybe<Scalars["String"]["output"]>;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageCookiePolicy) */
 export type PageCookiePolicyContentArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageCookiePolicy) */
 export type PageCookiePolicyInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageCookiePolicy) */
 export type PageCookiePolicyLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageCookiePolicy) */
 export type PageCookiePolicyPageDescriptionArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageCookiePolicy) */
 export type PageCookiePolicyPageTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageCookiePolicy) */
 export type PageCookiePolicyTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type PageCookiePolicyCollection = {
-  __typename?: 'PageCookiePolicyCollection';
+  __typename?: "PageCookiePolicyCollection";
   items: Array<Maybe<PageCookiePolicy>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type PageCookiePolicyContent = {
-  __typename?: 'PageCookiePolicyContent';
-  json: Scalars['JSON']['output'];
+  __typename?: "PageCookiePolicyContent";
+  json: Scalars["JSON"]["output"];
   links: PageCookiePolicyContentLinks;
 };
 
 export type PageCookiePolicyContentAssets = {
-  __typename?: 'PageCookiePolicyContentAssets';
+  __typename?: "PageCookiePolicyContentAssets";
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type PageCookiePolicyContentEntries = {
-  __typename?: 'PageCookiePolicyContentEntries';
+  __typename?: "PageCookiePolicyContentEntries";
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type PageCookiePolicyContentLinks = {
-  __typename?: 'PageCookiePolicyContentLinks';
+  __typename?: "PageCookiePolicyContentLinks";
   assets: PageCookiePolicyContentAssets;
   entries: PageCookiePolicyContentEntries;
   resources: PageCookiePolicyContentResources;
 };
 
 export type PageCookiePolicyContentResources = {
-  __typename?: 'PageCookiePolicyContentResources';
+  __typename?: "PageCookiePolicyContentResources";
   block: Array<PageCookiePolicyContentResourcesBlock>;
   hyperlink: Array<PageCookiePolicyContentResourcesHyperlink>;
   inline: Array<PageCookiePolicyContentResourcesInline>;
 };
 
 export type PageCookiePolicyContentResourcesBlock = ResourceLink & {
-  __typename?: 'PageCookiePolicyContentResourcesBlock';
+  __typename?: "PageCookiePolicyContentResourcesBlock";
   sys: ResourceSys;
 };
 
 export type PageCookiePolicyContentResourcesHyperlink = ResourceLink & {
-  __typename?: 'PageCookiePolicyContentResourcesHyperlink';
+  __typename?: "PageCookiePolicyContentResourcesHyperlink";
   sys: ResourceSys;
 };
 
 export type PageCookiePolicyContentResourcesInline = ResourceLink & {
-  __typename?: 'PageCookiePolicyContentResourcesInline';
+  __typename?: "PageCookiePolicyContentResourcesInline";
   sys: ResourceSys;
 };
 
 export type PageCookiePolicyCursorCollection = {
-  __typename?: 'PageCookiePolicyCursorCollection';
+  __typename?: "PageCookiePolicyCursorCollection";
   items: Array<Maybe<PageCookiePolicy>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export type PageCookiePolicyFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageCookiePolicyFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageCookiePolicyFilter>>>;
-  content_contains?: InputMaybe<Scalars['String']['input']>;
-  content_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  content_not_contains?: InputMaybe<Scalars['String']['input']>;
+  content_contains?: InputMaybe<Scalars["String"]["input"]>;
+  content_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  content_not_contains?: InputMaybe<Scalars["String"]["input"]>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageDescription?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_contains?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageDescription_not?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageTitle?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_contains?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageTitle_not?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageDescription?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageDescription_not?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageTitle?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageTitle_not?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type PageCookiePolicyLinkingCollections = {
-  __typename?: 'PageCookiePolicyLinkingCollections';
+  __typename?: "PageCookiePolicyLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
-
 export type PageCookiePolicyLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type PageCookiePolicyLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum PageCookiePolicyOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PageDescriptionAsc = 'pageDescription_ASC',
-  PageDescriptionDesc = 'pageDescription_DESC',
-  PageTitleAsc = 'pageTitle_ASC',
-  PageTitleDesc = 'pageTitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PageDescriptionAsc = "pageDescription_ASC",
+  PageDescriptionDesc = "pageDescription_DESC",
+  PageTitleAsc = "pageTitle_ASC",
+  PageTitleDesc = "pageTitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageEmails) */
-export type PageEmails = Entry & _Node & {
-  __typename?: 'PageEmails';
-  _id: Scalars['ID']['output'];
-  contentfulMetadata: ContentfulMetadata;
-  emailsCollection?: Maybe<PageEmailsEmailsCollection>;
-  emailsCursorCollection?: Maybe<PageEmailsEmailsCursorCollection>;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<PageEmailsLinkingCollections>;
-  sys: Sys;
-};
-
+export type PageEmails = Entry &
+  _Node & {
+    __typename?: "PageEmails";
+    _id: Scalars["ID"]["output"];
+    contentfulMetadata: ContentfulMetadata;
+    emailsCollection?: Maybe<PageEmailsEmailsCollection>;
+    emailsCursorCollection?: Maybe<PageEmailsEmailsCursorCollection>;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<PageEmailsLinkingCollections>;
+    sys: Sys;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageEmails) */
 export type PageEmailsEmailsCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageEmailsEmailsCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentEmailFilter>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageEmails) */
 export type PageEmailsEmailsCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageEmailsEmailsCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentEmailFilter>;
 };
 
-
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageEmails) */
 export type PageEmailsInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageEmails) */
 export type PageEmailsLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type PageEmailsCollection = {
-  __typename?: 'PageEmailsCollection';
+  __typename?: "PageEmailsCollection";
   items: Array<Maybe<PageEmails>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type PageEmailsCursorCollection = {
-  __typename?: 'PageEmailsCursorCollection';
+  __typename?: "PageEmailsCursorCollection";
   items: Array<Maybe<PageEmails>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export type PageEmailsEmailsCollection = {
-  __typename?: 'PageEmailsEmailsCollection';
+  __typename?: "PageEmailsEmailsCollection";
   items: Array<Maybe<ComponentEmail>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export enum PageEmailsEmailsCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PreviewAsc = 'preview_ASC',
-  PreviewDesc = 'preview_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PreviewAsc = "preview_ASC",
+  PreviewDesc = "preview_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
 }
 
 export type PageEmailsEmailsCursorCollection = {
-  __typename?: 'PageEmailsEmailsCursorCollection';
+  __typename?: "PageEmailsEmailsCursorCollection";
   items: Array<Maybe<ComponentEmail>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export enum PageEmailsEmailsCursorCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PreviewAsc = 'preview_ASC',
-  PreviewDesc = 'preview_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PreviewAsc = "preview_ASC",
+  PreviewDesc = "preview_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
 }
 
 export type PageEmailsFilter = {
@@ -4725,149 +4587,140 @@ export type PageEmailsFilter = {
   OR?: InputMaybe<Array<InputMaybe<PageEmailsFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
   emails?: InputMaybe<CfComponentEmailNestedFilter>;
-  emailsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  emailsCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
 };
 
 export type PageEmailsLinkingCollections = {
-  __typename?: 'PageEmailsLinkingCollections';
+  __typename?: "PageEmailsLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
-
 export type PageEmailsLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type PageEmailsLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum PageEmailsOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageFaq) */
-export type PageFaq = Entry & _Node & {
-  __typename?: 'PageFaq';
-  _id: Scalars['ID']['output'];
-  contentfulMetadata: ContentfulMetadata;
-  internalName?: Maybe<Scalars['String']['output']>;
-  intro?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<PageFaqLinkingCollections>;
-  pageDescription?: Maybe<Scalars['String']['output']>;
-  pageTitle?: Maybe<Scalars['String']['output']>;
-  questionsCollection?: Maybe<PageFaqQuestionsCollection>;
-  questionsCursorCollection?: Maybe<PageFaqQuestionsCursorCollection>;
-  sys: Sys;
-  title?: Maybe<Scalars['String']['output']>;
-};
-
+export type PageFaq = Entry &
+  _Node & {
+    __typename?: "PageFaq";
+    _id: Scalars["ID"]["output"];
+    contentfulMetadata: ContentfulMetadata;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    intro?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<PageFaqLinkingCollections>;
+    pageDescription?: Maybe<Scalars["String"]["output"]>;
+    pageTitle?: Maybe<Scalars["String"]["output"]>;
+    questionsCollection?: Maybe<PageFaqQuestionsCollection>;
+    questionsCursorCollection?: Maybe<PageFaqQuestionsCursorCollection>;
+    sys: Sys;
+    title?: Maybe<Scalars["String"]["output"]>;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageFaq) */
 export type PageFaqInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageFaq) */
 export type PageFaqIntroArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageFaq) */
 export type PageFaqLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageFaq) */
 export type PageFaqPageDescriptionArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageFaq) */
 export type PageFaqPageTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageFaq) */
 export type PageFaqQuestionsCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageFaqQuestionsCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentFaqQuestionFilter>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageFaq) */
 export type PageFaqQuestionsCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageFaqQuestionsCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentFaqQuestionFilter>;
 };
 
-
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageFaq) */
 export type PageFaqTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type PageFaqCollection = {
-  __typename?: 'PageFaqCollection';
+  __typename?: "PageFaqCollection";
   items: Array<Maybe<PageFaq>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type PageFaqCursorCollection = {
-  __typename?: 'PageFaqCursorCollection';
+  __typename?: "PageFaqCursorCollection";
   items: Array<Maybe<PageFaq>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
@@ -4875,501 +4728,484 @@ export type PageFaqFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageFaqFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageFaqFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  intro?: InputMaybe<Scalars['String']['input']>;
-  intro_contains?: InputMaybe<Scalars['String']['input']>;
-  intro_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  intro_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  intro_not?: InputMaybe<Scalars['String']['input']>;
-  intro_not_contains?: InputMaybe<Scalars['String']['input']>;
-  intro_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageDescription?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_contains?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageDescription_not?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageTitle?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_contains?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageTitle_not?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  intro?: InputMaybe<Scalars["String"]["input"]>;
+  intro_contains?: InputMaybe<Scalars["String"]["input"]>;
+  intro_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  intro_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  intro_not?: InputMaybe<Scalars["String"]["input"]>;
+  intro_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  intro_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageDescription?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageDescription_not?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageTitle?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageTitle_not?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   questions?: InputMaybe<CfComponentFaqQuestionNestedFilter>;
-  questionsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  questionsCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type PageFaqLinkingCollections = {
-  __typename?: 'PageFaqLinkingCollections';
+  __typename?: "PageFaqLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
-
 export type PageFaqLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type PageFaqLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum PageFaqOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  IntroAsc = 'intro_ASC',
-  IntroDesc = 'intro_DESC',
-  PageDescriptionAsc = 'pageDescription_ASC',
-  PageDescriptionDesc = 'pageDescription_DESC',
-  PageTitleAsc = 'pageTitle_ASC',
-  PageTitleDesc = 'pageTitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  IntroAsc = "intro_ASC",
+  IntroDesc = "intro_DESC",
+  PageDescriptionAsc = "pageDescription_ASC",
+  PageDescriptionDesc = "pageDescription_DESC",
+  PageTitleAsc = "pageTitle_ASC",
+  PageTitleDesc = "pageTitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export type PageFaqQuestionsCollection = {
-  __typename?: 'PageFaqQuestionsCollection';
+  __typename?: "PageFaqQuestionsCollection";
   items: Array<Maybe<ComponentFaqQuestion>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export enum PageFaqQuestionsCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  QuestionAsc = 'question_ASC',
-  QuestionDesc = 'question_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  QuestionAsc = "question_ASC",
+  QuestionDesc = "question_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
 }
 
 export type PageFaqQuestionsCursorCollection = {
-  __typename?: 'PageFaqQuestionsCursorCollection';
+  __typename?: "PageFaqQuestionsCursorCollection";
   items: Array<Maybe<ComponentFaqQuestion>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export enum PageFaqQuestionsCursorCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  QuestionAsc = 'question_ASC',
-  QuestionDesc = 'question_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  QuestionAsc = "question_ASC",
+  QuestionDesc = "question_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageForceUpdate) */
-export type PageForceUpdate = Entry & _Node & {
-  __typename?: 'PageForceUpdate';
-  _id: Scalars['ID']['output'];
-  active?: Maybe<Scalars['Boolean']['output']>;
-  body?: Maybe<PageForceUpdateBody>;
-  contentfulMetadata: ContentfulMetadata;
-  effectiveAt?: Maybe<Scalars['DateTime']['output']>;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<PageForceUpdateLinkingCollections>;
-  minVersion?: Maybe<Scalars['String']['output']>;
-  sys: Sys;
-  title?: Maybe<Scalars['String']['output']>;
-  updateCta?: Maybe<ComponentButton>;
-};
-
+export type PageForceUpdate = Entry &
+  _Node & {
+    __typename?: "PageForceUpdate";
+    _id: Scalars["ID"]["output"];
+    active?: Maybe<Scalars["Boolean"]["output"]>;
+    body?: Maybe<PageForceUpdateBody>;
+    contentfulMetadata: ContentfulMetadata;
+    effectiveAt?: Maybe<Scalars["DateTime"]["output"]>;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<PageForceUpdateLinkingCollections>;
+    minVersion?: Maybe<Scalars["String"]["output"]>;
+    sys: Sys;
+    title?: Maybe<Scalars["String"]["output"]>;
+    updateCta?: Maybe<ComponentButton>;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageForceUpdate) */
 export type PageForceUpdateActiveArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageForceUpdate) */
 export type PageForceUpdateBodyArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageForceUpdate) */
 export type PageForceUpdateEffectiveAtArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageForceUpdate) */
 export type PageForceUpdateInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageForceUpdate) */
 export type PageForceUpdateLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageForceUpdate) */
 export type PageForceUpdateMinVersionArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageForceUpdate) */
 export type PageForceUpdateTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageForceUpdate) */
 export type PageForceUpdateUpdateCtaArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
 
 export type PageForceUpdateBody = {
-  __typename?: 'PageForceUpdateBody';
-  json: Scalars['JSON']['output'];
+  __typename?: "PageForceUpdateBody";
+  json: Scalars["JSON"]["output"];
   links: PageForceUpdateBodyLinks;
 };
 
 export type PageForceUpdateBodyAssets = {
-  __typename?: 'PageForceUpdateBodyAssets';
+  __typename?: "PageForceUpdateBodyAssets";
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type PageForceUpdateBodyEntries = {
-  __typename?: 'PageForceUpdateBodyEntries';
+  __typename?: "PageForceUpdateBodyEntries";
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type PageForceUpdateBodyLinks = {
-  __typename?: 'PageForceUpdateBodyLinks';
+  __typename?: "PageForceUpdateBodyLinks";
   assets: PageForceUpdateBodyAssets;
   entries: PageForceUpdateBodyEntries;
   resources: PageForceUpdateBodyResources;
 };
 
 export type PageForceUpdateBodyResources = {
-  __typename?: 'PageForceUpdateBodyResources';
+  __typename?: "PageForceUpdateBodyResources";
   block: Array<PageForceUpdateBodyResourcesBlock>;
   hyperlink: Array<PageForceUpdateBodyResourcesHyperlink>;
   inline: Array<PageForceUpdateBodyResourcesInline>;
 };
 
 export type PageForceUpdateBodyResourcesBlock = ResourceLink & {
-  __typename?: 'PageForceUpdateBodyResourcesBlock';
+  __typename?: "PageForceUpdateBodyResourcesBlock";
   sys: ResourceSys;
 };
 
 export type PageForceUpdateBodyResourcesHyperlink = ResourceLink & {
-  __typename?: 'PageForceUpdateBodyResourcesHyperlink';
+  __typename?: "PageForceUpdateBodyResourcesHyperlink";
   sys: ResourceSys;
 };
 
 export type PageForceUpdateBodyResourcesInline = ResourceLink & {
-  __typename?: 'PageForceUpdateBodyResourcesInline';
+  __typename?: "PageForceUpdateBodyResourcesInline";
   sys: ResourceSys;
 };
 
 export type PageForceUpdateCollection = {
-  __typename?: 'PageForceUpdateCollection';
+  __typename?: "PageForceUpdateCollection";
   items: Array<Maybe<PageForceUpdate>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type PageForceUpdateCursorCollection = {
-  __typename?: 'PageForceUpdateCursorCollection';
+  __typename?: "PageForceUpdateCursorCollection";
   items: Array<Maybe<PageForceUpdate>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export type PageForceUpdateFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageForceUpdateFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageForceUpdateFilter>>>;
-  active?: InputMaybe<Scalars['Boolean']['input']>;
-  active_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  active_not?: InputMaybe<Scalars['Boolean']['input']>;
-  body_contains?: InputMaybe<Scalars['String']['input']>;
-  body_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  body_not_contains?: InputMaybe<Scalars['String']['input']>;
+  active?: InputMaybe<Scalars["Boolean"]["input"]>;
+  active_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  active_not?: InputMaybe<Scalars["Boolean"]["input"]>;
+  body_contains?: InputMaybe<Scalars["String"]["input"]>;
+  body_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  body_not_contains?: InputMaybe<Scalars["String"]["input"]>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  effectiveAt?: InputMaybe<Scalars['DateTime']['input']>;
-  effectiveAt_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  effectiveAt_gt?: InputMaybe<Scalars['DateTime']['input']>;
-  effectiveAt_gte?: InputMaybe<Scalars['DateTime']['input']>;
-  effectiveAt_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
-  effectiveAt_lt?: InputMaybe<Scalars['DateTime']['input']>;
-  effectiveAt_lte?: InputMaybe<Scalars['DateTime']['input']>;
-  effectiveAt_not?: InputMaybe<Scalars['DateTime']['input']>;
-  effectiveAt_not_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  minVersion?: InputMaybe<Scalars['String']['input']>;
-  minVersion_contains?: InputMaybe<Scalars['String']['input']>;
-  minVersion_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  minVersion_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  minVersion_not?: InputMaybe<Scalars['String']['input']>;
-  minVersion_not_contains?: InputMaybe<Scalars['String']['input']>;
-  minVersion_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  effectiveAt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  effectiveAt_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  effectiveAt_gt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  effectiveAt_gte?: InputMaybe<Scalars["DateTime"]["input"]>;
+  effectiveAt_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
+  effectiveAt_lt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  effectiveAt_lte?: InputMaybe<Scalars["DateTime"]["input"]>;
+  effectiveAt_not?: InputMaybe<Scalars["DateTime"]["input"]>;
+  effectiveAt_not_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  minVersion?: InputMaybe<Scalars["String"]["input"]>;
+  minVersion_contains?: InputMaybe<Scalars["String"]["input"]>;
+  minVersion_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  minVersion_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  minVersion_not?: InputMaybe<Scalars["String"]["input"]>;
+  minVersion_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  minVersion_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   updateCta?: InputMaybe<CfComponentButtonNestedFilter>;
-  updateCta_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  updateCta_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type PageForceUpdateLinkingCollections = {
-  __typename?: 'PageForceUpdateLinkingCollections';
+  __typename?: "PageForceUpdateLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
-
 export type PageForceUpdateLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type PageForceUpdateLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum PageForceUpdateOrder {
-  ActiveAsc = 'active_ASC',
-  ActiveDesc = 'active_DESC',
-  EffectiveAtAsc = 'effectiveAt_ASC',
-  EffectiveAtDesc = 'effectiveAt_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  MinVersionAsc = 'minVersion_ASC',
-  MinVersionDesc = 'minVersion_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  ActiveAsc = "active_ASC",
+  ActiveDesc = "active_DESC",
+  EffectiveAtAsc = "effectiveAt_ASC",
+  EffectiveAtDesc = "effectiveAt_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  MinVersionAsc = "minVersion_ASC",
+  MinVersionDesc = "minVersion_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeFeatures) */
-export type PageHomeFeatures = Entry & _Node & {
-  __typename?: 'PageHomeFeatures';
-  _id: Scalars['ID']['output'];
-  contentfulMetadata: ContentfulMetadata;
-  featuresCollection?: Maybe<PageHomeFeaturesFeaturesCollection>;
-  featuresCursorCollection?: Maybe<PageHomeFeaturesFeaturesCursorCollection>;
-  image?: Maybe<Asset>;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<PageHomeFeaturesLinkingCollections>;
-  subtitle?: Maybe<Scalars['String']['output']>;
-  sys: Sys;
-  title?: Maybe<Scalars['String']['output']>;
-};
-
+export type PageHomeFeatures = Entry &
+  _Node & {
+    __typename?: "PageHomeFeatures";
+    _id: Scalars["ID"]["output"];
+    contentfulMetadata: ContentfulMetadata;
+    featuresCollection?: Maybe<PageHomeFeaturesFeaturesCollection>;
+    featuresCursorCollection?: Maybe<PageHomeFeaturesFeaturesCursorCollection>;
+    image?: Maybe<Asset>;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<PageHomeFeaturesLinkingCollections>;
+    subtitle?: Maybe<Scalars["String"]["output"]>;
+    sys: Sys;
+    title?: Maybe<Scalars["String"]["output"]>;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeFeatures) */
 export type PageHomeFeaturesFeaturesCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageHomeFeaturesFeaturesCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentFeatureFilter>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeFeatures) */
 export type PageHomeFeaturesFeaturesCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageHomeFeaturesFeaturesCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentFeatureFilter>;
 };
 
-
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeFeatures) */
 export type PageHomeFeaturesImageArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeFeatures) */
 export type PageHomeFeaturesInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeFeatures) */
 export type PageHomeFeaturesLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeFeatures) */
 export type PageHomeFeaturesSubtitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeFeatures) */
 export type PageHomeFeaturesTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type PageHomeFeaturesCollection = {
-  __typename?: 'PageHomeFeaturesCollection';
+  __typename?: "PageHomeFeaturesCollection";
   items: Array<Maybe<PageHomeFeatures>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type PageHomeFeaturesCursorCollection = {
-  __typename?: 'PageHomeFeaturesCursorCollection';
+  __typename?: "PageHomeFeaturesCursorCollection";
   items: Array<Maybe<PageHomeFeatures>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export type PageHomeFeaturesFeaturesCollection = {
-  __typename?: 'PageHomeFeaturesFeaturesCollection';
+  __typename?: "PageHomeFeaturesFeaturesCollection";
   items: Array<Maybe<ComponentFeature>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export enum PageHomeFeaturesFeaturesCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SubtitleAsc = 'subtitle_ASC',
-  SubtitleDesc = 'subtitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SubtitleAsc = "subtitle_ASC",
+  SubtitleDesc = "subtitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export type PageHomeFeaturesFeaturesCursorCollection = {
-  __typename?: 'PageHomeFeaturesFeaturesCursorCollection';
+  __typename?: "PageHomeFeaturesFeaturesCursorCollection";
   items: Array<Maybe<ComponentFeature>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export enum PageHomeFeaturesFeaturesCursorCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SubtitleAsc = 'subtitle_ASC',
-  SubtitleDesc = 'subtitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SubtitleAsc = "subtitle_ASC",
+  SubtitleDesc = "subtitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export type PageHomeFeaturesFilter = {
@@ -5377,680 +5213,652 @@ export type PageHomeFeaturesFilter = {
   OR?: InputMaybe<Array<InputMaybe<PageHomeFeaturesFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
   features?: InputMaybe<CfComponentFeatureNestedFilter>;
-  featuresCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  image_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  subtitle?: InputMaybe<Scalars['String']['input']>;
-  subtitle_contains?: InputMaybe<Scalars['String']['input']>;
-  subtitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  subtitle_not?: InputMaybe<Scalars['String']['input']>;
-  subtitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  featuresCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  image_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  subtitle?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_contains?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  subtitle_not?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type PageHomeFeaturesLinkingCollections = {
-  __typename?: 'PageHomeFeaturesLinkingCollections';
+  __typename?: "PageHomeFeaturesLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
-
 export type PageHomeFeaturesLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type PageHomeFeaturesLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum PageHomeFeaturesOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SubtitleAsc = 'subtitle_ASC',
-  SubtitleDesc = 'subtitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SubtitleAsc = "subtitle_ASC",
+  SubtitleDesc = "subtitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeHero) */
-export type PageHomeHero = Entry & _Node & {
-  __typename?: 'PageHomeHero';
-  _id: Scalars['ID']['output'];
-  badge?: Maybe<Scalars['String']['output']>;
-  buttonsCollection?: Maybe<PageHomeHeroButtonsCollection>;
-  buttonsCursorCollection?: Maybe<PageHomeHeroButtonsCursorCollection>;
-  contentfulMetadata: ContentfulMetadata;
-  image?: Maybe<Asset>;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<PageHomeHeroLinkingCollections>;
-  subtitle?: Maybe<Scalars['String']['output']>;
-  sys: Sys;
-  title?: Maybe<Scalars['String']['output']>;
-};
-
+export type PageHomeHero = Entry &
+  _Node & {
+    __typename?: "PageHomeHero";
+    _id: Scalars["ID"]["output"];
+    badge?: Maybe<Scalars["String"]["output"]>;
+    buttonsCollection?: Maybe<PageHomeHeroButtonsCollection>;
+    buttonsCursorCollection?: Maybe<PageHomeHeroButtonsCursorCollection>;
+    contentfulMetadata: ContentfulMetadata;
+    image?: Maybe<Asset>;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<PageHomeHeroLinkingCollections>;
+    subtitle?: Maybe<Scalars["String"]["output"]>;
+    sys: Sys;
+    title?: Maybe<Scalars["String"]["output"]>;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeHero) */
 export type PageHomeHeroBadgeArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeHero) */
 export type PageHomeHeroButtonsCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageHomeHeroButtonsCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeHero) */
 export type PageHomeHeroButtonsCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageHomeHeroButtonsCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
 
-
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeHero) */
 export type PageHomeHeroImageArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeHero) */
 export type PageHomeHeroInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeHero) */
 export type PageHomeHeroLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeHero) */
 export type PageHomeHeroSubtitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeHero) */
 export type PageHomeHeroTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type PageHomeHeroButtonsCollection = {
-  __typename?: 'PageHomeHeroButtonsCollection';
+  __typename?: "PageHomeHeroButtonsCollection";
   items: Array<Maybe<ComponentButton>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export enum PageHomeHeroButtonsCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  LabelAsc = 'label_ASC',
-  LabelDesc = 'label_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  UrlAsc = 'url_ASC',
-  UrlDesc = 'url_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  LabelAsc = "label_ASC",
+  LabelDesc = "label_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  UrlAsc = "url_ASC",
+  UrlDesc = "url_DESC",
 }
 
 export type PageHomeHeroButtonsCursorCollection = {
-  __typename?: 'PageHomeHeroButtonsCursorCollection';
+  __typename?: "PageHomeHeroButtonsCursorCollection";
   items: Array<Maybe<ComponentButton>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export enum PageHomeHeroButtonsCursorCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  LabelAsc = 'label_ASC',
-  LabelDesc = 'label_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  UrlAsc = 'url_ASC',
-  UrlDesc = 'url_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  LabelAsc = "label_ASC",
+  LabelDesc = "label_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  UrlAsc = "url_ASC",
+  UrlDesc = "url_DESC",
 }
 
 export type PageHomeHeroCollection = {
-  __typename?: 'PageHomeHeroCollection';
+  __typename?: "PageHomeHeroCollection";
   items: Array<Maybe<PageHomeHero>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type PageHomeHeroCursorCollection = {
-  __typename?: 'PageHomeHeroCursorCollection';
+  __typename?: "PageHomeHeroCursorCollection";
   items: Array<Maybe<PageHomeHero>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export type PageHomeHeroFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageHomeHeroFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageHomeHeroFilter>>>;
-  badge?: InputMaybe<Scalars['String']['input']>;
-  badge_contains?: InputMaybe<Scalars['String']['input']>;
-  badge_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  badge_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  badge_not?: InputMaybe<Scalars['String']['input']>;
-  badge_not_contains?: InputMaybe<Scalars['String']['input']>;
-  badge_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  badge?: InputMaybe<Scalars["String"]["input"]>;
+  badge_contains?: InputMaybe<Scalars["String"]["input"]>;
+  badge_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  badge_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  badge_not?: InputMaybe<Scalars["String"]["input"]>;
+  badge_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  badge_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   buttons?: InputMaybe<CfComponentButtonNestedFilter>;
-  buttonsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  buttonsCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  image_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  subtitle?: InputMaybe<Scalars['String']['input']>;
-  subtitle_contains?: InputMaybe<Scalars['String']['input']>;
-  subtitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  subtitle_not?: InputMaybe<Scalars['String']['input']>;
-  subtitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  image_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  subtitle?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_contains?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  subtitle_not?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type PageHomeHeroLinkingCollections = {
-  __typename?: 'PageHomeHeroLinkingCollections';
+  __typename?: "PageHomeHeroLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
-
 export type PageHomeHeroLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type PageHomeHeroLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum PageHomeHeroOrder {
-  BadgeAsc = 'badge_ASC',
-  BadgeDesc = 'badge_DESC',
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SubtitleAsc = 'subtitle_ASC',
-  SubtitleDesc = 'subtitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  BadgeAsc = "badge_ASC",
+  BadgeDesc = "badge_DESC",
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SubtitleAsc = "subtitle_ASC",
+  SubtitleDesc = "subtitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
-export type PageHomeMission = Entry & _Node & {
-  __typename?: 'PageHomeMission';
-  _id: Scalars['ID']['output'];
-  about?: Maybe<PageHomeMissionAbout>;
-  contentfulMetadata: ContentfulMetadata;
-  image?: Maybe<Asset>;
-  imagesCollection?: Maybe<AssetCollection>;
-  imagesCursorCollection?: Maybe<AssetCursorCollection>;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<PageHomeMissionLinkingCollections>;
-  mission?: Maybe<PageHomeMissionMission>;
-  subtitle?: Maybe<Scalars['String']['output']>;
-  sys: Sys;
-  title?: Maybe<Scalars['String']['output']>;
-};
-
+export type PageHomeMission = Entry &
+  _Node & {
+    __typename?: "PageHomeMission";
+    _id: Scalars["ID"]["output"];
+    about?: Maybe<PageHomeMissionAbout>;
+    contentfulMetadata: ContentfulMetadata;
+    image?: Maybe<Asset>;
+    imagesCollection?: Maybe<AssetCollection>;
+    imagesCursorCollection?: Maybe<AssetCursorCollection>;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<PageHomeMissionLinkingCollections>;
+    mission?: Maybe<PageHomeMissionMission>;
+    subtitle?: Maybe<Scalars["String"]["output"]>;
+    sys: Sys;
+    title?: Maybe<Scalars["String"]["output"]>;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
 export type PageHomeMissionAboutArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
 export type PageHomeMissionImageArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
 export type PageHomeMissionImagesCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
 export type PageHomeMissionImagesCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
 export type PageHomeMissionInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
 export type PageHomeMissionLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
 export type PageHomeMissionMissionArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
 export type PageHomeMissionSubtitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomeMission) */
 export type PageHomeMissionTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type PageHomeMissionAbout = {
-  __typename?: 'PageHomeMissionAbout';
-  json: Scalars['JSON']['output'];
+  __typename?: "PageHomeMissionAbout";
+  json: Scalars["JSON"]["output"];
   links: PageHomeMissionAboutLinks;
 };
 
 export type PageHomeMissionAboutAssets = {
-  __typename?: 'PageHomeMissionAboutAssets';
+  __typename?: "PageHomeMissionAboutAssets";
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type PageHomeMissionAboutEntries = {
-  __typename?: 'PageHomeMissionAboutEntries';
+  __typename?: "PageHomeMissionAboutEntries";
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type PageHomeMissionAboutLinks = {
-  __typename?: 'PageHomeMissionAboutLinks';
+  __typename?: "PageHomeMissionAboutLinks";
   assets: PageHomeMissionAboutAssets;
   entries: PageHomeMissionAboutEntries;
   resources: PageHomeMissionAboutResources;
 };
 
 export type PageHomeMissionAboutResources = {
-  __typename?: 'PageHomeMissionAboutResources';
+  __typename?: "PageHomeMissionAboutResources";
   block: Array<PageHomeMissionAboutResourcesBlock>;
   hyperlink: Array<PageHomeMissionAboutResourcesHyperlink>;
   inline: Array<PageHomeMissionAboutResourcesInline>;
 };
 
 export type PageHomeMissionAboutResourcesBlock = ResourceLink & {
-  __typename?: 'PageHomeMissionAboutResourcesBlock';
+  __typename?: "PageHomeMissionAboutResourcesBlock";
   sys: ResourceSys;
 };
 
 export type PageHomeMissionAboutResourcesHyperlink = ResourceLink & {
-  __typename?: 'PageHomeMissionAboutResourcesHyperlink';
+  __typename?: "PageHomeMissionAboutResourcesHyperlink";
   sys: ResourceSys;
 };
 
 export type PageHomeMissionAboutResourcesInline = ResourceLink & {
-  __typename?: 'PageHomeMissionAboutResourcesInline';
+  __typename?: "PageHomeMissionAboutResourcesInline";
   sys: ResourceSys;
 };
 
 export type PageHomeMissionCollection = {
-  __typename?: 'PageHomeMissionCollection';
+  __typename?: "PageHomeMissionCollection";
   items: Array<Maybe<PageHomeMission>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type PageHomeMissionCursorCollection = {
-  __typename?: 'PageHomeMissionCursorCollection';
+  __typename?: "PageHomeMissionCursorCollection";
   items: Array<Maybe<PageHomeMission>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export type PageHomeMissionFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageHomeMissionFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageHomeMissionFilter>>>;
-  about_contains?: InputMaybe<Scalars['String']['input']>;
-  about_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  about_not_contains?: InputMaybe<Scalars['String']['input']>;
+  about_contains?: InputMaybe<Scalars["String"]["input"]>;
+  about_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  about_not_contains?: InputMaybe<Scalars["String"]["input"]>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  image_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  imagesCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  mission_contains?: InputMaybe<Scalars['String']['input']>;
-  mission_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  mission_not_contains?: InputMaybe<Scalars['String']['input']>;
-  subtitle?: InputMaybe<Scalars['String']['input']>;
-  subtitle_contains?: InputMaybe<Scalars['String']['input']>;
-  subtitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  subtitle_not?: InputMaybe<Scalars['String']['input']>;
-  subtitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  image_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  imagesCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  mission_contains?: InputMaybe<Scalars["String"]["input"]>;
+  mission_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  mission_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_contains?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  subtitle_not?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type PageHomeMissionLinkingCollections = {
-  __typename?: 'PageHomeMissionLinkingCollections';
+  __typename?: "PageHomeMissionLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
-
 export type PageHomeMissionLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type PageHomeMissionLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type PageHomeMissionMission = {
-  __typename?: 'PageHomeMissionMission';
-  json: Scalars['JSON']['output'];
+  __typename?: "PageHomeMissionMission";
+  json: Scalars["JSON"]["output"];
   links: PageHomeMissionMissionLinks;
 };
 
 export type PageHomeMissionMissionAssets = {
-  __typename?: 'PageHomeMissionMissionAssets';
+  __typename?: "PageHomeMissionMissionAssets";
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type PageHomeMissionMissionEntries = {
-  __typename?: 'PageHomeMissionMissionEntries';
+  __typename?: "PageHomeMissionMissionEntries";
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type PageHomeMissionMissionLinks = {
-  __typename?: 'PageHomeMissionMissionLinks';
+  __typename?: "PageHomeMissionMissionLinks";
   assets: PageHomeMissionMissionAssets;
   entries: PageHomeMissionMissionEntries;
   resources: PageHomeMissionMissionResources;
 };
 
 export type PageHomeMissionMissionResources = {
-  __typename?: 'PageHomeMissionMissionResources';
+  __typename?: "PageHomeMissionMissionResources";
   block: Array<PageHomeMissionMissionResourcesBlock>;
   hyperlink: Array<PageHomeMissionMissionResourcesHyperlink>;
   inline: Array<PageHomeMissionMissionResourcesInline>;
 };
 
 export type PageHomeMissionMissionResourcesBlock = ResourceLink & {
-  __typename?: 'PageHomeMissionMissionResourcesBlock';
+  __typename?: "PageHomeMissionMissionResourcesBlock";
   sys: ResourceSys;
 };
 
 export type PageHomeMissionMissionResourcesHyperlink = ResourceLink & {
-  __typename?: 'PageHomeMissionMissionResourcesHyperlink';
+  __typename?: "PageHomeMissionMissionResourcesHyperlink";
   sys: ResourceSys;
 };
 
 export type PageHomeMissionMissionResourcesInline = ResourceLink & {
-  __typename?: 'PageHomeMissionMissionResourcesInline';
+  __typename?: "PageHomeMissionMissionResourcesInline";
   sys: ResourceSys;
 };
 
 export enum PageHomeMissionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SubtitleAsc = 'subtitle_ASC',
-  SubtitleDesc = 'subtitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SubtitleAsc = "subtitle_ASC",
+  SubtitleDesc = "subtitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomePartners) */
-export type PageHomePartners = Entry & _Node & {
-  __typename?: 'PageHomePartners';
-  _id: Scalars['ID']['output'];
-  contentfulMetadata: ContentfulMetadata;
-  imagesCollection?: Maybe<AssetCollection>;
-  imagesCursorCollection?: Maybe<AssetCursorCollection>;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<PageHomePartnersLinkingCollections>;
-  partnersCollection?: Maybe<PageHomePartnersPartnersCollection>;
-  partnersCursorCollection?: Maybe<PageHomePartnersPartnersCursorCollection>;
-  subtitle?: Maybe<Scalars['String']['output']>;
-  sys: Sys;
-  title?: Maybe<Scalars['String']['output']>;
-};
-
+export type PageHomePartners = Entry &
+  _Node & {
+    __typename?: "PageHomePartners";
+    _id: Scalars["ID"]["output"];
+    contentfulMetadata: ContentfulMetadata;
+    imagesCollection?: Maybe<AssetCollection>;
+    imagesCursorCollection?: Maybe<AssetCursorCollection>;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<PageHomePartnersLinkingCollections>;
+    partnersCollection?: Maybe<PageHomePartnersPartnersCollection>;
+    partnersCursorCollection?: Maybe<PageHomePartnersPartnersCursorCollection>;
+    subtitle?: Maybe<Scalars["String"]["output"]>;
+    sys: Sys;
+    title?: Maybe<Scalars["String"]["output"]>;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomePartners) */
 export type PageHomePartnersImagesCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomePartners) */
 export type PageHomePartnersImagesCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomePartners) */
 export type PageHomePartnersInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomePartners) */
 export type PageHomePartnersLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomePartners) */
 export type PageHomePartnersPartnersCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageHomePartnersPartnersCollectionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentPartnerFilter>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomePartners) */
 export type PageHomePartnersPartnersCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageHomePartnersPartnersCursorCollectionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentPartnerFilter>;
 };
 
-
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomePartners) */
 export type PageHomePartnersSubtitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageHomePartners) */
 export type PageHomePartnersTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type PageHomePartnersCollection = {
-  __typename?: 'PageHomePartnersCollection';
+  __typename?: "PageHomePartnersCollection";
   items: Array<Maybe<PageHomePartners>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type PageHomePartnersCursorCollection = {
-  __typename?: 'PageHomePartnersCursorCollection';
+  __typename?: "PageHomePartnersCursorCollection";
   items: Array<Maybe<PageHomePartners>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
@@ -6058,179 +5866,174 @@ export type PageHomePartnersFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageHomePartnersFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageHomePartnersFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  imagesCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  imagesCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   partners?: InputMaybe<CfComponentPartnerNestedFilter>;
-  partnersCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  subtitle?: InputMaybe<Scalars['String']['input']>;
-  subtitle_contains?: InputMaybe<Scalars['String']['input']>;
-  subtitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  subtitle_not?: InputMaybe<Scalars['String']['input']>;
-  subtitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  partnersCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  subtitle?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_contains?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  subtitle_not?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type PageHomePartnersLinkingCollections = {
-  __typename?: 'PageHomePartnersLinkingCollections';
+  __typename?: "PageHomePartnersLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
-
 export type PageHomePartnersLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type PageHomePartnersLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum PageHomePartnersOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SubtitleAsc = 'subtitle_ASC',
-  SubtitleDesc = 'subtitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SubtitleAsc = "subtitle_ASC",
+  SubtitleDesc = "subtitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export type PageHomePartnersPartnersCollection = {
-  __typename?: 'PageHomePartnersPartnersCollection';
+  __typename?: "PageHomePartnersPartnersCollection";
   items: Array<Maybe<ComponentPartner>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export enum PageHomePartnersPartnersCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SubtitleAsc = 'subtitle_ASC',
-  SubtitleDesc = 'subtitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  UrlAsc = 'url_ASC',
-  UrlDesc = 'url_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SubtitleAsc = "subtitle_ASC",
+  SubtitleDesc = "subtitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  UrlAsc = "url_ASC",
+  UrlDesc = "url_DESC",
 }
 
 export type PageHomePartnersPartnersCursorCollection = {
-  __typename?: 'PageHomePartnersPartnersCursorCollection';
+  __typename?: "PageHomePartnersPartnersCursorCollection";
   items: Array<Maybe<ComponentPartner>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export enum PageHomePartnersPartnersCursorCollectionOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SubtitleAsc = 'subtitle_ASC',
-  SubtitleDesc = 'subtitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  UrlAsc = 'url_ASC',
-  UrlDesc = 'url_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SubtitleAsc = "subtitle_ASC",
+  SubtitleDesc = "subtitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  UrlAsc = "url_ASC",
+  UrlDesc = "url_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageLanding) */
-export type PageLanding = Entry & _Node & {
-  __typename?: 'PageLanding';
-  _id: Scalars['ID']['output'];
-  contentfulMetadata: ContentfulMetadata;
-  featuredBlogPost?: Maybe<PageBlogPost>;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<PageLandingLinkingCollections>;
-  seoFields?: Maybe<ComponentSeo>;
-  sys: Sys;
-};
-
+export type PageLanding = Entry &
+  _Node & {
+    __typename?: "PageLanding";
+    _id: Scalars["ID"]["output"];
+    contentfulMetadata: ContentfulMetadata;
+    featuredBlogPost?: Maybe<PageBlogPost>;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<PageLandingLinkingCollections>;
+    seoFields?: Maybe<ComponentSeo>;
+    sys: Sys;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageLanding) */
 export type PageLandingFeaturedBlogPostArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageBlogPostFilter>;
 };
 
-
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageLanding) */
 export type PageLandingInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageLanding) */
 export type PageLandingLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageLanding) */
 export type PageLandingSeoFieldsArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentSeoFilter>;
 };
 
 export type PageLandingCollection = {
-  __typename?: 'PageLandingCollection';
+  __typename?: "PageLandingCollection";
   items: Array<Maybe<PageLanding>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type PageLandingCursorCollection = {
-  __typename?: 'PageLandingCursorCollection';
+  __typename?: "PageLandingCursorCollection";
   items: Array<Maybe<PageLanding>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
@@ -6239,459 +6042,443 @@ export type PageLandingFilter = {
   OR?: InputMaybe<Array<InputMaybe<PageLandingFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
   featuredBlogPost?: InputMaybe<CfPageBlogPostNestedFilter>;
-  featuredBlogPost_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  featuredBlogPost_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   seoFields?: InputMaybe<CfComponentSeoNestedFilter>;
-  seoFields_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  seoFields_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
   sys?: InputMaybe<SysFilter>;
 };
 
 export type PageLandingLinkingCollections = {
-  __typename?: 'PageLandingLinkingCollections';
+  __typename?: "PageLandingLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
-
 export type PageLandingLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type PageLandingLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum PageLandingOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pagePolicies) */
-export type PagePolicies = Entry & _Node & {
-  __typename?: 'PagePolicies';
-  _id: Scalars['ID']['output'];
-  content?: Maybe<PagePoliciesContent>;
-  contentfulMetadata: ContentfulMetadata;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<PagePoliciesLinkingCollections>;
-  pageDescription?: Maybe<Scalars['String']['output']>;
-  pageTitle?: Maybe<Scalars['String']['output']>;
-  sys: Sys;
-  title?: Maybe<Scalars['String']['output']>;
-};
-
+export type PagePolicies = Entry &
+  _Node & {
+    __typename?: "PagePolicies";
+    _id: Scalars["ID"]["output"];
+    content?: Maybe<PagePoliciesContent>;
+    contentfulMetadata: ContentfulMetadata;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<PagePoliciesLinkingCollections>;
+    pageDescription?: Maybe<Scalars["String"]["output"]>;
+    pageTitle?: Maybe<Scalars["String"]["output"]>;
+    sys: Sys;
+    title?: Maybe<Scalars["String"]["output"]>;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pagePolicies) */
 export type PagePoliciesContentArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pagePolicies) */
 export type PagePoliciesInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pagePolicies) */
 export type PagePoliciesLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pagePolicies) */
 export type PagePoliciesPageDescriptionArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pagePolicies) */
 export type PagePoliciesPageTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pagePolicies) */
 export type PagePoliciesTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type PagePoliciesCollection = {
-  __typename?: 'PagePoliciesCollection';
+  __typename?: "PagePoliciesCollection";
   items: Array<Maybe<PagePolicies>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type PagePoliciesContent = {
-  __typename?: 'PagePoliciesContent';
-  json: Scalars['JSON']['output'];
+  __typename?: "PagePoliciesContent";
+  json: Scalars["JSON"]["output"];
   links: PagePoliciesContentLinks;
 };
 
 export type PagePoliciesContentAssets = {
-  __typename?: 'PagePoliciesContentAssets';
+  __typename?: "PagePoliciesContentAssets";
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type PagePoliciesContentEntries = {
-  __typename?: 'PagePoliciesContentEntries';
+  __typename?: "PagePoliciesContentEntries";
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type PagePoliciesContentLinks = {
-  __typename?: 'PagePoliciesContentLinks';
+  __typename?: "PagePoliciesContentLinks";
   assets: PagePoliciesContentAssets;
   entries: PagePoliciesContentEntries;
   resources: PagePoliciesContentResources;
 };
 
 export type PagePoliciesContentResources = {
-  __typename?: 'PagePoliciesContentResources';
+  __typename?: "PagePoliciesContentResources";
   block: Array<PagePoliciesContentResourcesBlock>;
   hyperlink: Array<PagePoliciesContentResourcesHyperlink>;
   inline: Array<PagePoliciesContentResourcesInline>;
 };
 
 export type PagePoliciesContentResourcesBlock = ResourceLink & {
-  __typename?: 'PagePoliciesContentResourcesBlock';
+  __typename?: "PagePoliciesContentResourcesBlock";
   sys: ResourceSys;
 };
 
 export type PagePoliciesContentResourcesHyperlink = ResourceLink & {
-  __typename?: 'PagePoliciesContentResourcesHyperlink';
+  __typename?: "PagePoliciesContentResourcesHyperlink";
   sys: ResourceSys;
 };
 
 export type PagePoliciesContentResourcesInline = ResourceLink & {
-  __typename?: 'PagePoliciesContentResourcesInline';
+  __typename?: "PagePoliciesContentResourcesInline";
   sys: ResourceSys;
 };
 
 export type PagePoliciesCursorCollection = {
-  __typename?: 'PagePoliciesCursorCollection';
+  __typename?: "PagePoliciesCursorCollection";
   items: Array<Maybe<PagePolicies>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export type PagePoliciesFilter = {
   AND?: InputMaybe<Array<InputMaybe<PagePoliciesFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PagePoliciesFilter>>>;
-  content_contains?: InputMaybe<Scalars['String']['input']>;
-  content_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  content_not_contains?: InputMaybe<Scalars['String']['input']>;
+  content_contains?: InputMaybe<Scalars["String"]["input"]>;
+  content_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  content_not_contains?: InputMaybe<Scalars["String"]["input"]>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageDescription?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_contains?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageDescription_not?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageTitle?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_contains?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageTitle_not?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageDescription?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageDescription_not?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageTitle?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageTitle_not?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type PagePoliciesLinkingCollections = {
-  __typename?: 'PagePoliciesLinkingCollections';
+  __typename?: "PagePoliciesLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
-
 export type PagePoliciesLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type PagePoliciesLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum PagePoliciesOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PageDescriptionAsc = 'pageDescription_ASC',
-  PageDescriptionDesc = 'pageDescription_DESC',
-  PageTitleAsc = 'pageTitle_ASC',
-  PageTitleDesc = 'pageTitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PageDescriptionAsc = "pageDescription_ASC",
+  PageDescriptionDesc = "pageDescription_DESC",
+  PageTitleAsc = "pageTitle_ASC",
+  PageTitleDesc = "pageTitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageTermsAndConditions) */
-export type PageTermsAndConditions = Entry & _Node & {
-  __typename?: 'PageTermsAndConditions';
-  _id: Scalars['ID']['output'];
-  content?: Maybe<PageTermsAndConditionsContent>;
-  contentfulMetadata: ContentfulMetadata;
-  internalName?: Maybe<Scalars['String']['output']>;
-  linkedFrom?: Maybe<PageTermsAndConditionsLinkingCollections>;
-  pageDescription?: Maybe<Scalars['String']['output']>;
-  pageTitle?: Maybe<Scalars['String']['output']>;
-  sys: Sys;
-  title?: Maybe<Scalars['String']['output']>;
-};
-
+export type PageTermsAndConditions = Entry &
+  _Node & {
+    __typename?: "PageTermsAndConditions";
+    _id: Scalars["ID"]["output"];
+    content?: Maybe<PageTermsAndConditionsContent>;
+    contentfulMetadata: ContentfulMetadata;
+    internalName?: Maybe<Scalars["String"]["output"]>;
+    linkedFrom?: Maybe<PageTermsAndConditionsLinkingCollections>;
+    pageDescription?: Maybe<Scalars["String"]["output"]>;
+    pageTitle?: Maybe<Scalars["String"]["output"]>;
+    sys: Sys;
+    title?: Maybe<Scalars["String"]["output"]>;
+  };
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageTermsAndConditions) */
 export type PageTermsAndConditionsContentArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageTermsAndConditions) */
 export type PageTermsAndConditionsInternalNameArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageTermsAndConditions) */
 export type PageTermsAndConditionsLinkedFromArgs = {
-  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  allowedLocales?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageTermsAndConditions) */
 export type PageTermsAndConditionsPageDescriptionArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageTermsAndConditions) */
 export type PageTermsAndConditionsPageTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 /** [See type definition](https://app.contentful.com/spaces/9h8woqnnje85/content_types/pageTermsAndConditions) */
 export type PageTermsAndConditionsTitleArgs = {
-  locale?: InputMaybe<Scalars['String']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export type PageTermsAndConditionsCollection = {
-  __typename?: 'PageTermsAndConditionsCollection';
+  __typename?: "PageTermsAndConditionsCollection";
   items: Array<Maybe<PageTermsAndConditions>>;
-  limit: Scalars['Int']['output'];
-  skip: Scalars['Int']['output'];
-  total: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
+  skip: Scalars["Int"]["output"];
+  total: Scalars["Int"]["output"];
 };
 
 export type PageTermsAndConditionsContent = {
-  __typename?: 'PageTermsAndConditionsContent';
-  json: Scalars['JSON']['output'];
+  __typename?: "PageTermsAndConditionsContent";
+  json: Scalars["JSON"]["output"];
   links: PageTermsAndConditionsContentLinks;
 };
 
 export type PageTermsAndConditionsContentAssets = {
-  __typename?: 'PageTermsAndConditionsContentAssets';
+  __typename?: "PageTermsAndConditionsContentAssets";
   block: Array<Maybe<Asset>>;
   hyperlink: Array<Maybe<Asset>>;
 };
 
 export type PageTermsAndConditionsContentEntries = {
-  __typename?: 'PageTermsAndConditionsContentEntries';
+  __typename?: "PageTermsAndConditionsContentEntries";
   block: Array<Maybe<Entry>>;
   hyperlink: Array<Maybe<Entry>>;
   inline: Array<Maybe<Entry>>;
 };
 
 export type PageTermsAndConditionsContentLinks = {
-  __typename?: 'PageTermsAndConditionsContentLinks';
+  __typename?: "PageTermsAndConditionsContentLinks";
   assets: PageTermsAndConditionsContentAssets;
   entries: PageTermsAndConditionsContentEntries;
   resources: PageTermsAndConditionsContentResources;
 };
 
 export type PageTermsAndConditionsContentResources = {
-  __typename?: 'PageTermsAndConditionsContentResources';
+  __typename?: "PageTermsAndConditionsContentResources";
   block: Array<PageTermsAndConditionsContentResourcesBlock>;
   hyperlink: Array<PageTermsAndConditionsContentResourcesHyperlink>;
   inline: Array<PageTermsAndConditionsContentResourcesInline>;
 };
 
 export type PageTermsAndConditionsContentResourcesBlock = ResourceLink & {
-  __typename?: 'PageTermsAndConditionsContentResourcesBlock';
+  __typename?: "PageTermsAndConditionsContentResourcesBlock";
   sys: ResourceSys;
 };
 
 export type PageTermsAndConditionsContentResourcesHyperlink = ResourceLink & {
-  __typename?: 'PageTermsAndConditionsContentResourcesHyperlink';
+  __typename?: "PageTermsAndConditionsContentResourcesHyperlink";
   sys: ResourceSys;
 };
 
 export type PageTermsAndConditionsContentResourcesInline = ResourceLink & {
-  __typename?: 'PageTermsAndConditionsContentResourcesInline';
+  __typename?: "PageTermsAndConditionsContentResourcesInline";
   sys: ResourceSys;
 };
 
 export type PageTermsAndConditionsCursorCollection = {
-  __typename?: 'PageTermsAndConditionsCursorCollection';
+  __typename?: "PageTermsAndConditionsCursorCollection";
   items: Array<Maybe<PageTermsAndConditions>>;
-  limit: Scalars['Int']['output'];
+  limit: Scalars["Int"]["output"];
   pages: CursorPages;
 };
 
 export type PageTermsAndConditionsFilter = {
   AND?: InputMaybe<Array<InputMaybe<PageTermsAndConditionsFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<PageTermsAndConditionsFilter>>>;
-  content_contains?: InputMaybe<Scalars['String']['input']>;
-  content_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  content_not_contains?: InputMaybe<Scalars['String']['input']>;
+  content_contains?: InputMaybe<Scalars["String"]["input"]>;
+  content_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  content_not_contains?: InputMaybe<Scalars["String"]["input"]>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageDescription?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_contains?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageDescription_not?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageTitle?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_contains?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageTitle_not?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageDescription?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageDescription_not?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageTitle?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageTitle_not?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type PageTermsAndConditionsLinkingCollections = {
-  __typename?: 'PageTermsAndConditionsLinkingCollections';
+  __typename?: "PageTermsAndConditionsLinkingCollections";
   entryCollection?: Maybe<EntryCollection>;
   entryCursorCollection?: Maybe<EntryCursorCollection>;
 };
 
-
 export type PageTermsAndConditionsLinkingCollectionsEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type PageTermsAndConditionsLinkingCollectionsEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
 export enum PageTermsAndConditionsOrder {
-  InternalNameAsc = 'internalName_ASC',
-  InternalNameDesc = 'internalName_DESC',
-  PageDescriptionAsc = 'pageDescription_ASC',
-  PageDescriptionDesc = 'pageDescription_DESC',
-  PageTitleAsc = 'pageTitle_ASC',
-  PageTitleDesc = 'pageTitle_DESC',
-  SysFirstPublishedAtAsc = 'sys_firstPublishedAt_ASC',
-  SysFirstPublishedAtDesc = 'sys_firstPublishedAt_DESC',
-  SysIdAsc = 'sys_id_ASC',
-  SysIdDesc = 'sys_id_DESC',
-  SysPublishedAtAsc = 'sys_publishedAt_ASC',
-  SysPublishedAtDesc = 'sys_publishedAt_DESC',
-  SysPublishedVersionAsc = 'sys_publishedVersion_ASC',
-  SysPublishedVersionDesc = 'sys_publishedVersion_DESC',
-  TitleAsc = 'title_ASC',
-  TitleDesc = 'title_DESC'
+  InternalNameAsc = "internalName_ASC",
+  InternalNameDesc = "internalName_DESC",
+  PageDescriptionAsc = "pageDescription_ASC",
+  PageDescriptionDesc = "pageDescription_DESC",
+  PageTitleAsc = "pageTitle_ASC",
+  PageTitleDesc = "pageTitle_DESC",
+  SysFirstPublishedAtAsc = "sys_firstPublishedAt_ASC",
+  SysFirstPublishedAtDesc = "sys_firstPublishedAt_DESC",
+  SysIdAsc = "sys_id_ASC",
+  SysIdDesc = "sys_id_DESC",
+  SysPublishedAtAsc = "sys_publishedAt_ASC",
+  SysPublishedAtDesc = "sys_publishedAt_DESC",
+  SysPublishedVersionAsc = "sys_publishedVersion_ASC",
+  SysPublishedVersionDesc = "sys_publishedVersion_DESC",
+  TitleAsc = "title_ASC",
+  TitleDesc = "title_DESC",
 }
 
 export type Query = {
-  __typename?: 'Query';
+  __typename?: "Query";
   _node?: Maybe<_Node>;
   _nodes: Array<Maybe<_Node>>;
   asset?: Maybe<Asset>;
@@ -6776,848 +6563,766 @@ export type Query = {
   pageTermsAndConditionsCursorCollection?: Maybe<PageTermsAndConditionsCursorCollection>;
 };
 
-
 export type Query_NodeArgs = {
-  id: Scalars['ID']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["ID"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type Query_NodesArgs = {
-  ids: Array<Scalars['ID']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  ids: Array<Scalars["ID"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryAssetArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryAssetCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<AssetOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<AssetFilter>;
 };
-
 
 export type QueryAssetCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<AssetOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<AssetFilter>;
 };
 
-
 export type QueryComponentAlertArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryComponentAlertCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentAlertOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentAlertFilter>;
 };
-
 
 export type QueryComponentAlertCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentAlertOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentAlertFilter>;
 };
 
-
 export type QueryComponentAuthorArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryComponentAuthorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentAuthorOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentAuthorFilter>;
 };
-
 
 export type QueryComponentAuthorCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentAuthorOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentAuthorFilter>;
 };
 
-
 export type QueryComponentButtonArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryComponentButtonCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentButtonOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
-
 
 export type QueryComponentButtonCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentButtonOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentButtonFilter>;
 };
 
-
 export type QueryComponentEmailArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryComponentEmailCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentEmailOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentEmailFilter>;
 };
-
 
 export type QueryComponentEmailCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentEmailOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentEmailFilter>;
 };
 
-
 export type QueryComponentFaqQuestionArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryComponentFaqQuestionCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentFaqQuestionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentFaqQuestionFilter>;
 };
-
 
 export type QueryComponentFaqQuestionCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentFaqQuestionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentFaqQuestionFilter>;
 };
 
-
 export type QueryComponentFeatureArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryComponentFeatureCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentFeatureOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentFeatureFilter>;
 };
-
 
 export type QueryComponentFeatureCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentFeatureOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentFeatureFilter>;
 };
 
-
 export type QueryComponentPartnerArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryComponentPartnerCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentPartnerOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentPartnerFilter>;
 };
-
 
 export type QueryComponentPartnerCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentPartnerOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentPartnerFilter>;
 };
 
-
 export type QueryComponentReleaseNoteArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryComponentReleaseNoteCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentReleaseNoteOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentReleaseNoteFilter>;
 };
-
 
 export type QueryComponentReleaseNoteCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentReleaseNoteOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentReleaseNoteFilter>;
 };
 
-
 export type QueryComponentRichImageArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryComponentRichImageCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentRichImageOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentRichImageFilter>;
 };
-
 
 export type QueryComponentRichImageCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentRichImageOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentRichImageFilter>;
 };
 
-
 export type QueryComponentSeoArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryComponentSeoCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentSeoOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentSeoFilter>;
 };
-
 
 export type QueryComponentSeoCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<ComponentSeoOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<ComponentSeoFilter>;
 };
 
-
 export type QueryEntryCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<EntryOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<EntryFilter>;
 };
-
 
 export type QueryEntryCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<EntryOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<EntryFilter>;
 };
 
-
 export type QueryFooterArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryFooterCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<FooterOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<FooterFilter>;
 };
-
 
 export type QueryFooterCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<FooterOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<FooterFilter>;
 };
 
-
 export type QueryLandingMetadataArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryLandingMetadataCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<LandingMetadataOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<LandingMetadataFilter>;
 };
-
 
 export type QueryLandingMetadataCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<LandingMetadataOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<LandingMetadataFilter>;
 };
 
-
 export type QueryPageAboutArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryPageAboutCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageAboutOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageAboutFilter>;
 };
-
 
 export type QueryPageAboutCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageAboutOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageAboutFilter>;
 };
 
-
 export type QueryPageBlogPostArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryPageBlogPostCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageBlogPostOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageBlogPostFilter>;
 };
-
 
 export type QueryPageBlogPostCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageBlogPostOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageBlogPostFilter>;
 };
 
-
 export type QueryPageCookiePolicyArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryPageCookiePolicyCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageCookiePolicyOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageCookiePolicyFilter>;
 };
-
 
 export type QueryPageCookiePolicyCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageCookiePolicyOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageCookiePolicyFilter>;
 };
 
-
 export type QueryPageEmailsArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryPageEmailsCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageEmailsOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageEmailsFilter>;
 };
-
 
 export type QueryPageEmailsCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageEmailsOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageEmailsFilter>;
 };
 
-
 export type QueryPageFaqArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryPageFaqCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageFaqOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageFaqFilter>;
 };
-
 
 export type QueryPageFaqCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageFaqOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageFaqFilter>;
 };
 
-
 export type QueryPageForceUpdateArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryPageForceUpdateCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageForceUpdateOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageForceUpdateFilter>;
 };
-
 
 export type QueryPageForceUpdateCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageForceUpdateOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageForceUpdateFilter>;
 };
 
-
 export type QueryPageHomeFeaturesArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryPageHomeFeaturesCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageHomeFeaturesOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageHomeFeaturesFilter>;
 };
-
 
 export type QueryPageHomeFeaturesCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageHomeFeaturesOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageHomeFeaturesFilter>;
 };
 
-
 export type QueryPageHomeHeroArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryPageHomeHeroCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageHomeHeroOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageHomeHeroFilter>;
 };
-
 
 export type QueryPageHomeHeroCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageHomeHeroOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageHomeHeroFilter>;
 };
 
-
 export type QueryPageHomeMissionArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryPageHomeMissionCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageHomeMissionOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageHomeMissionFilter>;
 };
-
 
 export type QueryPageHomeMissionCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageHomeMissionOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageHomeMissionFilter>;
 };
 
-
 export type QueryPageHomePartnersArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryPageHomePartnersCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageHomePartnersOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageHomePartnersFilter>;
 };
-
 
 export type QueryPageHomePartnersCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageHomePartnersOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageHomePartnersFilter>;
 };
 
-
 export type QueryPageLandingArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryPageLandingCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageLandingOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageLandingFilter>;
 };
-
 
 export type QueryPageLandingCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageLandingOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageLandingFilter>;
 };
 
-
 export type QueryPagePoliciesArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
-
 
 export type QueryPagePoliciesCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PagePoliciesOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PagePoliciesFilter>;
 };
-
 
 export type QueryPagePoliciesCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PagePoliciesOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PagePoliciesFilter>;
 };
 
-
 export type QueryPageTermsAndConditionsArgs = {
-  id: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  id: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
 };
 
-
 export type QueryPageTermsAndConditionsCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageTermsAndConditionsOrder>>>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  skip?: InputMaybe<Scalars['Int']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  skip?: InputMaybe<Scalars["Int"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageTermsAndConditionsFilter>;
 };
 
-
 export type QueryPageTermsAndConditionsCursorCollectionArgs = {
-  limit?: InputMaybe<Scalars['Int']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageTermsAndConditionsOrder>>>;
-  pageNext?: InputMaybe<Scalars['String']['input']>;
-  pagePrev?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  useFallbackLocale?: InputMaybe<Scalars['Boolean']['input']>;
+  pageNext?: InputMaybe<Scalars["String"]["input"]>;
+  pagePrev?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  useFallbackLocale?: InputMaybe<Scalars["Boolean"]["input"]>;
   where?: InputMaybe<PageTermsAndConditionsFilter>;
 };
 
@@ -7626,58 +7331,58 @@ export type ResourceLink = {
 };
 
 export type ResourceSys = {
-  __typename?: 'ResourceSys';
-  linkType: Scalars['String']['output'];
-  urn: Scalars['String']['output'];
+  __typename?: "ResourceSys";
+  linkType: Scalars["String"]["output"];
+  urn: Scalars["String"]["output"];
 };
 
 export type Sys = {
-  __typename?: 'Sys';
-  environmentId: Scalars['String']['output'];
-  firstPublishedAt?: Maybe<Scalars['DateTime']['output']>;
-  id: Scalars['String']['output'];
+  __typename?: "Sys";
+  environmentId: Scalars["String"]["output"];
+  firstPublishedAt?: Maybe<Scalars["DateTime"]["output"]>;
+  id: Scalars["String"]["output"];
   /** The locale that was requested. */
-  locale?: Maybe<Scalars['String']['output']>;
-  publishedAt?: Maybe<Scalars['DateTime']['output']>;
-  publishedVersion?: Maybe<Scalars['Int']['output']>;
-  spaceId: Scalars['String']['output'];
+  locale?: Maybe<Scalars["String"]["output"]>;
+  publishedAt?: Maybe<Scalars["DateTime"]["output"]>;
+  publishedVersion?: Maybe<Scalars["Int"]["output"]>;
+  spaceId: Scalars["String"]["output"];
 };
 
 export type SysFilter = {
-  firstPublishedAt?: InputMaybe<Scalars['DateTime']['input']>;
-  firstPublishedAt_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  firstPublishedAt_gt?: InputMaybe<Scalars['DateTime']['input']>;
-  firstPublishedAt_gte?: InputMaybe<Scalars['DateTime']['input']>;
-  firstPublishedAt_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
-  firstPublishedAt_lt?: InputMaybe<Scalars['DateTime']['input']>;
-  firstPublishedAt_lte?: InputMaybe<Scalars['DateTime']['input']>;
-  firstPublishedAt_not?: InputMaybe<Scalars['DateTime']['input']>;
-  firstPublishedAt_not_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
-  id?: InputMaybe<Scalars['String']['input']>;
-  id_contains?: InputMaybe<Scalars['String']['input']>;
-  id_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  id_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  id_not?: InputMaybe<Scalars['String']['input']>;
-  id_not_contains?: InputMaybe<Scalars['String']['input']>;
-  id_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  publishedAt?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedAt_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  publishedAt_gt?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedAt_gte?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedAt_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
-  publishedAt_lt?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedAt_lte?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedAt_not?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedAt_not_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
-  publishedVersion?: InputMaybe<Scalars['Float']['input']>;
-  publishedVersion_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  publishedVersion_gt?: InputMaybe<Scalars['Float']['input']>;
-  publishedVersion_gte?: InputMaybe<Scalars['Float']['input']>;
-  publishedVersion_in?: InputMaybe<Array<InputMaybe<Scalars['Float']['input']>>>;
-  publishedVersion_lt?: InputMaybe<Scalars['Float']['input']>;
-  publishedVersion_lte?: InputMaybe<Scalars['Float']['input']>;
-  publishedVersion_not?: InputMaybe<Scalars['Float']['input']>;
-  publishedVersion_not_in?: InputMaybe<Array<InputMaybe<Scalars['Float']['input']>>>;
+  firstPublishedAt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  firstPublishedAt_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  firstPublishedAt_gt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  firstPublishedAt_gte?: InputMaybe<Scalars["DateTime"]["input"]>;
+  firstPublishedAt_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
+  firstPublishedAt_lt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  firstPublishedAt_lte?: InputMaybe<Scalars["DateTime"]["input"]>;
+  firstPublishedAt_not?: InputMaybe<Scalars["DateTime"]["input"]>;
+  firstPublishedAt_not_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
+  id?: InputMaybe<Scalars["String"]["input"]>;
+  id_contains?: InputMaybe<Scalars["String"]["input"]>;
+  id_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  id_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  id_not?: InputMaybe<Scalars["String"]["input"]>;
+  id_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  id_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  publishedAt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedAt_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  publishedAt_gt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedAt_gte?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedAt_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
+  publishedAt_lt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedAt_lte?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedAt_not?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedAt_not_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
+  publishedVersion?: InputMaybe<Scalars["Float"]["input"]>;
+  publishedVersion_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  publishedVersion_gt?: InputMaybe<Scalars["Float"]["input"]>;
+  publishedVersion_gte?: InputMaybe<Scalars["Float"]["input"]>;
+  publishedVersion_in?: InputMaybe<Array<InputMaybe<Scalars["Float"]["input"]>>>;
+  publishedVersion_lt?: InputMaybe<Scalars["Float"]["input"]>;
+  publishedVersion_lte?: InputMaybe<Scalars["Float"]["input"]>;
+  publishedVersion_not?: InputMaybe<Scalars["Float"]["input"]>;
+  publishedVersion_not_in?: InputMaybe<Array<InputMaybe<Scalars["Float"]["input"]>>>;
 };
 
 /**
@@ -7685,47 +7390,47 @@ export type SysFilter = {
  *         Find out more here: https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/content-concepts
  */
 export type TaxonomyConcept = {
-  __typename?: 'TaxonomyConcept';
-  id?: Maybe<Scalars['String']['output']>;
+  __typename?: "TaxonomyConcept";
+  id?: Maybe<Scalars["String"]["output"]>;
 };
 
 export type TimelineFilterInput = {
   /** Preview content starting from a given release date */
-  release_lte?: InputMaybe<Scalars['String']['input']>;
+  release_lte?: InputMaybe<Scalars["String"]["input"]>;
   /** Preview content starting from a given timestamp */
-  timestamp_lte?: InputMaybe<Scalars['DateTime']['input']>;
+  timestamp_lte?: InputMaybe<Scalars["DateTime"]["input"]>;
 };
 
 export type _Node = {
-  _id: Scalars['ID']['output'];
+  _id: Scalars["ID"]["output"];
 };
 
 export type CfComponentAuthorNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfComponentAuthorNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfComponentAuthorNestedFilter>>>;
-  avatar_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  avatar_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  name?: InputMaybe<Scalars['String']['input']>;
-  name_contains?: InputMaybe<Scalars['String']['input']>;
-  name_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  name_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  name_not?: InputMaybe<Scalars['String']['input']>;
-  name_not_contains?: InputMaybe<Scalars['String']['input']>;
-  name_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  profession?: InputMaybe<Scalars['String']['input']>;
-  profession_contains?: InputMaybe<Scalars['String']['input']>;
-  profession_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  profession_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  profession_not?: InputMaybe<Scalars['String']['input']>;
-  profession_not_contains?: InputMaybe<Scalars['String']['input']>;
-  profession_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  name?: InputMaybe<Scalars["String"]["input"]>;
+  name_contains?: InputMaybe<Scalars["String"]["input"]>;
+  name_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  name_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  name_not?: InputMaybe<Scalars["String"]["input"]>;
+  name_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  name_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  profession?: InputMaybe<Scalars["String"]["input"]>;
+  profession_contains?: InputMaybe<Scalars["String"]["input"]>;
+  profession_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  profession_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  profession_not?: InputMaybe<Scalars["String"]["input"]>;
+  profession_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  profession_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
 };
 
@@ -7733,82 +7438,82 @@ export type CfComponentButtonNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfComponentButtonNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfComponentButtonNestedFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  label?: InputMaybe<Scalars['String']['input']>;
-  label_contains?: InputMaybe<Scalars['String']['input']>;
-  label_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  label_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  label_not?: InputMaybe<Scalars['String']['input']>;
-  label_not_contains?: InputMaybe<Scalars['String']['input']>;
-  label_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  label?: InputMaybe<Scalars["String"]["input"]>;
+  label_contains?: InputMaybe<Scalars["String"]["input"]>;
+  label_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  label_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  label_not?: InputMaybe<Scalars["String"]["input"]>;
+  label_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  label_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  url?: InputMaybe<Scalars['String']['input']>;
-  url_contains?: InputMaybe<Scalars['String']['input']>;
-  url_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  url_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  url_not?: InputMaybe<Scalars['String']['input']>;
-  url_not_contains?: InputMaybe<Scalars['String']['input']>;
-  url_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  url?: InputMaybe<Scalars["String"]["input"]>;
+  url_contains?: InputMaybe<Scalars["String"]["input"]>;
+  url_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  url_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  url_not?: InputMaybe<Scalars["String"]["input"]>;
+  url_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  url_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type CfComponentEmailNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfComponentEmailNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfComponentEmailNestedFilter>>>;
-  availableVariables?: InputMaybe<Scalars['String']['input']>;
-  availableVariables_contains?: InputMaybe<Scalars['String']['input']>;
-  availableVariables_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  availableVariables_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  availableVariables_not?: InputMaybe<Scalars['String']['input']>;
-  availableVariables_not_contains?: InputMaybe<Scalars['String']['input']>;
-  availableVariables_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  content_contains?: InputMaybe<Scalars['String']['input']>;
-  content_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  content_not_contains?: InputMaybe<Scalars['String']['input']>;
+  availableVariables?: InputMaybe<Scalars["String"]["input"]>;
+  availableVariables_contains?: InputMaybe<Scalars["String"]["input"]>;
+  availableVariables_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  availableVariables_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  availableVariables_not?: InputMaybe<Scalars["String"]["input"]>;
+  availableVariables_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  availableVariables_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  content_contains?: InputMaybe<Scalars["String"]["input"]>;
+  content_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  content_not_contains?: InputMaybe<Scalars["String"]["input"]>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  preview?: InputMaybe<Scalars['String']['input']>;
-  preview_contains?: InputMaybe<Scalars['String']['input']>;
-  preview_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  preview_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  preview_not?: InputMaybe<Scalars['String']['input']>;
-  preview_not_contains?: InputMaybe<Scalars['String']['input']>;
-  preview_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  preview?: InputMaybe<Scalars["String"]["input"]>;
+  preview_contains?: InputMaybe<Scalars["String"]["input"]>;
+  preview_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  preview_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  preview_not?: InputMaybe<Scalars["String"]["input"]>;
+  preview_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  preview_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
 };
 
 export type CfComponentFaqQuestionNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfComponentFaqQuestionNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfComponentFaqQuestionNestedFilter>>>;
-  answer_contains?: InputMaybe<Scalars['String']['input']>;
-  answer_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  answer_not_contains?: InputMaybe<Scalars['String']['input']>;
+  answer_contains?: InputMaybe<Scalars["String"]["input"]>;
+  answer_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  answer_not_contains?: InputMaybe<Scalars["String"]["input"]>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  question?: InputMaybe<Scalars['String']['input']>;
-  question_contains?: InputMaybe<Scalars['String']['input']>;
-  question_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  question_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  question_not?: InputMaybe<Scalars['String']['input']>;
-  question_not_contains?: InputMaybe<Scalars['String']['input']>;
-  question_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  question?: InputMaybe<Scalars["String"]["input"]>;
+  question_contains?: InputMaybe<Scalars["String"]["input"]>;
+  question_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  question_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  question_not?: InputMaybe<Scalars["String"]["input"]>;
+  question_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  question_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
 };
 
@@ -7816,1808 +7521,2566 @@ export type CfComponentFeatureNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfComponentFeatureNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfComponentFeatureNestedFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  icon_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  subtitle?: InputMaybe<Scalars['String']['input']>;
-  subtitle_contains?: InputMaybe<Scalars['String']['input']>;
-  subtitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  subtitle_not?: InputMaybe<Scalars['String']['input']>;
-  subtitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  icon_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  subtitle?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_contains?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  subtitle_not?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type CfComponentPartnerNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfComponentPartnerNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfComponentPartnerNestedFilter>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  logo_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  subtitle?: InputMaybe<Scalars['String']['input']>;
-  subtitle_contains?: InputMaybe<Scalars['String']['input']>;
-  subtitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  subtitle_not?: InputMaybe<Scalars['String']['input']>;
-  subtitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  logo_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  subtitle?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_contains?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  subtitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  subtitle_not?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  subtitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  url?: InputMaybe<Scalars['String']['input']>;
-  url_contains?: InputMaybe<Scalars['String']['input']>;
-  url_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  url_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  url_not?: InputMaybe<Scalars['String']['input']>;
-  url_not_contains?: InputMaybe<Scalars['String']['input']>;
-  url_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  url?: InputMaybe<Scalars["String"]["input"]>;
+  url_contains?: InputMaybe<Scalars["String"]["input"]>;
+  url_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  url_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  url_not?: InputMaybe<Scalars["String"]["input"]>;
+  url_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  url_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
 export type CfComponentSeoNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfComponentSeoNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfComponentSeoNestedFilter>>>;
-  canonicalUrl?: InputMaybe<Scalars['String']['input']>;
-  canonicalUrl_contains?: InputMaybe<Scalars['String']['input']>;
-  canonicalUrl_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  canonicalUrl_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  canonicalUrl_not?: InputMaybe<Scalars['String']['input']>;
-  canonicalUrl_not_contains?: InputMaybe<Scalars['String']['input']>;
-  canonicalUrl_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  canonicalUrl?: InputMaybe<Scalars["String"]["input"]>;
+  canonicalUrl_contains?: InputMaybe<Scalars["String"]["input"]>;
+  canonicalUrl_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  canonicalUrl_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  canonicalUrl_not?: InputMaybe<Scalars["String"]["input"]>;
+  canonicalUrl_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  canonicalUrl_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  nofollow?: InputMaybe<Scalars['Boolean']['input']>;
-  nofollow_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  nofollow_not?: InputMaybe<Scalars['Boolean']['input']>;
-  noindex?: InputMaybe<Scalars['Boolean']['input']>;
-  noindex_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  noindex_not?: InputMaybe<Scalars['Boolean']['input']>;
-  pageDescription?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_contains?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageDescription_not?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
-  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageTitle?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_contains?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  pageTitle_not?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_not_contains?: InputMaybe<Scalars['String']['input']>;
-  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  shareImagesCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  nofollow?: InputMaybe<Scalars["Boolean"]["input"]>;
+  nofollow_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  nofollow_not?: InputMaybe<Scalars["Boolean"]["input"]>;
+  noindex?: InputMaybe<Scalars["Boolean"]["input"]>;
+  noindex_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  noindex_not?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageDescription?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageDescription_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageDescription_not?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageTitle?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  pageTitle_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  pageTitle_not?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  pageTitle_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  shareImagesCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
   sys?: InputMaybe<SysFilter>;
 };
 
 export type CfPageBlogPostNestedFilter = {
   AND?: InputMaybe<Array<InputMaybe<CfPageBlogPostNestedFilter>>>;
   OR?: InputMaybe<Array<InputMaybe<CfPageBlogPostNestedFilter>>>;
-  author_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  content_contains?: InputMaybe<Scalars['String']['input']>;
-  content_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  content_not_contains?: InputMaybe<Scalars['String']['input']>;
+  author_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  content_contains?: InputMaybe<Scalars["String"]["input"]>;
+  content_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  content_not_contains?: InputMaybe<Scalars["String"]["input"]>;
   contentfulMetadata?: InputMaybe<ContentfulMetadataFilter>;
-  featuredImage_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName?: InputMaybe<Scalars['String']['input']>;
-  internalName_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  internalName_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  internalName_not?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_contains?: InputMaybe<Scalars['String']['input']>;
-  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  publishedDate?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedDate_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  publishedDate_gt?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedDate_gte?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedDate_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
-  publishedDate_lt?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedDate_lte?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedDate_not?: InputMaybe<Scalars['DateTime']['input']>;
-  publishedDate_not_in?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>;
-  relatedBlogPostsCollection_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  seoFields_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  shortDescription?: InputMaybe<Scalars['String']['input']>;
-  shortDescription_contains?: InputMaybe<Scalars['String']['input']>;
-  shortDescription_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  shortDescription_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  shortDescription_not?: InputMaybe<Scalars['String']['input']>;
-  shortDescription_not_contains?: InputMaybe<Scalars['String']['input']>;
-  shortDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  slug?: InputMaybe<Scalars['String']['input']>;
-  slug_contains?: InputMaybe<Scalars['String']['input']>;
-  slug_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  slug_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  slug_not?: InputMaybe<Scalars['String']['input']>;
-  slug_not_contains?: InputMaybe<Scalars['String']['input']>;
-  slug_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  featuredImage_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  internalName_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  internalName_not?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  internalName_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  publishedDate?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedDate_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  publishedDate_gt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedDate_gte?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedDate_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
+  publishedDate_lt?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedDate_lte?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedDate_not?: InputMaybe<Scalars["DateTime"]["input"]>;
+  publishedDate_not_in?: InputMaybe<Array<InputMaybe<Scalars["DateTime"]["input"]>>>;
+  relatedBlogPostsCollection_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  seoFields_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  shortDescription?: InputMaybe<Scalars["String"]["input"]>;
+  shortDescription_contains?: InputMaybe<Scalars["String"]["input"]>;
+  shortDescription_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  shortDescription_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  shortDescription_not?: InputMaybe<Scalars["String"]["input"]>;
+  shortDescription_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  shortDescription_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  slug?: InputMaybe<Scalars["String"]["input"]>;
+  slug_contains?: InputMaybe<Scalars["String"]["input"]>;
+  slug_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  slug_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  slug_not?: InputMaybe<Scalars["String"]["input"]>;
+  slug_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  slug_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   sys?: InputMaybe<SysFilter>;
-  title?: InputMaybe<Scalars['String']['input']>;
-  title_contains?: InputMaybe<Scalars['String']['input']>;
-  title_exists?: InputMaybe<Scalars['Boolean']['input']>;
-  title_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  title_not?: InputMaybe<Scalars['String']['input']>;
-  title_not_contains?: InputMaybe<Scalars['String']['input']>;
-  title_not_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  title?: InputMaybe<Scalars["String"]["input"]>;
+  title_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_exists?: InputMaybe<Scalars["Boolean"]["input"]>;
+  title_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
+  title_not?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_contains?: InputMaybe<Scalars["String"]["input"]>;
+  title_not_in?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
 };
 
-export type AuthorFieldsFragment = { __typename: 'ComponentAuthor', name?: string | null, profession?: string | null, sys: { __typename?: 'Sys', id: string }, avatar?: (
-    { __typename?: 'Asset' }
-    & ImageFieldsFragment
-  ) | null };
+export type AuthorFieldsFragment = {
+  __typename: "ComponentAuthor";
+  name?: string | null;
+  profession?: string | null;
+  sys: { __typename?: "Sys"; id: string };
+  avatar?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
+};
 
-export type ComponentAlertFieldsFragment = { __typename: 'ComponentAlert', internalName?: string | null, title?: string | null, type?: string | null, severity?: string | null, dismissible?: boolean | null, audience?: string | null, startAt?: any | null, endAt?: any | null, active?: boolean | null, sys: { __typename?: 'Sys', id: string }, body?: { __typename?: 'ComponentAlertBody', json: any } | null, link?: (
-    { __typename?: 'ComponentButton' }
-    & ButtonFieldsFragment
-  ) | null };
+export type ComponentAlertFieldsFragment = {
+  __typename: "ComponentAlert";
+  internalName?: string | null;
+  title?: string | null;
+  type?: string | null;
+  severity?: string | null;
+  dismissible?: boolean | null;
+  audience?: string | null;
+  startAt?: any | null;
+  endAt?: any | null;
+  active?: boolean | null;
+  sys: { __typename?: "Sys"; id: string };
+  body?: { __typename?: "ComponentAlertBody"; json: any } | null;
+  link?: ({ __typename?: "ComponentButton" } & ButtonFieldsFragment) | null;
+};
 
 export type ActiveAlertsQueryVariables = Exact<{
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  now: Scalars['DateTime']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  audience?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>> | InputMaybe<Scalars['String']['input']>>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  now: Scalars["DateTime"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  audience?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>> | InputMaybe<Scalars["String"]["input"]>
+  >;
 }>;
 
+export type ActiveAlertsQuery = {
+  __typename?: "Query";
+  componentAlertCollection?: {
+    __typename?: "ComponentAlertCollection";
+    items: Array<({ __typename?: "ComponentAlert" } & ComponentAlertFieldsFragment) | null>;
+  } | null;
+};
 
-export type ActiveAlertsQuery = { __typename?: 'Query', componentAlertCollection?: { __typename?: 'ComponentAlertCollection', items: Array<(
-      { __typename?: 'ComponentAlert' }
-      & ComponentAlertFieldsFragment
-    ) | null> } | null };
+export type FooterFieldsFragment = {
+  __typename: "Footer";
+  internalName?: string | null;
+  brand?: string | null;
+  title?: string | null;
+  badge?: string | null;
+  menuTitle?: string | null;
+  supportTitle?: string | null;
+  copyright?: string | null;
+  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
+  menuButtonsCollection?: {
+    __typename?: "FooterMenuButtonsCollection";
+    items: Array<({ __typename?: "ComponentButton" } & ButtonFieldsFragment) | null>;
+  } | null;
+  supportButtonsCollection?: {
+    __typename?: "FooterSupportButtonsCollection";
+    items: Array<({ __typename?: "ComponentButton" } & ButtonFieldsFragment) | null>;
+  } | null;
+};
 
-export type FooterFieldsFragment = { __typename: 'Footer', internalName?: string | null, brand?: string | null, title?: string | null, badge?: string | null, menuTitle?: string | null, supportTitle?: string | null, copyright?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, menuButtonsCollection?: { __typename?: 'FooterMenuButtonsCollection', items: Array<(
-      { __typename?: 'ComponentButton' }
-      & ButtonFieldsFragment
-    ) | null> } | null, supportButtonsCollection?: { __typename?: 'FooterSupportButtonsCollection', items: Array<(
-      { __typename?: 'ComponentButton' }
-      & ButtonFieldsFragment
-    ) | null> } | null };
-
-export type ButtonFieldsFragment = { __typename: 'ComponentButton', label?: string | null, url?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string } };
+export type ButtonFieldsFragment = {
+  __typename: "ComponentButton";
+  label?: string | null;
+  url?: string | null;
+  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
+};
 
 export type FooterQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
+export type FooterQuery = {
+  __typename?: "Query";
+  footerCollection?: {
+    __typename?: "FooterCollection";
+    items: Array<({ __typename?: "Footer" } & FooterFieldsFragment) | null>;
+  } | null;
+};
 
-export type FooterQuery = { __typename?: 'Query', footerCollection?: { __typename?: 'FooterCollection', items: Array<(
-      { __typename?: 'Footer' }
-      & FooterFieldsFragment
-    ) | null> } | null };
+export type ImageFieldsFragment = {
+  __typename: "Asset";
+  title?: string | null;
+  description?: string | null;
+  width?: number | null;
+  height?: number | null;
+  url?: string | null;
+  contentType?: string | null;
+  sys: { __typename?: "Sys"; id: string };
+};
 
-export type ImageFieldsFragment = { __typename: 'Asset', title?: string | null, description?: string | null, width?: number | null, height?: number | null, url?: string | null, contentType?: string | null, sys: { __typename?: 'Sys', id: string } };
-
-export type LandingMetadataFieldsFragment = { __typename: 'LandingMetadata', internalName?: string | null, title?: string | null, description?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string } };
+export type LandingMetadataFieldsFragment = {
+  __typename: "LandingMetadata";
+  internalName?: string | null;
+  title?: string | null;
+  description?: string | null;
+  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
+};
 
 export type LandingMetadataQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
+export type LandingMetadataQuery = {
+  __typename?: "Query";
+  landingMetadataCollection?: {
+    __typename?: "LandingMetadataCollection";
+    items: Array<({ __typename?: "LandingMetadata" } & LandingMetadataFieldsFragment) | null>;
+  } | null;
+};
 
-export type LandingMetadataQuery = { __typename?: 'Query', landingMetadataCollection?: { __typename?: 'LandingMetadataCollection', items: Array<(
-      { __typename?: 'LandingMetadata' }
-      & LandingMetadataFieldsFragment
-    ) | null> } | null };
-
-export type PageAboutFieldsFragment = { __typename: 'PageAbout', pageTitle?: string | null, pageDescription?: string | null, internalName?: string | null, title?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, description?: { __typename?: 'PageAboutDescription', json: any, links: { __typename?: 'PageAboutDescriptionLinks', entries: { __typename?: 'PageAboutDescriptionEntries', block: Array<
-          | { __typename?: 'ComponentAlert' }
-          | { __typename?: 'ComponentAuthor' }
-          | { __typename?: 'ComponentButton' }
-          | { __typename?: 'ComponentEmail' }
-          | { __typename?: 'ComponentFaqQuestion' }
-          | { __typename?: 'ComponentFeature' }
-          | { __typename?: 'ComponentPartner' }
-          | { __typename?: 'ComponentReleaseNote' }
-          | (
-            { __typename?: 'ComponentRichImage' }
-            & RichImageFieldsFragment
-          )
-          | { __typename?: 'ComponentSeo' }
-          | { __typename?: 'Footer' }
-          | { __typename?: 'LandingMetadata' }
-          | { __typename?: 'PageAbout' }
-          | { __typename?: 'PageBlogPost' }
-          | { __typename?: 'PageCookiePolicy' }
-          | { __typename?: 'PageEmails' }
-          | { __typename?: 'PageFaq' }
-          | { __typename?: 'PageForceUpdate' }
-          | { __typename?: 'PageHomeFeatures' }
-          | { __typename?: 'PageHomeHero' }
-          | { __typename?: 'PageHomeMission' }
-          | { __typename?: 'PageHomePartners' }
-          | { __typename?: 'PageLanding' }
-          | { __typename?: 'PagePolicies' }
-          | { __typename?: 'PageTermsAndConditions' }
-         | null> } } } | null, image?: (
-    { __typename?: 'Asset' }
-    & ImageFieldsFragment
-  ) | null };
+export type PageAboutFieldsFragment = {
+  __typename: "PageAbout";
+  pageTitle?: string | null;
+  pageDescription?: string | null;
+  internalName?: string | null;
+  title?: string | null;
+  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
+  description?: {
+    __typename?: "PageAboutDescription";
+    json: any;
+    links: {
+      __typename?: "PageAboutDescriptionLinks";
+      entries: {
+        __typename?: "PageAboutDescriptionEntries";
+        block: Array<
+          | { __typename?: "ComponentAlert" }
+          | { __typename?: "ComponentAuthor" }
+          | { __typename?: "ComponentButton" }
+          | { __typename?: "ComponentEmail" }
+          | { __typename?: "ComponentFaqQuestion" }
+          | { __typename?: "ComponentFeature" }
+          | { __typename?: "ComponentPartner" }
+          | { __typename?: "ComponentReleaseNote" }
+          | ({ __typename?: "ComponentRichImage" } & RichImageFieldsFragment)
+          | { __typename?: "ComponentSeo" }
+          | { __typename?: "Footer" }
+          | { __typename?: "LandingMetadata" }
+          | { __typename?: "PageAbout" }
+          | { __typename?: "PageBlogPost" }
+          | { __typename?: "PageCookiePolicy" }
+          | { __typename?: "PageEmails" }
+          | { __typename?: "PageFaq" }
+          | { __typename?: "PageForceUpdate" }
+          | { __typename?: "PageHomeFeatures" }
+          | { __typename?: "PageHomeHero" }
+          | { __typename?: "PageHomeMission" }
+          | { __typename?: "PageHomePartners" }
+          | { __typename?: "PageLanding" }
+          | { __typename?: "PagePolicies" }
+          | { __typename?: "PageTermsAndConditions" }
+          | null
+        >;
+      };
+    };
+  } | null;
+  image?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
+};
 
 export type PageAboutQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
-
-export type PageAboutQuery = { __typename?: 'Query', pageAboutCollection?: { __typename?: 'PageAboutCollection', items: Array<(
-      { __typename?: 'PageAbout' }
-      & PageAboutFieldsFragment
-    ) | null> } | null };
+export type PageAboutQuery = {
+  __typename?: "Query";
+  pageAboutCollection?: {
+    __typename?: "PageAboutCollection";
+    items: Array<({ __typename?: "PageAbout" } & PageAboutFieldsFragment) | null>;
+  } | null;
+};
 
 export type PageBlogQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageBlogPostOrder>> | InputMaybe<PageBlogPostOrder>>;
   where?: InputMaybe<PageBlogPostFilter>;
 }>;
 
-
-export type PageBlogQuery = { __typename?: 'Query', pageLandingCollection?: { __typename?: 'PageLandingCollection', items: Array<(
-      { __typename?: 'PageLanding' }
-      & PageLandingFieldsFragment
-    ) | null> } | null, pageBlogPostCollection?: { __typename?: 'PageBlogPostCollection', items: Array<(
-      { __typename?: 'PageBlogPost' }
-      & PageBlogPostFieldsFragment
-    ) | null> } | null };
+export type PageBlogQuery = {
+  __typename?: "Query";
+  pageLandingCollection?: {
+    __typename?: "PageLandingCollection";
+    items: Array<({ __typename?: "PageLanding" } & PageLandingFieldsFragment) | null>;
+  } | null;
+  pageBlogPostCollection?: {
+    __typename?: "PageBlogPostCollection";
+    items: Array<({ __typename?: "PageBlogPost" } & PageBlogPostFieldsFragment) | null>;
+  } | null;
+};
 
 export type PageBlogDetailQueryVariables = Exact<{
-  slug: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  slug: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
+export type PageBlogDetailQuery = {
+  __typename?: "Query";
+  pageBlogPostCollection?: {
+    __typename?: "PageBlogPostCollection";
+    items: Array<({ __typename?: "PageBlogPost" } & PageBlogPostFieldsFragment) | null>;
+  } | null;
+  pageLandingCollection?: {
+    __typename?: "PageLandingCollection";
+    items: Array<({ __typename?: "PageLanding" } & PageLandingFieldsFragment) | null>;
+  } | null;
+};
 
-export type PageBlogDetailQuery = { __typename?: 'Query', pageBlogPostCollection?: { __typename?: 'PageBlogPostCollection', items: Array<(
-      { __typename?: 'PageBlogPost' }
-      & PageBlogPostFieldsFragment
-    ) | null> } | null, pageLandingCollection?: { __typename?: 'PageLandingCollection', items: Array<(
-      { __typename?: 'PageLanding' }
-      & PageLandingFieldsFragment
-    ) | null> } | null };
+export type ReferencePageBlogPostFieldsFragment = {
+  __typename: "PageBlogPost";
+  slug?: string | null;
+  publishedDate?: any | null;
+  title?: string | null;
+  shortDescription?: string | null;
+  sys: { __typename?: "Sys"; id: string; spaceId: string };
+  author?: ({ __typename?: "ComponentAuthor" } & AuthorFieldsFragment) | null;
+  featuredImage?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
+};
 
-export type ReferencePageBlogPostFieldsFragment = { __typename: 'PageBlogPost', slug?: string | null, publishedDate?: any | null, title?: string | null, shortDescription?: string | null, sys: { __typename?: 'Sys', id: string, spaceId: string }, author?: (
-    { __typename?: 'ComponentAuthor' }
-    & AuthorFieldsFragment
-  ) | null, featuredImage?: (
-    { __typename?: 'Asset' }
-    & ImageFieldsFragment
-  ) | null };
-
-export type PageBlogPostFieldsFragment = { __typename: 'PageBlogPost', internalName?: string | null, slug?: string | null, publishedDate?: any | null, title?: string | null, shortDescription?: string | null, sys: { __typename?: 'Sys', id: string, spaceId: string }, seoFields?: (
-    { __typename?: 'ComponentSeo' }
-    & SeoFieldsFragment
-  ) | null, author?: (
-    { __typename?: 'ComponentAuthor' }
-    & AuthorFieldsFragment
-  ) | null, featuredImage?: (
-    { __typename?: 'Asset' }
-    & ImageFieldsFragment
-  ) | null, content?: { __typename?: 'PageBlogPostContent', json: any, links: { __typename?: 'PageBlogPostContentLinks', entries: { __typename?: 'PageBlogPostContentEntries', block: Array<
-          | { __typename?: 'ComponentAlert' }
-          | { __typename?: 'ComponentAuthor' }
-          | { __typename?: 'ComponentButton' }
-          | { __typename?: 'ComponentEmail' }
-          | { __typename?: 'ComponentFaqQuestion' }
-          | { __typename?: 'ComponentFeature' }
-          | { __typename?: 'ComponentPartner' }
-          | { __typename?: 'ComponentReleaseNote' }
-          | (
-            { __typename?: 'ComponentRichImage' }
-            & RichImageFieldsFragment
-          )
-          | { __typename?: 'ComponentSeo' }
-          | { __typename?: 'Footer' }
-          | { __typename?: 'LandingMetadata' }
-          | { __typename?: 'PageAbout' }
-          | { __typename?: 'PageBlogPost' }
-          | { __typename?: 'PageCookiePolicy' }
-          | { __typename?: 'PageEmails' }
-          | { __typename?: 'PageFaq' }
-          | { __typename?: 'PageForceUpdate' }
-          | { __typename?: 'PageHomeFeatures' }
-          | { __typename?: 'PageHomeHero' }
-          | { __typename?: 'PageHomeMission' }
-          | { __typename?: 'PageHomePartners' }
-          | { __typename?: 'PageLanding' }
-          | { __typename?: 'PagePolicies' }
-          | { __typename?: 'PageTermsAndConditions' }
-         | null> } } } | null, relatedBlogPostsCollection?: { __typename?: 'PageBlogPostRelatedBlogPostsCollection', items: Array<(
-      { __typename?: 'PageBlogPost' }
-      & ReferencePageBlogPostFieldsFragment
-    ) | null> } | null };
+export type PageBlogPostFieldsFragment = {
+  __typename: "PageBlogPost";
+  internalName?: string | null;
+  slug?: string | null;
+  publishedDate?: any | null;
+  title?: string | null;
+  shortDescription?: string | null;
+  sys: { __typename?: "Sys"; id: string; spaceId: string };
+  seoFields?: ({ __typename?: "ComponentSeo" } & SeoFieldsFragment) | null;
+  author?: ({ __typename?: "ComponentAuthor" } & AuthorFieldsFragment) | null;
+  featuredImage?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
+  content?: {
+    __typename?: "PageBlogPostContent";
+    json: any;
+    links: {
+      __typename?: "PageBlogPostContentLinks";
+      entries: {
+        __typename?: "PageBlogPostContentEntries";
+        block: Array<
+          | { __typename?: "ComponentAlert" }
+          | { __typename?: "ComponentAuthor" }
+          | { __typename?: "ComponentButton" }
+          | { __typename?: "ComponentEmail" }
+          | { __typename?: "ComponentFaqQuestion" }
+          | { __typename?: "ComponentFeature" }
+          | { __typename?: "ComponentPartner" }
+          | { __typename?: "ComponentReleaseNote" }
+          | ({ __typename?: "ComponentRichImage" } & RichImageFieldsFragment)
+          | { __typename?: "ComponentSeo" }
+          | { __typename?: "Footer" }
+          | { __typename?: "LandingMetadata" }
+          | { __typename?: "PageAbout" }
+          | { __typename?: "PageBlogPost" }
+          | { __typename?: "PageCookiePolicy" }
+          | { __typename?: "PageEmails" }
+          | { __typename?: "PageFaq" }
+          | { __typename?: "PageForceUpdate" }
+          | { __typename?: "PageHomeFeatures" }
+          | { __typename?: "PageHomeHero" }
+          | { __typename?: "PageHomeMission" }
+          | { __typename?: "PageHomePartners" }
+          | { __typename?: "PageLanding" }
+          | { __typename?: "PagePolicies" }
+          | { __typename?: "PageTermsAndConditions" }
+          | null
+        >;
+      };
+    };
+  } | null;
+  relatedBlogPostsCollection?: {
+    __typename?: "PageBlogPostRelatedBlogPostsCollection";
+    items: Array<({ __typename?: "PageBlogPost" } & ReferencePageBlogPostFieldsFragment) | null>;
+  } | null;
+};
 
 export type PageBlogPostQueryVariables = Exact<{
-  slug: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  slug: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
-
-export type PageBlogPostQuery = { __typename?: 'Query', pageBlogPostCollection?: { __typename?: 'PageBlogPostCollection', items: Array<(
-      { __typename?: 'PageBlogPost' }
-      & PageBlogPostFieldsFragment
-    ) | null> } | null };
+export type PageBlogPostQuery = {
+  __typename?: "Query";
+  pageBlogPostCollection?: {
+    __typename?: "PageBlogPostCollection";
+    items: Array<({ __typename?: "PageBlogPost" } & PageBlogPostFieldsFragment) | null>;
+  } | null;
+};
 
 export type PageBlogPostCollectionQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  limit?: InputMaybe<Scalars['Int']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
   order?: InputMaybe<Array<InputMaybe<PageBlogPostOrder>> | InputMaybe<PageBlogPostOrder>>;
   where?: InputMaybe<PageBlogPostFilter>;
 }>;
 
+export type PageBlogPostCollectionQuery = {
+  __typename?: "Query";
+  pageBlogPostCollection?: {
+    __typename?: "PageBlogPostCollection";
+    items: Array<({ __typename?: "PageBlogPost" } & PageBlogPostFieldsFragment) | null>;
+  } | null;
+};
 
-export type PageBlogPostCollectionQuery = { __typename?: 'Query', pageBlogPostCollection?: { __typename?: 'PageBlogPostCollection', items: Array<(
-      { __typename?: 'PageBlogPost' }
-      & PageBlogPostFieldsFragment
-    ) | null> } | null };
-
-export type PageCookiePolicyFieldsFragment = { __typename: 'PageCookiePolicy', pageTitle?: string | null, pageDescription?: string | null, internalName?: string | null, title?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, content?: { __typename?: 'PageCookiePolicyContent', json: any, links: { __typename?: 'PageCookiePolicyContentLinks', entries: { __typename?: 'PageCookiePolicyContentEntries', block: Array<
-          | { __typename?: 'ComponentAlert' }
-          | { __typename?: 'ComponentAuthor' }
-          | { __typename?: 'ComponentButton' }
-          | { __typename?: 'ComponentEmail' }
-          | { __typename?: 'ComponentFaqQuestion' }
-          | { __typename?: 'ComponentFeature' }
-          | { __typename?: 'ComponentPartner' }
-          | { __typename?: 'ComponentReleaseNote' }
-          | (
-            { __typename?: 'ComponentRichImage' }
-            & RichImageFieldsFragment
-          )
-          | { __typename?: 'ComponentSeo' }
-          | { __typename?: 'Footer' }
-          | { __typename?: 'LandingMetadata' }
-          | { __typename?: 'PageAbout' }
-          | { __typename?: 'PageBlogPost' }
-          | { __typename?: 'PageCookiePolicy' }
-          | { __typename?: 'PageEmails' }
-          | { __typename?: 'PageFaq' }
-          | { __typename?: 'PageForceUpdate' }
-          | { __typename?: 'PageHomeFeatures' }
-          | { __typename?: 'PageHomeHero' }
-          | { __typename?: 'PageHomeMission' }
-          | { __typename?: 'PageHomePartners' }
-          | { __typename?: 'PageLanding' }
-          | { __typename?: 'PagePolicies' }
-          | { __typename?: 'PageTermsAndConditions' }
-         | null> } } } | null };
+export type PageCookiePolicyFieldsFragment = {
+  __typename: "PageCookiePolicy";
+  pageTitle?: string | null;
+  pageDescription?: string | null;
+  internalName?: string | null;
+  title?: string | null;
+  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
+  content?: {
+    __typename?: "PageCookiePolicyContent";
+    json: any;
+    links: {
+      __typename?: "PageCookiePolicyContentLinks";
+      entries: {
+        __typename?: "PageCookiePolicyContentEntries";
+        block: Array<
+          | { __typename?: "ComponentAlert" }
+          | { __typename?: "ComponentAuthor" }
+          | { __typename?: "ComponentButton" }
+          | { __typename?: "ComponentEmail" }
+          | { __typename?: "ComponentFaqQuestion" }
+          | { __typename?: "ComponentFeature" }
+          | { __typename?: "ComponentPartner" }
+          | { __typename?: "ComponentReleaseNote" }
+          | ({ __typename?: "ComponentRichImage" } & RichImageFieldsFragment)
+          | { __typename?: "ComponentSeo" }
+          | { __typename?: "Footer" }
+          | { __typename?: "LandingMetadata" }
+          | { __typename?: "PageAbout" }
+          | { __typename?: "PageBlogPost" }
+          | { __typename?: "PageCookiePolicy" }
+          | { __typename?: "PageEmails" }
+          | { __typename?: "PageFaq" }
+          | { __typename?: "PageForceUpdate" }
+          | { __typename?: "PageHomeFeatures" }
+          | { __typename?: "PageHomeHero" }
+          | { __typename?: "PageHomeMission" }
+          | { __typename?: "PageHomePartners" }
+          | { __typename?: "PageLanding" }
+          | { __typename?: "PagePolicies" }
+          | { __typename?: "PageTermsAndConditions" }
+          | null
+        >;
+      };
+    };
+  } | null;
+};
 
 export type PageCookiePolicyQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
+export type PageCookiePolicyQuery = {
+  __typename?: "Query";
+  pageCookiePolicyCollection?: {
+    __typename?: "PageCookiePolicyCollection";
+    items: Array<({ __typename?: "PageCookiePolicy" } & PageCookiePolicyFieldsFragment) | null>;
+  } | null;
+};
 
-export type PageCookiePolicyQuery = { __typename?: 'Query', pageCookiePolicyCollection?: { __typename?: 'PageCookiePolicyCollection', items: Array<(
-      { __typename?: 'PageCookiePolicy' }
-      & PageCookiePolicyFieldsFragment
-    ) | null> } | null };
-
-export type ComponentEmailFieldsFragment = { __typename: 'ComponentEmail', internalName?: string | null, availableVariables?: string | null, preview?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, content?: { __typename?: 'ComponentEmailContent', json: any, links: { __typename?: 'ComponentEmailContentLinks', entries: { __typename?: 'ComponentEmailContentEntries', block: Array<
-          | { __typename?: 'ComponentAlert' }
-          | { __typename?: 'ComponentAuthor' }
-          | (
-            { __typename?: 'ComponentButton' }
-            & ButtonFieldsFragment
-          )
-          | { __typename?: 'ComponentEmail' }
-          | { __typename?: 'ComponentFaqQuestion' }
-          | { __typename?: 'ComponentFeature' }
-          | { __typename?: 'ComponentPartner' }
-          | { __typename?: 'ComponentReleaseNote' }
-          | { __typename?: 'ComponentRichImage' }
-          | { __typename?: 'ComponentSeo' }
-          | { __typename?: 'Footer' }
-          | { __typename?: 'LandingMetadata' }
-          | { __typename?: 'PageAbout' }
-          | { __typename?: 'PageBlogPost' }
-          | { __typename?: 'PageCookiePolicy' }
-          | { __typename?: 'PageEmails' }
-          | { __typename?: 'PageFaq' }
-          | { __typename?: 'PageForceUpdate' }
-          | { __typename?: 'PageHomeFeatures' }
-          | { __typename?: 'PageHomeHero' }
-          | { __typename?: 'PageHomeMission' }
-          | { __typename?: 'PageHomePartners' }
-          | { __typename?: 'PageLanding' }
-          | { __typename?: 'PagePolicies' }
-          | { __typename?: 'PageTermsAndConditions' }
-         | null> } } } | null };
+export type ComponentEmailFieldsFragment = {
+  __typename: "ComponentEmail";
+  internalName?: string | null;
+  availableVariables?: string | null;
+  preview?: string | null;
+  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
+  content?: {
+    __typename?: "ComponentEmailContent";
+    json: any;
+    links: {
+      __typename?: "ComponentEmailContentLinks";
+      entries: {
+        __typename?: "ComponentEmailContentEntries";
+        block: Array<
+          | { __typename?: "ComponentAlert" }
+          | { __typename?: "ComponentAuthor" }
+          | ({ __typename?: "ComponentButton" } & ButtonFieldsFragment)
+          | { __typename?: "ComponentEmail" }
+          | { __typename?: "ComponentFaqQuestion" }
+          | { __typename?: "ComponentFeature" }
+          | { __typename?: "ComponentPartner" }
+          | { __typename?: "ComponentReleaseNote" }
+          | { __typename?: "ComponentRichImage" }
+          | { __typename?: "ComponentSeo" }
+          | { __typename?: "Footer" }
+          | { __typename?: "LandingMetadata" }
+          | { __typename?: "PageAbout" }
+          | { __typename?: "PageBlogPost" }
+          | { __typename?: "PageCookiePolicy" }
+          | { __typename?: "PageEmails" }
+          | { __typename?: "PageFaq" }
+          | { __typename?: "PageForceUpdate" }
+          | { __typename?: "PageHomeFeatures" }
+          | { __typename?: "PageHomeHero" }
+          | { __typename?: "PageHomeMission" }
+          | { __typename?: "PageHomePartners" }
+          | { __typename?: "PageLanding" }
+          | { __typename?: "PagePolicies" }
+          | { __typename?: "PageTermsAndConditions" }
+          | null
+        >;
+      };
+    };
+  } | null;
+};
 
 export type ComponentEmailByNameQueryVariables = Exact<{
-  internalName: Scalars['String']['input'];
+  internalName: Scalars["String"]["input"];
 }>;
 
+export type ComponentEmailByNameQuery = {
+  __typename?: "Query";
+  componentEmailCollection?: {
+    __typename?: "ComponentEmailCollection";
+    items: Array<({ __typename?: "ComponentEmail" } & ComponentEmailFieldsFragment) | null>;
+  } | null;
+};
 
-export type ComponentEmailByNameQuery = { __typename?: 'Query', componentEmailCollection?: { __typename?: 'ComponentEmailCollection', items: Array<(
-      { __typename?: 'ComponentEmail' }
-      & ComponentEmailFieldsFragment
-    ) | null> } | null };
+export type FaqQuestionFieldsFragment = {
+  __typename: "ComponentFaqQuestion";
+  question?: string | null;
+  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
+  answer?: { __typename?: "ComponentFaqQuestionAnswer"; json: any } | null;
+};
 
-export type FaqQuestionFieldsFragment = { __typename: 'ComponentFaqQuestion', question?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, answer?: { __typename?: 'ComponentFaqQuestionAnswer', json: any } | null };
-
-export type PageFaqFieldsFragment = { __typename: 'PageFaq', pageTitle?: string | null, pageDescription?: string | null, internalName?: string | null, title?: string | null, intro?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, questionsCollection?: { __typename?: 'PageFaqQuestionsCollection', items: Array<(
-      { __typename?: 'ComponentFaqQuestion' }
-      & FaqQuestionFieldsFragment
-    ) | null> } | null };
+export type PageFaqFieldsFragment = {
+  __typename: "PageFaq";
+  pageTitle?: string | null;
+  pageDescription?: string | null;
+  internalName?: string | null;
+  title?: string | null;
+  intro?: string | null;
+  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
+  questionsCollection?: {
+    __typename?: "PageFaqQuestionsCollection";
+    items: Array<({ __typename?: "ComponentFaqQuestion" } & FaqQuestionFieldsFragment) | null>;
+  } | null;
+};
 
 export type PageFaqQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
+export type PageFaqQuery = {
+  __typename?: "Query";
+  pageFaqCollection?: {
+    __typename?: "PageFaqCollection";
+    items: Array<({ __typename?: "PageFaq" } & PageFaqFieldsFragment) | null>;
+  } | null;
+};
 
-export type PageFaqQuery = { __typename?: 'Query', pageFaqCollection?: { __typename?: 'PageFaqCollection', items: Array<(
-      { __typename?: 'PageFaq' }
-      & PageFaqFieldsFragment
-    ) | null> } | null };
-
-export type PageForceUpdateFieldsFragment = { __typename: 'PageForceUpdate', internalName?: string | null, title?: string | null, minVersion?: string | null, effectiveAt?: any | null, active?: boolean | null, sys: { __typename?: 'Sys', id: string }, body?: { __typename?: 'PageForceUpdateBody', json: any } | null, updateCta?: (
-    { __typename?: 'ComponentButton' }
-    & ButtonFieldsFragment
-  ) | null };
+export type PageForceUpdateFieldsFragment = {
+  __typename: "PageForceUpdate";
+  internalName?: string | null;
+  title?: string | null;
+  minVersion?: string | null;
+  effectiveAt?: any | null;
+  active?: boolean | null;
+  sys: { __typename?: "Sys"; id: string };
+  body?: { __typename?: "PageForceUpdateBody"; json: any } | null;
+  updateCta?: ({ __typename?: "ComponentButton" } & ButtonFieldsFragment) | null;
+};
 
 export type PageForceUpdateQueryVariables = Exact<{
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
 }>;
 
-
-export type PageForceUpdateQuery = { __typename?: 'Query', pageForceUpdateCollection?: { __typename?: 'PageForceUpdateCollection', items: Array<(
-      { __typename?: 'PageForceUpdate' }
-      & PageForceUpdateFieldsFragment
-    ) | null> } | null };
+export type PageForceUpdateQuery = {
+  __typename?: "Query";
+  pageForceUpdateCollection?: {
+    __typename?: "PageForceUpdateCollection";
+    items: Array<({ __typename?: "PageForceUpdate" } & PageForceUpdateFieldsFragment) | null>;
+  } | null;
+};
 
 export type PageHomeQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
+export type PageHomeQuery = {
+  __typename?: "Query";
+  pageHomeHeroCollection?: {
+    __typename?: "PageHomeHeroCollection";
+    items: Array<({ __typename?: "PageHomeHero" } & PageHomeHeroFieldsFragment) | null>;
+  } | null;
+  pageHomeMissionCollection?: {
+    __typename?: "PageHomeMissionCollection";
+    items: Array<({ __typename?: "PageHomeMission" } & PageHomeMissionFieldsFragment) | null>;
+  } | null;
+  pageHomeFeaturesCollection?: {
+    __typename?: "PageHomeFeaturesCollection";
+    items: Array<({ __typename?: "PageHomeFeatures" } & PageHomeFeaturesFieldsFragment) | null>;
+  } | null;
+  pageHomePartnersCollection?: {
+    __typename?: "PageHomePartnersCollection";
+    items: Array<({ __typename?: "PageHomePartners" } & PageHomePartnersFieldsFragment) | null>;
+  } | null;
+  footerCollection?: {
+    __typename?: "FooterCollection";
+    items: Array<({ __typename?: "Footer" } & FooterFieldsFragment) | null>;
+  } | null;
+  landingMetadataCollection?: {
+    __typename?: "LandingMetadataCollection";
+    items: Array<({ __typename?: "LandingMetadata" } & LandingMetadataFieldsFragment) | null>;
+  } | null;
+};
 
-export type PageHomeQuery = { __typename?: 'Query', pageHomeHeroCollection?: { __typename?: 'PageHomeHeroCollection', items: Array<(
-      { __typename?: 'PageHomeHero' }
-      & PageHomeHeroFieldsFragment
-    ) | null> } | null, pageHomeMissionCollection?: { __typename?: 'PageHomeMissionCollection', items: Array<(
-      { __typename?: 'PageHomeMission' }
-      & PageHomeMissionFieldsFragment
-    ) | null> } | null, pageHomeFeaturesCollection?: { __typename?: 'PageHomeFeaturesCollection', items: Array<(
-      { __typename?: 'PageHomeFeatures' }
-      & PageHomeFeaturesFieldsFragment
-    ) | null> } | null, pageHomePartnersCollection?: { __typename?: 'PageHomePartnersCollection', items: Array<(
-      { __typename?: 'PageHomePartners' }
-      & PageHomePartnersFieldsFragment
-    ) | null> } | null, footerCollection?: { __typename?: 'FooterCollection', items: Array<(
-      { __typename?: 'Footer' }
-      & FooterFieldsFragment
-    ) | null> } | null, landingMetadataCollection?: { __typename?: 'LandingMetadataCollection', items: Array<(
-      { __typename?: 'LandingMetadata' }
-      & LandingMetadataFieldsFragment
-    ) | null> } | null };
+export type PageHomeFeaturesFieldsFragment = {
+  __typename: "PageHomeFeatures";
+  internalName?: string | null;
+  title?: string | null;
+  subtitle?: string | null;
+  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
+  featuresCollection?: {
+    __typename?: "PageHomeFeaturesFeaturesCollection";
+    items: Array<({ __typename?: "ComponentFeature" } & FeatureFieldsFragment) | null>;
+  } | null;
+  image?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
+};
 
-export type PageHomeFeaturesFieldsFragment = { __typename: 'PageHomeFeatures', internalName?: string | null, title?: string | null, subtitle?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, featuresCollection?: { __typename?: 'PageHomeFeaturesFeaturesCollection', items: Array<(
-      { __typename?: 'ComponentFeature' }
-      & FeatureFieldsFragment
-    ) | null> } | null, image?: (
-    { __typename?: 'Asset' }
-    & ImageFieldsFragment
-  ) | null };
-
-export type FeatureFieldsFragment = { __typename: 'ComponentFeature', title?: string | null, subtitle?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, icon?: (
-    { __typename?: 'Asset' }
-    & ImageFieldsFragment
-  ) | null };
+export type FeatureFieldsFragment = {
+  __typename: "ComponentFeature";
+  title?: string | null;
+  subtitle?: string | null;
+  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
+  icon?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
+};
 
 export type PageHomeFeaturesQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
+export type PageHomeFeaturesQuery = {
+  __typename?: "Query";
+  pageHomeFeaturesCollection?: {
+    __typename?: "PageHomeFeaturesCollection";
+    items: Array<({ __typename?: "PageHomeFeatures" } & PageHomeFeaturesFieldsFragment) | null>;
+  } | null;
+};
 
-export type PageHomeFeaturesQuery = { __typename?: 'Query', pageHomeFeaturesCollection?: { __typename?: 'PageHomeFeaturesCollection', items: Array<(
-      { __typename?: 'PageHomeFeatures' }
-      & PageHomeFeaturesFieldsFragment
-    ) | null> } | null };
-
-export type PageHomeHeroFieldsFragment = { __typename: 'PageHomeHero', internalName?: string | null, badge?: string | null, title?: string | null, subtitle?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, buttonsCollection?: { __typename?: 'PageHomeHeroButtonsCollection', items: Array<(
-      { __typename?: 'ComponentButton' }
-      & ButtonFieldsFragment
-    ) | null> } | null, image?: { __typename?: 'Asset', url?: string | null, title?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string } } | null };
+export type PageHomeHeroFieldsFragment = {
+  __typename: "PageHomeHero";
+  internalName?: string | null;
+  badge?: string | null;
+  title?: string | null;
+  subtitle?: string | null;
+  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
+  buttonsCollection?: {
+    __typename?: "PageHomeHeroButtonsCollection";
+    items: Array<({ __typename?: "ComponentButton" } & ButtonFieldsFragment) | null>;
+  } | null;
+  image?: {
+    __typename?: "Asset";
+    url?: string | null;
+    title?: string | null;
+    sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
+  } | null;
+};
 
 export type PageHomeHeroQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
+export type PageHomeHeroQuery = {
+  __typename?: "Query";
+  pageHomeHeroCollection?: {
+    __typename?: "PageHomeHeroCollection";
+    items: Array<({ __typename?: "PageHomeHero" } & PageHomeHeroFieldsFragment) | null>;
+  } | null;
+};
 
-export type PageHomeHeroQuery = { __typename?: 'Query', pageHomeHeroCollection?: { __typename?: 'PageHomeHeroCollection', items: Array<(
-      { __typename?: 'PageHomeHero' }
-      & PageHomeHeroFieldsFragment
-    ) | null> } | null };
-
-export type PageHomeMissionFieldsFragment = { __typename: 'PageHomeMission', internalName?: string | null, title?: string | null, subtitle?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, about?: { __typename?: 'PageHomeMissionAbout', json: any, links: { __typename?: 'PageHomeMissionAboutLinks', entries: { __typename?: 'PageHomeMissionAboutEntries', block: Array<
-          | { __typename?: 'ComponentAlert' }
-          | { __typename?: 'ComponentAuthor' }
-          | { __typename?: 'ComponentButton' }
-          | { __typename?: 'ComponentEmail' }
-          | { __typename?: 'ComponentFaqQuestion' }
-          | { __typename?: 'ComponentFeature' }
-          | { __typename?: 'ComponentPartner' }
-          | { __typename?: 'ComponentReleaseNote' }
-          | (
-            { __typename?: 'ComponentRichImage' }
-            & RichImageFieldsFragment
-          )
-          | { __typename?: 'ComponentSeo' }
-          | { __typename?: 'Footer' }
-          | { __typename?: 'LandingMetadata' }
-          | { __typename?: 'PageAbout' }
-          | { __typename?: 'PageBlogPost' }
-          | { __typename?: 'PageCookiePolicy' }
-          | { __typename?: 'PageEmails' }
-          | { __typename?: 'PageFaq' }
-          | { __typename?: 'PageForceUpdate' }
-          | { __typename?: 'PageHomeFeatures' }
-          | { __typename?: 'PageHomeHero' }
-          | { __typename?: 'PageHomeMission' }
-          | { __typename?: 'PageHomePartners' }
-          | { __typename?: 'PageLanding' }
-          | { __typename?: 'PagePolicies' }
-          | { __typename?: 'PageTermsAndConditions' }
-         | null> } } } | null, mission?: { __typename?: 'PageHomeMissionMission', json: any, links: { __typename?: 'PageHomeMissionMissionLinks', entries: { __typename?: 'PageHomeMissionMissionEntries', block: Array<
-          | { __typename?: 'ComponentAlert' }
-          | { __typename?: 'ComponentAuthor' }
-          | { __typename?: 'ComponentButton' }
-          | { __typename?: 'ComponentEmail' }
-          | { __typename?: 'ComponentFaqQuestion' }
-          | { __typename?: 'ComponentFeature' }
-          | { __typename?: 'ComponentPartner' }
-          | { __typename?: 'ComponentReleaseNote' }
-          | (
-            { __typename?: 'ComponentRichImage' }
-            & RichImageFieldsFragment
-          )
-          | { __typename?: 'ComponentSeo' }
-          | { __typename?: 'Footer' }
-          | { __typename?: 'LandingMetadata' }
-          | { __typename?: 'PageAbout' }
-          | { __typename?: 'PageBlogPost' }
-          | { __typename?: 'PageCookiePolicy' }
-          | { __typename?: 'PageEmails' }
-          | { __typename?: 'PageFaq' }
-          | { __typename?: 'PageForceUpdate' }
-          | { __typename?: 'PageHomeFeatures' }
-          | { __typename?: 'PageHomeHero' }
-          | { __typename?: 'PageHomeMission' }
-          | { __typename?: 'PageHomePartners' }
-          | { __typename?: 'PageLanding' }
-          | { __typename?: 'PagePolicies' }
-          | { __typename?: 'PageTermsAndConditions' }
-         | null> } } } | null, image?: { __typename?: 'Asset', url?: string | null, title?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string } } | null, imagesCollection?: { __typename?: 'AssetCollection', items: Array<(
-      { __typename?: 'Asset' }
-      & ImageFieldsFragment
-    ) | null> } | null };
+export type PageHomeMissionFieldsFragment = {
+  __typename: "PageHomeMission";
+  internalName?: string | null;
+  title?: string | null;
+  subtitle?: string | null;
+  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
+  about?: {
+    __typename?: "PageHomeMissionAbout";
+    json: any;
+    links: {
+      __typename?: "PageHomeMissionAboutLinks";
+      entries: {
+        __typename?: "PageHomeMissionAboutEntries";
+        block: Array<
+          | { __typename?: "ComponentAlert" }
+          | { __typename?: "ComponentAuthor" }
+          | { __typename?: "ComponentButton" }
+          | { __typename?: "ComponentEmail" }
+          | { __typename?: "ComponentFaqQuestion" }
+          | { __typename?: "ComponentFeature" }
+          | { __typename?: "ComponentPartner" }
+          | { __typename?: "ComponentReleaseNote" }
+          | ({ __typename?: "ComponentRichImage" } & RichImageFieldsFragment)
+          | { __typename?: "ComponentSeo" }
+          | { __typename?: "Footer" }
+          | { __typename?: "LandingMetadata" }
+          | { __typename?: "PageAbout" }
+          | { __typename?: "PageBlogPost" }
+          | { __typename?: "PageCookiePolicy" }
+          | { __typename?: "PageEmails" }
+          | { __typename?: "PageFaq" }
+          | { __typename?: "PageForceUpdate" }
+          | { __typename?: "PageHomeFeatures" }
+          | { __typename?: "PageHomeHero" }
+          | { __typename?: "PageHomeMission" }
+          | { __typename?: "PageHomePartners" }
+          | { __typename?: "PageLanding" }
+          | { __typename?: "PagePolicies" }
+          | { __typename?: "PageTermsAndConditions" }
+          | null
+        >;
+      };
+    };
+  } | null;
+  mission?: {
+    __typename?: "PageHomeMissionMission";
+    json: any;
+    links: {
+      __typename?: "PageHomeMissionMissionLinks";
+      entries: {
+        __typename?: "PageHomeMissionMissionEntries";
+        block: Array<
+          | { __typename?: "ComponentAlert" }
+          | { __typename?: "ComponentAuthor" }
+          | { __typename?: "ComponentButton" }
+          | { __typename?: "ComponentEmail" }
+          | { __typename?: "ComponentFaqQuestion" }
+          | { __typename?: "ComponentFeature" }
+          | { __typename?: "ComponentPartner" }
+          | { __typename?: "ComponentReleaseNote" }
+          | ({ __typename?: "ComponentRichImage" } & RichImageFieldsFragment)
+          | { __typename?: "ComponentSeo" }
+          | { __typename?: "Footer" }
+          | { __typename?: "LandingMetadata" }
+          | { __typename?: "PageAbout" }
+          | { __typename?: "PageBlogPost" }
+          | { __typename?: "PageCookiePolicy" }
+          | { __typename?: "PageEmails" }
+          | { __typename?: "PageFaq" }
+          | { __typename?: "PageForceUpdate" }
+          | { __typename?: "PageHomeFeatures" }
+          | { __typename?: "PageHomeHero" }
+          | { __typename?: "PageHomeMission" }
+          | { __typename?: "PageHomePartners" }
+          | { __typename?: "PageLanding" }
+          | { __typename?: "PagePolicies" }
+          | { __typename?: "PageTermsAndConditions" }
+          | null
+        >;
+      };
+    };
+  } | null;
+  image?: {
+    __typename?: "Asset";
+    url?: string | null;
+    title?: string | null;
+    sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
+  } | null;
+  imagesCollection?: {
+    __typename?: "AssetCollection";
+    items: Array<({ __typename?: "Asset" } & ImageFieldsFragment) | null>;
+  } | null;
+};
 
 export type PageHomeMissionQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
+export type PageHomeMissionQuery = {
+  __typename?: "Query";
+  pageHomeMissionCollection?: {
+    __typename?: "PageHomeMissionCollection";
+    items: Array<({ __typename?: "PageHomeMission" } & PageHomeMissionFieldsFragment) | null>;
+  } | null;
+};
 
-export type PageHomeMissionQuery = { __typename?: 'Query', pageHomeMissionCollection?: { __typename?: 'PageHomeMissionCollection', items: Array<(
-      { __typename?: 'PageHomeMission' }
-      & PageHomeMissionFieldsFragment
-    ) | null> } | null };
+export type PageHomePartnersFieldsFragment = {
+  __typename: "PageHomePartners";
+  title?: string | null;
+  subtitle?: string | null;
+  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
+  partnersCollection?: {
+    __typename?: "PageHomePartnersPartnersCollection";
+    items: Array<({ __typename?: "ComponentPartner" } & PartnerFieldsFragment) | null>;
+  } | null;
+  imagesCollection?: {
+    __typename?: "AssetCollection";
+    items: Array<({ __typename?: "Asset" } & ImageFieldsFragment) | null>;
+  } | null;
+};
 
-export type PageHomePartnersFieldsFragment = { __typename: 'PageHomePartners', title?: string | null, subtitle?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, partnersCollection?: { __typename?: 'PageHomePartnersPartnersCollection', items: Array<(
-      { __typename?: 'ComponentPartner' }
-      & PartnerFieldsFragment
-    ) | null> } | null, imagesCollection?: { __typename?: 'AssetCollection', items: Array<(
-      { __typename?: 'Asset' }
-      & ImageFieldsFragment
-    ) | null> } | null };
-
-export type PartnerFieldsFragment = { __typename: 'ComponentPartner', subtitle?: string | null, url?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, logo?: (
-    { __typename?: 'Asset' }
-    & ImageFieldsFragment
-  ) | null };
+export type PartnerFieldsFragment = {
+  __typename: "ComponentPartner";
+  subtitle?: string | null;
+  url?: string | null;
+  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
+  logo?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
+};
 
 export type PageHomePartnersQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
+export type PageHomePartnersQuery = {
+  __typename?: "Query";
+  pageHomePartnersCollection?: {
+    __typename?: "PageHomePartnersCollection";
+    items: Array<({ __typename?: "PageHomePartners" } & PageHomePartnersFieldsFragment) | null>;
+  } | null;
+};
 
-export type PageHomePartnersQuery = { __typename?: 'Query', pageHomePartnersCollection?: { __typename?: 'PageHomePartnersCollection', items: Array<(
-      { __typename?: 'PageHomePartners' }
-      & PageHomePartnersFieldsFragment
-    ) | null> } | null };
-
-export type PageLandingFieldsFragment = { __typename: 'PageLanding', internalName?: string | null, sys: { __typename?: 'Sys', id: string, spaceId: string }, seoFields?: (
-    { __typename?: 'ComponentSeo' }
-    & SeoFieldsFragment
-  ) | null, featuredBlogPost?: (
-    { __typename?: 'PageBlogPost' }
-    & ReferencePageBlogPostFieldsFragment
-  ) | null };
+export type PageLandingFieldsFragment = {
+  __typename: "PageLanding";
+  internalName?: string | null;
+  sys: { __typename?: "Sys"; id: string; spaceId: string };
+  seoFields?: ({ __typename?: "ComponentSeo" } & SeoFieldsFragment) | null;
+  featuredBlogPost?: ({ __typename?: "PageBlogPost" } & ReferencePageBlogPostFieldsFragment) | null;
+};
 
 export type PageLandingQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
-
-export type PageLandingQuery = { __typename?: 'Query', pageLandingCollection?: { __typename?: 'PageLandingCollection', items: Array<(
-      { __typename?: 'PageLanding' }
-      & PageLandingFieldsFragment
-    ) | null> } | null };
+export type PageLandingQuery = {
+  __typename?: "Query";
+  pageLandingCollection?: {
+    __typename?: "PageLandingCollection";
+    items: Array<({ __typename?: "PageLanding" } & PageLandingFieldsFragment) | null>;
+  } | null;
+};
 
 export type PageLandingCollectionQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
+export type PageLandingCollectionQuery = {
+  __typename?: "Query";
+  pageLandingCollection?: {
+    __typename?: "PageLandingCollection";
+    items: Array<({ __typename?: "PageLanding" } & PageLandingFieldsFragment) | null>;
+  } | null;
+};
 
-export type PageLandingCollectionQuery = { __typename?: 'Query', pageLandingCollection?: { __typename?: 'PageLandingCollection', items: Array<(
-      { __typename?: 'PageLanding' }
-      & PageLandingFieldsFragment
-    ) | null> } | null };
-
-export type PagePoliciesFieldsFragment = { __typename: 'PagePolicies', pageTitle?: string | null, pageDescription?: string | null, internalName?: string | null, title?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, content?: { __typename?: 'PagePoliciesContent', json: any, links: { __typename?: 'PagePoliciesContentLinks', entries: { __typename?: 'PagePoliciesContentEntries', block: Array<
-          | { __typename?: 'ComponentAlert' }
-          | { __typename?: 'ComponentAuthor' }
-          | { __typename?: 'ComponentButton' }
-          | { __typename?: 'ComponentEmail' }
-          | { __typename?: 'ComponentFaqQuestion' }
-          | { __typename?: 'ComponentFeature' }
-          | { __typename?: 'ComponentPartner' }
-          | { __typename?: 'ComponentReleaseNote' }
-          | (
-            { __typename?: 'ComponentRichImage' }
-            & RichImageFieldsFragment
-          )
-          | { __typename?: 'ComponentSeo' }
-          | { __typename?: 'Footer' }
-          | { __typename?: 'LandingMetadata' }
-          | { __typename?: 'PageAbout' }
-          | { __typename?: 'PageBlogPost' }
-          | { __typename?: 'PageCookiePolicy' }
-          | { __typename?: 'PageEmails' }
-          | { __typename?: 'PageFaq' }
-          | { __typename?: 'PageForceUpdate' }
-          | { __typename?: 'PageHomeFeatures' }
-          | { __typename?: 'PageHomeHero' }
-          | { __typename?: 'PageHomeMission' }
-          | { __typename?: 'PageHomePartners' }
-          | { __typename?: 'PageLanding' }
-          | { __typename?: 'PagePolicies' }
-          | { __typename?: 'PageTermsAndConditions' }
-         | null> } } } | null };
+export type PagePoliciesFieldsFragment = {
+  __typename: "PagePolicies";
+  pageTitle?: string | null;
+  pageDescription?: string | null;
+  internalName?: string | null;
+  title?: string | null;
+  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
+  content?: {
+    __typename?: "PagePoliciesContent";
+    json: any;
+    links: {
+      __typename?: "PagePoliciesContentLinks";
+      entries: {
+        __typename?: "PagePoliciesContentEntries";
+        block: Array<
+          | { __typename?: "ComponentAlert" }
+          | { __typename?: "ComponentAuthor" }
+          | { __typename?: "ComponentButton" }
+          | { __typename?: "ComponentEmail" }
+          | { __typename?: "ComponentFaqQuestion" }
+          | { __typename?: "ComponentFeature" }
+          | { __typename?: "ComponentPartner" }
+          | { __typename?: "ComponentReleaseNote" }
+          | ({ __typename?: "ComponentRichImage" } & RichImageFieldsFragment)
+          | { __typename?: "ComponentSeo" }
+          | { __typename?: "Footer" }
+          | { __typename?: "LandingMetadata" }
+          | { __typename?: "PageAbout" }
+          | { __typename?: "PageBlogPost" }
+          | { __typename?: "PageCookiePolicy" }
+          | { __typename?: "PageEmails" }
+          | { __typename?: "PageFaq" }
+          | { __typename?: "PageForceUpdate" }
+          | { __typename?: "PageHomeFeatures" }
+          | { __typename?: "PageHomeHero" }
+          | { __typename?: "PageHomeMission" }
+          | { __typename?: "PageHomePartners" }
+          | { __typename?: "PageLanding" }
+          | { __typename?: "PagePolicies" }
+          | { __typename?: "PageTermsAndConditions" }
+          | null
+        >;
+      };
+    };
+  } | null;
+};
 
 export type PagePoliciesQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
+export type PagePoliciesQuery = {
+  __typename?: "Query";
+  pagePoliciesCollection?: {
+    __typename?: "PagePoliciesCollection";
+    items: Array<({ __typename?: "PagePolicies" } & PagePoliciesFieldsFragment) | null>;
+  } | null;
+};
 
-export type PagePoliciesQuery = { __typename?: 'Query', pagePoliciesCollection?: { __typename?: 'PagePoliciesCollection', items: Array<(
-      { __typename?: 'PagePolicies' }
-      & PagePoliciesFieldsFragment
-    ) | null> } | null };
-
-export type PageTermsAndConditionsFieldsFragment = { __typename: 'PageTermsAndConditions', pageTitle?: string | null, pageDescription?: string | null, internalName?: string | null, title?: string | null, sys: { __typename?: 'Sys', id: string, publishedAt?: any | null, environmentId: string }, content?: { __typename?: 'PageTermsAndConditionsContent', json: any, links: { __typename?: 'PageTermsAndConditionsContentLinks', entries: { __typename?: 'PageTermsAndConditionsContentEntries', block: Array<
-          | { __typename?: 'ComponentAlert' }
-          | { __typename?: 'ComponentAuthor' }
-          | { __typename?: 'ComponentButton' }
-          | { __typename?: 'ComponentEmail' }
-          | { __typename?: 'ComponentFaqQuestion' }
-          | { __typename?: 'ComponentFeature' }
-          | { __typename?: 'ComponentPartner' }
-          | { __typename?: 'ComponentReleaseNote' }
-          | (
-            { __typename?: 'ComponentRichImage' }
-            & RichImageFieldsFragment
-          )
-          | { __typename?: 'ComponentSeo' }
-          | { __typename?: 'Footer' }
-          | { __typename?: 'LandingMetadata' }
-          | { __typename?: 'PageAbout' }
-          | { __typename?: 'PageBlogPost' }
-          | { __typename?: 'PageCookiePolicy' }
-          | { __typename?: 'PageEmails' }
-          | { __typename?: 'PageFaq' }
-          | { __typename?: 'PageForceUpdate' }
-          | { __typename?: 'PageHomeFeatures' }
-          | { __typename?: 'PageHomeHero' }
-          | { __typename?: 'PageHomeMission' }
-          | { __typename?: 'PageHomePartners' }
-          | { __typename?: 'PageLanding' }
-          | { __typename?: 'PagePolicies' }
-          | { __typename?: 'PageTermsAndConditions' }
-         | null> } } } | null };
+export type PageTermsAndConditionsFieldsFragment = {
+  __typename: "PageTermsAndConditions";
+  pageTitle?: string | null;
+  pageDescription?: string | null;
+  internalName?: string | null;
+  title?: string | null;
+  sys: { __typename?: "Sys"; id: string; publishedAt?: any | null; environmentId: string };
+  content?: {
+    __typename?: "PageTermsAndConditionsContent";
+    json: any;
+    links: {
+      __typename?: "PageTermsAndConditionsContentLinks";
+      entries: {
+        __typename?: "PageTermsAndConditionsContentEntries";
+        block: Array<
+          | { __typename?: "ComponentAlert" }
+          | { __typename?: "ComponentAuthor" }
+          | { __typename?: "ComponentButton" }
+          | { __typename?: "ComponentEmail" }
+          | { __typename?: "ComponentFaqQuestion" }
+          | { __typename?: "ComponentFeature" }
+          | { __typename?: "ComponentPartner" }
+          | { __typename?: "ComponentReleaseNote" }
+          | ({ __typename?: "ComponentRichImage" } & RichImageFieldsFragment)
+          | { __typename?: "ComponentSeo" }
+          | { __typename?: "Footer" }
+          | { __typename?: "LandingMetadata" }
+          | { __typename?: "PageAbout" }
+          | { __typename?: "PageBlogPost" }
+          | { __typename?: "PageCookiePolicy" }
+          | { __typename?: "PageEmails" }
+          | { __typename?: "PageFaq" }
+          | { __typename?: "PageForceUpdate" }
+          | { __typename?: "PageHomeFeatures" }
+          | { __typename?: "PageHomeHero" }
+          | { __typename?: "PageHomeMission" }
+          | { __typename?: "PageHomePartners" }
+          | { __typename?: "PageLanding" }
+          | { __typename?: "PagePolicies" }
+          | { __typename?: "PageTermsAndConditions" }
+          | null
+        >;
+      };
+    };
+  } | null;
+};
 
 export type PageTermsAndConditionsQueryVariables = Exact<{
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
+export type PageTermsAndConditionsQuery = {
+  __typename?: "Query";
+  pageTermsAndConditionsCollection?: {
+    __typename?: "PageTermsAndConditionsCollection";
+    items: Array<
+      ({ __typename?: "PageTermsAndConditions" } & PageTermsAndConditionsFieldsFragment) | null
+    >;
+  } | null;
+};
 
-export type PageTermsAndConditionsQuery = { __typename?: 'Query', pageTermsAndConditionsCollection?: { __typename?: 'PageTermsAndConditionsCollection', items: Array<(
-      { __typename?: 'PageTermsAndConditions' }
-      & PageTermsAndConditionsFieldsFragment
-    ) | null> } | null };
-
-export type ComponentReleaseNoteFieldsFragment = { __typename: 'ComponentReleaseNote', slug?: string | null, title?: string | null, summary?: string | null, category?: string | null, surfaces?: string | null, publishedAt?: any | null, active?: boolean | null, sys: { __typename?: 'Sys', id: string }, body?: { __typename?: 'ComponentReleaseNoteBody', json: any } | null, media?: (
-    { __typename?: 'Asset' }
-    & ImageFieldsFragment
-  ) | null, cta?: (
-    { __typename?: 'ComponentButton' }
-    & ButtonFieldsFragment
-  ) | null, seoFields?: (
-    { __typename?: 'ComponentSeo' }
-    & SeoFieldsFragment
-  ) | null };
+export type ComponentReleaseNoteFieldsFragment = {
+  __typename: "ComponentReleaseNote";
+  slug?: string | null;
+  title?: string | null;
+  summary?: string | null;
+  category?: string | null;
+  surfaces?: string | null;
+  publishedAt?: any | null;
+  active?: boolean | null;
+  sys: { __typename?: "Sys"; id: string };
+  body?: { __typename?: "ComponentReleaseNoteBody"; json: any } | null;
+  media?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
+  cta?: ({ __typename?: "ComponentButton" } & ButtonFieldsFragment) | null;
+  seoFields?: ({ __typename?: "ComponentSeo" } & SeoFieldsFragment) | null;
+};
 
 export type ActiveReleaseNotesQueryVariables = Exact<{
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  now: Scalars['DateTime']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  surfaces?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>> | InputMaybe<Scalars['String']['input']>>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  now: Scalars["DateTime"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  surfaces?: InputMaybe<
+    Array<InputMaybe<Scalars["String"]["input"]>> | InputMaybe<Scalars["String"]["input"]>
+  >;
 }>;
 
-
-export type ActiveReleaseNotesQuery = { __typename?: 'Query', componentReleaseNoteCollection?: { __typename?: 'ComponentReleaseNoteCollection', items: Array<(
-      { __typename?: 'ComponentReleaseNote' }
-      & ComponentReleaseNoteFieldsFragment
-    ) | null> } | null };
+export type ActiveReleaseNotesQuery = {
+  __typename?: "Query";
+  componentReleaseNoteCollection?: {
+    __typename?: "ComponentReleaseNoteCollection";
+    items: Array<
+      ({ __typename?: "ComponentReleaseNote" } & ComponentReleaseNoteFieldsFragment) | null
+    >;
+  } | null;
+};
 
 export type AllReleaseNotesQueryVariables = Exact<{
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
-  now: Scalars['DateTime']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
+  now: Scalars["DateTime"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
 }>;
 
-
-export type AllReleaseNotesQuery = { __typename?: 'Query', componentReleaseNoteCollection?: { __typename?: 'ComponentReleaseNoteCollection', items: Array<(
-      { __typename?: 'ComponentReleaseNote' }
-      & ComponentReleaseNoteFieldsFragment
-    ) | null> } | null };
+export type AllReleaseNotesQuery = {
+  __typename?: "Query";
+  componentReleaseNoteCollection?: {
+    __typename?: "ComponentReleaseNoteCollection";
+    items: Array<
+      ({ __typename?: "ComponentReleaseNote" } & ComponentReleaseNoteFieldsFragment) | null
+    >;
+  } | null;
+};
 
 export type ReleaseNoteBySlugQueryVariables = Exact<{
-  slug: Scalars['String']['input'];
-  locale?: InputMaybe<Scalars['String']['input']>;
-  preview?: InputMaybe<Scalars['Boolean']['input']>;
+  slug: Scalars["String"]["input"];
+  locale?: InputMaybe<Scalars["String"]["input"]>;
+  preview?: InputMaybe<Scalars["Boolean"]["input"]>;
 }>;
 
+export type ReleaseNoteBySlugQuery = {
+  __typename?: "Query";
+  componentReleaseNoteCollection?: {
+    __typename?: "ComponentReleaseNoteCollection";
+    items: Array<
+      ({ __typename?: "ComponentReleaseNote" } & ComponentReleaseNoteFieldsFragment) | null
+    >;
+  } | null;
+};
 
-export type ReleaseNoteBySlugQuery = { __typename?: 'Query', componentReleaseNoteCollection?: { __typename?: 'ComponentReleaseNoteCollection', items: Array<(
-      { __typename?: 'ComponentReleaseNote' }
-      & ComponentReleaseNoteFieldsFragment
-    ) | null> } | null };
+export type RichImageFieldsFragment = {
+  __typename: "ComponentRichImage";
+  internalName?: string | null;
+  caption?: string | null;
+  fullWidth?: boolean | null;
+  sys: { __typename?: "Sys"; id: string };
+  image?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
+};
 
-export type RichImageFieldsFragment = { __typename: 'ComponentRichImage', internalName?: string | null, caption?: string | null, fullWidth?: boolean | null, sys: { __typename?: 'Sys', id: string }, image?: (
-    { __typename?: 'Asset' }
-    & ImageFieldsFragment
-  ) | null };
+export type SeoFieldsFragment = {
+  __typename: "ComponentSeo";
+  pageTitle?: string | null;
+  pageDescription?: string | null;
+  canonicalUrl?: string | null;
+  nofollow?: boolean | null;
+  noindex?: boolean | null;
+  shareImagesCollection?: {
+    __typename?: "AssetCollection";
+    items: Array<({ __typename?: "Asset" } & ImageFieldsFragment) | null>;
+  } | null;
+};
 
-export type SeoFieldsFragment = { __typename: 'ComponentSeo', pageTitle?: string | null, pageDescription?: string | null, canonicalUrl?: string | null, nofollow?: boolean | null, noindex?: boolean | null, shareImagesCollection?: { __typename?: 'AssetCollection', items: Array<(
-      { __typename?: 'Asset' }
-      & ImageFieldsFragment
-    ) | null> } | null };
-
-export type SitemapPagesFieldsFragment = { __typename?: 'Query', pageBlogPostCollection?: { __typename?: 'PageBlogPostCollection', items: Array<{ __typename?: 'PageBlogPost', slug?: string | null, sys: { __typename?: 'Sys', publishedAt?: any | null } } | null> } | null, pageLandingCollection?: { __typename?: 'PageLandingCollection', items: Array<{ __typename?: 'PageLanding', sys: { __typename?: 'Sys', publishedAt?: any | null } } | null> } | null };
+export type SitemapPagesFieldsFragment = {
+  __typename?: "Query";
+  pageBlogPostCollection?: {
+    __typename?: "PageBlogPostCollection";
+    items: Array<{
+      __typename?: "PageBlogPost";
+      slug?: string | null;
+      sys: { __typename?: "Sys"; publishedAt?: any | null };
+    } | null>;
+  } | null;
+  pageLandingCollection?: {
+    __typename?: "PageLandingCollection";
+    items: Array<{
+      __typename?: "PageLanding";
+      sys: { __typename?: "Sys"; publishedAt?: any | null };
+    } | null>;
+  } | null;
+};
 
 export type SitemapPagesQueryVariables = Exact<{
-  locale: Scalars['String']['input'];
+  locale: Scalars["String"]["input"];
 }>;
 
-
-export type SitemapPagesQuery = (
-  { __typename?: 'Query' }
-  & SitemapPagesFieldsFragment
-);
+export type SitemapPagesQuery = { __typename?: "Query" } & SitemapPagesFieldsFragment;
 
 export const ButtonFieldsFragmentDoc = gql`
-    fragment ButtonFields on ComponentButton {
-  __typename
-  sys {
-    id
-    publishedAt
-    environmentId
+  fragment ButtonFields on ComponentButton {
+    __typename
+    sys {
+      id
+      publishedAt
+      environmentId
+    }
+    label
+    url
   }
-  label
-  url
-}
-    `;
+`;
 export const ComponentAlertFieldsFragmentDoc = gql`
-    fragment ComponentAlertFields on ComponentAlert {
-  __typename
-  sys {
-    id
+  fragment ComponentAlertFields on ComponentAlert {
+    __typename
+    sys {
+      id
+    }
+    internalName
+    title
+    body {
+      json
+    }
+    type
+    severity
+    dismissible
+    link {
+      ...ButtonFields
+    }
+    audience
+    startAt
+    endAt
+    active
   }
-  internalName
-  title
-  body {
-    json
-  }
-  type
-  severity
-  dismissible
-  link {
-    ...ButtonFields
-  }
-  audience
-  startAt
-  endAt
-  active
-}
-    ${ButtonFieldsFragmentDoc}`;
+  ${ButtonFieldsFragmentDoc}
+`;
 export const FooterFieldsFragmentDoc = gql`
-    fragment FooterFields on Footer {
-  __typename
-  sys {
-    id
-    publishedAt
-    environmentId
-  }
-  internalName
-  brand
-  title
-  badge
-  menuTitle
-  supportTitle
-  copyright
-  menuButtonsCollection {
-    items {
-      ...ButtonFields
+  fragment FooterFields on Footer {
+    __typename
+    sys {
+      id
+      publishedAt
+      environmentId
     }
-  }
-  supportButtonsCollection {
-    items {
-      ...ButtonFields
+    internalName
+    brand
+    title
+    badge
+    menuTitle
+    supportTitle
+    copyright
+    menuButtonsCollection {
+      items {
+        ...ButtonFields
+      }
     }
-  }
-}
-    ${ButtonFieldsFragmentDoc}`;
-export const LandingMetadataFieldsFragmentDoc = gql`
-    fragment LandingMetadataFields on LandingMetadata {
-  __typename
-  sys {
-    id
-    publishedAt
-    environmentId
-  }
-  internalName
-  title
-  description
-}
-    `;
-export const ImageFieldsFragmentDoc = gql`
-    fragment ImageFields on Asset {
-  __typename
-  sys {
-    id
-  }
-  title
-  description
-  width
-  height
-  url
-  contentType
-}
-    `;
-export const RichImageFieldsFragmentDoc = gql`
-    fragment RichImageFields on ComponentRichImage {
-  __typename
-  internalName
-  sys {
-    id
-  }
-  image {
-    ...ImageFields
-  }
-  caption
-  fullWidth
-}
-    ${ImageFieldsFragmentDoc}`;
-export const PageAboutFieldsFragmentDoc = gql`
-    fragment PageAboutFields on PageAbout {
-  __typename
-  sys {
-    id
-    publishedAt
-    environmentId
-  }
-  pageTitle
-  pageDescription
-  internalName
-  title
-  description {
-    json
-    links {
-      entries {
-        block {
-          ...RichImageFields
-        }
+    supportButtonsCollection {
+      items {
+        ...ButtonFields
       }
     }
   }
-  image {
-    ...ImageFields
+  ${ButtonFieldsFragmentDoc}
+`;
+export const LandingMetadataFieldsFragmentDoc = gql`
+  fragment LandingMetadataFields on LandingMetadata {
+    __typename
+    sys {
+      id
+      publishedAt
+      environmentId
+    }
+    internalName
+    title
+    description
   }
-}
-    ${RichImageFieldsFragmentDoc}
-${ImageFieldsFragmentDoc}`;
-export const SeoFieldsFragmentDoc = gql`
-    fragment SeoFields on ComponentSeo {
-  __typename
-  pageTitle
-  pageDescription
-  canonicalUrl
-  nofollow
-  noindex
-  shareImagesCollection(limit: 3, locale: $locale) {
-    items {
+`;
+export const ImageFieldsFragmentDoc = gql`
+  fragment ImageFields on Asset {
+    __typename
+    sys {
+      id
+    }
+    title
+    description
+    width
+    height
+    url
+    contentType
+  }
+`;
+export const RichImageFieldsFragmentDoc = gql`
+  fragment RichImageFields on ComponentRichImage {
+    __typename
+    internalName
+    sys {
+      id
+    }
+    image {
+      ...ImageFields
+    }
+    caption
+    fullWidth
+  }
+  ${ImageFieldsFragmentDoc}
+`;
+export const PageAboutFieldsFragmentDoc = gql`
+  fragment PageAboutFields on PageAbout {
+    __typename
+    sys {
+      id
+      publishedAt
+      environmentId
+    }
+    pageTitle
+    pageDescription
+    internalName
+    title
+    description {
+      json
+      links {
+        entries {
+          block {
+            ...RichImageFields
+          }
+        }
+      }
+    }
+    image {
       ...ImageFields
     }
   }
-}
-    ${ImageFieldsFragmentDoc}`;
+  ${RichImageFieldsFragmentDoc}
+  ${ImageFieldsFragmentDoc}
+`;
+export const SeoFieldsFragmentDoc = gql`
+  fragment SeoFields on ComponentSeo {
+    __typename
+    pageTitle
+    pageDescription
+    canonicalUrl
+    nofollow
+    noindex
+    shareImagesCollection(limit: 3, locale: $locale) {
+      items {
+        ...ImageFields
+      }
+    }
+  }
+  ${ImageFieldsFragmentDoc}
+`;
 export const AuthorFieldsFragmentDoc = gql`
-    fragment AuthorFields on ComponentAuthor {
-  __typename
-  sys {
-    id
+  fragment AuthorFields on ComponentAuthor {
+    __typename
+    sys {
+      id
+    }
+    name
+    profession
+    avatar {
+      ...ImageFields
+    }
   }
-  name
-  profession
-  avatar {
-    ...ImageFields
-  }
-}
-    ${ImageFieldsFragmentDoc}`;
+  ${ImageFieldsFragmentDoc}
+`;
 export const ReferencePageBlogPostFieldsFragmentDoc = gql`
-    fragment ReferencePageBlogPostFields on PageBlogPost {
-  __typename
-  sys {
-    id
-    spaceId
+  fragment ReferencePageBlogPostFields on PageBlogPost {
+    __typename
+    sys {
+      id
+      spaceId
+    }
+    slug
+    author {
+      ...AuthorFields
+    }
+    publishedDate
+    title
+    shortDescription
+    featuredImage {
+      ...ImageFields
+    }
   }
-  slug
-  author {
-    ...AuthorFields
-  }
-  publishedDate
-  title
-  shortDescription
-  featuredImage {
-    ...ImageFields
-  }
-}
-    ${AuthorFieldsFragmentDoc}
-${ImageFieldsFragmentDoc}`;
+  ${AuthorFieldsFragmentDoc}
+  ${ImageFieldsFragmentDoc}
+`;
 export const PageBlogPostFieldsFragmentDoc = gql`
-    fragment PageBlogPostFields on PageBlogPost {
-  __typename
-  sys {
-    id
-    spaceId
+  fragment PageBlogPostFields on PageBlogPost {
+    __typename
+    sys {
+      id
+      spaceId
+    }
+    internalName
+    seoFields {
+      ...SeoFields
+    }
+    slug
+    author {
+      ...AuthorFields
+    }
+    publishedDate
+    title
+    shortDescription
+    featuredImage {
+      ...ImageFields
+    }
+    content {
+      json
+      links {
+        entries {
+          block {
+            ...RichImageFields
+          }
+        }
+      }
+    }
+    relatedBlogPostsCollection(limit: 2) {
+      items {
+        ...ReferencePageBlogPostFields
+      }
+    }
   }
-  internalName
-  seoFields {
-    ...SeoFields
-  }
-  slug
-  author {
-    ...AuthorFields
-  }
-  publishedDate
-  title
-  shortDescription
-  featuredImage {
-    ...ImageFields
-  }
-  content {
-    json
-    links {
-      entries {
-        block {
-          ...RichImageFields
+  ${SeoFieldsFragmentDoc}
+  ${AuthorFieldsFragmentDoc}
+  ${ImageFieldsFragmentDoc}
+  ${RichImageFieldsFragmentDoc}
+  ${ReferencePageBlogPostFieldsFragmentDoc}
+`;
+export const PageCookiePolicyFieldsFragmentDoc = gql`
+  fragment PageCookiePolicyFields on PageCookiePolicy {
+    __typename
+    sys {
+      id
+      publishedAt
+      environmentId
+    }
+    pageTitle
+    pageDescription
+    internalName
+    title
+    content {
+      json
+      links {
+        entries {
+          block {
+            ...RichImageFields
+          }
         }
       }
     }
   }
-  relatedBlogPostsCollection(limit: 2) {
-    items {
+  ${RichImageFieldsFragmentDoc}
+`;
+export const ComponentEmailFieldsFragmentDoc = gql`
+  fragment ComponentEmailFields on ComponentEmail {
+    __typename
+    sys {
+      id
+      publishedAt
+      environmentId
+    }
+    internalName
+    availableVariables
+    preview
+    content {
+      json
+      links {
+        entries {
+          block {
+            ...ButtonFields
+          }
+        }
+      }
+    }
+  }
+  ${ButtonFieldsFragmentDoc}
+`;
+export const FaqQuestionFieldsFragmentDoc = gql`
+  fragment FaqQuestionFields on ComponentFaqQuestion {
+    __typename
+    sys {
+      id
+      publishedAt
+      environmentId
+    }
+    question
+    answer {
+      json
+    }
+  }
+`;
+export const PageFaqFieldsFragmentDoc = gql`
+  fragment PageFaqFields on PageFaq {
+    __typename
+    sys {
+      id
+      publishedAt
+      environmentId
+    }
+    pageTitle
+    pageDescription
+    internalName
+    title
+    intro
+    questionsCollection {
+      items {
+        ...FaqQuestionFields
+      }
+    }
+  }
+  ${FaqQuestionFieldsFragmentDoc}
+`;
+export const PageForceUpdateFieldsFragmentDoc = gql`
+  fragment PageForceUpdateFields on PageForceUpdate {
+    __typename
+    sys {
+      id
+    }
+    internalName
+    title
+    body {
+      json
+    }
+    updateCta {
+      ...ButtonFields
+    }
+    minVersion
+    effectiveAt
+    active
+  }
+  ${ButtonFieldsFragmentDoc}
+`;
+export const FeatureFieldsFragmentDoc = gql`
+  fragment FeatureFields on ComponentFeature {
+    __typename
+    sys {
+      id
+      publishedAt
+      environmentId
+    }
+    title
+    subtitle
+    icon {
+      ...ImageFields
+    }
+  }
+  ${ImageFieldsFragmentDoc}
+`;
+export const PageHomeFeaturesFieldsFragmentDoc = gql`
+  fragment PageHomeFeaturesFields on PageHomeFeatures {
+    __typename
+    sys {
+      id
+      publishedAt
+      environmentId
+    }
+    internalName
+    title
+    subtitle
+    featuresCollection {
+      items {
+        ...FeatureFields
+      }
+    }
+    image {
+      ...ImageFields
+    }
+  }
+  ${FeatureFieldsFragmentDoc}
+  ${ImageFieldsFragmentDoc}
+`;
+export const PageHomeHeroFieldsFragmentDoc = gql`
+  fragment PageHomeHeroFields on PageHomeHero {
+    __typename
+    sys {
+      id
+      publishedAt
+      environmentId
+    }
+    internalName
+    badge
+    title
+    subtitle
+    buttonsCollection {
+      items {
+        ...ButtonFields
+      }
+    }
+    image {
+      url
+      title
+      sys {
+        id
+        publishedAt
+        environmentId
+      }
+    }
+  }
+  ${ButtonFieldsFragmentDoc}
+`;
+export const PageHomeMissionFieldsFragmentDoc = gql`
+  fragment PageHomeMissionFields on PageHomeMission {
+    __typename
+    sys {
+      id
+      publishedAt
+      environmentId
+    }
+    internalName
+    title
+    about {
+      json
+      links {
+        entries {
+          block {
+            ...RichImageFields
+          }
+        }
+      }
+    }
+    subtitle
+    mission {
+      json
+      links {
+        entries {
+          block {
+            ...RichImageFields
+          }
+        }
+      }
+    }
+    image {
+      url
+      title
+      sys {
+        id
+        publishedAt
+        environmentId
+      }
+    }
+    imagesCollection {
+      items {
+        ...ImageFields
+      }
+    }
+  }
+  ${RichImageFieldsFragmentDoc}
+  ${ImageFieldsFragmentDoc}
+`;
+export const PartnerFieldsFragmentDoc = gql`
+  fragment PartnerFields on ComponentPartner {
+    __typename
+    sys {
+      id
+      publishedAt
+      environmentId
+    }
+    logo {
+      ...ImageFields
+    }
+    subtitle
+    url
+  }
+  ${ImageFieldsFragmentDoc}
+`;
+export const PageHomePartnersFieldsFragmentDoc = gql`
+  fragment PageHomePartnersFields on PageHomePartners {
+    __typename
+    sys {
+      id
+      publishedAt
+      environmentId
+    }
+    title
+    subtitle
+    partnersCollection {
+      items {
+        ...PartnerFields
+      }
+    }
+    imagesCollection {
+      items {
+        ...ImageFields
+      }
+    }
+  }
+  ${PartnerFieldsFragmentDoc}
+  ${ImageFieldsFragmentDoc}
+`;
+export const PageLandingFieldsFragmentDoc = gql`
+  fragment PageLandingFields on PageLanding {
+    __typename
+    sys {
+      id
+      spaceId
+    }
+    internalName
+    seoFields {
+      ...SeoFields
+    }
+    featuredBlogPost {
       ...ReferencePageBlogPostFields
     }
   }
-}
-    ${SeoFieldsFragmentDoc}
-${AuthorFieldsFragmentDoc}
-${ImageFieldsFragmentDoc}
-${RichImageFieldsFragmentDoc}
-${ReferencePageBlogPostFieldsFragmentDoc}`;
-export const PageCookiePolicyFieldsFragmentDoc = gql`
-    fragment PageCookiePolicyFields on PageCookiePolicy {
-  __typename
-  sys {
-    id
-    publishedAt
-    environmentId
-  }
-  pageTitle
-  pageDescription
-  internalName
-  title
-  content {
-    json
-    links {
-      entries {
-        block {
-          ...RichImageFields
+  ${SeoFieldsFragmentDoc}
+  ${ReferencePageBlogPostFieldsFragmentDoc}
+`;
+export const PagePoliciesFieldsFragmentDoc = gql`
+  fragment PagePoliciesFields on PagePolicies {
+    __typename
+    sys {
+      id
+      publishedAt
+      environmentId
+    }
+    pageTitle
+    pageDescription
+    internalName
+    title
+    content {
+      json
+      links {
+        entries {
+          block {
+            ...RichImageFields
+          }
         }
       }
     }
   }
-}
-    ${RichImageFieldsFragmentDoc}`;
-export const ComponentEmailFieldsFragmentDoc = gql`
-    fragment ComponentEmailFields on ComponentEmail {
-  __typename
-  sys {
-    id
-    publishedAt
-    environmentId
-  }
-  internalName
-  availableVariables
-  preview
-  content {
-    json
-    links {
-      entries {
-        block {
-          ...ButtonFields
+  ${RichImageFieldsFragmentDoc}
+`;
+export const PageTermsAndConditionsFieldsFragmentDoc = gql`
+  fragment PageTermsAndConditionsFields on PageTermsAndConditions {
+    __typename
+    sys {
+      id
+      publishedAt
+      environmentId
+    }
+    pageTitle
+    pageDescription
+    internalName
+    title
+    content {
+      json
+      links {
+        entries {
+          block {
+            ...RichImageFields
+          }
         }
       }
     }
   }
-}
-    ${ButtonFieldsFragmentDoc}`;
-export const FaqQuestionFieldsFragmentDoc = gql`
-    fragment FaqQuestionFields on ComponentFaqQuestion {
-  __typename
-  sys {
-    id
-    publishedAt
-    environmentId
-  }
-  question
-  answer {
-    json
-  }
-}
-    `;
-export const PageFaqFieldsFragmentDoc = gql`
-    fragment PageFaqFields on PageFaq {
-  __typename
-  sys {
-    id
-    publishedAt
-    environmentId
-  }
-  pageTitle
-  pageDescription
-  internalName
-  title
-  intro
-  questionsCollection {
-    items {
-      ...FaqQuestionFields
+  ${RichImageFieldsFragmentDoc}
+`;
+export const ComponentReleaseNoteFieldsFragmentDoc = gql`
+  fragment ComponentReleaseNoteFields on ComponentReleaseNote {
+    __typename
+    sys {
+      id
     }
-  }
-}
-    ${FaqQuestionFieldsFragmentDoc}`;
-export const PageForceUpdateFieldsFragmentDoc = gql`
-    fragment PageForceUpdateFields on PageForceUpdate {
-  __typename
-  sys {
-    id
-  }
-  internalName
-  title
-  body {
-    json
-  }
-  updateCta {
-    ...ButtonFields
-  }
-  minVersion
-  effectiveAt
-  active
-}
-    ${ButtonFieldsFragmentDoc}`;
-export const FeatureFieldsFragmentDoc = gql`
-    fragment FeatureFields on ComponentFeature {
-  __typename
-  sys {
-    id
-    publishedAt
-    environmentId
-  }
-  title
-  subtitle
-  icon {
-    ...ImageFields
-  }
-}
-    ${ImageFieldsFragmentDoc}`;
-export const PageHomeFeaturesFieldsFragmentDoc = gql`
-    fragment PageHomeFeaturesFields on PageHomeFeatures {
-  __typename
-  sys {
-    id
-    publishedAt
-    environmentId
-  }
-  internalName
-  title
-  subtitle
-  featuresCollection {
-    items {
-      ...FeatureFields
+    slug
+    title
+    summary
+    body {
+      json
     }
-  }
-  image {
-    ...ImageFields
-  }
-}
-    ${FeatureFieldsFragmentDoc}
-${ImageFieldsFragmentDoc}`;
-export const PageHomeHeroFieldsFragmentDoc = gql`
-    fragment PageHomeHeroFields on PageHomeHero {
-  __typename
-  sys {
-    id
+    media {
+      ...ImageFields
+    }
+    category
+    surfaces
     publishedAt
-    environmentId
-  }
-  internalName
-  badge
-  title
-  subtitle
-  buttonsCollection {
-    items {
+    cta {
       ...ButtonFields
     }
-  }
-  image {
-    url
-    title
-    sys {
-      id
-      publishedAt
-      environmentId
+    seoFields {
+      ...SeoFields
     }
+    active
   }
-}
-    ${ButtonFieldsFragmentDoc}`;
-export const PageHomeMissionFieldsFragmentDoc = gql`
-    fragment PageHomeMissionFields on PageHomeMission {
-  __typename
-  sys {
-    id
-    publishedAt
-    environmentId
-  }
-  internalName
-  title
-  about {
-    json
-    links {
-      entries {
-        block {
-          ...RichImageFields
-        }
-      }
-    }
-  }
-  subtitle
-  mission {
-    json
-    links {
-      entries {
-        block {
-          ...RichImageFields
-        }
-      }
-    }
-  }
-  image {
-    url
-    title
-    sys {
-      id
-      publishedAt
-      environmentId
-    }
-  }
-  imagesCollection {
-    items {
-      ...ImageFields
-    }
-  }
-}
-    ${RichImageFieldsFragmentDoc}
-${ImageFieldsFragmentDoc}`;
-export const PartnerFieldsFragmentDoc = gql`
-    fragment PartnerFields on ComponentPartner {
-  __typename
-  sys {
-    id
-    publishedAt
-    environmentId
-  }
-  logo {
-    ...ImageFields
-  }
-  subtitle
-  url
-}
-    ${ImageFieldsFragmentDoc}`;
-export const PageHomePartnersFieldsFragmentDoc = gql`
-    fragment PageHomePartnersFields on PageHomePartners {
-  __typename
-  sys {
-    id
-    publishedAt
-    environmentId
-  }
-  title
-  subtitle
-  partnersCollection {
-    items {
-      ...PartnerFields
-    }
-  }
-  imagesCollection {
-    items {
-      ...ImageFields
-    }
-  }
-}
-    ${PartnerFieldsFragmentDoc}
-${ImageFieldsFragmentDoc}`;
-export const PageLandingFieldsFragmentDoc = gql`
-    fragment PageLandingFields on PageLanding {
-  __typename
-  sys {
-    id
-    spaceId
-  }
-  internalName
-  seoFields {
-    ...SeoFields
-  }
-  featuredBlogPost {
-    ...ReferencePageBlogPostFields
-  }
-}
-    ${SeoFieldsFragmentDoc}
-${ReferencePageBlogPostFieldsFragmentDoc}`;
-export const PagePoliciesFieldsFragmentDoc = gql`
-    fragment PagePoliciesFields on PagePolicies {
-  __typename
-  sys {
-    id
-    publishedAt
-    environmentId
-  }
-  pageTitle
-  pageDescription
-  internalName
-  title
-  content {
-    json
-    links {
-      entries {
-        block {
-          ...RichImageFields
-        }
-      }
-    }
-  }
-}
-    ${RichImageFieldsFragmentDoc}`;
-export const PageTermsAndConditionsFieldsFragmentDoc = gql`
-    fragment PageTermsAndConditionsFields on PageTermsAndConditions {
-  __typename
-  sys {
-    id
-    publishedAt
-    environmentId
-  }
-  pageTitle
-  pageDescription
-  internalName
-  title
-  content {
-    json
-    links {
-      entries {
-        block {
-          ...RichImageFields
-        }
-      }
-    }
-  }
-}
-    ${RichImageFieldsFragmentDoc}`;
-export const ComponentReleaseNoteFieldsFragmentDoc = gql`
-    fragment ComponentReleaseNoteFields on ComponentReleaseNote {
-  __typename
-  sys {
-    id
-  }
-  slug
-  title
-  summary
-  body {
-    json
-  }
-  media {
-    ...ImageFields
-  }
-  category
-  surfaces
-  publishedAt
-  cta {
-    ...ButtonFields
-  }
-  seoFields {
-    ...SeoFields
-  }
-  active
-}
-    ${ImageFieldsFragmentDoc}
-${ButtonFieldsFragmentDoc}
-${SeoFieldsFragmentDoc}`;
+  ${ImageFieldsFragmentDoc}
+  ${ButtonFieldsFragmentDoc}
+  ${SeoFieldsFragmentDoc}
+`;
 export const SitemapPagesFieldsFragmentDoc = gql`
-    fragment sitemapPagesFields on Query {
-  pageBlogPostCollection(limit: 100, locale: $locale) {
-    items {
-      slug
-      sys {
-        publishedAt
+  fragment sitemapPagesFields on Query {
+    pageBlogPostCollection(limit: 100, locale: $locale) {
+      items {
+        slug
+        sys {
+          publishedAt
+        }
+      }
+    }
+    pageLandingCollection(limit: 1, locale: $locale) {
+      items {
+        sys {
+          publishedAt
+        }
       }
     }
   }
-  pageLandingCollection(limit: 1, locale: $locale) {
-    items {
-      sys {
-        publishedAt
-      }
-    }
-  }
-}
-    `;
+`;
 export const ActiveAlertsDocument = gql`
-    query activeAlerts($preview: Boolean, $now: DateTime!, $locale: String, $audience: [String]) {
-  componentAlertCollection(
-    preview: $preview
-    locale: $locale
-    where: {active: true, audience_in: $audience, startAt_lte: $now, OR: [{endAt_gt: $now}, {endAt_exists: false}]}
-  ) {
-    items {
-      ...ComponentAlertFields
+  query activeAlerts($preview: Boolean, $now: DateTime!, $locale: String, $audience: [String]) {
+    componentAlertCollection(
+      preview: $preview
+      locale: $locale
+      where: {
+        active: true
+        audience_in: $audience
+        startAt_lte: $now
+        OR: [{ endAt_gt: $now }, { endAt_exists: false }]
+      }
+    ) {
+      items {
+        ...ComponentAlertFields
+      }
     }
   }
-}
-    ${ComponentAlertFieldsFragmentDoc}`;
+  ${ComponentAlertFieldsFragmentDoc}
+`;
 export const FooterDocument = gql`
-    query footer($locale: String, $preview: Boolean) {
-  footerCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...FooterFields
+  query footer($locale: String, $preview: Boolean) {
+    footerCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...FooterFields
+      }
     }
   }
-}
-    ${FooterFieldsFragmentDoc}`;
+  ${FooterFieldsFragmentDoc}
+`;
 export const LandingMetadataDocument = gql`
-    query landingMetadata($locale: String, $preview: Boolean) {
-  landingMetadataCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...LandingMetadataFields
+  query landingMetadata($locale: String, $preview: Boolean) {
+    landingMetadataCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...LandingMetadataFields
+      }
     }
   }
-}
-    ${LandingMetadataFieldsFragmentDoc}`;
+  ${LandingMetadataFieldsFragmentDoc}
+`;
 export const PageAboutDocument = gql`
-    query pageAbout($locale: String, $preview: Boolean) {
-  pageAboutCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...PageAboutFields
+  query pageAbout($locale: String, $preview: Boolean) {
+    pageAboutCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...PageAboutFields
+      }
     }
   }
-}
-    ${PageAboutFieldsFragmentDoc}`;
+  ${PageAboutFieldsFragmentDoc}
+`;
 export const PageBlogDocument = gql`
-    query pageBlog($locale: String, $preview: Boolean, $limit: Int, $order: [PageBlogPostOrder], $where: PageBlogPostFilter) {
-  pageLandingCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...PageLandingFields
-    }
-  }
-  pageBlogPostCollection(
-    limit: $limit
-    locale: $locale
-    preview: $preview
-    order: $order
-    where: $where
+  query pageBlog(
+    $locale: String
+    $preview: Boolean
+    $limit: Int
+    $order: [PageBlogPostOrder]
+    $where: PageBlogPostFilter
   ) {
-    items {
-      ...PageBlogPostFields
+    pageLandingCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...PageLandingFields
+      }
+    }
+    pageBlogPostCollection(
+      limit: $limit
+      locale: $locale
+      preview: $preview
+      order: $order
+      where: $where
+    ) {
+      items {
+        ...PageBlogPostFields
+      }
     }
   }
-}
-    ${PageLandingFieldsFragmentDoc}
-${PageBlogPostFieldsFragmentDoc}`;
+  ${PageLandingFieldsFragmentDoc}
+  ${PageBlogPostFieldsFragmentDoc}
+`;
 export const PageBlogDetailDocument = gql`
-    query pageBlogDetail($slug: String!, $locale: String, $preview: Boolean) {
-  pageBlogPostCollection(
-    limit: 1
-    where: {slug: $slug}
-    locale: $locale
-    preview: $preview
-  ) {
-    items {
-      ...PageBlogPostFields
+  query pageBlogDetail($slug: String!, $locale: String, $preview: Boolean) {
+    pageBlogPostCollection(limit: 1, where: { slug: $slug }, locale: $locale, preview: $preview) {
+      items {
+        ...PageBlogPostFields
+      }
+    }
+    pageLandingCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...PageLandingFields
+      }
     }
   }
-  pageLandingCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...PageLandingFields
-    }
-  }
-}
-    ${PageBlogPostFieldsFragmentDoc}
-${PageLandingFieldsFragmentDoc}`;
+  ${PageBlogPostFieldsFragmentDoc}
+  ${PageLandingFieldsFragmentDoc}
+`;
 export const PageBlogPostDocument = gql`
-    query pageBlogPost($slug: String!, $locale: String, $preview: Boolean) {
-  pageBlogPostCollection(
-    limit: 1
-    where: {slug: $slug}
-    locale: $locale
-    preview: $preview
-  ) {
-    items {
-      ...PageBlogPostFields
+  query pageBlogPost($slug: String!, $locale: String, $preview: Boolean) {
+    pageBlogPostCollection(limit: 1, where: { slug: $slug }, locale: $locale, preview: $preview) {
+      items {
+        ...PageBlogPostFields
+      }
     }
   }
-}
-    ${PageBlogPostFieldsFragmentDoc}`;
+  ${PageBlogPostFieldsFragmentDoc}
+`;
 export const PageBlogPostCollectionDocument = gql`
-    query pageBlogPostCollection($locale: String, $preview: Boolean, $limit: Int, $order: [PageBlogPostOrder], $where: PageBlogPostFilter) {
-  pageBlogPostCollection(
-    limit: $limit
-    locale: $locale
-    preview: $preview
-    order: $order
-    where: $where
+  query pageBlogPostCollection(
+    $locale: String
+    $preview: Boolean
+    $limit: Int
+    $order: [PageBlogPostOrder]
+    $where: PageBlogPostFilter
   ) {
-    items {
-      ...PageBlogPostFields
+    pageBlogPostCollection(
+      limit: $limit
+      locale: $locale
+      preview: $preview
+      order: $order
+      where: $where
+    ) {
+      items {
+        ...PageBlogPostFields
+      }
     }
   }
-}
-    ${PageBlogPostFieldsFragmentDoc}`;
+  ${PageBlogPostFieldsFragmentDoc}
+`;
 export const PageCookiePolicyDocument = gql`
-    query pageCookiePolicy($locale: String, $preview: Boolean) {
-  pageCookiePolicyCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...PageCookiePolicyFields
+  query pageCookiePolicy($locale: String, $preview: Boolean) {
+    pageCookiePolicyCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...PageCookiePolicyFields
+      }
     }
   }
-}
-    ${PageCookiePolicyFieldsFragmentDoc}`;
+  ${PageCookiePolicyFieldsFragmentDoc}
+`;
 export const ComponentEmailByNameDocument = gql`
-    query componentEmailByName($internalName: String!) {
-  componentEmailCollection(limit: 1, where: {internalName: $internalName}) {
-    items {
-      ...ComponentEmailFields
+  query componentEmailByName($internalName: String!) {
+    componentEmailCollection(limit: 1, where: { internalName: $internalName }) {
+      items {
+        ...ComponentEmailFields
+      }
     }
   }
-}
-    ${ComponentEmailFieldsFragmentDoc}`;
+  ${ComponentEmailFieldsFragmentDoc}
+`;
 export const PageFaqDocument = gql`
-    query pageFaq($locale: String, $preview: Boolean) {
-  pageFaqCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...PageFaqFields
+  query pageFaq($locale: String, $preview: Boolean) {
+    pageFaqCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...PageFaqFields
+      }
     }
   }
-}
-    ${PageFaqFieldsFragmentDoc}`;
+  ${PageFaqFieldsFragmentDoc}
+`;
 export const PageForceUpdateDocument = gql`
-    query pageForceUpdate($preview: Boolean, $locale: String) {
-  pageForceUpdateCollection(
-    limit: 1
-    order: [sys_publishedAt_DESC]
-    preview: $preview
-    locale: $locale
-  ) {
-    items {
-      ...PageForceUpdateFields
+  query pageForceUpdate($preview: Boolean, $locale: String) {
+    pageForceUpdateCollection(
+      limit: 1
+      order: [sys_publishedAt_DESC]
+      preview: $preview
+      locale: $locale
+    ) {
+      items {
+        ...PageForceUpdateFields
+      }
     }
   }
-}
-    ${PageForceUpdateFieldsFragmentDoc}`;
+  ${PageForceUpdateFieldsFragmentDoc}
+`;
 export const PageHomeDocument = gql`
-    query pageHome($locale: String, $preview: Boolean) {
-  pageHomeHeroCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...PageHomeHeroFields
+  query pageHome($locale: String, $preview: Boolean) {
+    pageHomeHeroCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...PageHomeHeroFields
+      }
+    }
+    pageHomeMissionCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...PageHomeMissionFields
+      }
+    }
+    pageHomeFeaturesCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...PageHomeFeaturesFields
+      }
+    }
+    pageHomePartnersCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...PageHomePartnersFields
+      }
+    }
+    footerCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...FooterFields
+      }
+    }
+    landingMetadataCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...LandingMetadataFields
+      }
     }
   }
-  pageHomeMissionCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...PageHomeMissionFields
-    }
-  }
-  pageHomeFeaturesCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...PageHomeFeaturesFields
-    }
-  }
-  pageHomePartnersCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...PageHomePartnersFields
-    }
-  }
-  footerCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...FooterFields
-    }
-  }
-  landingMetadataCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...LandingMetadataFields
-    }
-  }
-}
-    ${PageHomeHeroFieldsFragmentDoc}
-${PageHomeMissionFieldsFragmentDoc}
-${PageHomeFeaturesFieldsFragmentDoc}
-${PageHomePartnersFieldsFragmentDoc}
-${FooterFieldsFragmentDoc}
-${LandingMetadataFieldsFragmentDoc}`;
+  ${PageHomeHeroFieldsFragmentDoc}
+  ${PageHomeMissionFieldsFragmentDoc}
+  ${PageHomeFeaturesFieldsFragmentDoc}
+  ${PageHomePartnersFieldsFragmentDoc}
+  ${FooterFieldsFragmentDoc}
+  ${LandingMetadataFieldsFragmentDoc}
+`;
 export const PageHomeFeaturesDocument = gql`
-    query pageHomeFeatures($locale: String, $preview: Boolean) {
-  pageHomeFeaturesCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...PageHomeFeaturesFields
+  query pageHomeFeatures($locale: String, $preview: Boolean) {
+    pageHomeFeaturesCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...PageHomeFeaturesFields
+      }
     }
   }
-}
-    ${PageHomeFeaturesFieldsFragmentDoc}`;
+  ${PageHomeFeaturesFieldsFragmentDoc}
+`;
 export const PageHomeHeroDocument = gql`
-    query pageHomeHero($locale: String, $preview: Boolean) {
-  pageHomeHeroCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...PageHomeHeroFields
+  query pageHomeHero($locale: String, $preview: Boolean) {
+    pageHomeHeroCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...PageHomeHeroFields
+      }
     }
   }
-}
-    ${PageHomeHeroFieldsFragmentDoc}`;
+  ${PageHomeHeroFieldsFragmentDoc}
+`;
 export const PageHomeMissionDocument = gql`
-    query pageHomeMission($locale: String, $preview: Boolean) {
-  pageHomeMissionCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...PageHomeMissionFields
+  query pageHomeMission($locale: String, $preview: Boolean) {
+    pageHomeMissionCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...PageHomeMissionFields
+      }
     }
   }
-}
-    ${PageHomeMissionFieldsFragmentDoc}`;
+  ${PageHomeMissionFieldsFragmentDoc}
+`;
 export const PageHomePartnersDocument = gql`
-    query pageHomePartners($locale: String, $preview: Boolean) {
-  pageHomePartnersCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...PageHomePartnersFields
+  query pageHomePartners($locale: String, $preview: Boolean) {
+    pageHomePartnersCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...PageHomePartnersFields
+      }
     }
   }
-}
-    ${PageHomePartnersFieldsFragmentDoc}`;
+  ${PageHomePartnersFieldsFragmentDoc}
+`;
 export const PageLandingDocument = gql`
-    query pageLanding($locale: String, $preview: Boolean) {
-  pageLandingCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...PageLandingFields
+  query pageLanding($locale: String, $preview: Boolean) {
+    pageLandingCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...PageLandingFields
+      }
     }
   }
-}
-    ${PageLandingFieldsFragmentDoc}`;
+  ${PageLandingFieldsFragmentDoc}
+`;
 export const PageLandingCollectionDocument = gql`
-    query pageLandingCollection($locale: String, $preview: Boolean) {
-  pageLandingCollection(limit: 100, locale: $locale, preview: $preview) {
-    items {
-      ...PageLandingFields
+  query pageLandingCollection($locale: String, $preview: Boolean) {
+    pageLandingCollection(limit: 100, locale: $locale, preview: $preview) {
+      items {
+        ...PageLandingFields
+      }
     }
   }
-}
-    ${PageLandingFieldsFragmentDoc}`;
+  ${PageLandingFieldsFragmentDoc}
+`;
 export const PagePoliciesDocument = gql`
-    query pagePolicies($locale: String, $preview: Boolean) {
-  pagePoliciesCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...PagePoliciesFields
+  query pagePolicies($locale: String, $preview: Boolean) {
+    pagePoliciesCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...PagePoliciesFields
+      }
     }
   }
-}
-    ${PagePoliciesFieldsFragmentDoc}`;
+  ${PagePoliciesFieldsFragmentDoc}
+`;
 export const PageTermsAndConditionsDocument = gql`
-    query pageTermsAndConditions($locale: String, $preview: Boolean) {
-  pageTermsAndConditionsCollection(limit: 1, locale: $locale, preview: $preview) {
-    items {
-      ...PageTermsAndConditionsFields
+  query pageTermsAndConditions($locale: String, $preview: Boolean) {
+    pageTermsAndConditionsCollection(limit: 1, locale: $locale, preview: $preview) {
+      items {
+        ...PageTermsAndConditionsFields
+      }
     }
   }
-}
-    ${PageTermsAndConditionsFieldsFragmentDoc}`;
+  ${PageTermsAndConditionsFieldsFragmentDoc}
+`;
 export const ActiveReleaseNotesDocument = gql`
-    query activeReleaseNotes($preview: Boolean, $now: DateTime!, $locale: String, $surfaces: [String]) {
-  componentReleaseNoteCollection(
-    preview: $preview
-    locale: $locale
-    order: [publishedAt_DESC]
-    where: {active: true, surfaces_in: $surfaces, publishedAt_lte: $now}
+  query activeReleaseNotes(
+    $preview: Boolean
+    $now: DateTime!
+    $locale: String
+    $surfaces: [String]
   ) {
-    items {
-      ...ComponentReleaseNoteFields
+    componentReleaseNoteCollection(
+      preview: $preview
+      locale: $locale
+      order: [publishedAt_DESC]
+      where: { active: true, surfaces_in: $surfaces, publishedAt_lte: $now }
+    ) {
+      items {
+        ...ComponentReleaseNoteFields
+      }
     }
   }
-}
-    ${ComponentReleaseNoteFieldsFragmentDoc}`;
+  ${ComponentReleaseNoteFieldsFragmentDoc}
+`;
 export const AllReleaseNotesDocument = gql`
-    query allReleaseNotes($preview: Boolean, $now: DateTime!, $locale: String) {
-  componentReleaseNoteCollection(
-    preview: $preview
-    locale: $locale
-    order: [publishedAt_DESC]
-    where: {active: true, publishedAt_lte: $now}
-  ) {
-    items {
-      ...ComponentReleaseNoteFields
+  query allReleaseNotes($preview: Boolean, $now: DateTime!, $locale: String) {
+    componentReleaseNoteCollection(
+      preview: $preview
+      locale: $locale
+      order: [publishedAt_DESC]
+      where: { active: true, publishedAt_lte: $now }
+    ) {
+      items {
+        ...ComponentReleaseNoteFields
+      }
     }
   }
-}
-    ${ComponentReleaseNoteFieldsFragmentDoc}`;
+  ${ComponentReleaseNoteFieldsFragmentDoc}
+`;
 export const ReleaseNoteBySlugDocument = gql`
-    query releaseNoteBySlug($slug: String!, $locale: String, $preview: Boolean) {
-  componentReleaseNoteCollection(
-    limit: 1
-    preview: $preview
-    locale: $locale
-    where: {slug: $slug, active: true}
-  ) {
-    items {
-      ...ComponentReleaseNoteFields
+  query releaseNoteBySlug($slug: String!, $locale: String, $preview: Boolean) {
+    componentReleaseNoteCollection(
+      limit: 1
+      preview: $preview
+      locale: $locale
+      where: { slug: $slug, active: true }
+    ) {
+      items {
+        ...ComponentReleaseNoteFields
+      }
     }
   }
-}
-    ${ComponentReleaseNoteFieldsFragmentDoc}`;
+  ${ComponentReleaseNoteFieldsFragmentDoc}
+`;
 export const SitemapPagesDocument = gql`
-    query sitemapPages($locale: String!) {
-  ...sitemapPagesFields
-}
-    ${SitemapPagesFieldsFragmentDoc}`;
+  query sitemapPages($locale: String!) {
+    ...sitemapPagesFields
+  }
+  ${SitemapPagesFieldsFragmentDoc}
+`;
 
-export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string, variables?: any) => Promise<T>;
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
 
-
-const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType, _variables) => action();
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType, _variables) =>
+  action();
 
 export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    activeAlerts(variables: ActiveAlertsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<ActiveAlertsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ActiveAlertsQuery>({ document: ActiveAlertsDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'activeAlerts', 'query', variables);
+    activeAlerts(
+      variables: ActiveAlertsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<ActiveAlertsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ActiveAlertsQuery>({
+            document: ActiveAlertsDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "activeAlerts",
+        "query",
+        variables,
+      );
     },
-    footer(variables?: FooterQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<FooterQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<FooterQuery>({ document: FooterDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'footer', 'query', variables);
+    footer(
+      variables?: FooterQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<FooterQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FooterQuery>({
+            document: FooterDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "footer",
+        "query",
+        variables,
+      );
     },
-    landingMetadata(variables?: LandingMetadataQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<LandingMetadataQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<LandingMetadataQuery>({ document: LandingMetadataDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'landingMetadata', 'query', variables);
+    landingMetadata(
+      variables?: LandingMetadataQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<LandingMetadataQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<LandingMetadataQuery>({
+            document: LandingMetadataDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "landingMetadata",
+        "query",
+        variables,
+      );
     },
-    pageAbout(variables?: PageAboutQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageAboutQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PageAboutQuery>({ document: PageAboutDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageAbout', 'query', variables);
+    pageAbout(
+      variables?: PageAboutQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<PageAboutQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PageAboutQuery>({
+            document: PageAboutDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "pageAbout",
+        "query",
+        variables,
+      );
     },
-    pageBlog(variables?: PageBlogQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageBlogQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PageBlogQuery>({ document: PageBlogDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageBlog', 'query', variables);
+    pageBlog(
+      variables?: PageBlogQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<PageBlogQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PageBlogQuery>({
+            document: PageBlogDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "pageBlog",
+        "query",
+        variables,
+      );
     },
-    pageBlogDetail(variables: PageBlogDetailQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageBlogDetailQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PageBlogDetailQuery>({ document: PageBlogDetailDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageBlogDetail', 'query', variables);
+    pageBlogDetail(
+      variables: PageBlogDetailQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<PageBlogDetailQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PageBlogDetailQuery>({
+            document: PageBlogDetailDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "pageBlogDetail",
+        "query",
+        variables,
+      );
     },
-    pageBlogPost(variables: PageBlogPostQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageBlogPostQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PageBlogPostQuery>({ document: PageBlogPostDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageBlogPost', 'query', variables);
+    pageBlogPost(
+      variables: PageBlogPostQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<PageBlogPostQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PageBlogPostQuery>({
+            document: PageBlogPostDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "pageBlogPost",
+        "query",
+        variables,
+      );
     },
-    pageBlogPostCollection(variables?: PageBlogPostCollectionQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageBlogPostCollectionQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PageBlogPostCollectionQuery>({ document: PageBlogPostCollectionDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageBlogPostCollection', 'query', variables);
+    pageBlogPostCollection(
+      variables?: PageBlogPostCollectionQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<PageBlogPostCollectionQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PageBlogPostCollectionQuery>({
+            document: PageBlogPostCollectionDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "pageBlogPostCollection",
+        "query",
+        variables,
+      );
     },
-    pageCookiePolicy(variables?: PageCookiePolicyQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageCookiePolicyQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PageCookiePolicyQuery>({ document: PageCookiePolicyDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageCookiePolicy', 'query', variables);
+    pageCookiePolicy(
+      variables?: PageCookiePolicyQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<PageCookiePolicyQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PageCookiePolicyQuery>({
+            document: PageCookiePolicyDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "pageCookiePolicy",
+        "query",
+        variables,
+      );
     },
-    componentEmailByName(variables: ComponentEmailByNameQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<ComponentEmailByNameQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ComponentEmailByNameQuery>({ document: ComponentEmailByNameDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'componentEmailByName', 'query', variables);
+    componentEmailByName(
+      variables: ComponentEmailByNameQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<ComponentEmailByNameQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ComponentEmailByNameQuery>({
+            document: ComponentEmailByNameDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "componentEmailByName",
+        "query",
+        variables,
+      );
     },
-    pageFaq(variables?: PageFaqQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageFaqQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PageFaqQuery>({ document: PageFaqDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageFaq', 'query', variables);
+    pageFaq(
+      variables?: PageFaqQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<PageFaqQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PageFaqQuery>({
+            document: PageFaqDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "pageFaq",
+        "query",
+        variables,
+      );
     },
-    pageForceUpdate(variables?: PageForceUpdateQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageForceUpdateQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PageForceUpdateQuery>({ document: PageForceUpdateDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageForceUpdate', 'query', variables);
+    pageForceUpdate(
+      variables?: PageForceUpdateQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<PageForceUpdateQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PageForceUpdateQuery>({
+            document: PageForceUpdateDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "pageForceUpdate",
+        "query",
+        variables,
+      );
     },
-    pageHome(variables?: PageHomeQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageHomeQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PageHomeQuery>({ document: PageHomeDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageHome', 'query', variables);
+    pageHome(
+      variables?: PageHomeQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<PageHomeQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PageHomeQuery>({
+            document: PageHomeDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "pageHome",
+        "query",
+        variables,
+      );
     },
-    pageHomeFeatures(variables?: PageHomeFeaturesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageHomeFeaturesQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PageHomeFeaturesQuery>({ document: PageHomeFeaturesDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageHomeFeatures', 'query', variables);
+    pageHomeFeatures(
+      variables?: PageHomeFeaturesQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<PageHomeFeaturesQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PageHomeFeaturesQuery>({
+            document: PageHomeFeaturesDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "pageHomeFeatures",
+        "query",
+        variables,
+      );
     },
-    pageHomeHero(variables?: PageHomeHeroQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageHomeHeroQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PageHomeHeroQuery>({ document: PageHomeHeroDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageHomeHero', 'query', variables);
+    pageHomeHero(
+      variables?: PageHomeHeroQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<PageHomeHeroQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PageHomeHeroQuery>({
+            document: PageHomeHeroDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "pageHomeHero",
+        "query",
+        variables,
+      );
     },
-    pageHomeMission(variables?: PageHomeMissionQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageHomeMissionQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PageHomeMissionQuery>({ document: PageHomeMissionDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageHomeMission', 'query', variables);
+    pageHomeMission(
+      variables?: PageHomeMissionQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<PageHomeMissionQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PageHomeMissionQuery>({
+            document: PageHomeMissionDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "pageHomeMission",
+        "query",
+        variables,
+      );
     },
-    pageHomePartners(variables?: PageHomePartnersQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageHomePartnersQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PageHomePartnersQuery>({ document: PageHomePartnersDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageHomePartners', 'query', variables);
+    pageHomePartners(
+      variables?: PageHomePartnersQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<PageHomePartnersQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PageHomePartnersQuery>({
+            document: PageHomePartnersDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "pageHomePartners",
+        "query",
+        variables,
+      );
     },
-    pageLanding(variables?: PageLandingQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageLandingQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PageLandingQuery>({ document: PageLandingDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageLanding', 'query', variables);
+    pageLanding(
+      variables?: PageLandingQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<PageLandingQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PageLandingQuery>({
+            document: PageLandingDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "pageLanding",
+        "query",
+        variables,
+      );
     },
-    pageLandingCollection(variables?: PageLandingCollectionQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageLandingCollectionQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PageLandingCollectionQuery>({ document: PageLandingCollectionDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageLandingCollection', 'query', variables);
+    pageLandingCollection(
+      variables?: PageLandingCollectionQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<PageLandingCollectionQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PageLandingCollectionQuery>({
+            document: PageLandingCollectionDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "pageLandingCollection",
+        "query",
+        variables,
+      );
     },
-    pagePolicies(variables?: PagePoliciesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PagePoliciesQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PagePoliciesQuery>({ document: PagePoliciesDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pagePolicies', 'query', variables);
+    pagePolicies(
+      variables?: PagePoliciesQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<PagePoliciesQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PagePoliciesQuery>({
+            document: PagePoliciesDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "pagePolicies",
+        "query",
+        variables,
+      );
     },
-    pageTermsAndConditions(variables?: PageTermsAndConditionsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<PageTermsAndConditionsQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<PageTermsAndConditionsQuery>({ document: PageTermsAndConditionsDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'pageTermsAndConditions', 'query', variables);
+    pageTermsAndConditions(
+      variables?: PageTermsAndConditionsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<PageTermsAndConditionsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<PageTermsAndConditionsQuery>({
+            document: PageTermsAndConditionsDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "pageTermsAndConditions",
+        "query",
+        variables,
+      );
     },
-    activeReleaseNotes(variables: ActiveReleaseNotesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<ActiveReleaseNotesQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ActiveReleaseNotesQuery>({ document: ActiveReleaseNotesDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'activeReleaseNotes', 'query', variables);
+    activeReleaseNotes(
+      variables: ActiveReleaseNotesQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<ActiveReleaseNotesQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ActiveReleaseNotesQuery>({
+            document: ActiveReleaseNotesDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "activeReleaseNotes",
+        "query",
+        variables,
+      );
     },
-    allReleaseNotes(variables: AllReleaseNotesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<AllReleaseNotesQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<AllReleaseNotesQuery>({ document: AllReleaseNotesDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'allReleaseNotes', 'query', variables);
+    allReleaseNotes(
+      variables: AllReleaseNotesQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<AllReleaseNotesQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<AllReleaseNotesQuery>({
+            document: AllReleaseNotesDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "allReleaseNotes",
+        "query",
+        variables,
+      );
     },
-    releaseNoteBySlug(variables: ReleaseNoteBySlugQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<ReleaseNoteBySlugQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<ReleaseNoteBySlugQuery>({ document: ReleaseNoteBySlugDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'releaseNoteBySlug', 'query', variables);
+    releaseNoteBySlug(
+      variables: ReleaseNoteBySlugQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<ReleaseNoteBySlugQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<ReleaseNoteBySlugQuery>({
+            document: ReleaseNoteBySlugDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "releaseNoteBySlug",
+        "query",
+        variables,
+      );
     },
-    sitemapPages(variables: SitemapPagesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<SitemapPagesQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<SitemapPagesQuery>({ document: SitemapPagesDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'sitemapPages', 'query', variables);
-    }
+    sitemapPages(
+      variables: SitemapPagesQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit["signal"],
+    ): Promise<SitemapPagesQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<SitemapPagesQuery>({
+            document: SitemapPagesDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        "sitemapPages",
+        "query",
+        variables,
+      );
+    },
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;

--- a/packages/cms/src/lib/graphql/releaseNotes.graphql
+++ b/packages/cms/src/lib/graphql/releaseNotes.graphql
@@ -1,0 +1,76 @@
+fragment ComponentReleaseNoteFields on ComponentReleaseNote {
+  __typename
+  sys {
+    id
+  }
+  slug
+  title
+  summary
+  body {
+    json
+  }
+  media {
+    ...ImageFields
+  }
+  category
+  surfaces
+  publishedAt
+  cta {
+    ...ButtonFields
+  }
+  seoFields {
+    ...SeoFields
+  }
+  active
+}
+
+# Active release notes for the caller's surface, newest first. `surfaces` is a single-select
+# (web / mobile / both); callers pass e.g. ["web", "both"] so the "both" entries always show.
+# This mirrors the alert banner's `audience` filtering (componentAlerts.graphql).
+query activeReleaseNotes(
+  $preview: Boolean
+  $now: DateTime!
+  $locale: String
+  $surfaces: [String]
+) {
+  componentReleaseNoteCollection(
+    preview: $preview
+    locale: $locale
+    order: [publishedAt_DESC]
+    where: { active: true, surfaces_in: $surfaces, publishedAt_lte: $now }
+  ) {
+    items {
+      ...ComponentReleaseNoteFields
+    }
+  }
+}
+
+# All active release notes (no surface filter) for the public openjii.org/releases changelog
+# page (OJD-1394). The public page shows everything, regardless of in-app `surfaces`, while
+# still honoring the `active` kill switch and the scheduled `publishedAt` reveal.
+query allReleaseNotes($preview: Boolean, $now: DateTime!, $locale: String) {
+  componentReleaseNoteCollection(
+    preview: $preview
+    locale: $locale
+    order: [publishedAt_DESC]
+    where: { active: true, publishedAt_lte: $now }
+  ) {
+    items {
+      ...ComponentReleaseNoteFields
+    }
+  }
+}
+
+# A single release note by its slug, for the public /releases/[slug] detail page (OJD-1394).
+query releaseNoteBySlug($slug: String!, $locale: String, $preview: Boolean) {
+  componentReleaseNoteCollection(
+    limit: 1
+    preview: $preview
+    locale: $locale
+    where: { slug: $slug, active: true }
+  ) {
+    items {
+      ...ComponentReleaseNoteFields
+    }
+  }
+}

--- a/packages/database/drizzle/0031_hot_doorman.sql
+++ b/packages/database/drizzle/0031_hot_doorman.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "profiles" ADD COLUMN "whats_new_last_seen_at" timestamp;

--- a/packages/database/drizzle/meta/0031_snapshot.json
+++ b/packages/database/drizzle/meta/0031_snapshot.json
@@ -1,0 +1,2168 @@
+{
+  "id": "25cc6d66-6a35-4951-864c-675cb7bd574e",
+  "prevId": "226948eb-85d8-421d-b363-f4569ecaa212",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_dashboards": {
+      "name": "experiment_dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"columns\":12,\"rowHeight\":80,\"gap\":16}'::jsonb"
+        },
+        "widgets": {
+          "name": "widgets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "experiment_dashboards_experiment_id_idx": {
+          "name": "experiment_dashboards_experiment_id_idx",
+          "columns": [
+            {
+              "expression": "experiment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiment_dashboards_experiment_id_experiments_id_fk": {
+          "name": "experiment_dashboards_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_dashboards",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_dashboards_created_by_users_id_fk": {
+          "name": "experiment_dashboards_created_by_users_id_fk",
+          "tableFrom": "experiment_dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_join_requests": {
+      "name": "experiment_join_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "join_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "experiment_join_requests_pending_uniq": {
+          "name": "experiment_join_requests_pending_uniq",
+          "columns": [
+            {
+              "expression": "experiment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"experiment_join_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "experiment_join_requests_experiment_idx": {
+          "name": "experiment_join_requests_experiment_idx",
+          "columns": [
+            {
+              "expression": "experiment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiment_join_requests_experiment_id_experiments_id_fk": {
+          "name": "experiment_join_requests_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_join_requests",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_join_requests_user_id_users_id_fk": {
+          "name": "experiment_join_requests_user_id_users_id_fk",
+          "tableFrom": "experiment_join_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_join_requests_decided_by_users_id_fk": {
+          "name": "experiment_join_requests_decided_by_users_id_fk",
+          "tableFrom": "experiment_join_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_locations": {
+      "name": "experiment_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "numeric(10, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "numeric(11, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "municipality": {
+          "name": "municipality",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_label": {
+          "name": "address_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_locations_experiment_id_experiments_id_fk": {
+          "name": "experiment_locations_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_locations",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_members": {
+      "name": "experiment_members",
+      "schema": "",
+      "columns": {
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "experiment_members_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_members_experiment_id_experiments_id_fk": {
+          "name": "experiment_members_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_members",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "experiment_members_user_id_users_id_fk": {
+          "name": "experiment_members_user_id_users_id_fk",
+          "tableFrom": "experiment_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "experiment_members_experiment_id_user_id_pk": {
+          "name": "experiment_members_experiment_id_user_id_pk",
+          "columns": [
+            "experiment_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_visualizations": {
+      "name": "experiment_visualizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chart_family": {
+          "name": "chart_family",
+          "type": "chart_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chart_type": {
+          "name": "chart_type",
+          "type": "chart_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_config": {
+          "name": "data_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_visualizations_experiment_id_experiments_id_fk": {
+          "name": "experiment_visualizations_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_visualizations",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_visualizations_created_by_users_id_fk": {
+          "name": "experiment_visualizations_created_by_users_id_fk",
+          "tableFrom": "experiment_visualizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiments": {
+      "name": "experiments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "experiment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "experiment_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "embargo_until": {
+          "name": "embargo_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "((now() AT TIME ZONE 'UTC') + interval '90 days')"
+        },
+        "anonymize_contributors": {
+          "name": "anonymize_contributors",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "workbook_id": {
+          "name": "workbook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workbook_version_id": {
+          "name": "workbook_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiments_workbook_id_workbooks_id_fk": {
+          "name": "experiments_workbook_id_workbooks_id_fk",
+          "tableFrom": "experiments",
+          "tableTo": "workbooks",
+          "columnsFrom": [
+            "workbook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "experiments_workbook_version_id_workbook_versions_id_fk": {
+          "name": "experiments_workbook_version_id_workbook_versions_id_fk",
+          "tableFrom": "experiments",
+          "tableTo": "workbook_versions",
+          "columnsFrom": [
+            "workbook_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "experiments_created_by_users_id_fk": {
+          "name": "experiments_created_by_users_id_fk",
+          "tableFrom": "experiments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "experiments_name_unique": {
+          "name": "experiments_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flows": {
+      "name": "flows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "flows_experiment_id_experiments_id_fk": {
+          "name": "flows_experiment_id_experiments_id_fk",
+          "tableFrom": "flows",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flows_experiment_id_unique": {
+          "name": "flows_experiment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "experiment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "invitation_resource_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_invited_by_users_id_fk": {
+          "name": "invitations_invited_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "resource_id_check": {
+          "name": "resource_id_check",
+          "value": "(\"invitations\".\"resource_type\" = 'platform' AND \"invitations\".\"resource_id\" IS NULL) OR (\"invitations\".\"resource_type\" != 'platform' AND \"invitations\".\"resource_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.macros": {
+      "name": "macros",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "macro_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "macros_created_by_users_id_fk": {
+          "name": "macros_created_by_users_id_fk",
+          "tableFrom": "macros",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "macros_name_unique": {
+          "name": "macros_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "macros_filename_unique": {
+          "name": "macros_filename_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "filename"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "organization_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated": {
+          "name": "activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whats_new_last_seen_at": {
+          "name": "whats_new_last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_user_id_users_id_fk": {
+          "name": "profiles_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profiles_organization_id_organizations_id_fk": {
+          "name": "profiles_organization_id_organizations_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_user_id_unique": {
+          "name": "profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.protocol_macros": {
+      "name": "protocol_macros",
+      "schema": "",
+      "columns": {
+        "protocol_id": {
+          "name": "protocol_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "macro_id": {
+          "name": "macro_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "protocol_macros_protocol_id_protocols_id_fk": {
+          "name": "protocol_macros_protocol_id_protocols_id_fk",
+          "tableFrom": "protocol_macros",
+          "tableTo": "protocols",
+          "columnsFrom": [
+            "protocol_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "protocol_macros_macro_id_macros_id_fk": {
+          "name": "protocol_macros_macro_id_macros_id_fk",
+          "tableFrom": "protocol_macros",
+          "tableTo": "macros",
+          "columnsFrom": [
+            "macro_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "protocol_macros_protocol_id_macro_id_pk": {
+          "name": "protocol_macros_protocol_id_macro_id_pk",
+          "columns": [
+            "protocol_id",
+            "macro_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.protocols": {
+      "name": "protocols",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "sensor_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "protocols_created_by_users_id_fk": {
+          "name": "protocols_created_by_users_id_fk",
+          "tableFrom": "protocols",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "protocols_name_unique": {
+          "name": "protocols_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rate_limits_key_unique": {
+          "name": "rate_limits_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sensors": {
+      "name": "sensors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "sensor_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sensors_serial_number_unique": {
+          "name": "sensors_serial_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "serial_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered": {
+          "name": "registered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workbook_versions": {
+      "name": "workbook_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workbook_id": {
+          "name": "workbook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cells": {
+          "name": "cells",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "entity_snapshots": {
+          "name": "entity_snapshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"protocols\":{},\"macros\":{}}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workbook_versions_workbook_id_idx": {
+          "name": "workbook_versions_workbook_id_idx",
+          "columns": [
+            {
+              "expression": "workbook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workbook_versions_workbook_id_workbooks_id_fk": {
+          "name": "workbook_versions_workbook_id_workbooks_id_fk",
+          "tableFrom": "workbook_versions",
+          "tableTo": "workbooks",
+          "columnsFrom": [
+            "workbook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workbook_versions_created_by_users_id_fk": {
+          "name": "workbook_versions_created_by_users_id_fk",
+          "tableFrom": "workbook_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workbook_versions_workbook_version_uniq": {
+          "name": "workbook_versions_workbook_version_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workbook_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workbooks": {
+      "name": "workbooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cells": {
+          "name": "cells",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "workbooks_created_by_idx": {
+          "name": "workbooks_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workbooks_created_by_users_id_fk": {
+          "name": "workbooks_created_by_users_id_fk",
+          "tableFrom": "workbooks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.chart_family": {
+      "name": "chart_family",
+      "schema": "public",
+      "values": [
+        "basic",
+        "scientific",
+        "3d",
+        "statistical"
+      ]
+    },
+    "public.chart_type": {
+      "name": "chart_type",
+      "schema": "public",
+      "values": [
+        "line",
+        "scatter",
+        "bar",
+        "pie",
+        "area",
+        "dot-plot",
+        "bubble",
+        "lollipop",
+        "box-plot",
+        "histogram",
+        "violin-plot",
+        "density-plot",
+        "ridge-plot",
+        "histogram-2d",
+        "density-plot-2d",
+        "spc-control-chart",
+        "heatmap",
+        "contour",
+        "carpet",
+        "ternary",
+        "parallel-coordinates",
+        "wind-rose",
+        "radar",
+        "polar",
+        "correlation-matrix",
+        "alluvial"
+      ]
+    },
+    "public.experiment_members_role": {
+      "name": "experiment_members_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member"
+      ]
+    },
+    "public.experiment_status": {
+      "name": "experiment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "stale",
+        "archived",
+        "published"
+      ]
+    },
+    "public.experiment_visibility": {
+      "name": "experiment_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "public"
+      ]
+    },
+    "public.invitation_resource_type": {
+      "name": "invitation_resource_type",
+      "schema": "public",
+      "values": [
+        "platform",
+        "experiment"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "revoked"
+      ]
+    },
+    "public.join_request_status": {
+      "name": "join_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "cancelled"
+      ]
+    },
+    "public.macro_language": {
+      "name": "macro_language",
+      "schema": "public",
+      "values": [
+        "python",
+        "r",
+        "javascript"
+      ]
+    },
+    "public.organization_type": {
+      "name": "organization_type",
+      "schema": "public",
+      "values": [
+        "research_institute",
+        "non_profit",
+        "private_company",
+        "government_agency",
+        "university"
+      ]
+    },
+    "public.sensor_family": {
+      "name": "sensor_family",
+      "schema": "public",
+      "values": [
+        "multispeq",
+        "ambit",
+        "generic"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1780050152410,
       "tag": "0030_aberrant_joshua_kane",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1782737363482,
+      "tag": "0031_hot_doorman",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -101,6 +101,7 @@ export const profiles = pgTable("profiles", {
   avatarUrl: varchar("avatar_url", { length: 500 }),
   activated: boolean("activated").default(true).notNull(),
   deletedAt: timestamp("deleted_at"),
+  whatsNewLastSeenAt: timestamp("whats_new_last_seen_at"),
   userId: uuid("user_id")
     .references(() => users.id)
     .unique()

--- a/packages/i18n/locales/de-DE/navigation.json
+++ b/packages/i18n/locales/de-DE/navigation.json
@@ -48,5 +48,36 @@
     "new": "Neu",
     "edit": "Bearbeiten",
     "view": "Ansehen"
+  },
+  "whatsNew": {
+    "navLabel": "Neuigkeiten",
+    "title": "Neuigkeiten",
+    "description": "Neueste Releases und Funktionsankündigungen",
+    "fullChangelog": "Vollständiges Änderungsprotokoll",
+    "showMore": "Mehr lesen",
+    "showLess": "Weniger anzeigen",
+    "readMore": "Mehr lesen",
+    "empty": "Noch keine Neuigkeiten.",
+    "unreadBadge": "{{count}} ungelesen",
+    "category": {
+      "new_feature": "Neue Funktion",
+      "improvement": "Verbesserung",
+      "bug_fix": "Fehlerbehebung",
+      "announcement": "Ankündigung"
+    }
+  },
+  "releases": {
+    "metaTitle": "Releases",
+    "metaDescription": "Die neuesten Funktionen, Verbesserungen und Fehlerbehebungen auf der openJII-Plattform.",
+    "heading": "Releases",
+    "subheading": "Die neuesten Funktionen, Verbesserungen und Fehlerbehebungen auf der openJII-Plattform.",
+    "backToReleases": "Alle Releases",
+    "eyebrow": "Changelog",
+    "filterAll": "Alle",
+    "readUpdate": "Update lesen",
+    "previous": "Vorherige",
+    "next": "Nächste",
+    "notFoundTitle": "Release-Notiz nicht gefunden",
+    "notFoundDescription": "Diese Release-Notiz existiert nicht oder ist nicht mehr verfügbar."
   }
 }

--- a/packages/i18n/locales/de-DE/navigation.json
+++ b/packages/i18n/locales/de-DE/navigation.json
@@ -67,7 +67,7 @@
     }
   },
   "releases": {
-    "metaTitle": "Releases",
+    "metaTitle": "Releases - openJII",
     "metaDescription": "Die neuesten Funktionen, Verbesserungen und Fehlerbehebungen auf der openJII-Plattform.",
     "heading": "Releases",
     "subheading": "Die neuesten Funktionen, Verbesserungen und Fehlerbehebungen auf der openJII-Plattform.",

--- a/packages/i18n/locales/de-DE/navigation.json
+++ b/packages/i18n/locales/de-DE/navigation.json
@@ -51,7 +51,7 @@
   },
   "whatsNew": {
     "navLabel": "Neuigkeiten",
-    "title": "Neuigkeiten",
+    "title": "Neuigkeiten im Web",
     "description": "Neueste Releases und Funktionsankündigungen",
     "fullChangelog": "Vollständiges Änderungsprotokoll",
     "showMore": "Mehr lesen",
@@ -64,6 +64,10 @@
       "improvement": "Verbesserung",
       "bug_fix": "Fehlerbehebung",
       "announcement": "Ankündigung"
+    },
+    "surface": {
+      "web": "Web",
+      "mobile": "Mobil"
     }
   },
   "releases": {

--- a/packages/i18n/locales/de-DE/navigation.json
+++ b/packages/i18n/locales/de-DE/navigation.json
@@ -58,6 +58,8 @@
     "showLess": "Weniger anzeigen",
     "readMore": "Mehr lesen",
     "empty": "Noch keine Neuigkeiten.",
+    "emptyTitle": "Noch nichts Neues",
+    "emptyDescription": "Updates, Korrekturen und Ankündigungen erscheinen hier, sobald sie veröffentlicht sind.",
     "unreadBadge": "{{count}} ungelesen",
     "category": {
       "new_feature": "Neue Funktion",
@@ -78,6 +80,8 @@
     "backToReleases": "Alle Releases",
     "eyebrow": "Changelog",
     "filterAll": "Alle",
+    "emptyTitle": "Noch keine Releases veröffentlicht",
+    "emptyDescription": "Dieses Änderungsprotokoll ist bereit für das erste Update. Zukünftige Funktionen, Verbesserungen und Fehlerbehebungen erscheinen hier.",
     "readUpdate": "Update lesen",
     "previous": "Vorherige",
     "next": "Nächste",

--- a/packages/i18n/locales/en-US/navigation.json
+++ b/packages/i18n/locales/en-US/navigation.json
@@ -58,6 +58,8 @@
     "showLess": "Show less",
     "readMore": "Read more",
     "empty": "No release notes yet.",
+    "emptyTitle": "Nothing new yet",
+    "emptyDescription": "Updates, fixes, and announcements will appear here once they are published.",
     "unreadBadge": "{{count}} unread",
     "category": {
       "new_feature": "New feature",
@@ -78,6 +80,8 @@
     "backToReleases": "All releases",
     "eyebrow": "Changelog",
     "filterAll": "All",
+    "emptyTitle": "No releases published yet",
+    "emptyDescription": "This changelog is ready for the first update. Future features, improvements, and fixes will appear here.",
     "readUpdate": "Read the update",
     "previous": "Previous",
     "next": "Next",

--- a/packages/i18n/locales/en-US/navigation.json
+++ b/packages/i18n/locales/en-US/navigation.json
@@ -48,5 +48,36 @@
     "new": "New",
     "edit": "Edit",
     "view": "View"
+  },
+  "whatsNew": {
+    "navLabel": "What's new",
+    "title": "What's new",
+    "description": "Latest releases and feature announcements",
+    "fullChangelog": "Full changelog",
+    "showMore": "Read more",
+    "showLess": "Show less",
+    "readMore": "Read more",
+    "empty": "No release notes yet.",
+    "unreadBadge": "{{count}} unread",
+    "category": {
+      "new_feature": "New feature",
+      "improvement": "Improvement",
+      "bug_fix": "Bug fix",
+      "announcement": "Announcement"
+    }
+  },
+  "releases": {
+    "metaTitle": "Releases",
+    "metaDescription": "The latest features, improvements, and fixes on the openJII platform.",
+    "heading": "Releases",
+    "subheading": "The latest features, improvements, and fixes on the openJII platform.",
+    "backToReleases": "All releases",
+    "eyebrow": "Changelog",
+    "filterAll": "All",
+    "readUpdate": "Read the update",
+    "previous": "Previous",
+    "next": "Next",
+    "notFoundTitle": "Release note not found",
+    "notFoundDescription": "This release note doesn't exist or is no longer available."
   }
 }

--- a/packages/i18n/locales/en-US/navigation.json
+++ b/packages/i18n/locales/en-US/navigation.json
@@ -51,7 +51,7 @@
   },
   "whatsNew": {
     "navLabel": "What's new",
-    "title": "What's new",
+    "title": "What's new on web",
     "description": "Latest releases and feature announcements",
     "fullChangelog": "Full changelog",
     "showMore": "Read more",
@@ -64,6 +64,10 @@
       "improvement": "Improvement",
       "bug_fix": "Bug fix",
       "announcement": "Announcement"
+    },
+    "surface": {
+      "web": "Web",
+      "mobile": "Mobile"
     }
   },
   "releases": {

--- a/packages/i18n/locales/en-US/navigation.json
+++ b/packages/i18n/locales/en-US/navigation.json
@@ -67,7 +67,7 @@
     }
   },
   "releases": {
-    "metaTitle": "Releases",
+    "metaTitle": "Releases - openJII",
     "metaDescription": "The latest features, improvements, and fixes on the openJII platform.",
     "heading": "Releases",
     "subheading": "The latest features, improvements, and fixes on the openJII platform.",

--- a/packages/i18n/locales/nl-NL/navigation.json
+++ b/packages/i18n/locales/nl-NL/navigation.json
@@ -63,7 +63,7 @@
     }
   },
   "releases": {
-    "metaTitle": "Releases",
+    "metaTitle": "Releases - openJII",
     "metaDescription": "De nieuwste functies, verbeteringen en bugfixes op het openJII-platform.",
     "heading": "Releases",
     "subheading": "De nieuwste functies, verbeteringen en bugfixes op het openJII-platform.",

--- a/packages/i18n/locales/nl-NL/navigation.json
+++ b/packages/i18n/locales/nl-NL/navigation.json
@@ -44,5 +44,36 @@
     "new": "Nieuw",
     "edit": "Bewerken",
     "view": "Bekijken"
+  },
+  "whatsNew": {
+    "navLabel": "Wat is er nieuw",
+    "title": "Wat is er nieuw",
+    "description": "Nieuwste releases en functieaankondigingen",
+    "fullChangelog": "Volledig wijzigingslogboek",
+    "showMore": "Meer lezen",
+    "showLess": "Minder tonen",
+    "readMore": "Meer lezen",
+    "empty": "Nog geen release-notities.",
+    "unreadBadge": "{{count}} ongelezen",
+    "category": {
+      "new_feature": "Nieuwe functie",
+      "improvement": "Verbetering",
+      "bug_fix": "Bugfix",
+      "announcement": "Aankondiging"
+    }
+  },
+  "releases": {
+    "metaTitle": "Releases",
+    "metaDescription": "De nieuwste functies, verbeteringen en bugfixes op het openJII-platform.",
+    "heading": "Releases",
+    "subheading": "De nieuwste functies, verbeteringen en bugfixes op het openJII-platform.",
+    "backToReleases": "Alle releases",
+    "eyebrow": "Changelog",
+    "filterAll": "Alles",
+    "readUpdate": "Lees de update",
+    "previous": "Vorige",
+    "next": "Volgende",
+    "notFoundTitle": "Release-notitie niet gevonden",
+    "notFoundDescription": "Deze release-notitie bestaat niet of is niet meer beschikbaar."
   }
 }

--- a/packages/i18n/locales/nl-NL/navigation.json
+++ b/packages/i18n/locales/nl-NL/navigation.json
@@ -54,6 +54,8 @@
     "showLess": "Minder tonen",
     "readMore": "Meer lezen",
     "empty": "Nog geen release-notities.",
+    "emptyTitle": "Nog niets nieuws",
+    "emptyDescription": "Updates, fixes en aankondigingen verschijnen hier zodra ze gepubliceerd zijn.",
     "unreadBadge": "{{count}} ongelezen",
     "category": {
       "new_feature": "Nieuwe functie",
@@ -70,6 +72,8 @@
     "backToReleases": "Alle releases",
     "eyebrow": "Changelog",
     "filterAll": "Alles",
+    "emptyTitle": "Nog geen releases gepubliceerd",
+    "emptyDescription": "Dit wijzigingslogboek staat klaar voor de eerste update. Toekomstige functies, verbeteringen en bugfixes verschijnen hier.",
     "readUpdate": "Lees de update",
     "previous": "Vorige",
     "next": "Volgende",

--- a/packages/ui/src/components/__tests__/nav-tabs.test.tsx
+++ b/packages/ui/src/components/__tests__/nav-tabs.test.tsx
@@ -2,7 +2,7 @@ import "@testing-library/jest-dom/vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { NavTabs, NavTabsList, NavTabsTrigger, NavTabsContent } from "../nav-tabs";
 
@@ -65,12 +65,13 @@ describe("NavTabs", () => {
 
       const list = screen.getByTestId("tabs-list");
       expect(list).toBeInTheDocument();
-      // Underline-style tabs: inline-flex row, capped at max-w-full, bottom border.
+      // Underline-style tabs: inline-flex row, capped at max-w-full, with a 2px
+      // baseline that matches the active indicator's height.
       // Assert exact class tokens so e.g. "flex" can't pass on "inline-flex".
       const tokens = list.className.split(/\s+/);
       expect(tokens).toContain("inline-flex");
       expect(tokens).toContain("max-w-full");
-      expect(tokens).toContain("border-b");
+      expect(tokens).toContain("border-b-2");
       expect(tokens).toContain("gap-6");
     });
 
@@ -134,9 +135,8 @@ describe("NavTabs", () => {
       expect(activeTrigger).toHaveAttribute("data-state", "active");
       expect(inactiveTrigger).toHaveAttribute("data-state", "inactive");
 
-      // Underline-style trigger: relative + bottom border + brand-teal active state.
-      expect(activeTrigger.className).toContain("border-b-2");
-      expect(activeTrigger.className).toContain("data-[state=active]:border-primary");
+      // Active tab is marked by brand-teal text; the underline itself is drawn by
+      // the list's separate sliding indicator, not a per-trigger border.
       expect(activeTrigger.className).toContain("data-[state=active]:text-primary");
     });
 
@@ -387,6 +387,61 @@ describe("NavTabs", () => {
       expect(tab2).toHaveAttribute("role", "tab");
       expect(tab1).toHaveAttribute("data-state", "active");
       expect(tab2).toHaveAttribute("data-state", "inactive");
+    });
+  });
+
+  describe("Mobile dropdown", () => {
+    const originalMatchMedia = window.matchMedia;
+
+    // Force the mobile breakpoint so NavTabsList renders its dropdown variant.
+    beforeEach(() => {
+      window.matchMedia = ((query: string) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })) as unknown as typeof window.matchMedia;
+    });
+
+    afterEach(() => {
+      window.matchMedia = originalMatchMedia;
+    });
+
+    it("collapses tabs into a dropdown labelled by the active tab", () => {
+      render(
+        <NavTabs value="data">
+          <NavTabsList>
+            <NavTabsTrigger value="overview">Overview</NavTabsTrigger>
+            <NavTabsTrigger value="data">Data</NavTabsTrigger>
+          </NavTabsList>
+        </NavTabs>,
+      );
+
+      // Closed dropdown shows the active tab's label; the tab rows stay collapsed.
+      expect(screen.getByRole("button", { name: /data/i })).toBeInTheDocument();
+      expect(screen.queryByRole("tab")).not.toBeInTheDocument();
+    });
+
+    it("reveals the tabs when the dropdown is opened", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <NavTabs value="overview">
+          <NavTabsList>
+            <NavTabsTrigger value="overview">Overview</NavTabsTrigger>
+            <NavTabsTrigger value="data">Data</NavTabsTrigger>
+          </NavTabsList>
+        </NavTabs>,
+      );
+
+      await user.click(screen.getByRole("button", { name: /overview/i }));
+
+      expect(screen.getByRole("tab", { name: /overview/i })).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: /data/i })).toBeInTheDocument();
     });
   });
 });

--- a/packages/ui/src/components/__tests__/nav-tabs.test.tsx
+++ b/packages/ui/src/components/__tests__/nav-tabs.test.tsx
@@ -443,5 +443,43 @@ describe("NavTabs", () => {
       expect(screen.getByRole("tab", { name: /overview/i })).toBeInTheDocument();
       expect(screen.getByRole("tab", { name: /data/i })).toBeInTheDocument();
     });
+
+    it("collapses the dropdown again once a tab is selected", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <NavTabs value="overview">
+          <NavTabsList>
+            <NavTabsTrigger value="overview">Overview</NavTabsTrigger>
+            <NavTabsTrigger value="data">Data</NavTabsTrigger>
+          </NavTabsList>
+        </NavTabs>,
+      );
+
+      await user.click(screen.getByRole("button", { name: /overview/i }));
+      await user.click(screen.getByRole("tab", { name: /data/i }));
+
+      // Selecting a row closes the popover, so the tab rows collapse back to the button.
+      expect(screen.queryByRole("tab")).not.toBeInTheDocument();
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    it("labels the closed dropdown from an asChild trigger's inner content", () => {
+      render(
+        <NavTabs value="data">
+          <NavTabsList>
+            <NavTabsTrigger value="overview" asChild>
+              <a href="/overview">Overview</a>
+            </NavTabsTrigger>
+            <NavTabsTrigger value="data" asChild>
+              <a href="/data">Data</a>
+            </NavTabsTrigger>
+          </NavTabsList>
+        </NavTabs>,
+      );
+
+      // The active trigger wraps a link, so its label lives one level in — the button still reads "Data".
+      expect(screen.getByRole("button", { name: /data/i })).toBeInTheDocument();
+    });
   });
 });

--- a/packages/ui/src/components/__tests__/nav-tabs.test.tsx
+++ b/packages/ui/src/components/__tests__/nav-tabs.test.tsx
@@ -464,6 +464,28 @@ describe("NavTabs", () => {
       expect(screen.getByRole("button")).toBeInTheDocument();
     });
 
+    it("runs a consumer-supplied onClick and still closes the dropdown on selection", async () => {
+      const user = userEvent.setup();
+      const onClick = vi.fn();
+
+      render(
+        <NavTabs value="overview">
+          <NavTabsList onClick={onClick}>
+            <NavTabsTrigger value="overview">Overview</NavTabsTrigger>
+            <NavTabsTrigger value="data">Data</NavTabsTrigger>
+          </NavTabsList>
+        </NavTabs>,
+      );
+
+      await user.click(screen.getByRole("button", { name: /overview/i }));
+      await user.click(screen.getByRole("tab", { name: /data/i }));
+
+      // The consumer's handler is composed with the internal one (not clobbered by it)...
+      expect(onClick).toHaveBeenCalled();
+      // ...and the internal close behavior still fires.
+      expect(screen.queryByRole("tab")).not.toBeInTheDocument();
+    });
+
     it("labels the closed dropdown from an asChild trigger's inner content", () => {
       render(
         <NavTabs value="data">

--- a/packages/ui/src/components/nav-tabs.tsx
+++ b/packages/ui/src/components/nav-tabs.tsx
@@ -1,71 +1,294 @@
 "use client";
 
+import { Check, ChevronDown } from "lucide-react";
 import { Tabs as TabsPrimitive } from "radix-ui";
 import * as React from "react";
 
+import { useIsMobile } from "../hooks/use-mobile";
 import { cn } from "../lib/utils";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 
-const NavTabs = TabsPrimitive.Root;
+// Position the indicator before the browser paints so it never animates in from
+// the top-left on first mount; falls back to useEffect during SSR.
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? React.useLayoutEffect : React.useEffect;
 
-// List — shrinks to fit its tabs (the 1px bottom border only spans the actual
-// tab row, not the full content area). `self-start` opts out of stretch-align
-// inside flex-col parents. No `overflow-x-auto` because CSS coerces the other
-// axis to auto, which clips the active trigger's `-mb-px` underline and turns
-// the row into a 1-pixel vertical scroll trap.
+// Shared count-badge styling (desktop tab + mobile menu row).
+const countBadgeClass =
+  "bg-muted text-muted-foreground group-data-[state=active]:bg-primary/20 group-data-[state=active]:text-primary inline-flex min-w-5 items-center justify-center rounded px-1.5 text-[11px] font-semibold tabular-nums";
+
+// Active value mirrored from Radix so the closed mobile dropdown can show its label.
+const NavTabsValueContext = React.createContext<string | undefined>(undefined);
+
+// Which skin a trigger renders: desktop underline tab vs. mobile menu row.
+const NavTabsLayoutContext = React.createContext<"horizontal" | "menu">("horizontal");
+
+// Wraps Radix Root to expose the active value via context (for the mobile
+// dropdown), tracking both controlled and uncontrolled usage.
+const NavTabs = React.forwardRef<
+  React.ComponentRef<typeof TabsPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root>
+>(({ value, defaultValue, onValueChange, children, ...props }, ref) => {
+  const [internalValue, setInternalValue] = React.useState<string | undefined>(
+    value ?? defaultValue,
+  );
+  const currentValue = value ?? internalValue;
+
+  const handleValueChange = React.useCallback(
+    (next: string) => {
+      setInternalValue(next);
+      onValueChange?.(next);
+    },
+    [onValueChange],
+  );
+
+  return (
+    <NavTabsValueContext.Provider value={currentValue}>
+      <TabsPrimitive.Root
+        ref={ref}
+        value={value}
+        defaultValue={defaultValue}
+        onValueChange={handleValueChange}
+        {...props}
+      >
+        {children}
+      </TabsPrimitive.Root>
+    </NavTabsValueContext.Provider>
+  );
+});
+NavTabs.displayName = "NavTabs";
+
+// Pull the visible label out of a trigger. With `asChild` the real child is a
+// wrapper element (e.g. a Next.js `<Link>`), so the label lives one level in.
+function getTriggerLabel(child: React.ReactElement): React.ReactNode {
+  const props = child.props as { children?: React.ReactNode; asChild?: boolean };
+  if (props.asChild && React.isValidElement(props.children)) {
+    return (props.children.props as { children?: React.ReactNode }).children;
+  }
+  return props.children;
+}
+
+// Mobile list — tabs collapse into a popover. Real triggers render as menu rows
+// (navigation/switching still works); the closed button shows the active label.
+const NavTabsMobileList = ({
+  className,
+  children,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>) => {
+  const currentValue = React.useContext(NavTabsValueContext);
+  const [open, setOpen] = React.useState(false);
+
+  const items = React.Children.toArray(children).filter(
+    React.isValidElement,
+  ) as React.ReactElement[];
+  const active =
+    items.find((child) => (child.props as { value?: string }).value === currentValue) ?? items[0];
+  const activeCount = active ? (active.props as { count?: number }).count : undefined;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "border-border bg-background text-foreground hover:bg-muted/40 focus-visible:ring-ring data-[state=open]:border-primary/60 flex w-full items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-2",
+            className,
+          )}
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="truncate">{active ? getTriggerLabel(active) : null}</span>
+            {typeof activeCount === "number" ? (
+              <span className={countBadgeClass}>{activeCount}</span>
+            ) : null}
+          </span>
+          <ChevronDown className="text-muted-foreground h-4 w-4 shrink-0" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        sideOffset={6}
+        className="w-[var(--radix-popover-trigger-width)] p-1"
+      >
+        <TabsPrimitive.List
+          className="flex flex-col gap-0.5"
+          {...props}
+          // Close once a row is chosen (covers both mouse and keyboard activation).
+          onClick={(event) => {
+            if ((event.target as HTMLElement).closest('[role="tab"]')) setOpen(false);
+          }}
+        >
+          {children}
+        </TabsPrimitive.List>
+      </PopoverContent>
+    </Popover>
+  );
+};
+NavTabsMobileList.displayName = "NavTabsMobileList";
+
+// Desktop list — horizontal tab row with a single indicator that slides under
+// the active tab, sharing the 2px height of the baseline (`border-b-2`).
+// `self-start` avoids stretch-align in flex-col parents.
+const NavTabsDesktopList = React.forwardRef<
+  React.ComponentRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, children, ...props }, ref) => {
+  const currentValue = React.useContext(NavTabsValueContext);
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
+  const [rect, setRect] = React.useState<{ left: number; top: number; width: number } | null>(null);
+
+  useIsomorphicLayoutEffect(() => {
+    const node = wrapperRef.current;
+    if (!node) return;
+
+    const measure = () => {
+      const active = node.querySelector<HTMLElement>('[role="tab"][data-state="active"]');
+      // 0-width means an unmeasured layout (SSR / jsdom) — keep the bar hidden.
+      if (!active || active.offsetWidth === 0) {
+        setRect(null);
+        return;
+      }
+      setRect({
+        left: active.offsetLeft,
+        width: active.offsetWidth,
+        top: active.offsetTop + active.offsetHeight,
+      });
+    };
+
+    measure();
+
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [currentValue]);
+
+  return (
+    // Positioning context for the indicator.
+    <div ref={wrapperRef} className="relative max-w-full self-start">
+      <TabsPrimitive.List
+        ref={ref}
+        className={cn(
+          "border-border inline-flex max-w-full flex-wrap items-end gap-6 border-b-2",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </TabsPrimitive.List>
+      {/* Mounted only once measured: a fresh element doesn't transition its initial
+          style, so the bar appears in place on load but still animates between tabs. */}
+      {rect ? (
+        <span
+          aria-hidden
+          className="bg-primary pointer-events-none absolute left-0 top-0 h-0.5 rounded-full transition-[transform,width,top] duration-300 ease-out"
+          style={{ transform: `translateX(${rect.left}px)`, width: rect.width, top: rect.top }}
+        />
+      ) : null}
+    </div>
+  );
+});
+NavTabsDesktopList.displayName = "NavTabsDesktopList";
+
+// List — a horizontal underline tab row on desktop; collapses to a dropdown on
+// mobile.
 const NavTabsList = React.forwardRef<
   React.ComponentRef<typeof TabsPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    className={cn(
-      "border-border inline-flex max-w-full flex-wrap items-end gap-6 self-start border-b",
-      className,
-    )}
-    {...props}
-  />
-));
+>(({ children, ...props }, ref) => {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <NavTabsLayoutContext.Provider value="menu">
+        <NavTabsMobileList {...props}>{children}</NavTabsMobileList>
+      </NavTabsLayoutContext.Provider>
+    );
+  }
+
+  return (
+    <NavTabsLayoutContext.Provider value="horizontal">
+      <NavTabsDesktopList ref={ref} {...props}>
+        {children}
+      </NavTabsDesktopList>
+    </NavTabsLayoutContext.Provider>
+  );
+});
 NavTabsList.displayName = "NavTabsList";
 
 interface NavTabsTriggerProps extends React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> {
   count?: number;
 }
 
-// Trigger — underline style. `-mb-px` lifts the 2px active border so it sits on
-// top of the list's 1px bottom border (single continuous line, no gap).
+// Trigger — desktop underline tab or mobile menu row. The desktop underline is
+// drawn by the list's sliding indicator, so the trigger only styles its text.
 const NavTabsTrigger = React.forwardRef<
   React.ComponentRef<typeof TabsPrimitive.Trigger>,
   NavTabsTriggerProps
->(({ className, children, count, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      "focus-visible:ring-ring outline-hidden group relative -mb-px inline-flex shrink-0 select-none items-center gap-2 whitespace-nowrap border-b-2 border-transparent px-1 pb-3 pt-2 text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-offset-2",
+>(({ className, children, count, asChild, ...props }, ref) => {
+  const layout = React.useContext(NavTabsLayoutContext);
 
-      // active — brand teal underline + brand teal text
-      "data-[state=active]:border-primary data-[state=active]:text-primary",
+  if (layout === "menu") {
+    return (
+      <TabsPrimitive.Trigger
+        ref={ref}
+        asChild={asChild}
+        className={cn(
+          "focus-visible:ring-ring group relative flex w-full select-none items-center gap-2 rounded-md px-3 py-2 text-left text-sm font-medium outline-none transition-colors focus-visible:ring-2",
+          // active — brand teal text on a faint teal wash
+          "data-[state=active]:bg-primary/10 data-[state=active]:text-primary",
+          // inactive — muted text, hover surfaces a row background
+          "data-[state=inactive]:text-muted-foreground data-[state=inactive]:hover:bg-muted data-[state=inactive]:hover:text-foreground",
+          "disabled:pointer-events-none disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      >
+        {/* asChild merges onto a single element (e.g. a Link), so don't inject siblings. */}
+        {asChild ? (
+          children
+        ) : (
+          <>
+            <span className="flex-1 truncate">{children}</span>
+            {typeof count === "number" ? <span className={countBadgeClass}>{count}</span> : null}
+            <Check className="text-primary h-4 w-4 shrink-0 opacity-0 group-data-[state=active]:opacity-100" />
+          </>
+        )}
+      </TabsPrimitive.Trigger>
+    );
+  }
 
-      // inactive — muted text, hover darkens + adds a faint border preview
-      "data-[state=inactive]:text-muted-foreground data-[state=inactive]:hover:border-muted-foreground/40 data-[state=inactive]:hover:text-foreground",
+  return (
+    <TabsPrimitive.Trigger
+      ref={ref}
+      asChild={asChild}
+      className={cn(
+        "focus-visible:ring-ring group relative inline-flex shrink-0 select-none items-center gap-2 whitespace-nowrap px-1 pb-3 pt-2 text-sm font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-2",
 
-      // disabled
-      "disabled:pointer-events-none disabled:opacity-50",
-      className,
-    )}
-    {...props}
-  >
-    {typeof count === "number" ? (
-      <>
-        <span>{children}</span>
-        <span className="bg-muted text-muted-foreground group-data-[state=active]:bg-primary/20 group-data-[state=active]:text-primary inline-flex min-w-5 items-center justify-center rounded px-1.5 text-[11px] font-semibold tabular-nums">
-          {count}
-        </span>
-      </>
-    ) : (
-      children
-    )}
-  </TabsPrimitive.Trigger>
-));
+        // active — brand teal text (the sliding indicator draws the underline)
+        "data-[state=active]:text-primary",
+
+        // inactive — muted text, hover only darkens the text (no underline preview)
+        "data-[state=inactive]:text-muted-foreground data-[state=inactive]:hover:text-foreground",
+
+        // disabled
+        "disabled:pointer-events-none disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      {asChild ? (
+        children
+      ) : typeof count === "number" ? (
+        <>
+          <span>{children}</span>
+          <span className={countBadgeClass}>{count}</span>
+        </>
+      ) : (
+        children
+      )}
+    </TabsPrimitive.Trigger>
+  );
+});
 NavTabsTrigger.displayName = "NavTabsTrigger";
 
 const NavTabsContent = React.forwardRef<

--- a/packages/ui/src/components/nav-tabs.tsx
+++ b/packages/ui/src/components/nav-tabs.tsx
@@ -73,14 +73,13 @@ function getTriggerLabel(child: React.ReactElement): React.ReactNode {
 const NavTabsMobileList = ({
   className,
   children,
+  onClick,
   ...props
 }: React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>) => {
   const currentValue = React.useContext(NavTabsValueContext);
   const [open, setOpen] = React.useState(false);
 
-  const items = React.Children.toArray(children).filter(
-    React.isValidElement,
-  ) as React.ReactElement[];
+  const items = React.Children.toArray(children).filter(React.isValidElement);
   const active =
     items.find((child) => (child.props as { value?: string }).value === currentValue) ?? items[0];
   const activeCount = active ? (active.props as { count?: number }).count : undefined;
@@ -112,8 +111,10 @@ const NavTabsMobileList = ({
         <TabsPrimitive.List
           className="flex flex-col gap-0.5"
           {...props}
-          // Close once a row is chosen (covers both mouse and keyboard activation).
+          // Compose with any consumer-passed handler, then close once a row is chosen (covers both
+          // mouse and keyboard activation).
           onClick={(event) => {
+            onClick?.(event);
             if ((event.target as HTMLElement).closest('[role="tab"]')) setOpen(false);
           }}
         >

--- a/packages/ui/vitest.setup.ts
+++ b/packages/ui/vitest.setup.ts
@@ -14,3 +14,17 @@ global.ResizeObserver = class ResizeObserver {
   unobserve() {}
   disconnect() {}
 };
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Adds a release-notes system backed by Contentful `ComponentReleaseNote` entries, surfaced three ways from that single source:

- an in-app **What's New** panel on **web** and **mobile**, with a per-user "last seen" timestamp stored server-side so the unread indicator stays in sync across a user's devices;
- a public, pre-login **`/releases`** changelog with a per-note **`/releases/[slug]`** detail page (its own SEO).

Each note has a **`surfaces`** field (web / mobile / both): the web sheet shows `web` + `both`, the mobile sheet shows `mobile` + `both`, and the public `/releases` page shows all of them. In-app feeds are cached **~5 min** (web via Next `unstable_cache`, mobile via TanStack Query); the public page fetches Contentful live per request. *

The backend only tracks *when* a user last opened the panel — release-note content is fetched straight from Contentful by each client, and the unread count is computed there by comparing publish dates to that timestamp.

## Changes made

### Backend
- **`GetWhatsNewSeenUseCase` / `MarkWhatsNewSeenUseCase`** (+ specs) — read and stamp (`now()`) the caller's last-seen timestamp. Both first check the profile row exists and return `NOT_FOUND` if not, so a write matching zero rows fails loudly instead of silently succeeding.
- **`UserRepository.findWhatsNewLastSeen` / `markWhatsNewSeen`** (+ specs) — the Drizzle reads/writes against `profiles`, stamping in UTC (`now() AT TIME ZONE 'UTC'`).

### Database
- New **`profiles.whatsNewLastSeenAt`** column (nullable = "never opened").

### CMS package (`@repo/cms`)
- **`releaseNotes.graphql`**: extended the shared fragment with `slug` (stable permalink), `surfaces` (web / mobile / both — which app a note targets), and `seoFields`; added queries `activeReleaseNotes` (filtered to the caller's surface — `web`+`both` or `mobile`+`both` — for the in-app feeds), `allReleaseNotes` (no surface filter, for the public page), and `releaseNoteBySlug` (detail). Regenerated the SDK/schema.
- **Shared components** (used by web): `ReleaseHero` (split media/text card, reused by the changelog spotlight *and* the detail-page header), `ReleaseNoteArticle` (full note with rich-text body), `ReleaseNoteEntry` + `ReleaseNotesFeed` (month-grouped list/sheet), `SurfaceBadges` (Web/Mobile badges — both when `surfaces: both`), and `category.ts` (category → badge color/label).

### Web — public `/releases`
- **`page.tsx`** (all notes, newest-first, grouped by month, hero on top), **`[slug]/page.tsx`** (full note + prev/next nav + SEO mapped from `seoFields`, `notFound()` on a bad slug), plus `not-found.tsx` / `[...notFound]/page.tsx`.
- **`fetch-public-release-notes.ts`** — `cache()`-wrapped fetchers showing **all** surfaces; `cache()` only dedups the metadata + body calls per request (the route is dynamic via `draftMode()`, so it fetches Contentful live per request). **`releases-changelog.tsx`** (client filtering via `NavTabs` with per-category counts), **`release-nav.tsx`** (prev/next).

### Web — in-app What's New panel
- **`whats-new-sheet.tsx`** (right-side 480px sheet, "What's new on web"; shows `web` + `both`), **`whats-new-footer-item.tsx`** (sidebar entry point with unread dot), **`whats-new-shared.ts`** (open-event + `countUnread` helper), **`fetch-release-notes.ts`** (surface-filtered fetch, cached ~5 min via Next `unstable_cache`), and hooks **`useWhatsNewLastSeen` / `useMarkWhatsNewSeen`**.
- Wired into `platform/layout.tsx`, the navigation sidebar, unified navbar, and command palette, with a **`G R`** keyboard shortcut in `shortcuts-root`. Related tests updated.

### Mobile
- **`whats-new-sheet.tsx`** (full-height drawer, "What's new on mobile"; shows `mobile` + `both`, with an **offline empty state**), **`whats-new-feed.tsx`** (month-grouped), **`release-note-entry.tsx`**, **`category.ts`**, hooks **`use-active-release-notes`** (surface-filtered Contentful fetch, cached ~5 min via TanStack Query) **/ `use-whats-new`** (joins content with backend last-seen for the unread count), **`fetch-active-release-notes.ts`**, and **`use-whats-new-sheet-store.ts`** (decouples the trigger from the sheet across the DDD boundary).
- **`home-whats-new-card.tsx`** — home-screen entry point that opens the drawer and shows an unread dot; `WhatsNewSheet` is mounted in `(tabs)/_layout`.
- Mobile i18n namespace `whats-new.json` (`en-US`, `nl-NL`), registered in `shared/i18n/index.ts`.
- `home-device-card.tsx` badge styling converted to Tailwind (no behavior change).

### Alerts (mobile)
- **`resolve-external-url.ts`** (+ test) — turns a relative CMS link into an absolute URL, since `Linking.openURL` needs a scheme. `alert-banner` / `alerts-container` now resolve the alert link against `NEXT_AUTH_URI` before opening (previously a bare `/path` silently failed to open).

### Shared i18n & UI
- `navigation.json` (`en-US`, `de-DE`, `nl-NL`): `whatsNew` (incl. `surface` labels), `releases`, and `readMore` copy.
- Reverted **`nav-tabs.tsx`** and its test to the pre-`#1351` version (restores the sliding underline indicator + mobile dropdown), and restored the `matchMedia` mock in `packages/ui/vitest.setup.ts` that those tests need.

## Additional notes
- **`/releases` index metadata is hardcoded** (static i18n copy) for now. Per-note detail pages already use Contentful `ComponentSeo`; making the index CMS-driven is a follow-up needing **either a new content model or a refactor of the existing `PageLanding`** — both part of the upcoming CMS content-model cleanup.

Closes [OJD-1394](https://linear.app/openjii/issue/OJD-1394/add-releases-page-to-openjiiorg), [OJD-1507](https://linear.app/openjii/issue/OJD-1507/in-app-whats-new-feed-for-release-notes-and-feature-announcements)