### PR TITLE
ci(release): dependency-aware monorepo releases + PR release preview

### DIFF
--- a/.github/actions/semantic-release/action.yml
+++ b/.github/actions/semantic-release/action.yml
@@ -82,7 +82,10 @@ runs:
           # set +e + PIPESTATUS so we read semantic-release's exit code, not tee's.
           if [ "$DRY_RUN" = "true" ]; then
             echo "🔍 DRY RUN MODE - Preview only"
-            # --no-ci so the preview still computes on PR builds.
+            # Preview as a push to main so a PR shows what merging would release
+            # (env-ci reads these from the process env; the YAML env: key can't set them).
+            export GITHUB_REF="refs/heads/main"
+            export GITHUB_EVENT_NAME="push"
             set +e
             ../../tooling/release/node_modules/.bin/semantic-release --dry-run --no-ci 2>&1 | tee release-output.txt
             RELEASE_EXIT_CODE=${PIPESTATUS[0]}

--- a/.github/actions/semantic-release/action.yml
+++ b/.github/actions/semantic-release/action.yml
@@ -79,13 +79,10 @@ runs:
           # Run semantic-release for this app
           cd "$APP_PATH"
           
-          # `set +e` around the pipeline so `pipefail` does not abort the step
-          # before we read the exit code; `${PIPESTATUS[0]}` is semantic-release's
-          # code (not tee's) so the failure block below actually runs.
+          # set +e + PIPESTATUS so we read semantic-release's exit code, not tee's.
           if [ "$DRY_RUN" = "true" ]; then
             echo "🔍 DRY RUN MODE - Preview only"
-            # --no-ci so the preview still computes a version on PR builds
-            # (semantic-release otherwise refuses to run for pull requests).
+            # --no-ci so the preview still computes on PR builds.
             set +e
             ../../tooling/release/node_modules/.bin/semantic-release --dry-run --no-ci 2>&1 | tee release-output.txt
             RELEASE_EXIT_CODE=${PIPESTATUS[0]}

--- a/.github/actions/semantic-release/action.yml
+++ b/.github/actions/semantic-release/action.yml
@@ -79,14 +79,23 @@ runs:
           # Run semantic-release for this app
           cd "$APP_PATH"
           
+          # `set +e` around the pipeline so `pipefail` does not abort the step
+          # before we read the exit code; `${PIPESTATUS[0]}` is semantic-release's
+          # code (not tee's) so the failure block below actually runs.
           if [ "$DRY_RUN" = "true" ]; then
             echo "🔍 DRY RUN MODE - Preview only"
-            ../../tooling/release/node_modules/.bin/semantic-release --dry-run 2>&1 | tee release-output.txt
-            RELEASE_EXIT_CODE=$?
+            # --no-ci so the preview still computes a version on PR builds
+            # (semantic-release otherwise refuses to run for pull requests).
+            set +e
+            ../../tooling/release/node_modules/.bin/semantic-release --dry-run --no-ci 2>&1 | tee release-output.txt
+            RELEASE_EXIT_CODE=${PIPESTATUS[0]}
+            set -e
           else
             echo "🚀 Creating release..."
+            set +e
             ../../tooling/release/node_modules/.bin/semantic-release 2>&1 | tee release-output.txt
-            RELEASE_EXIT_CODE=$?
+            RELEASE_EXIT_CODE=${PIPESTATUS[0]}
+            set -e
           fi
           
           # Check if semantic-release failed

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -195,6 +195,104 @@ jobs:
     with:
       affected-apps: ${{ needs.detect.outputs.affected_apps || '[]' }}
 
+  release_preview:
+    name: Release Preview (dry run)
+    needs: detect
+    # Skip forks / Dependabot: their token is read-only, so semantic-release's
+    # push-dry-run auth check cannot run.
+    if: >
+      needs.detect.outputs.has_affected_apps == 'true' &&
+      github.event.pull_request.head.repo.fork != true &&
+      github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      # `contents: write` lets semantic-release's `git push --dry-run` auth check
+      # pass. Nothing is pushed: the whole run is `--dry-run`. `pull-requests:
+      # write` is for the preview comment.
+      contents: write
+      pull-requests: write
+    env:
+      DO_NOT_TRACK: 1
+      TURBO_TELEMETRY_DISABLED: 1
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-nodejs-pnpm
+        with:
+          node-version: "22"
+
+      - name: Filter Apps for Release
+        id: filter_apps
+        shell: bash
+        run: |
+          # Only actual apps release; drop @repo/* library packages.
+          AFFECTED_APPS='${{ needs.detect.outputs.affected_apps }}'
+          RELEASE_APPS=$(echo "$AFFECTED_APPS" | jq -c '[.[] | select(startswith("@repo/") | not)]')
+          echo "release_apps=$RELEASE_APPS" >> $GITHUB_OUTPUT
+          echo "app_count=$(echo "$RELEASE_APPS" | jq 'length')" >> $GITHUB_OUTPUT
+          echo "Preview release candidates: $RELEASE_APPS"
+
+      - name: Treat merge ref as main
+        if: steps.filter_apps.outputs.app_count > 0
+        shell: bash
+        run: |
+          # semantic-release only releases from `main`; on a PR we are on a
+          # detached merge commit (main + this PR). Name it `main` so the dry
+          # run reports exactly what merging would release.
+          git checkout -B main
+
+      - name: Compute release preview
+        id: preview
+        if: steps.filter_apps.outputs.app_count > 0
+        continue-on-error: true
+        uses: ./.github/actions/semantic-release
+        with:
+          affected_apps: ${{ steps.filter_apps.outputs.release_apps }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: "true"
+
+      - name: Post release preview
+        if: always()
+        env:
+          RELEASES: ${{ steps.preview.outputs.releases_created }}
+          # 'failure' means the dry run itself errored (continue-on-error kept the
+          # job green); we must NOT report that as "nothing will release".
+          PREVIEW_OUTCOME: ${{ steps.preview.outcome }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          RELEASES="${RELEASES:-{}}"
+          {
+            echo "## 📦 Release preview"
+            echo ""
+            if [ "$PREVIEW_OUTCOME" = "failure" ]; then
+              echo "⚠️ Release preview could not be computed (semantic-release failed)."
+              echo "Check the workflow logs. This does **not** mean no releases will be cut."
+            elif [ "$RELEASES" = "{}" ] || [ -z "$RELEASES" ]; then
+              echo "Merging this PR will **not** create any new releases."
+            else
+              echo "Merging this PR into \`main\` will publish:"
+              echo ""
+              echo "| App | Next version | Tag |"
+              echo "|---|---|---|"
+              echo "$RELEASES" | jq -r 'to_entries[] | "| \(.key) | v\(.value) | `\(.key)-v\(.value)` |"'
+            fi
+            echo ""
+            echo "_Preview only. Actual releases are cut when this merges to \`main\`._"
+          } > preview.md
+          cat preview.md >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr comment "$PR_NUMBER" --body-file preview.md --edit-last \
+              || gh pr comment "$PR_NUMBER" --body-file preview.md \
+              || echo "::warning::Could not post release-preview comment"
+          fi
+
   tofu:
     name: OpenTofu (Plan)
     needs: detect

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -226,9 +226,10 @@ jobs:
       - name: Filter Apps for Release
         id: filter_apps
         shell: bash
+        env:
+          AFFECTED_APPS: ${{ needs.detect.outputs.affected_apps }}
         run: |
           # Only actual apps release; drop @repo/* library packages.
-          AFFECTED_APPS='${{ needs.detect.outputs.affected_apps }}'
           RELEASE_APPS=$(echo "$AFFECTED_APPS" | jq -c '[.[] | select(startswith("@repo/") | not)]')
           echo "release_apps=$RELEASE_APPS" >> $GITHUB_OUTPUT
           echo "app_count=$(echo "$RELEASE_APPS" | jq 'length')" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -211,9 +211,6 @@ jobs:
     env:
       DO_NOT_TRACK: 1
       TURBO_TELEMETRY_DISABLED: 1
-      # Make env-ci see a push to main (checkout still uses the PR merge commit).
-      GITHUB_REF: refs/heads/main
-      GITHUB_EVENT_NAME: push
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -198,22 +198,22 @@ jobs:
   release_preview:
     name: Release Preview (dry run)
     needs: detect
-    # Skip forks / Dependabot: their token is read-only, so semantic-release's
-    # push-dry-run auth check cannot run.
+    # Skip forks/Dependabot: read-only token can't run the push --dry-run auth check.
     if: >
       needs.detect.outputs.has_affected_apps == 'true' &&
       github.event.pull_request.head.repo.fork != true &&
       github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
-      # `contents: write` lets semantic-release's `git push --dry-run` auth check
-      # pass. Nothing is pushed: the whole run is `--dry-run`. `pull-requests:
-      # write` is for the preview comment.
+      # contents:write only so semantic-release's push --dry-run auth check passes.
       contents: write
       pull-requests: write
     env:
       DO_NOT_TRACK: 1
       TURBO_TELEMETRY_DISABLED: 1
+      # Make env-ci see a push to main (checkout still uses the PR merge commit).
+      GITHUB_REF: refs/heads/main
+      GITHUB_EVENT_NAME: push
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
@@ -237,15 +237,6 @@ jobs:
           echo "app_count=$(echo "$RELEASE_APPS" | jq 'length')" >> $GITHUB_OUTPUT
           echo "Preview release candidates: $RELEASE_APPS"
 
-      - name: Treat merge ref as main
-        if: steps.filter_apps.outputs.app_count > 0
-        shell: bash
-        run: |
-          # semantic-release only releases from `main`; on a PR we are on a
-          # detached merge commit (main + this PR). Name it `main` so the dry
-          # run reports exactly what merging would release.
-          git checkout -B main
-
       - name: Compute release preview
         id: preview
         if: steps.filter_apps.outputs.app_count > 0
@@ -260,14 +251,13 @@ jobs:
         if: always()
         env:
           RELEASES: ${{ steps.preview.outputs.releases_created }}
-          # 'failure' means the dry run itself errored (continue-on-error kept the
-          # job green); we must NOT report that as "nothing will release".
+          # failure = dry run errored; don't report it as "nothing will release".
           PREVIEW_OUTCOME: ${{ steps.preview.outcome }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         shell: bash
         run: |
-          RELEASES="${RELEASES:-{}}"
+          if [ -z "$RELEASES" ]; then RELEASES="{}"; fi
           {
             echo "## 📦 Release preview"
             echo ""

--- a/apps/backend/.releaserc.js
+++ b/apps/backend/.releaserc.js
@@ -2,13 +2,14 @@
  * Semantic release configuration for Backend app
  * Tag format: backend-vX.Y.Z
  */
-import baseConfig from "../../.releaserc.js";
 import {
   analyzeCommits,
   fail,
   generateNotes,
   success,
-} from "../../tooling/release/monorepo-deps.js";
+} from "@open-jii/release-tools/monorepo-deps.js";
+
+import baseConfig from "../../.releaserc.js";
 
 export default {
   ...baseConfig,

--- a/apps/backend/.releaserc.js
+++ b/apps/backend/.releaserc.js
@@ -3,11 +3,20 @@
  * Tag format: backend-vX.Y.Z
  */
 import baseConfig from "../../.releaserc.js";
+import {
+  analyzeCommits,
+  fail,
+  generateNotes,
+  success,
+} from "../../tooling/release/monorepo-deps.js";
 
 export default {
   ...baseConfig,
-  extends: "semantic-release-monorepo",
   tagFormat: "backend-v${version}",
+  analyzeCommits,
+  generateNotes,
+  success,
+  fail,
   plugins: [
     ...baseConfig.plugins,
     [

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -63,6 +63,7 @@
     "@nestjs/cli": "^11.0.19",
     "@nestjs/schematics": "^11.0.10",
     "@nestjs/testing": "^11.1.18",
+    "@open-jii/release-tools": "workspace:*",
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@repo/vitest-config": "workspace:*",

--- a/apps/docs/.releaserc.js
+++ b/apps/docs/.releaserc.js
@@ -2,13 +2,14 @@
  * Semantic release configuration for Docs app
  * Tag format: docs-vX.Y.Z
  */
-import baseConfig from "../../.releaserc.js";
 import {
   analyzeCommits,
   fail,
   generateNotes,
   success,
-} from "../../tooling/release/monorepo-deps.js";
+} from "@open-jii/release-tools/monorepo-deps.js";
+
+import baseConfig from "../../.releaserc.js";
 
 export default {
   ...baseConfig,

--- a/apps/docs/.releaserc.js
+++ b/apps/docs/.releaserc.js
@@ -3,11 +3,20 @@
  * Tag format: docs-vX.Y.Z
  */
 import baseConfig from "../../.releaserc.js";
+import {
+  analyzeCommits,
+  fail,
+  generateNotes,
+  success,
+} from "../../tooling/release/monorepo-deps.js";
 
 export default {
   ...baseConfig,
-  extends: "semantic-release-monorepo",
   tagFormat: "docs-v${version}",
+  analyzeCommits,
+  generateNotes,
+  success,
+  fail,
   plugins: [
     ...baseConfig.plugins,
     [

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -35,6 +35,7 @@
     "@docusaurus/theme-mermaid": "^3.10.0",
     "@docusaurus/tsconfig": "^3.10.0",
     "@docusaurus/types": "^3.10.0",
+    "@open-jii/release-tools": "workspace:*",
     "@types/js-yaml": "^4.0.9",
     "@types/swagger-ui-react": "^5.18.0",
     "typescript": "catalog:"

--- a/apps/mobile/.releaserc.js
+++ b/apps/mobile/.releaserc.js
@@ -3,11 +3,20 @@
  * Tag format: mobile-vX.Y.Z
  */
 import baseConfig from "../../.releaserc.js";
+import {
+  analyzeCommits,
+  fail,
+  generateNotes,
+  success,
+} from "../../tooling/release/monorepo-deps.js";
 
 export default {
   ...baseConfig,
-  extends: "semantic-release-monorepo",
   tagFormat: "mobile-v${version}",
+  analyzeCommits,
+  generateNotes,
+  success,
+  fail,
   plugins: [
     ...baseConfig.plugins,
     [

--- a/apps/mobile/.releaserc.js
+++ b/apps/mobile/.releaserc.js
@@ -2,13 +2,14 @@
  * Semantic release configuration for Mobile app
  * Tag format: mobile-vX.Y.Z
  */
-import baseConfig from "../../.releaserc.js";
 import {
   analyzeCommits,
   fail,
   generateNotes,
   success,
-} from "../../tooling/release/monorepo-deps.js";
+} from "@open-jii/release-tools/monorepo-deps.js";
+
+import baseConfig from "../../.releaserc.js";
 
 export default {
   ...baseConfig,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -121,6 +121,7 @@
   "devDependencies": {
     "@babel/core": "^7.29.0",
     "@babel/plugin-transform-class-static-block": "^7.28.6",
+    "@open-jii/release-tools": "workspace:*",
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@repo/vitest-config": "workspace:*",

--- a/apps/web/.releaserc.js
+++ b/apps/web/.releaserc.js
@@ -2,13 +2,14 @@
  * Semantic release configuration for Web app
  * Tag format: web-vX.Y.Z
  */
-import baseConfig from "../../.releaserc.js";
 import {
   analyzeCommits,
   fail,
   generateNotes,
   success,
-} from "../../tooling/release/monorepo-deps.js";
+} from "@open-jii/release-tools/monorepo-deps.js";
+
+import baseConfig from "../../.releaserc.js";
 
 export default {
   ...baseConfig,

--- a/apps/web/.releaserc.js
+++ b/apps/web/.releaserc.js
@@ -3,11 +3,20 @@
  * Tag format: web-vX.Y.Z
  */
 import baseConfig from "../../.releaserc.js";
+import {
+  analyzeCommits,
+  fail,
+  generateNotes,
+  success,
+} from "../../tooling/release/monorepo-deps.js";
 
 export default {
   ...baseConfig,
-  extends: "semantic-release-monorepo",
   tagFormat: "web-v${version}",
+  analyzeCommits,
+  generateNotes,
+  success,
+  fail,
   plugins: [
     ...baseConfig.plugins,
     [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -67,6 +67,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@open-jii/release-tools": "workspace:*",
     "@repo/eslint-config": "workspace:*",
     "@repo/tailwind-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1578,6 +1578,9 @@ importers:
       semantic-release-monorepo:
         specifier: ^8.0.2
         version: 8.0.2(semantic-release@25.0.5(typescript@5.9.3))
+      semantic-release-plugin-decorators:
+        specifier: ^4.0.0
+        version: 4.0.0(semantic-release@25.0.5(typescript@5.9.3))
 
   tooling/tailwind:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,9 @@ importers:
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/platform-express@11.1.18)
+      '@open-jii/release-tools':
+        specifier: workspace:*
+        version: link:../../tooling/release
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint
@@ -400,6 +403,9 @@ importers:
       '@docusaurus/types':
         specifier: ^3.10.0
         version: 3.10.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@open-jii/release-tools':
+        specifier: workspace:*
+        version: link:../../tooling/release
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
@@ -698,6 +704,9 @@ importers:
       '@babel/plugin-transform-class-static-block':
         specifier: ^7.28.6
         version: 7.28.6(@babel/core@7.29.0)
+      '@open-jii/release-tools':
+        specifier: workspace:*
+        version: link:../../tooling/release
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint
@@ -932,6 +941,9 @@ importers:
         specifier: 'catalog:'
         version: 3.25.76
     devDependencies:
+      '@open-jii/release-tools':
+        specifier: workspace:*
+        version: link:../../tooling/release
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint

--- a/tooling/release/monorepo-deps.js
+++ b/tooling/release/monorepo-deps.js
@@ -1,24 +1,9 @@
 /**
- * Dependency-aware replacement for `semantic-release-monorepo`'s commit filter.
- *
- * `semantic-release-monorepo` scopes each app's release to commits that touched
- * the app's OWN directory. In this monorepo the apps (`mobile`, `web`,
- * `backend`) ship shared `@repo/*` packages, so a fix landed in a shared package
- * (e.g. `fix(iot)` under `packages/iot`) never cut a release for the apps that
- * bundle it: the app's next release silently swallowed the fix with no version.
- *
- * This module keeps the per-app monorepo scoping (tag format, notes, success)
- * but widens the "relevant commit" path set to the app PLUS its transitive
- * workspace runtime `dependencies`. Only runtime `dependencies` propagate a
- * release: config/tooling packages consumed as `devDependencies` (eslint-config,
- * typescript-config, vitest-config, tailwind-config) deliberately do NOT bump an
- * app version. The turbo affected graph (used by the release workflow to pick
- * which apps to run) also follows devDependencies, so it may enter an app into
- * the release loop where this filter then correctly finds no relevant commit.
- *
- * Wired into each app via `apps/<app>/.releaserc.js` (replaces
- * `extends: "semantic-release-monorepo"`). Reuses the upstream plugin's file
- * listing and version->tag transforms so changelog/tag behaviour is unchanged.
+ * Dependency-aware replacement for semantic-release-monorepo's commit filter:
+ * an app releases on commits touching its own dir OR any workspace package in
+ * its transitive runtime `dependencies` (so fix(iot) cuts the apps bundling
+ * @repo/iot). devDependency-only config/tooling packages deliberately do not.
+ * Wired via apps/<app>/.releaserc.js in place of extends:semantic-release-monorepo.
  */
 import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
@@ -59,11 +44,7 @@ const indexWorkspace = (root) => {
   return byName;
 };
 
-/**
- * Directories (relative to the git root) whose commits count towards the
- * current package's release: the package itself plus its transitive workspace
- * runtime dependencies. External (published) deps are ignored.
- */
+/** Package dir + its transitive workspace runtime-dep dirs (git-root-relative). */
 export const computeRelevantPaths = () => {
   const root = gitRoot();
   const byName = indexWorkspace(root);

--- a/tooling/release/monorepo-deps.js
+++ b/tooling/release/monorepo-deps.js
@@ -1,0 +1,143 @@
+/**
+ * Dependency-aware replacement for `semantic-release-monorepo`'s commit filter.
+ *
+ * `semantic-release-monorepo` scopes each app's release to commits that touched
+ * the app's OWN directory. In this monorepo the apps (`mobile`, `web`,
+ * `backend`) ship shared `@repo/*` packages, so a fix landed in a shared package
+ * (e.g. `fix(iot)` under `packages/iot`) never cut a release for the apps that
+ * bundle it: the app's next release silently swallowed the fix with no version.
+ *
+ * This module keeps the per-app monorepo scoping (tag format, notes, success)
+ * but widens the "relevant commit" path set to the app PLUS its transitive
+ * workspace runtime `dependencies`. Only runtime `dependencies` propagate a
+ * release: config/tooling packages consumed as `devDependencies` (eslint-config,
+ * typescript-config, vitest-config, tailwind-config) deliberately do NOT bump an
+ * app version. The turbo affected graph (used by the release workflow to pick
+ * which apps to run) also follows devDependencies, so it may enter an app into
+ * the release loop where this filter then correctly finds no relevant commit.
+ *
+ * Wired into each app via `apps/<app>/.releaserc.js` (replaces
+ * `extends: "semantic-release-monorepo"`). Reuses the upstream plugin's file
+ * listing and version->tag transforms so changelog/tag behaviour is unchanged.
+ */
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { withFiles } from "semantic-release-monorepo/src/only-package-commits.js";
+import {
+  mapCommits,
+  mapNextReleaseVersion,
+  withOptionsTransforms,
+} from "semantic-release-monorepo/src/options-transforms.js";
+import versionToGitTag from "semantic-release-monorepo/src/version-to-git-tag.js";
+import { wrapStep } from "semantic-release-plugin-decorators";
+
+const WORKSPACE_GROUPS = ["apps", "packages", "tooling"];
+
+const gitRoot = () =>
+  execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
+
+const readJson = (file) => JSON.parse(readFileSync(file, "utf8"));
+
+/** Map every workspace package name -> its absolute directory. */
+const indexWorkspace = (root) => {
+  const byName = new Map();
+  for (const group of WORKSPACE_GROUPS) {
+    const base = path.join(root, group);
+    if (!existsSync(base)) continue;
+    for (const entry of readdirSync(base)) {
+      const manifest = path.join(base, entry, "package.json");
+      if (!existsSync(manifest)) continue;
+      try {
+        const { name } = readJson(manifest);
+        if (name) byName.set(name, path.join(base, entry));
+      } catch {
+        // ignore unreadable / malformed manifests
+      }
+    }
+  }
+  return byName;
+};
+
+/**
+ * Directories (relative to the git root) whose commits count towards the
+ * current package's release: the package itself plus its transitive workspace
+ * runtime dependencies. External (published) deps are ignored.
+ */
+export const computeRelevantPaths = () => {
+  const root = gitRoot();
+  const byName = indexWorkspace(root);
+  const start = readJson(path.join(process.cwd(), "package.json")).name;
+
+  const dirs = new Set([process.cwd()]);
+  const seen = new Set();
+  const queue = [start];
+  while (queue.length > 0) {
+    const name = queue.shift();
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    const dir = byName.get(name);
+    if (!dir) continue; // external dependency, not a workspace package
+    dirs.add(dir);
+    let deps = {};
+    try {
+      deps = readJson(path.join(dir, "package.json")).dependencies ?? {};
+    } catch {
+      continue;
+    }
+    for (const dep of Object.keys(deps)) {
+      if (byName.has(dep)) queue.push(dep);
+    }
+  }
+  return [...dirs].map((dir) => path.relative(root, dir)).filter(Boolean);
+};
+
+// Keyed by cwd so a hypothetical multi-app process never reuses stale paths.
+const segmentCache = new Map();
+const relevantSegments = () => {
+  const key = process.cwd();
+  if (!segmentCache.has(key)) {
+    segmentCache.set(
+      key,
+      computeRelevantPaths().map((relPath) => relPath.split(path.sep)),
+    );
+  }
+  return segmentCache.get(key);
+};
+
+const isRelevantFile = (file) => {
+  const fileSegments = path.normalize(file).split(path.sep);
+  return relevantSegments().some((segments) =>
+    segments.every((segment, i) => segment === fileSegments[i]),
+  );
+};
+
+/** Filter a commit list to those touching the package or its workspace deps. */
+export const onlyRelevantCommits = async (commits) => {
+  const commitsWithFiles = await withFiles(commits);
+  return commitsWithFiles.filter(({ files }) => files.some(isRelevantFile));
+};
+
+const withOnlyRelevantCommits = (plugin) => async (pluginConfig, config) =>
+  plugin(pluginConfig, await mapCommits(onlyRelevantCommits)(config));
+
+const withReleaseTag = withOptionsTransforms([mapNextReleaseVersion(versionToGitTag)]);
+
+const wrapperName = "monorepo-deps";
+
+export const analyzeCommits = wrapStep("analyzeCommits", withOnlyRelevantCommits, {
+  wrapperName,
+});
+export const generateNotes = wrapStep(
+  "generateNotes",
+  (plugin) => withOnlyRelevantCommits(withReleaseTag(plugin)),
+  { wrapperName },
+);
+export const success = wrapStep(
+  "success",
+  (plugin) => withOnlyRelevantCommits(withReleaseTag(plugin)),
+  { wrapperName },
+);
+export const fail = wrapStep("fail", (plugin) => withOnlyRelevantCommits(withReleaseTag(plugin)), {
+  wrapperName,
+});

--- a/tooling/release/package.json
+++ b/tooling/release/package.json
@@ -14,6 +14,7 @@
     "@semantic-release/github": "^11.0.6",
     "conventional-changelog-conventionalcommits": "^8.0.0",
     "semantic-release": "^25.0.5",
-    "semantic-release-monorepo": "^8.0.2"
+    "semantic-release-monorepo": "^8.0.2",
+    "semantic-release-plugin-decorators": "^4.0.0"
   }
 }


### PR DESCRIPTION
## Problem

A merge to `main` whose only releasing change lives in a shared `@repo/*` package cuts **no release**. The last merge, `fix(iot)` #1734 (MultispeQ scan-timeout fix under `packages/iot`), produced no new tag and never triggered the mobile internal-track release. The last 5 merges cut zero tags; latest tags are all from 2026-06-29.

## Root cause

`semantic-release-monorepo` scopes each app's release to commits touching the app's **own** directory. `@repo/*` packages are filtered out of the releasable set, and monorepo path-scoping means an app's release analysis never sees commits under a shared package it bundles. So `fix(iot)` is invisible to `mobile`/`web` even though both ship `@repo/iot`. The turbo affected graph (used by `detect`) already knew mobile/web were affected; only the release step disagreed.

## Changes

1. **`tooling/release/monorepo-deps.js`** — dependency-aware replacement for `semantic-release-monorepo`'s commit filter. Keeps per-app scoping but widens the relevant path set to the app **plus its transitive workspace runtime `dependencies`**. Wired into `apps/{mobile,web,backend,docs}/.releaserc.js` (replaces `extends: "semantic-release-monorepo"`). Reuses the upstream plugin's file-listing and version→tag transforms, so changelog/tag behaviour is unchanged.
2. **PR release preview** — new `release_preview` job in `pr.yml` + `--no-ci` in the semantic-release action's dry-run. Every PR now comments/summarizes exactly which app versions a merge would cut. Skips forks/Dependabot (read-only token) and is non-blocking.

## Effect on merge

- **`mobile-v2.1.7`** is cut (triggers the internal track, carrying the scan-timeout fix) and **`web-v1.50.4`** (web also bundles `@repo/iot`).
- `backend`/`docs` correctly stay put.
- Going forward, a `fix`/`feat` in a shared package bumps every dependent app automatically, matching the turbo affected graph.

This PR is intentionally typed `ci(release):` (a non-releasing type) so the merge commit itself does not cut `backend`/`docs` versions purely from the `.releaserc.js` edits; the mobile/web releases come from the existing `fix(iot)` commit becoming visible to the new filter. Only runtime `dependencies` propagate releases; devDependency-only config/tooling packages deliberately do not bump app versions.

## Verification

- Filter unit-tested against real history: `fix(iot)` #1734 is **kept** for mobile & web, **dropped** for backend (no `@repo/iot` dep).
- Wiring proven via a real `semantic-release --dry-run` that loaded the config and invoked the new steps.
- Full adversarial review of the diff; findings folded in (preview now distinguishes "failed to compute" from "nothing to release"; action captures the real exit code via `PIPESTATUS`).
- Watch this PR's **Release Preview (dry run)** check for the live version numbers.

OJD-1666