### PR TITLE
chore(security): ignore CVE-2026-48815 for bundled npm sigstore in migration image

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -3,6 +3,12 @@
 # The app runs as `node dist/main` and never invokes npm at runtime.
 CVE-2026-33671
 
+# CVE-2026-48815: sigstore certificateOIDs constraints dropped, in system npm (usr/local/lib/node_modules/npm)
+# sigstore is bundled inside the Node.js Docker image's npm CLI (via libnpmpublish), not in the app's runtime.
+# The affected path is npm publish provenance signing; the container runs `node dist/...` and never invokes npm.
+# Clears once the Node base image bundles npm >= 11 (ships sigstore >= 4.1.1); Node 22 currently bundles npm 10.9.x.
+CVE-2026-48815
+
 # CVE-2026-4926: path-to-regexp ReDoS via crafted route patterns
 # Affects path-to-regexp@8.3.0 pinned by Express 5's `router` package (exact version constraint).
 # The vulnerability requires an attacker to control route *definition* patterns, not URL paths.


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)