### PR TITLE
fix(iot): size MultispeQ scan timeout for long pre-illumination protocols

### DIFF
--- a/packages/iot/src/driver/multispeq/multispeq-protocol-estimator.spec.ts
+++ b/packages/iot/src/driver/multispeq/multispeq-protocol-estimator.spec.ts
@@ -208,7 +208,16 @@ describe("estimateProtocolDurationMs", () => {
   it("sums the multi-LED pre_illumination form", () => {
     expect(
       estimateProtocolDurationMs([
-        { _protocol_set_: [{ pre_illumination: [[2, 200, 600_000], [3, 100, 300_000]] }] },
+        {
+          _protocol_set_: [
+            {
+              pre_illumination: [
+                [2, 200, 600_000],
+                [3, 100, 300_000],
+              ],
+            },
+          ],
+        },
       ]),
     ).toBe(900_000);
   });

--- a/packages/iot/src/driver/multispeq/multispeq-protocol-estimator.spec.ts
+++ b/packages/iot/src/driver/multispeq/multispeq-protocol-estimator.spec.ts
@@ -187,6 +187,40 @@ describe("estimateProtocolDurationMs", () => {
     expect(estimateProtocolDurationMs(protocol)).toBe(2001);
   });
 
+  it("counts a standalone pre_illumination block that has no pulses", () => {
+    // Documented construct: a pulseless block that only pre-illuminates the
+    // sample (help.photosynq.com pre-illumination example is a 10 min soak).
+    expect(
+      estimateProtocolDurationMs([
+        { _protocol_set_: [{ label: "Pre-Illumination", pre_illumination: [2, 200, 600_000] }] },
+      ]),
+    ).toBe(600_000);
+  });
+
+  it("multiplies a pulseless pre_illumination block by protocol_repeats", () => {
+    expect(
+      estimateProtocolDurationMs([
+        { _protocol_set_: [{ pre_illumination: [2, 200, 10_000], protocol_repeats: 3 }] },
+      ]),
+    ).toBe(30_000);
+  });
+
+  it("sums the multi-LED pre_illumination form", () => {
+    expect(
+      estimateProtocolDurationMs([
+        { _protocol_set_: [{ pre_illumination: [[2, 200, 600_000], [3, 100, 300_000]] }] },
+      ]),
+    ).toBe(900_000);
+  });
+
+  it("sums a ramped pre_illumination duration array", () => {
+    expect(
+      estimateProtocolDurationMs([
+        { _protocol_set_: [{ pre_illumination: [2, 200, [1_000, 2_000, 3_000]] }] },
+      ]),
+    ).toBe(6_000);
+  });
+
   it("treats repeats/averages as at least 1 when missing", () => {
     const protocol = [
       {

--- a/packages/iot/src/driver/multispeq/multispeq-protocol-estimator.ts
+++ b/packages/iot/src/driver/multispeq/multispeq-protocol-estimator.ts
@@ -124,18 +124,43 @@ function channelCount(detectorsEntry: Json): number {
   return Array.isArray(detectorsEntry) ? Math.max(1, detectorsEntry.length) : 1;
 }
 
+/**
+ * Total pre-illumination wait (ms) for a block. Single form is
+ * `[led, intensity, duration]`; the multi-LED form is an array of those tuples.
+ * The duration (index 2) may itself be a ramp array. Durations are summed, the
+ * safe direction for sizing a timeout. See OJD-1565.
+ */
+function preIlluminationMs(
+  block: Record<string, unknown>,
+  vArrays: VArrays,
+  vars: Record<string, number>,
+): number {
+  const pi = block.pre_illumination;
+  if (!Array.isArray(pi) || pi.length === 0) return 0;
+  const tuples = Array.isArray(pi[0]) ? (pi as Json[][]) : [pi as Json[]];
+  let total = 0;
+  for (const tuple of tuples) {
+    const duration = tuple[2];
+    const parts = Array.isArray(duration) ? duration : [duration];
+    for (const part of parts) total += resolveField(part, vArrays, vars) ?? 0;
+  }
+  return total;
+}
+
 function estimateBlockMs(block: Json, vArrays: VArrays, vars: Record<string, number>): number {
   if (!isRecord(block)) return 0;
 
   const repeats = Math.max(1, resolveField(block.protocol_repeats, vArrays, vars) ?? 1);
   const delayMs = (resolveField(block.protocols_delay, vArrays, vars) ?? 0) * 1_000;
+  const preIllumMs = preIlluminationMs(block, vArrays, vars);
 
-  // Setup blocks (autogain, etc.) carry a fixed cost rather than a pulse train,
-  // but a setup-only / delay-only block still waits its protocols_delay.
+  // A block with no pulse train still waits its pre_illumination and
+  // protocols_delay. A standalone pre_illumination block (no pulses) is a
+  // documented construct, so count it rather than treating it as 0.
   const hasPulses = Array.isArray(block.pulses) && block.pulses.length > 0;
   if (!hasPulses) {
     const setupMs = "autogain" in block ? SETUP_BLOCK_MS : 0;
-    return setupMs + delayMs * repeats;
+    return setupMs + (preIllumMs + delayMs) * repeats;
   }
 
   const pulses = block.pulses as Json[];
@@ -150,14 +175,9 @@ function estimateBlockMs(block: Json, vArrays: VArrays, vars: Record<string, num
   }
   const pulseTrainMs = pulseTrainUs / 1000;
 
-  const preIllumination = Array.isArray(block.pre_illumination)
-    ? (block.pre_illumination as Json[])
-    : [];
-  const preIlluminationMs = resolveField(preIllumination[2], vArrays, vars) ?? 0;
-
   const averages = Math.max(1, resolveField(block.protocol_averages, vArrays, vars) ?? 1);
 
-  return (pulseTrainMs + preIlluminationMs) * repeats * averages + delayMs * repeats;
+  return (pulseTrainMs + preIllumMs) * repeats * averages + delayMs * repeats;
 }
 
 function estimateSetMs(set: Json): number {

--- a/packages/iot/src/driver/multispeq/multispeq-protocol-estimator.ts
+++ b/packages/iot/src/driver/multispeq/multispeq-protocol-estimator.ts
@@ -22,7 +22,7 @@ export interface ScanTimeoutOptions {
   graceMs?: number;
   /** Lower bound, in ms (default 60_000). */
   minMs?: number;
-  /** Upper bound so a dead device cannot hang forever, in ms (default 600_000). */
+  /** Upper bound so a dead device cannot hang forever, in ms (default 1_200_000). */
   maxMs?: number;
 }
 
@@ -30,7 +30,7 @@ export const SCAN_TIMEOUT_DEFAULTS: Required<ScanTimeoutOptions> = {
   safetyFactor: 2,
   graceMs: 10_000,
   minMs: 60_000,
-  maxMs: 600_000,
+  maxMs: 1_200_000,
 };
 
 /**
@@ -39,7 +39,7 @@ export const SCAN_TIMEOUT_DEFAULTS: Required<ScanTimeoutOptions> = {
  * gate (`par_led_start_on_*`) where the device sits silent for as long as the
  * user takes to open/close the clamp. 2 min covers a typical hand-measured
  * DIRK/PAM workflow while still letting a truly dead device fail well before
- * the 10 min maxMs. See OJD-1643.
+ * the 20 min maxMs. See OJD-1643.
  */
 export const MEASUREMENT_TIMEOUT_FLOOR_MS = 120_000;
 


### PR DESCRIPTION
## Problem

A long MultispeQ protocol (a light-response / soak-heavy protocol running ~10 min) times out mid-measurement on the mobile app. The scan-timeout estimator undercounts and its hard ceiling clamps a legitimately long protocol.

## Root cause

Two issues in `multispeq-protocol-estimator.ts`, both live on `main`:

1. **10-minute ceiling.** `SCAN_TIMEOUT_DEFAULTS.maxMs = 600_000` clamps the response-timeout budget to 10 min. A protocol whose real runtime is ~10 min lands at or above the ceiling (after safety factor) and gets cut off.
2. **Standalone `pre_illumination` blocks counted as 0.** `estimateBlockMs` returned early for any block without a `pulses` array (`setupMs + delayMs * repeats`) and only read `pre_illumination` in the pulse branch. A pulseless pre-illumination block is a [documented construct](https://help.photosynq.com/protocols/pre-illumination.html) (the doc's own example is a 10-min soak), so its duration was silently dropped. The multi-LED (`[[led,int,dur], ...]`) and ramped-duration-array forms were also unread.

For the reported protocol the two 60 s `preillum` blocks (120 s total) contributed 0 to the estimate; verified by running it through the estimator with and without those blocks (identical result).

## Fix

- Raise `maxMs` to `1_200_000` (20 min).
- Compute `pre_illumination` in the pulseless branch too, via a helper that handles the single form `[led, intensity, duration]`, the multi-LED array-of-tuples form, and ramped duration arrays. Durations are summed (the safe direction for sizing a timeout).

## Effect on the reported protocol

- Estimate: `0` for the two soaks → now `638_460 ms (~10.6 min)` including the 120 s of pre-illumination.
- Resolved timeout: was clamped to 600_000 ms (10 min, at/under real runtime) → now `1_200_000 ms` (20 min), real head-room.

## Tests

Added spec cases for: standalone pulseless pre-illumination, `protocol_repeats` on a pulseless block, the multi-LED form, and ramped duration arrays. Existing cases (single-form pre-illumination, `protocols_delay`, `do_once`, the light-response-curve fixture) are unaffected.

Refs OJD-1565, OJD-1643.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
