### PR TITLE
fix(viz): dashboard chart sizing, WebGL exhaustion, and correctness fixes

### DIFF
--- a/apps/web/components/data-filters/use-distinct-options.ts
+++ b/apps/web/components/data-filters/use-distinct-options.ts
@@ -6,14 +6,14 @@ import { WellKnownColumnTypes } from "@repo/api/schemas/experiment.schema";
 import { useExperimentDistinctValues } from "../../hooks/experiment/useExperimentDistinctValues/useExperimentDistinctValues";
 
 export function useDistinctOptions(column: DataColumn, experimentId: string, tableName: string) {
-  const { values, truncated, isLoading, error } = useExperimentDistinctValues({
+  const { values, truncated, isLoading, isSuccess, error } = useExperimentDistinctValues({
     experimentId,
     tableName,
     column: column.name,
   });
   const isContributor = column.type_text === WellKnownColumnTypes.CONTRIBUTOR;
   const contributorMap = useContributorIdMap(values, isContributor);
-  return { values, truncated, isLoading, error, isContributor, contributorMap };
+  return { values, truncated, isLoading, isSuccess, error, isContributor, contributorMap };
 }
 
 export function useContributorIdMap(

--- a/apps/web/components/data-filters/value-inputs/categorical-multi-input.test.tsx
+++ b/apps/web/components/data-filters/value-inputs/categorical-multi-input.test.tsx
@@ -140,4 +140,67 @@ describe("CategoricalMultiInput", () => {
 
     expect(onChange).toHaveBeenLastCalledWith(["u-1"]);
   });
+
+  it("drops a stale contributor id once the loaded list no longer contains it", async () => {
+    // Simulates an anonymization toggle: the selected real id is gone from the
+    // now-pseudonymised option list, so it should be pruned.
+    const pseudo = JSON.stringify({
+      id: "Contributor-ABC123",
+      name: "Contributor-ABC123",
+      avatar: null,
+    });
+    mountDistinct([pseudo]);
+    const onChange = vi.fn();
+    render(
+      <CategoricalMultiInput
+        column={contributorColumn}
+        experimentId="exp-1"
+        tableName="raw_data"
+        value={["real-uuid"]}
+        onChange={onChange}
+      />,
+    );
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith([]));
+  });
+
+  it("keeps a contributor selection that still resolves in the loaded list", async () => {
+    const struct = JSON.stringify({ id: "u-1", name: "Alice", avatar: null });
+    mountDistinct([struct]);
+    const onChange = vi.fn();
+    render(
+      <CategoricalMultiInput
+        column={contributorColumn}
+        experimentId="exp-1"
+        tableName="raw_data"
+        value={["u-1"]}
+        onChange={onChange}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText("Alice")).toBeInTheDocument());
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("does not prune when the option list is truncated (can't confirm staleness)", async () => {
+    const pseudo = JSON.stringify({
+      id: "Contributor-ABC123",
+      name: "Contributor-ABC123",
+      avatar: null,
+    });
+    mountDistinct([pseudo], true);
+    const onChange = vi.fn();
+    render(
+      <CategoricalMultiInput
+        column={contributorColumn}
+        experimentId="exp-1"
+        tableName="raw_data"
+        value={["real-uuid"]}
+        onChange={onChange}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByRole("combobox")).toHaveTextContent(/selectedCount/));
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/components/data-filters/value-inputs/categorical-multi-input.tsx
+++ b/apps/web/components/data-filters/value-inputs/categorical-multi-input.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChevronsUpDown, Loader2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import type { DataColumn, DataFilterValue } from "@repo/api/schemas/experiment.schema";
 import { useTranslation } from "@repo/i18n";
@@ -85,6 +85,22 @@ export function CategoricalMultiInput({
       return true;
     });
   }, [values, isContributor]);
+
+  // Toggling experiment anonymization re-pseudonymises contributor ids, so a
+  // selection made in the other mode can no longer resolve to an option and
+  // would show a raw id. Drop those stale ids once the full list has loaded.
+  // Guarded to contributor columns and a complete (non-truncated) list so a
+  // valid-but-beyond-limit id is never pruned.
+  useEffect(() => {
+    if (!isContributor || isLoading || truncated || selected.length === 0) {
+      return;
+    }
+    const valid = new Set(uniqueValues.map((v) => String(chipValueForOption(v, isContributor))));
+    const pruned = selected.filter((key) => valid.has(key));
+    if (pruned.length !== selected.length) {
+      onChange(pruned);
+    }
+  }, [isContributor, isLoading, truncated, uniqueValues, selected, onChange]);
 
   return (
     <div className="flex flex-col gap-1.5">

--- a/apps/web/components/data-filters/value-inputs/categorical-multi-input.tsx
+++ b/apps/web/components/data-filters/value-inputs/categorical-multi-input.tsx
@@ -37,11 +37,8 @@ export function CategoricalMultiInput({
 }: CategoricalMultiInputProps) {
   const { t } = useTranslation("common");
   const [open, setOpen] = useState(false);
-  const { values, isLoading, truncated, isContributor, contributorMap } = useDistinctOptions(
-    column,
-    experimentId,
-    tableName,
-  );
+  const { values, isLoading, isSuccess, truncated, isContributor, contributorMap } =
+    useDistinctOptions(column, experimentId, tableName);
 
   const selected = useMemo<string[]>(
     () => (Array.isArray(value) ? value.map((v) => String(v)) : []),
@@ -86,13 +83,12 @@ export function CategoricalMultiInput({
     });
   }, [values, isContributor]);
 
-  // Toggling experiment anonymization re-pseudonymises contributor ids, so a
-  // selection made in the other mode can no longer resolve to an option and
-  // would show a raw id. Drop those stale ids once the full list has loaded.
-  // Guarded to contributor columns and a complete (non-truncated) list so a
-  // valid-but-beyond-limit id is never pruned.
+  // Toggling anonymization re-pseudonymises contributor ids, so a selection
+  // from the other mode no longer resolves and would show a raw id. Prune only
+  // on a confirmed load (isSuccess, not `!isLoading` which is also false on
+  // error) of a complete list, so a valid-but-beyond-limit id is never dropped.
   useEffect(() => {
-    if (!isContributor || isLoading || truncated || selected.length === 0) {
+    if (!isContributor || !isSuccess || truncated || selected.length === 0) {
       return;
     }
     const valid = new Set(uniqueValues.map((v) => String(chipValueForOption(v, isContributor))));
@@ -100,7 +96,7 @@ export function CategoricalMultiInput({
     if (pruned.length !== selected.length) {
       onChange(pruned);
     }
-  }, [isContributor, isLoading, truncated, uniqueValues, selected, onChange]);
+  }, [isContributor, isSuccess, truncated, uniqueValues, selected, onChange]);
 
   return (
     <div className="flex flex-col gap-1.5">

--- a/apps/web/components/experiment-visualizations/charts/cartesian/cartesian-renderer.tsx
+++ b/apps/web/components/experiment-visualizations/charts/cartesian/cartesian-renderer.tsx
@@ -18,6 +18,9 @@ interface CartesianRendererProps extends ChartRendererProps {
   supportsSize?: boolean;
 }
 
+// Above this total point count SVG starts to jank and WebGL earns its context.
+const WEBGL_POINT_THRESHOLD = 5000;
+
 export function CartesianRenderer({
   visualization,
   experimentId,
@@ -28,14 +31,12 @@ export function CartesianRenderer({
 }: CartesianRendererProps) {
   const dataSources = visualization.dataConfig.dataSources;
   const xColumn = dataSources.find((ds) => ds.role === "x")?.columnName;
-  const colorColumn = dataSources.find((ds) => ds.role === "color")?.columnName;
 
   const { rows, isLoading, error } = useChartData(visualization, experimentId, providedData, {
     orderBy: xColumn,
   });
 
   const chartConfig = narrowChartConfig(visualization);
-  const isCategoricalColor = Boolean(colorColumn) && chartConfig.colorMode === "categorical";
 
   // KEEP IN SYNC with field reads in `transformCartesianData` and its helpers.
   // Re-derive: `grep -oE 'chartConfig\\.[a-zA-Z_]+' cartesian-transform.ts | sort -u`.
@@ -82,11 +83,16 @@ export function CartesianRenderer({
     chartConfig.textposition,
   ]);
 
-  // Override xAxisType when X is synthesized; force WebGL for many-trace categorical color.
+  // WebGL avoids SVG jank on large datasets, but each gl trace holds a scarce
+  // browser WebGL context; a dashboard full of gl charts exhausts the pool and
+  // the data layer vanishes on context loss. Auto-enable only for genuinely
+  // large charts so small (grouped) ones stay on SVG and cost no context.
+  const totalPoints = chartSeries.reduce((sum, s) => sum + s.y.length, 0);
+
   const effectiveConfig: PlotlyChartConfig = {
     ...chartConfig,
     xAxisType: useIndexForX ? "linear" : chartConfig.xAxisType,
-    useWebGL: isCategoricalColor || chartConfig.useWebGL,
+    useWebGL: chartConfig.useWebGL || totalPoints > WEBGL_POINT_THRESHOLD,
   };
 
   return (

--- a/apps/web/components/experiment-visualizations/charts/cartesian/cartesian-renderer.tsx
+++ b/apps/web/components/experiment-visualizations/charts/cartesian/cartesian-renderer.tsx
@@ -92,7 +92,7 @@ export function CartesianRenderer({
   const effectiveConfig: PlotlyChartConfig = {
     ...chartConfig,
     xAxisType: useIndexForX ? "linear" : chartConfig.xAxisType,
-    useWebGL: chartConfig.useWebGL || totalPoints > WEBGL_POINT_THRESHOLD,
+    useWebGL: chartConfig.useWebGL === true || totalPoints > WEBGL_POINT_THRESHOLD,
   };
 
   return (

--- a/apps/web/components/experiment-visualizations/charts/cartesian/cartesian-renderer.tsx
+++ b/apps/web/components/experiment-visualizations/charts/cartesian/cartesian-renderer.tsx
@@ -92,7 +92,7 @@ export function CartesianRenderer({
   const effectiveConfig: PlotlyChartConfig = {
     ...chartConfig,
     xAxisType: useIndexForX ? "linear" : chartConfig.xAxisType,
-    useWebGL: chartConfig.useWebGL === true || totalPoints > WEBGL_POINT_THRESHOLD,
+    useWebGL: chartConfig.useWebGL ?? totalPoints > WEBGL_POINT_THRESHOLD,
   };
 
   return (

--- a/apps/web/components/experiment-visualizations/charts/cartesian/cartesian-transform.test.ts
+++ b/apps/web/components/experiment-visualizations/charts/cartesian/cartesian-transform.test.ts
@@ -230,4 +230,41 @@ describe("transformCartesianData", () => {
     expect(a?.y).toEqual([25]);
     expect(b?.y).toEqual([100]);
   });
+
+  it("routes secondary-axis series onto per-cell overlay axes in facet mode", () => {
+    const rows = [
+      { x: 1, a: 10, b: 100, site: "X" },
+      { x: 2, a: 20, b: 200, site: "Y" },
+    ];
+    const sources = [
+      ds("x", "x"),
+      { tableName: "t", columnName: "a", role: "y" } as DataSourceConfig,
+      { tableName: "t", columnName: "b", role: "y", axis: "secondary" } as DataSourceConfig,
+      ds("facet", "site"),
+    ];
+    const result = transformCartesianData(rows, sources, baseConfig, baseOptions);
+
+    // Two cells (X, Y) → primary axes y / y2; overlays live above the grid.
+    expect(result.subplots?.cells.map((c) => c.secondaryYaxisId)).toEqual(["y3", "y4"]);
+
+    const cellX = result.chartSeries.filter((s) => s.xaxisId === "x");
+    const cellY = result.chartSeries.filter((s) => s.xaxisId === "x2");
+    const primaryX = cellX.find((s) => s.axis !== "secondary");
+    const secondaryX = cellX.find((s) => s.axis === "secondary");
+    const secondaryY = cellY.find((s) => s.axis === "secondary");
+
+    expect(primaryX?.yaxisId).toBe("y");
+    expect(secondaryX?.yaxisId).toBe("y3");
+    expect(secondaryY?.yaxisId).toBe("y4");
+  });
+
+  it("does not add overlay axes when no Y series targets the secondary axis", () => {
+    const rows = [
+      { x: 1, a: 10, site: "X" },
+      { x: 2, a: 20, site: "Y" },
+    ];
+    const sources = [ds("x", "x"), ds("y", "a"), ds("facet", "site")];
+    const result = transformCartesianData(rows, sources, baseConfig, baseOptions);
+    expect(result.subplots?.cells.every((c) => c.secondaryYaxisId === undefined)).toBe(true);
+  });
 });

--- a/apps/web/components/experiment-visualizations/charts/cartesian/cartesian-transform.test.ts
+++ b/apps/web/components/experiment-visualizations/charts/cartesian/cartesian-transform.test.ts
@@ -84,6 +84,10 @@ describe("transformCartesianData", () => {
     const result = transformCartesianData(rows, sources, config, baseOptions);
     expect(result.chartSeries).toHaveLength(4);
     expect(result.chartSeries.map((s) => s.name)).toEqual(["a — A", "a — B", "b — A", "b — B"]);
+    // Every (series × category) combo shows in the legend; keying the
+    // legendgroup on the series alone used to hide all but the first category.
+    const visible = result.chartSeries.filter((s) => s.showlegend !== false).map((s) => s.name);
+    expect(visible).toEqual(["a — A", "a — B", "b — A", "b — B"]);
   });
 
   it("uses continuous-color path when supportsContinuousColor and color column is numeric", () => {
@@ -171,6 +175,26 @@ describe("transformCartesianData", () => {
     const result = transformCartesianData(rows, sources, config, baseOptions);
     const visibleInLegend = result.chartSeries.filter((s) => s.showlegend !== false);
     expect(visibleInLegend.map((s) => s.name).sort()).toEqual(["Arabidopsis", "Tomato"]);
+  });
+
+  it("shows every (series × category) once across facet cells with multiple Y series", () => {
+    const rows = [
+      { a: 1, b: 10, g: "Students", region: "North" },
+      { a: 2, b: 20, g: "Teachers", region: "North" },
+      { a: 3, b: 30, g: "Students", region: "South" },
+      { a: 4, b: 40, g: "Teachers", region: "South" },
+    ];
+    const sources = [ds("y", "a"), ds("y", "b"), ds("color", "g"), ds("facet", "region")];
+    const config: ChartFormConfig = { colorMode: "categorical" };
+    const result = transformCartesianData(rows, sources, config, baseOptions);
+    const visible = result.chartSeries.filter((s) => s.showlegend !== false).map((s) => s.name);
+    // Both groups for both series, each exactly once (not collapsed to just Students).
+    expect(visible.sort()).toEqual([
+      "a — Students",
+      "a — Teachers",
+      "b — Students",
+      "b — Teachers",
+    ]);
   });
 
   it("stacks area traces with `stack-${axis}` so primary and secondary axes stack independently", () => {

--- a/apps/web/components/experiment-visualizations/charts/cartesian/cartesian-transform.test.ts
+++ b/apps/web/components/experiment-visualizations/charts/cartesian/cartesian-transform.test.ts
@@ -58,7 +58,7 @@ describe("transformCartesianData", () => {
     expect(result.chartSeries[1].name).toBe("b");
   });
 
-  it("emits one trace per (Y × category) on a categorical color split", () => {
+  it("emits one trace per (Y x category) on a categorical color split", () => {
     const rows = [
       { x: 1, v: 10, g: "A" },
       { x: 2, v: 20, g: "B" },
@@ -74,7 +74,7 @@ describe("transformCartesianData", () => {
     expect(result.chartSeries[1].x).toEqual([2, 4]);
   });
 
-  it("emits 2 Y × 2 categories = 4 traces with `Y — category` names", () => {
+  it("emits 2 Y x 2 categories = 4 traces with `Y — category` names", () => {
     const rows = [
       { x: 1, a: 10, b: 100, g: "A" },
       { x: 2, a: 20, b: 200, g: "B" },
@@ -84,7 +84,7 @@ describe("transformCartesianData", () => {
     const result = transformCartesianData(rows, sources, config, baseOptions);
     expect(result.chartSeries).toHaveLength(4);
     expect(result.chartSeries.map((s) => s.name)).toEqual(["a — A", "a — B", "b — A", "b — B"]);
-    // Every (series × category) combo shows in the legend; keying the
+    // Every (series x category) combo shows in the legend; keying the
     // legendgroup on the series alone used to hide all but the first category.
     const visible = result.chartSeries.filter((s) => s.showlegend !== false).map((s) => s.name);
     expect(visible).toEqual(["a — A", "a — B", "b — A", "b — B"]);
@@ -177,7 +177,7 @@ describe("transformCartesianData", () => {
     expect(visibleInLegend.map((s) => s.name).sort()).toEqual(["Arabidopsis", "Tomato"]);
   });
 
-  it("shows every (series × category) once across facet cells with multiple Y series", () => {
+  it("shows every (series x category) once across facet cells with multiple Y series", () => {
     const rows = [
       { a: 1, b: 10, g: "Students", region: "North" },
       { a: 2, b: 20, g: "Teachers", region: "North" },

--- a/apps/web/components/experiment-visualizations/charts/cartesian/cartesian-transform.ts
+++ b/apps/web/components/experiment-visualizations/charts/cartesian/cartesian-transform.ts
@@ -226,7 +226,7 @@ export function transformCartesianData(
 
   // Categorical color split: bucket this cell's rows by the global category
   // list so colours map consistently across cells, then emit one trace per
-  // (Y × category).
+  // (Y x category).
   const buildCategoricalColorCellSeries = (
     cellRows: Record<string, unknown>[],
     xaxisId: string | undefined,
@@ -252,7 +252,7 @@ export function transformCartesianData(
     }
 
     // X and (when sized) per-category size context are shared across every
-    // Y series; pre-compute once per category here so the (Y × category)
+    // Y series; pre-compute once per category here so the (Y x category)
     // inner loop is just per-Y work (y values + errors).
     const xByCategory = new Map<string, ReturnType<typeof buildXValues>>();
     const sizeContextByCategory = sizeCtx?.values ? new Map<string, SizeContext>() : null;
@@ -300,7 +300,7 @@ export function transformCartesianData(
             baseName,
           ),
           sizeContext: sizeContextForGroup,
-          // Group per (series × category) so each combo gets its own legend
+          // Group per (series x category) so each combo gets its own legend
           // entry and toggles together across facet cells. Keying on the
           // series alone collapsed every category into one legend row.
           legendgroup: effectiveYEntries.length > 1 ? traceName : undefined,

--- a/apps/web/components/experiment-visualizations/charts/cartesian/cartesian-transform.ts
+++ b/apps/web/components/experiment-visualizations/charts/cartesian/cartesian-transform.ts
@@ -142,6 +142,16 @@ export function transformCartesianData(
     return { xaxisId: `x${suffix}`, yaxisId: `y${suffix}` };
   };
 
+  // Secondary-axis Y series in facet mode need their own overlay y-axis per
+  // cell. The grid uses primary indices 1..N (y, y2, ..., yN); secondary
+  // overlays live above that range (y[N+cell+1]) so they never collide.
+  const totalCells = facetGroups.length;
+  const hasSecondaryAxis = effectiveYEntries.some(
+    ({ source }, seriesOrdinal) => seriesOrdinal !== 0 && source.axis === "secondary",
+  );
+  const secondaryYaxisIdFor = (cellIndex: number): string | undefined =>
+    facetColumn && hasSecondaryAxis ? `y${totalCells + cellIndex + 1}` : undefined;
+
   // Pick the per-series fallback color from the chart-level `color` prop:
   // either a single value or one-per-series array.
   const pickFallbackColor = (seriesOrdinal: number): string | undefined =>
@@ -304,14 +314,28 @@ export function transformCartesianData(
     cellIndex: number,
   ): CartesianSeries[] => {
     const { xaxisId, yaxisId } = buildAxisIds(cellIndex);
-    if (isContinuousColor && colorColumn) {
-      const showlegend = cellIndex === 0 ? undefined : false;
-      return buildContinuousColorCellSeries(cellRows, cellIndex, xaxisId, yaxisId, showlegend);
+    const cellSeries =
+      isContinuousColor && colorColumn
+        ? buildContinuousColorCellSeries(
+            cellRows,
+            cellIndex,
+            xaxisId,
+            yaxisId,
+            cellIndex === 0 ? undefined : false,
+          )
+        : !colorColumn
+          ? buildPlainCellSeries(cellRows, xaxisId, yaxisId, undefined)
+          : buildCategoricalColorCellSeries(cellRows, xaxisId, yaxisId, undefined);
+
+    // Route this cell's secondary-axis traces onto the cell's overlay axis;
+    // the builders above pinned every trace to the primary yaxis.
+    const secondaryYaxisId = secondaryYaxisIdFor(cellIndex);
+    if (!secondaryYaxisId) {
+      return cellSeries;
     }
-    if (!colorColumn) {
-      return buildPlainCellSeries(cellRows, xaxisId, yaxisId, undefined);
-    }
-    return buildCategoricalColorCellSeries(cellRows, xaxisId, yaxisId, undefined);
+    return cellSeries.map((s) =>
+      s.axis === "secondary" ? { ...s, yaxisId: secondaryYaxisId } : s,
+    );
   };
 
   const allSeries: CartesianSeries[] = [];
@@ -342,7 +366,6 @@ export function transformCartesianData(
 
   // Build the grid spec. `facetColumns` overrides the auto default;
   // `rows` is computed from total cells / columns, ceiling.
-  const totalCells = facetGroups.length;
   const requestedColumns = chartConfig.facetColumns;
   const cols =
     typeof requestedColumns === "number" && requestedColumns > 0
@@ -355,6 +378,7 @@ export function transformCartesianData(
       title: group.label,
       xaxisId: `x${suffix}`,
       yaxisId: `y${suffix}`,
+      secondaryYaxisId: hasSecondaryAxis ? `y${totalCells + i + 1}` : undefined,
     };
   });
 

--- a/apps/web/components/experiment-visualizations/charts/cartesian/cartesian-transform.ts
+++ b/apps/web/components/experiment-visualizations/charts/cartesian/cartesian-transform.ts
@@ -280,6 +280,8 @@ export function transformCartesianData(
         const key = globalCategoryKeys[catIndex];
         const groupRows = cellByCategory.get(key)?.rows ?? [];
         const categoryLabel = categoryValue == null ? "(none)" : String(categoryValue);
+        const traceName =
+          effectiveYEntries.length === 1 ? categoryLabel : `${baseName} — ${categoryLabel}`;
         const x = sharedX ?? xByCategory.get(key) ?? [];
         const y = sharedX
           ? alignYToSharedX(groupRows, xColumn, yKey, sharedX)
@@ -298,8 +300,11 @@ export function transformCartesianData(
             baseName,
           ),
           sizeContext: sizeContextForGroup,
-          legendgroup: effectiveYEntries.length > 1 ? baseName : undefined,
-          name: effectiveYEntries.length === 1 ? categoryLabel : `${baseName} — ${categoryLabel}`,
+          // Group per (series × category) so each combo gets its own legend
+          // entry and toggles together across facet cells. Keying on the
+          // series alone collapsed every category into one legend row.
+          legendgroup: effectiveYEntries.length > 1 ? traceName : undefined,
+          name: traceName,
           x,
           y,
           errorValues,

--- a/apps/web/components/experiment-visualizations/charts/data/contributor-cells.test.ts
+++ b/apps/web/components/experiment-visualizations/charts/data/contributor-cells.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { contributorDisplayName } from "./contributor-cells";
+
+describe("contributorDisplayName", () => {
+  it("extracts the trimmed name from a contributor struct JSON string", () => {
+    const raw = JSON.stringify({ id: "abc", name: "  Ada Lovelace  ", avatar: null });
+    expect(contributorDisplayName(raw)).toBe("Ada Lovelace");
+  });
+
+  it("falls back to Unknown when the name is empty", () => {
+    expect(contributorDisplayName(JSON.stringify({ id: "abc", name: "", avatar: null }))).toBe(
+      "Unknown",
+    );
+  });
+
+  it("falls back to Unknown for a non-string cell", () => {
+    expect(contributorDisplayName(null)).toBe("Unknown");
+    expect(contributorDisplayName(undefined)).toBe("Unknown");
+    expect(contributorDisplayName(42)).toBe("Unknown");
+  });
+
+  it("falls back to Unknown for unparseable JSON", () => {
+    expect(contributorDisplayName("not json")).toBe("Unknown");
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/data/contributor-cells.ts
+++ b/apps/web/components/experiment-visualizations/charts/data/contributor-cells.ts
@@ -1,0 +1,18 @@
+// CONTRIBUTOR columns come back as STRUCT<id, name, avatar> JSON strings.
+// Charts group and colour by the display name, so both the data hook and the
+// colour-map picker flatten each cell through this one converter to stay aligned.
+
+const UNKNOWN_CONTRIBUTOR = "Unknown";
+
+export function contributorDisplayName(value: unknown): string {
+  if (typeof value !== "string") {
+    return UNKNOWN_CONTRIBUTOR;
+  }
+  try {
+    const parsed = JSON.parse(value) as { name?: unknown };
+    const name = typeof parsed.name === "string" ? parsed.name.trim() : "";
+    return name.length > 0 ? name : UNKNOWN_CONTRIBUTOR;
+  } catch {
+    return UNKNOWN_CONTRIBUTOR;
+  }
+}

--- a/apps/web/components/experiment-visualizations/charts/data/correlation-alias.test.ts
+++ b/apps/web/components/experiment-visualizations/charts/data/correlation-alias.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { aliasForCorrelationPair } from "./correlation-alias";
+import { aliasForCorrelationPair, correlationPairFunctions } from "./correlation-alias";
 
 describe("aliasForCorrelationPair", () => {
   it("emits a corr__a__b alias for a sorted pair", () => {
@@ -32,5 +32,26 @@ describe("aliasForCorrelationPair", () => {
 
   it("sorts lexicographically (uppercase before lowercase)", () => {
     expect(aliasForCorrelationPair("Beta", "alpha")).toBe("corr__Beta__alpha");
+  });
+});
+
+describe("correlationPairFunctions", () => {
+  it("emits one corr function per unique unordered pair", () => {
+    const result = correlationPairFunctions(["a", "b", "c"]);
+    expect(result).toHaveLength(3);
+    expect(result.map((f) => f.alias)).toEqual(["corr__a__b", "corr__a__c", "corr__b__c"]);
+    expect(result.every((f) => f.function === "corr")).toBe(true);
+    expect(result[0]).toMatchObject({ column: "a", secondColumn: "b" });
+  });
+
+  it("dedupes repeated columns so no phantom self-pair is emitted", () => {
+    const result = correlationPairFunctions(["a", "a", "b"]);
+    expect(result).toHaveLength(1);
+    expect(result[0].alias).toBe("corr__a__b");
+  });
+
+  it("returns an empty array for fewer than two distinct columns", () => {
+    expect(correlationPairFunctions(["a"])).toEqual([]);
+    expect(correlationPairFunctions([])).toEqual([]);
   });
 });

--- a/apps/web/components/experiment-visualizations/charts/data/correlation-alias.ts
+++ b/apps/web/components/experiment-visualizations/charts/data/correlation-alias.ts
@@ -1,3 +1,5 @@
+import type { AggregationItem } from "@repo/api/schemas/experiment.schema";
+
 /**
  * Stable, order-independent alias for a correlation pair's SQL projection.
  * Both the data-panel and renderer compute this so they agree on the row key.
@@ -6,4 +8,21 @@ export function aliasForCorrelationPair(a: string, b: string): string {
   const [first, second] = a < b ? [a, b] : [b, a];
   const sanitize = (s: string) => s.replace(/\s+/g, "_");
   return `corr__${sanitize(first)}__${sanitize(second)}`;
+}
+
+/** Pairwise `corr` aggregation over the deduped column set (one per unordered pair). */
+export function correlationPairFunctions(columns: string[]): AggregationItem[] {
+  const unique = Array.from(new Set(columns));
+  const functions: AggregationItem[] = [];
+  for (let i = 0; i < unique.length; i++) {
+    for (let j = i + 1; j < unique.length; j++) {
+      functions.push({
+        column: unique[i],
+        function: "corr",
+        secondColumn: unique[j],
+        alias: aliasForCorrelationPair(unique[i], unique[j]),
+      });
+    }
+  }
+  return functions;
 }

--- a/apps/web/components/experiment-visualizations/charts/data/pivot-to-matrix.test.ts
+++ b/apps/web/components/experiment-visualizations/charts/data/pivot-to-matrix.test.ts
@@ -10,15 +10,33 @@ describe("pivotToMatrix", () => {
     expect(result.z).toEqual([]);
   });
 
-  it("preserves first-seen order for both axes", () => {
+  it("preserves first-seen order for string-category axes", () => {
     const rows = [
-      { x: "b", y: 2, z: 10 },
-      { x: "a", y: 1, z: 20 },
-      { x: "b", y: 1, z: 30 },
+      { x: "b", y: "hi", z: 10 },
+      { x: "a", y: "lo", z: 20 },
+      { x: "b", y: "lo", z: 30 },
     ];
     const result = pivotToMatrix(rows, "x", "y", "z");
     expect(result.xCategories).toEqual(["b", "a"]);
-    expect(result.yCategories).toEqual([2, 1]);
+    expect(result.yCategories).toEqual(["hi", "lo"]);
+  });
+
+  it("sorts a numeric axis ascending regardless of row order", () => {
+    // Rows arrive shuffled; a contour grid needs monotonic numeric axes or
+    // Plotly draws scrambled iso-lines.
+    const rows = [
+      { x: 2, y: 1.6, z: 10 },
+      { x: 0.2, y: 0.4, z: 20 },
+      { x: 1, y: 1.6, z: 30 },
+      { x: 0.2, y: 1.6, z: 40 },
+    ];
+    const result = pivotToMatrix(rows, "x", "y", "z");
+    expect(result.xCategories).toEqual([0.2, 1, 2]);
+    expect(result.yCategories).toEqual([0.4, 1.6]);
+    // z stays aligned to the sorted axes: (x=0.2, y=1.6) => 40.
+    const xi = result.xCategories.indexOf(0.2);
+    const yi = result.yCategories.indexOf(1.6);
+    expect(result.z[yi][xi]).toBe(40);
   });
 
   it("emits z indexed as `z[yIndex][xIndex]`", () => {

--- a/apps/web/components/experiment-visualizations/charts/data/pivot-to-matrix.ts
+++ b/apps/web/components/experiment-visualizations/charts/data/pivot-to-matrix.ts
@@ -3,8 +3,11 @@ import { coerceCell } from "./cell-coercion";
 /**
  * Reshape pre-aggregated `(x, y, z)` rows into the `(xCategories,
  * yCategories, z[][])` triple Plotly's `heatmap` and `contour` traces
- * expect. Categories preserve first-seen order. Plotly's z layout is
- * `z[yIndex][xIndex]`.
+ * expect. Plotly's z layout is `z[yIndex][xIndex]`.
+ *
+ * Numeric axes are sorted ascending so the grid is monotonic regardless of
+ * row order (an unsorted numeric axis makes `contour` draw scrambled iso-
+ * lines). Genuine string-category axes keep first-seen order.
  */
 export function pivotToMatrix(
   rows: Record<string, unknown>[],
@@ -12,14 +15,11 @@ export function pivotToMatrix(
   yColumn: string,
   zRowKey: string,
 ): { xCategories: (string | number)[]; yCategories: (string | number)[]; z: number[][] } {
-  // Single pass over rows: lazily assign x/y indices on first sight,
-  // record (xi, yi, z) in a flat list. Materialise the dense matrix
-  // once at the end when the final category counts are known.
-  const xIndex = new Map<string | number, number>();
-  const yIndex = new Map<string | number, number>();
-  const xCategories: (string | number)[] = [];
-  const yCategories: (string | number)[] = [];
-  const cells: { xi: number; yi: number; z: number }[] = [];
+  const xSeen = new Set<string | number>();
+  const ySeen = new Set<string | number>();
+  const xCategoriesRaw: (string | number)[] = [];
+  const yCategoriesRaw: (string | number)[] = [];
+  const cells: { x: string | number; y: string | number; z: number }[] = [];
 
   for (const row of rows) {
     const xCell = coerceCell(row[xColumn]);
@@ -32,29 +32,44 @@ export function pivotToMatrix(
       continue;
     }
 
-    let xi = xIndex.get(xCell);
-    if (xi === undefined) {
-      xi = xCategories.length;
-      xIndex.set(xCell, xi);
-      xCategories.push(xCell);
+    if (!xSeen.has(xCell)) {
+      xSeen.add(xCell);
+      xCategoriesRaw.push(xCell);
     }
-    let yi = yIndex.get(yCell);
-    if (yi === undefined) {
-      yi = yCategories.length;
-      yIndex.set(yCell, yi);
-      yCategories.push(yCell);
+    if (!ySeen.has(yCell)) {
+      ySeen.add(yCell);
+      yCategoriesRaw.push(yCell);
     }
-    cells.push({ xi, yi, z: zCell });
+    cells.push({ x: xCell, y: yCell, z: zCell });
   }
+
+  const xCategories = orderCategories(xCategoriesRaw);
+  const yCategories = orderCategories(yCategoriesRaw);
+  const xIndex = new Map<string | number, number>(xCategories.map((v, i) => [v, i]));
+  const yIndex = new Map<string | number, number>(yCategories.map((v, i) => [v, i]));
 
   const z: number[][] = new Array<number[]>(yCategories.length);
   for (let i = 0; i < yCategories.length; i++) {
     z[i] = new Array<number>(xCategories.length).fill(NaN);
   }
-  // Later cells with the same (xi, yi) overwrite earlier ones.
-  for (const { xi, yi, z: value } of cells) {
+  // Later cells with the same (x, y) overwrite earlier ones.
+  for (const { x, y, z: value } of cells) {
+    const xi = xIndex.get(x);
+    const yi = yIndex.get(y);
+    if (xi === undefined || yi === undefined) {
+      continue;
+    }
     z[yi][xi] = value;
   }
 
   return { xCategories, yCategories, z };
+}
+
+/** Sort a fully-numeric axis ascending; leave categorical axes first-seen. */
+function orderCategories(categories: (string | number)[]): (string | number)[] {
+  const allNumeric = categories.every((c) => typeof c === "number");
+  if (!allNumeric) {
+    return categories;
+  }
+  return [...categories].sort((a, b) => Number(a) - Number(b));
 }

--- a/apps/web/components/experiment-visualizations/charts/scientific/carpet/renderer.tsx
+++ b/apps/web/components/experiment-visualizations/charts/scientific/carpet/renderer.tsx
@@ -45,6 +45,7 @@ export function CarpetRenderer({
     chartConfig.carpetNContours,
     chartConfig.carpetContourColoring,
     chartConfig.carpetShowContourLabels,
+    chartConfig.showGrid,
   ]);
 
   if (visualization.chartType !== "carpet") {

--- a/apps/web/components/experiment-visualizations/charts/scientific/carpet/transform.test.ts
+++ b/apps/web/components/experiment-visualizations/charts/scientific/carpet/transform.test.ts
@@ -138,4 +138,34 @@ describe("transformCarpetData", () => {
     expect(onResult.carpetData[0].aaxis?.showgrid).toBe(true);
     expect(onResult.carpetData[0].baxis?.showgrid).toBe(true);
   });
+
+  it("emits monotonically sorted a / b axes regardless of row order", () => {
+    // Non-monotonic carpet axes crash plotly's contourcarpet makeCrossings;
+    // shuffled dashboard rows used to produce that. Axes must come out sorted.
+    const shuffled = [
+      { x: 2, y: 2, z: 40 },
+      { x: 1, y: 2, z: 20 },
+      { x: 2, y: 1, z: 30 },
+      { x: 1, y: 1, z: 10 },
+    ];
+    const sources = [ds("x", "x"), ds("y", "y"), ds("z", "z")];
+    const result = transformCarpetData(shuffled, sources, baseConfig);
+    expect(result.contourData[0].a).toEqual([1, 2]);
+    expect(result.contourData[0].b).toEqual([1, 2]);
+    // z stays aligned to the sorted axes: (a=1, b=1) => 10, (a=2, b=2) => 40.
+    // contourcarpet z is z[bIdx][aIdx].
+    expect(result.contourData[0].z[0][0]).toBe(10);
+    expect(result.contourData[0].z[1][1]).toBe(40);
+  });
+
+  it("propagates carpetReverseScale onto the contour trace", () => {
+    const sources = [ds("x", "x"), ds("y", "y"), ds("z", "z")];
+    expect(
+      transformCarpetData(wellShaped, sources, { carpetReverseScale: true }).contourData[0],
+    ).toHaveProperty("reversescale", true);
+    expect(transformCarpetData(wellShaped, sources, baseConfig).contourData[0]).toHaveProperty(
+      "reversescale",
+      false,
+    );
+  });
 });

--- a/apps/web/components/experiment-visualizations/charts/scientific/carpet/transform.ts
+++ b/apps/web/components/experiment-visualizations/charts/scientific/carpet/transform.ts
@@ -21,16 +21,9 @@ function toNumericAxis(values: readonly (string | number)[]): number[] | null {
   return out;
 }
 
-// Plotly's `contourcarpet` reads `reversescale` at the trace root, but
-// `CarpetContourSeriesData` from the UI wrapper doesn't expose it. Widen
-// the element type here rather than casting at each emit site.
-type CarpetContourSeriesDataWithReverse = CarpetContourSeriesData & {
-  reversescale?: boolean;
-};
-
 export interface CarpetTransformResult {
   carpetData: CarpetSeriesData[];
-  contourData: CarpetContourSeriesDataWithReverse[];
+  contourData: CarpetContourSeriesData[];
   degenerateReason: CarpetDegenerateReason | null;
 }
 

--- a/apps/web/components/experiment-visualizations/charts/scientific/correlation-matrix/renderer.tsx
+++ b/apps/web/components/experiment-visualizations/charts/scientific/correlation-matrix/renderer.tsx
@@ -8,6 +8,7 @@ import { CorrelationMatrix } from "@repo/ui/components/charts/heatmap";
 import { narrowChartConfig } from "../../chart-config";
 import { ChartConfigError, ChartFrame } from "../../chart-frame";
 import { resolveColorscale } from "../../colors/colorscales";
+import { correlationPairFunctions } from "../../data/correlation-alias";
 import { useChartData } from "../../hooks/use-chart-data";
 import type { ChartRendererProps } from "../../types";
 import { transformCorrelationMatrixData } from "./transform";
@@ -27,13 +28,34 @@ export function CorrelationMatrixRenderer({
       .map((ds) => ds.columnName),
   ).size;
 
+  // Derive the corr aggregation here rather than trusting the saved config:
+  // the data-shelf only seeds it while editing, so a dashboard's stale value
+  // would fetch raw rows and render an all-NaN matrix.
+  const visualizationForFetch = useMemo(() => {
+    const functions = correlationPairFunctions(
+      dataSources
+        .filter((ds) => ds.role === "y" && ds.columnName.length > 0)
+        .map((ds) => ds.columnName),
+    );
+    return {
+      ...visualization,
+      dataConfig: {
+        ...visualization.dataConfig,
+        aggregation: functions.length > 0 ? { groupBy: undefined, functions } : undefined,
+      },
+    };
+  }, [visualization, dataSources]);
+
   // Skip the SQL request entirely when correlation can't be computed.
   // Fewer than 2 distinct picks means no pairs and the renderer shows
   // the empty-state. Without `enabled: false` the hook would still
   // fetch raw rows for the picked columns (noise that never gets used).
-  const { rows, isLoading, error } = useChartData(visualization, experimentId, providedData, {
-    enabled: distinctYCount >= 2,
-  });
+  const { rows, isLoading, error } = useChartData(
+    visualizationForFetch,
+    experimentId,
+    providedData,
+    { enabled: distinctYCount >= 2 },
+  );
 
   const { matrix, labels } = useMemo(() => {
     if (visualization.chartType !== "correlation-matrix") {

--- a/apps/web/components/experiment-visualizations/charts/scientific/correlation-matrix/renderer.tsx
+++ b/apps/web/components/experiment-visualizations/charts/scientific/correlation-matrix/renderer.tsx
@@ -22,21 +22,20 @@ export function CorrelationMatrixRenderer({
 
   const chartConfig = narrowChartConfig(visualization);
   const dataSources = visualization.dataConfig.dataSources;
-  const distinctYCount = new Set(
-    dataSources
-      .filter((ds) => ds.role === "y" && ds.columnName.length > 0)
-      .map((ds) => ds.columnName),
-  ).size;
+  const yColumns = useMemo(
+    () =>
+      dataSources
+        .filter((ds) => ds.role === "y" && ds.columnName.length > 0)
+        .map((ds) => ds.columnName),
+    [dataSources],
+  );
+  const distinctYCount = new Set(yColumns).size;
 
   // Derive the corr aggregation here rather than trusting the saved config:
   // the data-shelf only seeds it while editing, so a dashboard's stale value
   // would fetch raw rows and render an all-NaN matrix.
   const visualizationForFetch = useMemo(() => {
-    const functions = correlationPairFunctions(
-      dataSources
-        .filter((ds) => ds.role === "y" && ds.columnName.length > 0)
-        .map((ds) => ds.columnName),
-    );
+    const functions = correlationPairFunctions(yColumns);
     return {
       ...visualization,
       dataConfig: {
@@ -44,7 +43,7 @@ export function CorrelationMatrixRenderer({
         aggregation: functions.length > 0 ? { groupBy: undefined, functions } : undefined,
       },
     };
-  }, [visualization, dataSources]);
+  }, [visualization, yColumns]);
 
   // Skip the SQL request entirely when correlation can't be computed.
   // Fewer than 2 distinct picks means no pairs and the renderer shows

--- a/apps/web/components/experiment-visualizations/charts/scientific/correlation-matrix/shelves/data-shelves.tsx
+++ b/apps/web/components/experiment-visualizations/charts/scientific/correlation-matrix/shelves/data-shelves.tsx
@@ -4,12 +4,11 @@ import { Variable } from "lucide-react";
 import { useEffect, useMemo } from "react";
 import { useWatch } from "react-hook-form";
 
-import type { AggregationItem } from "@repo/api/schemas/experiment.schema";
 import { filterColumnsForRole } from "@repo/api/utils/visualization-contracts";
 import { useTranslation } from "@repo/i18n";
 
 import { MultiColumnShelf } from "../../../../workspace/shelves/multi-column-shelf";
-import { aliasForCorrelationPair } from "../../../data/correlation-alias";
+import { correlationPairFunctions } from "../../../data/correlation-alias";
 import { dataSourcesByRole } from "../../../data/data-sources";
 import type { ChartPanelProps, ShelfDef } from "../../../types";
 
@@ -35,18 +34,7 @@ function CorrelationVariablesShelf({ form, columns }: ChartPanelProps) {
   );
 
   useEffect(() => {
-    const unique = Array.from(new Set(pickedYColumns));
-    const functions: AggregationItem[] = [];
-    for (let i = 0; i < unique.length; i++) {
-      for (let j = i + 1; j < unique.length; j++) {
-        functions.push({
-          column: unique[i],
-          function: "corr",
-          secondColumn: unique[j],
-          alias: aliasForCorrelationPair(unique[i], unique[j]),
-        });
-      }
-    }
+    const functions = correlationPairFunctions(pickedYColumns);
     // Aggregation needs at least one of groupBy / functions to be valid.
     // With < 2 unique columns there are no pairs, so drop aggregation and
     // let the renderer's empty-state explain why.

--- a/apps/web/components/experiment-visualizations/workspace/shelves/color/categorical-color-map.test.tsx
+++ b/apps/web/components/experiment-visualizations/workspace/shelves/color/categorical-color-map.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { contract } from "@repo/api/contract";
 import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+import { WellKnownColumnTypes } from "@repo/api/schemas/experiment.schema";
 
 import { lineChartType } from "../../../charts/basic/line";
 import type { ChartFormValues } from "../../../charts/chart-config";
@@ -13,6 +14,7 @@ import { CategoricalColorMap } from "./categorical-color-map";
 const columns: DataColumn[] = [
   { name: "temp", type_name: "DOUBLE", type_text: "DOUBLE" },
   { name: "sensor", type_name: "STRING", type_text: "STRING" },
+  { name: "contributor", type_name: "STRUCT", type_text: WellKnownColumnTypes.CONTRIBUTOR },
 ];
 
 function defaults(colorMap: Record<string, string> = {}): ChartFormValues {
@@ -27,6 +29,19 @@ function defaults(colorMap: Record<string, string> = {}): ChartFormValues {
       dataSources: [
         { tableName: "readings", columnName: "temp", role: "y" },
         { tableName: "readings", columnName: "sensor", role: "color" },
+      ],
+    },
+  };
+}
+
+function contributorDefaults(colorMap: Record<string, string> = {}): ChartFormValues {
+  return {
+    ...defaults(colorMap),
+    dataConfig: {
+      tableName: "readings",
+      dataSources: [
+        { tableName: "readings", columnName: "temp", role: "y" },
+        { tableName: "readings", columnName: "contributor", role: "color" },
       ],
     },
   };
@@ -71,6 +86,35 @@ describe("CategoricalColorMap", () => {
     // Merges against the live colorMap, so the existing alpha override survives.
     await waitFor(() => {
       expect(form.getValues("config.colorMap")).toEqual({ alpha: "#ff0000", beta: "#00ff00" });
+    });
+  });
+
+  it("keys a contributor column by display name, not the raw STRUCT JSON", async () => {
+    server.mount(contract.experiments.getDistinctColumnValues, {
+      body: {
+        values: [
+          JSON.stringify({ id: "u2", name: "Zoe" }),
+          JSON.stringify({ id: "u1", name: "Alice" }),
+        ],
+        truncated: false,
+      },
+    });
+
+    const { form, container } = renderWithForm<ChartFormValues>(
+      (form) => <CategoricalColorMap form={form} columns={columns} />,
+      { useFormProps: { defaultValues: contributorDefaults() } },
+    );
+
+    expect(await screen.findByTitle("Alice")).toBeInTheDocument();
+    expect(screen.getByTitle("Zoe")).toBeInTheDocument();
+    expect(screen.queryByTitle(/"name"/)).not.toBeInTheDocument();
+
+    await waitFor(() => expect(container.querySelectorAll('input[type="color"]')).toHaveLength(2));
+    const swatches = container.querySelectorAll<HTMLInputElement>('input[type="color"]');
+    fireEvent.change(swatches[0], { target: { value: "#00ff00" } });
+
+    await waitFor(() => {
+      expect(form.getValues("config.colorMap")).toEqual({ Alice: "#00ff00" });
     });
   });
 });

--- a/apps/web/components/experiment-visualizations/workspace/shelves/color/categorical-color-map.test.tsx
+++ b/apps/web/components/experiment-visualizations/workspace/shelves/color/categorical-color-map.test.tsx
@@ -4,10 +4,16 @@ import { useParams } from "next/navigation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { contract } from "@repo/api/contract";
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
 
 import { lineChartType } from "../../../charts/basic/line";
 import type { ChartFormValues } from "../../../charts/chart-config";
 import { CategoricalColorMap } from "./categorical-color-map";
+
+const columns: DataColumn[] = [
+  { name: "temp", type_name: "DOUBLE", type_text: "DOUBLE" },
+  { name: "sensor", type_name: "STRING", type_text: "STRING" },
+];
 
 function defaults(colorMap: Record<string, string> = {}): ChartFormValues {
   return {
@@ -37,7 +43,7 @@ describe("CategoricalColorMap", () => {
 
   it("clears a category override when its reset button is clicked", async () => {
     const { form } = renderWithForm<ChartFormValues>(
-      (form) => <CategoricalColorMap form={form} />,
+      (form) => <CategoricalColorMap form={form} columns={columns} />,
       {
         useFormProps: { defaultValues: defaults({ alpha: "#ff0000" }) },
       },
@@ -53,7 +59,7 @@ describe("CategoricalColorMap", () => {
 
   it("writes a category override (debounced) when a color is committed", async () => {
     const { form, container } = renderWithForm<ChartFormValues>(
-      (form) => <CategoricalColorMap form={form} />,
+      (form) => <CategoricalColorMap form={form} columns={columns} />,
       { useFormProps: { defaultValues: defaults({ alpha: "#ff0000" }) } },
     );
 

--- a/apps/web/components/experiment-visualizations/workspace/shelves/color/categorical-color-map.tsx
+++ b/apps/web/components/experiment-visualizations/workspace/shelves/color/categorical-color-map.tsx
@@ -6,6 +6,8 @@ import { useMemo } from "react";
 import type { UseFormReturn } from "react-hook-form";
 import { useWatch } from "react-hook-form";
 
+import type { DataColumn } from "@repo/api/schemas/experiment.schema";
+import { WellKnownColumnTypes } from "@repo/api/schemas/experiment.schema";
 import { useTranslation } from "@repo/i18n";
 import { Button } from "@repo/ui/components/button";
 import { FormColorInput } from "@repo/ui/components/form-color-input";
@@ -18,6 +20,7 @@ import {
   getCategoryColor,
 } from "../../../charts/colors/palettes";
 import { toBucketKey } from "../../../charts/data/cell-coercion";
+import { contributorDisplayName } from "../../../charts/data/contributor-cells";
 import { dataSourcesByRole, firstDataSourceByRole } from "../../../charts/data/data-sources";
 
 /** Cap the override list so a high-cardinality column doesn't make the
@@ -27,6 +30,7 @@ const MAX_CATEGORIES = 50;
 
 interface CategoricalColorMapProps {
   form: UseFormReturn<ChartFormValues>;
+  columns: DataColumn[];
 }
 
 interface Category {
@@ -47,7 +51,7 @@ interface Category {
  *   category key, then to the palette -- so old single-key colorMaps keep
  *   working as "default for all series".
  */
-export function CategoricalColorMap({ form }: CategoricalColorMapProps) {
+export function CategoricalColorMap({ form, columns }: CategoricalColorMapProps) {
   const { t } = useTranslation("experimentVisualizations");
   const params = useParams<{ id?: string }>();
   const experimentId = params.id;
@@ -58,6 +62,12 @@ export function CategoricalColorMap({ form }: CategoricalColorMapProps) {
 
   const colorEntry = firstDataSourceByRole(sources, "color");
   const colorColumn = colorEntry?.source.columnName ?? "";
+
+  // CONTRIBUTOR distinct values arrive as STRUCT JSON; the renderer flattens
+  // them to the contributor name, so the picker must key/label by name too or
+  // the overrides never match what the chart looks up.
+  const isContributor =
+    columns.find((c) => c.name === colorColumn)?.type_text === WellKnownColumnTypes.CONTRIBUTOR;
 
   // Mirror the renderer's seriesKey for `getCategoryColor` lookups.
   const seriesKeys = useMemo(() => {
@@ -83,14 +93,14 @@ export function CategoricalColorMap({ form }: CategoricalColorMapProps) {
     const seen = new Set<string>();
     const out: Category[] = [];
     for (const value of rawValues) {
-      const key = toBucketKey(value);
+      const key = isContributor ? contributorDisplayName(value) : toBucketKey(value);
       if (seen.has(key)) continue;
       seen.add(key);
       out.push({ key, label: key === "" ? t("workspace.shelves.colorMap.nullLabel") : key });
     }
     out.sort((a, b) => a.label.localeCompare(b.label));
     return out;
-  }, [rawValues, t]);
+  }, [rawValues, isContributor, t]);
 
   // Read the live colorMap at commit time, not the render-time snapshot:
   // debounced swatch commits from different rows can land close together and

--- a/apps/web/components/experiment-visualizations/workspace/shelves/color/color-dimension-shelf.tsx
+++ b/apps/web/components/experiment-visualizations/workspace/shelves/color/color-dimension-shelf.tsx
@@ -180,7 +180,7 @@ export function ColorDimensionShelf({
           )}
 
           {colorMode === "categorical" ? (
-            <CategoricalColorMap form={form} />
+            <CategoricalColorMap form={form} columns={columns} />
           ) : (
             <ContinuousColorSettings
               control={form.control}

--- a/apps/web/hooks/experiment/useExperimentDistinctValues/useExperimentDistinctValues.ts
+++ b/apps/web/hooks/experiment/useExperimentDistinctValues/useExperimentDistinctValues.ts
@@ -18,7 +18,7 @@ export const useExperimentDistinctValues = ({
   limit,
   enabled = true,
 }: UseExperimentDistinctValuesArgs) => {
-  const { data, isLoading, error } = tsr.experiments.getDistinctColumnValues.useQuery({
+  const { data, isLoading, isSuccess, error } = tsr.experiments.getDistinctColumnValues.useQuery({
     queryData: {
       params: { id: experimentId },
       query: { tableName, column, limit },
@@ -35,6 +35,7 @@ export const useExperimentDistinctValues = ({
     values: data?.body.values ?? [],
     truncated: data?.body.truncated ?? false,
     isLoading,
+    isSuccess,
     error,
   };
 };

--- a/apps/web/hooks/experiment/useExperimentUpdate/useExperimentUpdate.test.tsx
+++ b/apps/web/hooks/experiment/useExperimentUpdate/useExperimentUpdate.test.tsx
@@ -113,8 +113,8 @@ describe("useExperimentUpdate", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     const invalidatedKeys = invalidateSpy.mock.calls.map(([arg]) => arg?.queryKey);
-    expect(invalidatedKeys).toContainEqual(["experiment-distinct-values"]);
-    expect(invalidatedKeys).toContainEqual(["experiment-visualization-data"]);
+    expect(invalidatedKeys).toContainEqual(["experiment-distinct-values", "exp-1"]);
+    expect(invalidatedKeys).toContainEqual(["experiment-visualization-data", "exp-1"]);
   });
 
   it("does not invalidate distinct values / data on a non-anonymization update", async () => {
@@ -134,7 +134,7 @@ describe("useExperimentUpdate", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     const invalidatedKeys = invalidateSpy.mock.calls.map(([arg]) => arg?.queryKey);
-    expect(invalidatedKeys).not.toContainEqual(["experiment-distinct-values"]);
-    expect(invalidatedKeys).not.toContainEqual(["experiment-visualization-data"]);
+    expect(invalidatedKeys).not.toContainEqual(["experiment-distinct-values", "exp-1"]);
+    expect(invalidatedKeys).not.toContainEqual(["experiment-visualization-data", "exp-1"]);
   });
 });

--- a/apps/web/hooks/experiment/useExperimentUpdate/useExperimentUpdate.test.tsx
+++ b/apps/web/hooks/experiment/useExperimentUpdate/useExperimentUpdate.test.tsx
@@ -2,7 +2,7 @@ import { createExperiment } from "@/test/factories";
 import { server } from "@/test/msw/server";
 import { renderHook, waitFor, act, createTestQueryClient } from "@/test/test-utils";
 import { QueryClient } from "@tanstack/react-query";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { contract } from "@repo/api/contract";
 
@@ -94,5 +94,47 @@ describe("useExperimentUpdate", () => {
 
     expect(result.current.mutate).toBeDefined();
     expect(typeof result.current.mutate).toBe("function");
+  });
+
+  it("invalidates cached distinct values and data when anonymization is toggled", async () => {
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    server.mount(contract.experiments.updateExperiment, {
+      body: createExperiment({ id: "exp-1", anonymizeContributors: true }),
+    });
+
+    const { result } = renderHook(() => useExperimentUpdate(), { queryClient });
+
+    act(() => {
+      result.current.mutate({ params: { id: "exp-1" }, body: { anonymizeContributors: true } });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map(([arg]) => arg?.queryKey);
+    expect(invalidatedKeys).toContainEqual(["experiment-distinct-values"]);
+    expect(invalidatedKeys).toContainEqual(["experiment-visualization-data"]);
+  });
+
+  it("does not invalidate distinct values / data on a non-anonymization update", async () => {
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    server.mount(contract.experiments.updateExperiment, {
+      body: createExperiment({ id: "exp-1", name: "Renamed" }),
+    });
+
+    const { result } = renderHook(() => useExperimentUpdate(), { queryClient });
+
+    act(() => {
+      result.current.mutate({ params: { id: "exp-1" }, body: { name: "Renamed" } });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map(([arg]) => arg?.queryKey);
+    expect(invalidatedKeys).not.toContainEqual(["experiment-distinct-values"]);
+    expect(invalidatedKeys).not.toContainEqual(["experiment-visualization-data"]);
   });
 });

--- a/apps/web/hooks/experiment/useExperimentUpdate/useExperimentUpdate.ts
+++ b/apps/web/hooks/experiment/useExperimentUpdate/useExperimentUpdate.ts
@@ -73,6 +73,18 @@ export const useExperimentUpdate = () => {
       await queryClient.invalidateQueries({
         queryKey: ["experiments"],
       });
+
+      // Toggling contributor anonymization re-pseudonymizes distinct values
+      // and row data server-side; drop the cached reads so filters and
+      // charts reflect the new state without a hard refresh.
+      if (variables.body.anonymizeContributors !== undefined) {
+        await queryClient.invalidateQueries({
+          queryKey: ["experiment-distinct-values"],
+        });
+        await queryClient.invalidateQueries({
+          queryKey: ["experiment-visualization-data"],
+        });
+      }
     },
   });
 };

--- a/apps/web/hooks/experiment/useExperimentUpdate/useExperimentUpdate.ts
+++ b/apps/web/hooks/experiment/useExperimentUpdate/useExperimentUpdate.ts
@@ -77,7 +77,7 @@ export const useExperimentUpdate = () => {
       // Toggling contributor anonymization re-pseudonymizes distinct values
       // and row data server-side; drop the cached reads so filters and
       // charts reflect the new state without a hard refresh.
-      if (variables.body.anonymizeContributors !== undefined) {
+      if (variables.body?.anonymizeContributors !== undefined) {
         await queryClient.invalidateQueries({
           queryKey: ["experiment-distinct-values"],
         });

--- a/apps/web/hooks/experiment/useExperimentUpdate/useExperimentUpdate.ts
+++ b/apps/web/hooks/experiment/useExperimentUpdate/useExperimentUpdate.ts
@@ -78,11 +78,12 @@ export const useExperimentUpdate = () => {
       // and row data server-side; drop the cached reads so filters and
       // charts reflect the new state without a hard refresh.
       if (variables.body?.anonymizeContributors !== undefined) {
+        // Both caches key on the experiment id, so scope the prefix to it.
         await queryClient.invalidateQueries({
-          queryKey: ["experiment-distinct-values"],
+          queryKey: ["experiment-distinct-values", variables.params.id],
         });
         await queryClient.invalidateQueries({
-          queryKey: ["experiment-visualization-data"],
+          queryKey: ["experiment-visualization-data", variables.params.id],
         });
       }
     },

--- a/apps/web/hooks/experiment/useExperimentVisualizationData/useExperimentVisualizationData.ts
+++ b/apps/web/hooks/experiment/useExperimentVisualizationData/useExperimentVisualizationData.ts
@@ -1,3 +1,4 @@
+import { contributorDisplayName } from "@/components/experiment-visualizations/charts/data/contributor-cells";
 import { shouldRetryQuery } from "@/util/query-retry";
 import { useMemo } from "react";
 import { tsr } from "~/lib/tsr";
@@ -85,9 +86,6 @@ function isWindowOnlyAggregation(aggregation: DataAggregation): boolean {
 }
 
 // Flatten CONTRIBUTOR structs to their `name` so the chart layer sees plain strings.
-// Null/unparseable becomes "Unknown" to keep the bucket visible (Plotly skips null-x points).
-const UNKNOWN_CONTRIBUTOR = "Unknown";
-
 function flattenContributorCells<
   T extends {
     columns: { name: string; type_text: string }[];
@@ -103,14 +101,7 @@ function flattenContributorCells<
   const rows = table.rows.map((row) => {
     const out: Record<string, unknown> = { ...row };
     for (const col of contributorColumns) {
-      const v = row[col.name];
-      if (typeof v !== "string") {
-        out[col.name] = UNKNOWN_CONTRIBUTOR;
-        continue;
-      }
-      const parsed = JSON.parse(v) as { name?: string };
-      const name = parsed.name?.trim();
-      out[col.name] = name && name.length > 0 ? name : UNKNOWN_CONTRIBUTOR;
+      out[col.name] = contributorDisplayName(row[col.name]);
     }
     return out;
   });

--- a/packages/ui/src/components/__tests__/charts/box-plot.test.tsx
+++ b/packages/ui/src/components/__tests__/charts/box-plot.test.tsx
@@ -44,6 +44,7 @@ vi.mock("../../charts/utils", () => ({
   }),
   extendLayoutForFacets: vi.fn((layout) => layout),
   applyReferenceLines: vi.fn(),
+  truncateCategoryTicks: vi.fn((axis) => axis),
 }));
 
 vi.mock("../../charts/use-is-compact", () => ({

--- a/packages/ui/src/components/__tests__/charts/carpet.test.tsx
+++ b/packages/ui/src/components/__tests__/charts/carpet.test.tsx
@@ -32,6 +32,14 @@ vi.mock("../../charts/utils", () => ({
   getPlotType: vi.fn((type: string, renderer: string) =>
     renderer === "webgl" ? `${type}gl` : type,
   ),
+  responsiveChrome: vi.fn((config: any) => ({
+    title: config.title ? { text: config.title } : undefined,
+    showlegend: config.showLegend !== false,
+    legend: {},
+    autosize: true,
+    paper_bgcolor: config.backgroundColor || "white",
+  })),
+  tierAxisFontSizes: vi.fn(() => ({ tick: 12, axisTitle: 14 })),
 }));
 
 describe("CarpetPlot", () => {

--- a/packages/ui/src/components/__tests__/charts/cartesian-chart.test.tsx
+++ b/packages/ui/src/components/__tests__/charts/cartesian-chart.test.tsx
@@ -41,6 +41,7 @@ vi.mock("../../charts/utils", () => ({
   refineAxisType: vi.fn((axis) => axis ?? {}),
   extendLayoutForFacets: vi.fn((layout) => layout),
   applyReferenceLines: vi.fn(),
+  truncateCategoryTicks: vi.fn((axis) => axis),
 }));
 
 vi.mock("../../charts/use-is-compact", () => ({

--- a/packages/ui/src/components/__tests__/charts/dot-plot.test.tsx
+++ b/packages/ui/src/components/__tests__/charts/dot-plot.test.tsx
@@ -39,6 +39,7 @@ vi.mock("../../charts/utils", () => ({
   })),
   getRenderer: vi.fn((useWebGL) => (useWebGL ? "webgl" : "svg")),
   getPlotType: vi.fn((type, renderer) => `${type}${renderer === "webgl" ? "gl" : ""}`),
+  truncateCategoryTicks: vi.fn((axis) => axis),
 }));
 
 describe("DotPlot", () => {

--- a/packages/ui/src/components/__tests__/charts/heatmap.test.tsx
+++ b/packages/ui/src/components/__tests__/charts/heatmap.test.tsx
@@ -32,6 +32,7 @@ vi.mock("../../charts/utils", () => ({
   getPlotType: vi.fn((type: string, renderer: string) =>
     renderer === "webgl" ? `${type}gl` : type,
   ),
+  truncateCategoryTicks: vi.fn((axis) => axis),
 }));
 
 describe("Heatmap", () => {

--- a/packages/ui/src/components/__tests__/charts/parallel-coordinates.test.tsx
+++ b/packages/ui/src/components/__tests__/charts/parallel-coordinates.test.tsx
@@ -40,6 +40,7 @@ vi.mock("../../charts/utils", () => ({
   getPlotType: vi.fn((type: string, renderer: string) =>
     renderer === "webgl" ? `${type}gl` : type,
   ),
+  tierAxisFontSizes: vi.fn(() => ({ tick: 12, axisTitle: 14 })),
 }));
 
 describe("ParallelCoordinates", () => {

--- a/packages/ui/src/components/__tests__/charts/polar.test.tsx
+++ b/packages/ui/src/components/__tests__/charts/polar.test.tsx
@@ -28,6 +28,14 @@ vi.mock("../../charts/utils", () => ({
     renderer === "webgl" ? `${type}gl` : type,
   ),
   legendAnchorFor: vi.fn(() => ({})),
+  responsiveChrome: vi.fn((config: any) => ({
+    title: config.title ? { text: config.title } : undefined,
+    showlegend: config.showLegend !== false,
+    legend: {},
+    autosize: true,
+    paper_bgcolor: config.backgroundColor || "white",
+  })),
+  tierAxisFontSizes: vi.fn(() => ({ tick: 12, axisTitle: 14 })),
 }));
 
 describe("PolarPlot", () => {
@@ -337,7 +345,7 @@ describe("PolarPlot", () => {
 
     const chartLayout = JSON.parse(getByTestId("chart-layout").textContent || "{}");
     expect(chartLayout.polar.radialaxis).toMatchObject({
-      title: "Radius",
+      title: { text: "Radius", font: { size: 14 } },
       range: [0, 10],
       tickmode: "array",
       tick0: 1,
@@ -359,7 +367,7 @@ describe("PolarPlot", () => {
 
     const chartLayout = JSON.parse(getByTestId("chart-layout").textContent || "{}");
     expect(chartLayout.polar.radialaxis).toMatchObject({
-      title: "R",
+      title: { text: "R", font: { size: 14 } },
       tickmode: "linear",
       tick0: 0,
       angle: 90,
@@ -397,7 +405,7 @@ describe("PolarPlot", () => {
 
     const chartLayout = JSON.parse(getByTestId("chart-layout").textContent || "{}");
     expect(chartLayout.polar.angularaxis).toMatchObject({
-      title: "Angle",
+      title: { text: "Angle", font: { size: 14 } },
       tickmode: "array",
       tick0: 5,
       dtick: 30,
@@ -419,7 +427,7 @@ describe("PolarPlot", () => {
 
     const chartLayout = JSON.parse(getByTestId("chart-layout").textContent || "{}");
     expect(chartLayout.polar.angularaxis).toMatchObject({
-      title: "θ",
+      title: { text: "θ", font: { size: 14 } },
       tickmode: "linear",
       tick0: 0,
       dtick: 45,

--- a/packages/ui/src/components/__tests__/charts/polar.test.tsx
+++ b/packages/ui/src/components/__tests__/charts/polar.test.tsx
@@ -455,7 +455,6 @@ describe("PolarPlot", () => {
     const chartLayout = JSON.parse(getByTestId("chart-layout").textContent || "{}");
     expect(chartLayout.polar.hole).toBe(0.3);
     expect(chartLayout.polar.bgcolor).toBe("#f0f0f0");
-    expect(chartLayout.plot_bgcolor).toBe("#f0f0f0");
   });
 
   it("applies default hole and background", () => {
@@ -464,7 +463,6 @@ describe("PolarPlot", () => {
     const chartLayout = JSON.parse(getByTestId("chart-layout").textContent || "{}");
     expect(chartLayout.polar.hole).toBe(0);
     expect(chartLayout.polar.bgcolor).toBe("white");
-    expect(chartLayout.plot_bgcolor).toBe("white");
   });
 
   it("handles multiple series", () => {

--- a/packages/ui/src/components/__tests__/charts/radar.test.tsx
+++ b/packages/ui/src/components/__tests__/charts/radar.test.tsx
@@ -33,6 +33,14 @@ vi.mock("../../charts/utils", () => ({
     renderer === "webgl" ? `${type}gl` : type,
   ),
   legendAnchorFor: vi.fn(() => ({})),
+  responsiveChrome: vi.fn((config: any) => ({
+    title: config.title ? { text: config.title } : undefined,
+    showlegend: config.showLegend !== false,
+    legend: {},
+    autosize: true,
+    paper_bgcolor: config.backgroundColor || "white",
+  })),
+  tierAxisFontSizes: vi.fn(() => ({ tick: 12, axisTitle: 14 })),
 }));
 
 // Sample data for testing

--- a/packages/ui/src/components/__tests__/charts/responsive-chrome.test.ts
+++ b/packages/ui/src/components/__tests__/charts/responsive-chrome.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+
+import type { PlotlyChartConfig } from "../../charts/types";
+import {
+  createBaseLayout,
+  extendLayoutForFacets,
+  responsiveChrome,
+  tierAxisFontSizes,
+  truncateCategoryTicks,
+  truncateTickLabel,
+} from "../../charts/utils";
+
+describe("responsiveChrome", () => {
+  const config: PlotlyChartConfig = { title: "Chart", legendPosition: "right" };
+
+  it("matches createBaseLayout's chrome slice exactly (single source of truth)", () => {
+    const base = createBaseLayout(config, { compact: true });
+    const chrome = responsiveChrome(config, { compact: true });
+    expect(chrome.title).toEqual(base.title);
+    expect(chrome.legend).toEqual(base.legend);
+    expect(chrome.margin).toEqual(base.margin);
+    expect(chrome.font).toEqual(base.font);
+    expect(chrome.showlegend).toBe(base.showlegend);
+    expect(chrome.paper_bgcolor).toBe(base.paper_bgcolor);
+    expect(chrome.autosize).toBe(base.autosize);
+  });
+
+  it("carries no cartesian axes", () => {
+    const chrome = responsiveChrome(config);
+    expect(chrome).not.toHaveProperty("xaxis");
+    expect(chrome).not.toHaveProperty("yaxis");
+  });
+
+  it("shrinks margins as tiers tighten", () => {
+    const full = responsiveChrome(config);
+    const veryCompact = responsiveChrome(config, { veryCompact: true });
+    expect(veryCompact.margin?.l ?? 0).toBeLessThan(full.margin?.l ?? 0);
+    expect(veryCompact.margin?.t ?? 0).toBeLessThan(full.margin?.t ?? 0);
+  });
+
+  it("shrinks the chart title font per tier", () => {
+    const full = responsiveChrome(config);
+    const compact = responsiveChrome(config, { compact: true });
+    const fullSize = (full.title as { font?: { size?: number } }).font?.size ?? 0;
+    const compactSize = (compact.title as { font?: { size?: number } }).font?.size ?? 0;
+    expect(compactSize).toBeLessThan(fullSize);
+  });
+});
+
+describe("tierAxisFontSizes", () => {
+  it("mirrors the tick/axis-title tiers of createBaseLayout", () => {
+    expect(tierAxisFontSizes()).toEqual({ tick: 12, axisTitle: 14 });
+    expect(tierAxisFontSizes({ snug: true })).toEqual({ tick: 11, axisTitle: 13 });
+    expect(tierAxisFontSizes({ compact: true })).toEqual({ tick: 10, axisTitle: 11 });
+    expect(tierAxisFontSizes({ veryCompact: true })).toEqual({ tick: 9, axisTitle: 10 });
+  });
+});
+
+describe("truncateTickLabel", () => {
+  it("ellipsizes past the tier's char budget", () => {
+    const long = "Usefulness of materials in the field";
+    expect(truncateTickLabel(long, { veryCompact: true })).toBe("Usefuln…");
+    expect(truncateTickLabel(long, { veryCompact: true })).toHaveLength(8);
+  });
+
+  it("leaves short labels alone", () => {
+    expect(truncateTickLabel("Yield", { veryCompact: true })).toBe("Yield");
+  });
+});
+
+describe("truncateCategoryTicks", () => {
+  const longCategories = [
+    "Clarity of instructions",
+    "Instructor responsiveness",
+    "Usefulness of materials",
+  ];
+
+  it("no-ops on non-category axes", () => {
+    const axis = { type: "linear" as const };
+    expect(truncateCategoryTicks(axis, longCategories, { compact: true })).toBe(axis);
+  });
+
+  it("no-ops when explicit ticks are already set", () => {
+    const axis = { type: "category" as const, tickvals: ["a"], ticktext: ["A"] };
+    expect(truncateCategoryTicks(axis, longCategories, { compact: true })).toBe(axis);
+  });
+
+  it("no-ops when every label fits the budget", () => {
+    const axis = { type: "category" as const };
+    expect(truncateCategoryTicks(axis, ["A", "B"], { compact: true })).toBe(axis);
+  });
+
+  it("emits value-anchored tickvals with ellipsized ticktext", () => {
+    const axis = truncateCategoryTicks({ type: "category" }, longCategories, { compact: true });
+    expect(axis.tickmode).toBe("array");
+    // tickvals keep the FULL values so ticks anchor to the right category.
+    expect(axis.tickvals).toEqual(longCategories);
+    for (const label of axis.ticktext ?? []) {
+      expect(String(label).length).toBeLessThanOrEqual(12);
+    }
+    expect(axis.ticktext?.[0]).toBe("Clarity of …");
+  });
+
+  it("dedupes repeated values before building ticks", () => {
+    const axis = truncateCategoryTicks(
+      { type: "category" },
+      ["A very long category name", "A very long category name", "B"],
+      { compact: true },
+    );
+    expect(axis.tickvals).toHaveLength(2);
+  });
+
+  it("samples every Nth category when the count exceeds the tier's tick cap", () => {
+    const many = Array.from(
+      { length: 30 },
+      (_, i) => `Category number ${String(i).padStart(2, "0")}`,
+    );
+    const axis = truncateCategoryTicks({ type: "category" }, many, { veryCompact: true });
+    // veryCompact caps at 5 ticks: step ceil(30/5)=6 → 5 sampled values.
+    expect(axis.tickvals).toHaveLength(5);
+  });
+
+  it("samples in sorted order when categoryorder is category ascending", () => {
+    const axis = truncateCategoryTicks(
+      { type: "category", categoryorder: "category ascending" },
+      ["Zebra crossing counts", "Apple orchard yields", "Mango tree heights"],
+      { compact: true },
+    );
+    expect(axis.tickvals?.[0]).toBe("Apple orchard yields");
+  });
+});
+
+describe("extendLayoutForFacets ultraCompactCells", () => {
+  const cells = [
+    { title: "A", xaxisId: "x", yaxisId: "y" },
+    { title: "B", xaxisId: "x2", yaxisId: "y2" },
+  ];
+  const baseLayout = createBaseLayout({ xAxisTitle: "time", yAxisTitle: "value" });
+
+  it("suppresses cell titles and shared/axis titles when on", () => {
+    const out = extendLayoutForFacets(baseLayout, cells, {
+      rows: 1,
+      columns: 2,
+      sharedXTitle: true,
+      sharedYTitle: true,
+      ultraCompactCells: true,
+    });
+    expect(out.annotations).toEqual([]);
+    expect((out.xaxis as { title?: unknown }).title).toBeUndefined();
+    expect((out.yaxis as { title?: unknown }).title).toBeUndefined();
+  });
+
+  it("keeps cell titles and shared titles when off", () => {
+    const out = extendLayoutForFacets(baseLayout, cells, {
+      rows: 1,
+      columns: 2,
+      sharedXTitle: true,
+      sharedYTitle: true,
+    });
+    const texts = (out.annotations ?? []).map((a) => (a as { text?: string }).text);
+    expect(texts).toContain("A");
+    expect(texts).toContain("B");
+    expect(texts).toContain("time");
+    expect(texts).toContain("value");
+  });
+});

--- a/packages/ui/src/components/__tests__/charts/responsive-chrome.test.ts
+++ b/packages/ui/src/components/__tests__/charts/responsive-chrome.test.ts
@@ -120,6 +120,16 @@ describe("truncateCategoryTicks", () => {
     expect(axis.tickvals).toHaveLength(5);
   });
 
+  it("samples short labels purely on count when the tick cap is exceeded", () => {
+    // Every label fits the 8-char veryCompact budget, so no truncation fires;
+    // sampling must still run because 12 > the 5-tick cap.
+    const many = Array.from({ length: 12 }, (_, i) => `c${String(i).padStart(2, "0")}`);
+    const axis = truncateCategoryTicks({ type: "category" }, many, { veryCompact: true });
+    expect(axis.tickmode).toBe("array");
+    expect(axis.tickvals).toHaveLength(4); // step ceil(12/5)=3 → indices 0,3,6,9
+    expect(axis.ticktext).toEqual(axis.tickvals); // short labels stay verbatim
+  });
+
   it("samples in sorted order when categoryorder is category ascending", () => {
     const axis = truncateCategoryTicks(
       { type: "category", categoryorder: "category ascending" },

--- a/packages/ui/src/components/__tests__/charts/ternary.test.tsx
+++ b/packages/ui/src/components/__tests__/charts/ternary.test.tsx
@@ -32,6 +32,14 @@ vi.mock("../../charts/utils", () => ({
     displayModeBar: false,
   })),
   legendAnchorFor: vi.fn(() => ({})),
+  responsiveChrome: vi.fn((config: any) => ({
+    title: config.title ? { text: config.title } : undefined,
+    showlegend: config.showLegend !== false,
+    legend: {},
+    autosize: true,
+    paper_bgcolor: config.backgroundColor || "white",
+  })),
+  tierAxisFontSizes: vi.fn(() => ({ tick: 12, axisTitle: 14 })),
 }));
 
 describe("TernaryPlot", () => {
@@ -369,16 +377,19 @@ describe("TernaryPlot", () => {
       showticklabels: false,
     });
     expect(plotLayout.ternary?.baxis?.title).toEqual({ text: "Component B", font: { size: 14 } });
-    expect(plotLayout.ternary?.caxis?.title).toEqual({ text: "Component C" });
+    expect(plotLayout.ternary?.caxis?.title).toEqual({
+      text: "Component C",
+      font: { size: 14 },
+    });
   });
 
   it("applies default axis configuration", () => {
     render(<TernaryPlot data={mockData} />);
 
     const plotLayout = JSON.parse(screen.getByTestId("plot-layout").textContent || "{}");
-    expect(plotLayout.ternary?.aaxis?.title).toBe("A");
-    expect(plotLayout.ternary?.baxis?.title).toBe("B");
-    expect(plotLayout.ternary?.caxis?.title).toBe("C");
+    expect(plotLayout.ternary?.aaxis?.title).toEqual({ text: "A", font: { size: 14 } });
+    expect(plotLayout.ternary?.baxis?.title).toEqual({ text: "B", font: { size: 14 } });
+    expect(plotLayout.ternary?.caxis?.title).toEqual({ text: "C", font: { size: 14 } });
     expect(plotLayout.ternary?.aaxis?.showgrid).toBe(true);
     expect(plotLayout.ternary?.aaxis?.showline).toBe(true);
     expect(plotLayout.ternary?.aaxis?.showticklabels).toBe(true);
@@ -586,7 +597,7 @@ describe("TernaryPlot", () => {
     render(<TernaryPlot data={undefinedBaxisData} baxis={{}} />);
 
     const plotLayout = JSON.parse(screen.getByTestId("plot-layout").textContent || "{}");
-    expect(plotLayout.ternary.baxis.title).toBe("B");
+    expect(plotLayout.ternary.baxis.title).toEqual({ text: "B", font: { size: 14 } });
   });
 
   // Additional tests for missing branch coverage
@@ -626,7 +637,7 @@ describe("TernaryPlot", () => {
     render(<TernaryPlot data={stringTitleData} baxis={{ title: "String Title" }} />);
 
     const plotLayout = JSON.parse(screen.getByTestId("plot-layout").textContent || "{}");
-    expect(plotLayout.ternary.baxis.title).toEqual({ text: "String Title" });
+    expect(plotLayout.ternary.baxis.title).toEqual({ text: "String Title", font: { size: 14 } });
   });
 });
 

--- a/packages/ui/src/components/__tests__/charts/wind-rose.test.tsx
+++ b/packages/ui/src/components/__tests__/charts/wind-rose.test.tsx
@@ -23,6 +23,14 @@ vi.mock("../../charts/utils", () => ({
     displayModeBar: false,
   })),
   legendAnchorFor: vi.fn(() => ({})),
+  responsiveChrome: vi.fn((config: any) => ({
+    title: config.title ? { text: config.title } : undefined,
+    showlegend: config.showLegend !== false,
+    legend: {},
+    autosize: true,
+    paper_bgcolor: config.backgroundColor || "white",
+  })),
+  tierAxisFontSizes: vi.fn(() => ({ tick: 12, axisTitle: 14 })),
 }));
 
 const sampleData: WindRoseSeriesData[] = [
@@ -126,12 +134,12 @@ describe("WindRose", () => {
 
   it("defaults the radial-axis title to Frequency", () => {
     render(<WindRose data={sampleData} />);
-    expect(getLayout().polar.radialaxis.title).toEqual({ text: "Frequency" });
+    expect(getLayout().polar.radialaxis.title).toEqual({ text: "Frequency", font: { size: 14 } });
   });
 
   it("respects a custom radial-axis title (e.g. translated)", () => {
     render(<WindRose data={sampleData} radialAxisTitle="Häufigkeit" />);
-    expect(getLayout().polar.radialaxis.title).toEqual({ text: "Häufigkeit" });
+    expect(getLayout().polar.radialaxis.title).toEqual({ text: "Häufigkeit", font: { size: 14 } });
   });
 
   it("renders the radial axis horizontally to the east (angle: 0)", () => {

--- a/packages/ui/src/components/charts/box-plot.tsx
+++ b/packages/ui/src/components/charts/box-plot.tsx
@@ -15,6 +15,7 @@ import {
   extendLayoutForFacets,
   getRenderer,
   getPlotType,
+  truncateCategoryTicks,
 } from "./utils";
 
 export interface BoxSeriesData extends BaseSeries {
@@ -163,6 +164,7 @@ export function BoxPlot({
       sharedYTitle: effectiveSharedYTitle,
       roworder: subplots.roworder,
       titleFontSize: cellTitleFontSize,
+      ultraCompactCells: sizing.cellUltraCompact,
     });
     Object.assign(layout, faceted);
   }
@@ -179,22 +181,24 @@ export function BoxPlot({
   );
 
   if (hasStringX && orientation === "v") {
-    layout.xaxis = {
-      ...layout.xaxis,
-      type: "category",
-    };
+    layout.xaxis = truncateCategoryTicks(
+      { ...layout.xaxis, type: "category" },
+      data.flatMap((series) => series.x ?? []),
+      sizing,
+    );
   }
 
   if (hasStringY && orientation === "h") {
-    layout.yaxis = {
-      ...layout.yaxis,
-      type: "category",
-    };
+    layout.yaxis = truncateCategoryTicks(
+      { ...layout.yaxis, type: "category" },
+      data.flatMap((series) => series.y ?? []),
+      sizing,
+    );
   }
 
   applyReferenceLines(layout, config.referenceLines, { cells: subplots?.cells });
 
-  const plotConfig = createPlotlyConfig(config);
+  const plotConfig = createPlotlyConfig(config, sizing);
 
   return (
     <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>

--- a/packages/ui/src/components/charts/box-plot.tsx
+++ b/packages/ui/src/components/charts/box-plot.tsx
@@ -148,31 +148,10 @@ export function BoxPlot({
   );
 
   const layout = createBaseLayout(config, sizing);
-
-  // Faceted layout: same shape used by cartesian / histogram.
-  if (subplots) {
-    const { cellTitleFontSize } = facetTierStyles(sizing);
-    const forceSharedTitles = sizing.cellVeryCompact;
-    const effectiveSharedXTitle = forceSharedTitles || subplots.sharedXTitle === true;
-    const effectiveSharedYTitle = forceSharedTitles || subplots.sharedYTitle === true;
-    const faceted = extendLayoutForFacets(layout, subplots.cells, {
-      rows: subplots.rows,
-      columns: subplots.columns,
-      sharedX: subplots.sharedX,
-      sharedY: subplots.sharedY,
-      sharedXTitle: effectiveSharedXTitle,
-      sharedYTitle: effectiveSharedYTitle,
-      roworder: subplots.roworder,
-      titleFontSize: cellTitleFontSize,
-      ultraCompactCells: sizing.cellUltraCompact,
-    });
-    Object.assign(layout, faceted);
-  }
-
-  // Add box plot specific layout properties
   layout.boxmode = boxmode;
 
-  // Handle categorical axes - if we have string values on x or y axis
+  // Truncate category ticks before faceting so extendLayoutForFacets copies
+  // the truncated template into every cell (xaxisN/yaxisN).
   const hasStringX = data.some(
     (series) => series.x && series.x.some((val) => typeof val === "string"),
   );
@@ -194,6 +173,26 @@ export function BoxPlot({
       data.flatMap((series) => series.y ?? []),
       sizing,
     );
+  }
+
+  // Faceted layout: same shape used by cartesian / histogram.
+  if (subplots) {
+    const { cellTitleFontSize } = facetTierStyles(sizing);
+    const forceSharedTitles = sizing.cellVeryCompact;
+    const effectiveSharedXTitle = forceSharedTitles || subplots.sharedXTitle === true;
+    const effectiveSharedYTitle = forceSharedTitles || subplots.sharedYTitle === true;
+    const faceted = extendLayoutForFacets(layout, subplots.cells, {
+      rows: subplots.rows,
+      columns: subplots.columns,
+      sharedX: subplots.sharedX,
+      sharedY: subplots.sharedY,
+      sharedXTitle: effectiveSharedXTitle,
+      sharedYTitle: effectiveSharedYTitle,
+      roworder: subplots.roworder,
+      titleFontSize: cellTitleFontSize,
+      ultraCompactCells: sizing.cellUltraCompact,
+    });
+    Object.assign(layout, faceted);
   }
 
   applyReferenceLines(layout, config.referenceLines, { cells: subplots?.cells });

--- a/packages/ui/src/components/charts/carpet.tsx
+++ b/packages/ui/src/components/charts/carpet.tsx
@@ -67,6 +67,7 @@ export interface CarpetContourSeriesData extends BaseSeries {
   b: number[];
   carpet?: string; // Reference to carpet trace
   colorscale?: string | Array<[number, string]>;
+  reversescale?: boolean;
   showscale?: boolean;
   colorbar?: {
     title?: string;
@@ -215,6 +216,7 @@ export function CarpetPlot({
           carpet: series.carpet || `carpet${index + 1}`,
 
           colorscale: series.colorscale || "Viridis",
+          reversescale: series.reversescale,
           showscale: series.showscale !== false,
           colorbar: series.colorbar || {
             title: "Value",

--- a/packages/ui/src/components/charts/carpet.tsx
+++ b/packages/ui/src/components/charts/carpet.tsx
@@ -5,7 +5,7 @@ import React from "react";
 
 import { cn } from "../../lib/utils";
 import { PlotlyChart } from "./plotly-chart";
-import type { BaseChartProps, BaseSeries, SafeLayout } from "./types";
+import type { BaseChartProps, BaseSeries } from "./types";
 import { useChartSizing } from "./use-is-compact";
 import { createPlotlyConfig, getRenderer, responsiveChrome, tierAxisFontSizes } from "./utils";
 

--- a/packages/ui/src/components/charts/carpet.tsx
+++ b/packages/ui/src/components/charts/carpet.tsx
@@ -3,9 +3,11 @@
 import type { PlotData } from "plotly.js";
 import React from "react";
 
+import { cn } from "../../lib/utils";
 import { PlotlyChart } from "./plotly-chart";
 import type { BaseChartProps, BaseSeries, SafeLayout } from "./types";
-import { createPlotlyConfig, getRenderer } from "./utils";
+import { useChartSizing } from "./use-is-compact";
+import { createPlotlyConfig, getRenderer, responsiveChrome, tierAxisFontSizes } from "./utils";
 
 export interface CarpetSeriesData extends BaseSeries {
   a: number[];
@@ -101,6 +103,8 @@ export function CarpetPlot({
   loading,
   error,
 }: CarpetPlotProps) {
+  const [containerRef, sizing] = useChartSizing<HTMLDivElement>();
+  const fontSizes = tierAxisFontSizes(sizing);
   const renderer = getRenderer(config.useWebGL);
 
   const plotData: PlotData[] = [
@@ -119,6 +123,7 @@ export function CarpetPlot({
           aaxis: series.aaxis
             ? {
                 title: series.aaxis.title || "A",
+                tickfont: { size: fontSizes.tick },
                 tickmode: series.aaxis.tickmode || "linear",
                 tick0: series.aaxis.tick0 || 0,
                 dtick: series.aaxis.dtick || 1,
@@ -131,6 +136,7 @@ export function CarpetPlot({
               }
             : {
                 title: "A",
+                tickfont: { size: fontSizes.tick },
                 gridcolor: "#E6E6E6",
                 linecolor: "#444",
               },
@@ -138,6 +144,7 @@ export function CarpetPlot({
           baxis: series.baxis
             ? {
                 title: series.baxis.title || "B",
+                tickfont: { size: fontSizes.tick },
                 tickmode: series.baxis.tickmode || "linear",
                 tick0: series.baxis.tick0 || 0,
                 dtick: series.baxis.dtick || 1,
@@ -150,6 +157,7 @@ export function CarpetPlot({
               }
             : {
                 title: "B",
+                tickfont: { size: fontSizes.tick },
                 gridcolor: "#E6E6E6",
                 linecolor: "#444",
               },
@@ -245,18 +253,13 @@ export function CarpetPlot({
     ),
   ];
 
-  // Create layout
-  const layout = {
-    title: config.title ? { text: config.title } : undefined,
-    paper_bgcolor: config.backgroundColor || "white",
-    showlegend: config.showLegend !== false,
-    autosize: true,
-  } as any; // Layout type allows flexible property assignment
+  // Tier-aware chrome; the carpet axes live on the traces above.
+  const layout = responsiveChrome(config, sizing) as any;
 
-  const plotConfig = createPlotlyConfig(config);
+  const plotConfig = createPlotlyConfig(config, sizing);
 
   return (
-    <div className={className}>
+    <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>
       <PlotlyChart
         data={plotData}
         layout={layout}

--- a/packages/ui/src/components/charts/cartesian-chart.tsx
+++ b/packages/ui/src/components/charts/cartesian-chart.tsx
@@ -1,11 +1,18 @@
 "use client";
 
-import type { PlotData } from "plotly.js";
+import type { Layout, PlotData } from "plotly.js";
 import React from "react";
 
 import { cn } from "../../lib/utils";
 import { PlotlyChart } from "./plotly-chart";
-import type { BaseChartProps, BaseSeries, ErrorBarConfig, LineConfig, MarkerConfig } from "./types";
+import type {
+  BaseChartProps,
+  BaseSeries,
+  ErrorBarConfig,
+  LineConfig,
+  MarkerConfig,
+  PlotlyChartConfig,
+} from "./types";
 import { facetTierStyles, useChartSizing } from "./use-is-compact";
 import {
   applyReferenceLines,
@@ -95,6 +102,12 @@ export interface FacetCell {
   xaxisId: string;
   /** Plotly axis ID for this cell's Y axis (e.g. `"y2"`). */
   yaxisId: string;
+  /**
+   * Plotly axis ID for this cell's overlay (secondary) Y axis, when the
+   * chart has a secondary-axis Y series. The renderer emits a matching
+   * `yaxisN` that overlays `yaxisId` on the right side of the cell.
+   */
+  secondaryYaxisId?: string;
 }
 
 export interface FacetGridConfig {
@@ -201,9 +214,8 @@ export function CartesianChart({
   }
 
   // Faceted layout: convert the single-canvas xaxis/yaxis into a grid of
-  // numbered axes + per-cell title annotations. Done before secondary-Y
-  // composition because secondary axes don't compose with facets in v1
-  // (the `extendLayoutForFacets` helper skips yaxis2 entirely).
+  // numbered axes + per-cell title annotations. Runs before the secondary-Y
+  // step so the overlay axes can borrow each cell's primary styling.
   if (subplots) {
     const { cellTitleFontSize } = facetTierStyles(sizing);
     // At very/ultra-compact cell tiers force shared axis titles
@@ -225,7 +237,11 @@ export function CartesianChart({
   }
 
   const hasSecondary = data.some((s) => s.axis === "secondary");
-  if (hasSecondary && !subplots) {
+  if (hasSecondary && subplots) {
+    // Faceted dual-Y: one overlay axis per cell, built after the grid so it
+    // can borrow each cell's primary styling and overlay its y-domain.
+    applyFacetSecondaryAxes(layout, data, subplots, config);
+  } else if (hasSecondary) {
     const secondaryYValues = data.filter((s) => s.axis === "secondary").flatMap((s) => s.y ?? []);
     // Mirror tick/line styling from primary so the two axes look like a
     // matched pair rather than two unrelated widgets. The primary slice
@@ -272,6 +288,56 @@ export function CartesianChart({
       />
     </div>
   );
+}
+
+/**
+ * Faceted dual-Y: for every cell with a secondary series, emit an overlay
+ * `yaxisN` that shares the cell's y-domain (`overlaying`) and hangs its ticks
+ * on the right. Mirrors the single-canvas secondary styling per cell. When the
+ * Y scale is shared, only the rightmost column shows the secondary ticks/title
+ * and the other cells' secondaries match it so the scale stays comparable.
+ */
+function applyFacetSecondaryAxes(
+  layout: Partial<Layout>,
+  data: CartesianSeries[],
+  subplots: FacetGridConfig,
+  config: PlotlyChartConfig,
+): void {
+  const layoutRecord = layout as unknown as Record<string, unknown>;
+  const firstSecondaryId = subplots.cells.find((c) => c.secondaryYaxisId)?.secondaryYaxisId;
+  const sharedY = subplots.sharedY !== false;
+
+  subplots.cells.forEach((cell, i) => {
+    const secondaryId = cell.secondaryYaxisId;
+    if (!secondaryId) {
+      return;
+    }
+    const isLastColumn = i % subplots.columns === subplots.columns - 1;
+    const primaryKey = cell.yaxisId === "y" ? "yaxis" : `yaxis${cell.yaxisId.slice(1)}`;
+    const primary = (layoutRecord[primaryKey] ?? {}) as Record<string, unknown>;
+    const secondaryValues = data.filter((s) => s.yaxisId === secondaryId).flatMap((s) => s.y ?? []);
+
+    const base: Record<string, unknown> = {
+      overlaying: cell.yaxisId,
+      anchor: cell.xaxisId,
+      side: "right",
+      type: config.y2AxisType ?? "linear",
+      showgrid: false,
+      automargin: true,
+      tickfont: primary.tickfont,
+      color: primary.color,
+      linecolor: primary.linecolor,
+      tickcolor: primary.tickcolor,
+      showline: true,
+      // With a shared scale only the rightmost column carries ticks + title;
+      // the rest match it so every cell reads on the same secondary range.
+      showticklabels: sharedY ? isLastColumn : true,
+      title: isLastColumn && config.y2AxisTitle ? { text: config.y2AxisTitle } : undefined,
+      matches: sharedY && secondaryId !== firstSecondaryId ? firstSecondaryId : undefined,
+    };
+    const key = `yaxis${secondaryId.slice(1)}`;
+    layoutRecord[key] = config.y2AxisType ? base : refineAxisType(base, secondaryValues);
+  });
 }
 
 /**

--- a/packages/ui/src/components/charts/cartesian-chart.tsx
+++ b/packages/ui/src/components/charts/cartesian-chart.tsx
@@ -22,6 +22,7 @@ import {
   getPlotType,
   getRenderer,
   refineAxisType,
+  truncateCategoryTicks,
 } from "./utils";
 
 /**
@@ -213,6 +214,10 @@ export function CartesianChart({
     layout.yaxis = { ...layout.yaxis, type: "category" };
   }
 
+  // Truncate long category ticks before facets so cells inherit them.
+  layout.xaxis = truncateCategoryTicks(layout.xaxis ?? {}, xAxisValues, sizing);
+  layout.yaxis = truncateCategoryTicks(layout.yaxis ?? {}, primaryYValues, sizing);
+
   // Faceted layout: convert the single-canvas xaxis/yaxis into a grid of
   // numbered axes + per-cell title annotations. Runs before the secondary-Y
   // step so the overlay axes can borrow each cell's primary styling.
@@ -232,6 +237,7 @@ export function CartesianChart({
       sharedYTitle: effectiveSharedYTitle,
       roworder: subplots.roworder,
       titleFontSize: cellTitleFontSize,
+      ultraCompactCells: sizing.cellUltraCompact,
     });
     Object.assign(layout, faceted);
   }

--- a/packages/ui/src/components/charts/cartesian-chart.tsx
+++ b/packages/ui/src/components/charts/cartesian-chart.tsx
@@ -23,6 +23,7 @@ import {
   getRenderer,
   refineAxisType,
   truncateCategoryTicks,
+  cellPosition,
 } from "./utils";
 
 /**
@@ -318,10 +319,10 @@ function applyFacetSecondaryAxes(
     if (!secondaryId) {
       return;
     }
-    const isLastColumn = i % subplots.columns === subplots.columns - 1;
+    const { isLastColumn } = cellPosition(i, subplots.rows, subplots.columns);
     const primaryKey = cell.yaxisId === "y" ? "yaxis" : `yaxis${cell.yaxisId.slice(1)}`;
     const primary = (layoutRecord[primaryKey] ?? {}) as Record<string, unknown>;
-    const secondaryValues = data.filter((s) => s.yaxisId === secondaryId).flatMap((s) => s.y ?? []);
+    const secondaryValues = data.filter((s) => s.yaxisId === secondaryId).flatMap((s) => s.y);
 
     const base: Record<string, unknown> = {
       overlaying: cell.yaxisId,

--- a/packages/ui/src/components/charts/contour.tsx
+++ b/packages/ui/src/components/charts/contour.tsx
@@ -199,48 +199,58 @@ export function OverlayContour({
   const renderer = getRenderer(config.useWebGL);
   const contourType = getPlotType("contour", renderer);
 
-  // Convert contour data to plot data
-  const contourPlotData: PlotData[] = contourData.map(
-    (series) =>
-      ({
-        x: series.x,
-        y: series.y,
-        z: series.z,
-        name: series.name,
-        type: contourType,
+  const contourPlotData: PlotData[] = useMemo(
+    () =>
+      contourData.map(
+        (series) =>
+          ({
+            x: series.x,
+            y: series.y,
+            z: series.z,
+            name: series.name,
+            type: contourType,
 
-        ncontours: series.ncontours || 15,
-        contours: {
-          ...series.contours,
-          coloring: "lines",
-          showlines: true,
-        },
+            ncontours: series.ncontours || 15,
+            contours: {
+              ...series.contours,
+              coloring: "lines",
+              showlines: true,
+            },
 
-        line: {
-          color: series.line?.color || "black",
-          width: series.line?.width || 1,
-        },
+            line: {
+              color: series.line?.color || "black",
+              width: series.line?.width || 1,
+            },
 
-        showscale: false, // Don't show colorbar for overlay
+            showscale: false, // Don't show colorbar for overlay
 
-        visible: series.visible,
-        showlegend: series.showlegend,
-        legendgroup: series.legendgroup,
-        hovertemplate: series.hovertemplate,
-        hoverinfo: series.hoverinfo,
-        customdata: series.customdata,
-      }) as any as PlotData,
+            visible: series.visible,
+            showlegend: series.showlegend,
+            legendgroup: series.legendgroup,
+            hovertemplate: series.hovertemplate,
+            hoverinfo: series.hoverinfo,
+            customdata: series.customdata,
+          }) as any as PlotData,
+      ),
+    [contourData, contourType],
   );
 
-  // Combine base data with contour overlay
-  const allData = [...baseData, ...contourPlotData];
+  const allData = useMemo(
+    () => [...baseData, ...contourPlotData],
+    [baseData, contourPlotData],
+  );
 
-  const layout = createBaseLayout(config, sizing);
-  const plotConfig = createPlotlyConfig(config, sizing);
+  const layout = useMemo(() => createBaseLayout(config, sizing), [config, sizing]);
+  const plotConfig = useMemo(() => createPlotlyConfig(config, sizing), [config, sizing]);
+
+  // Same remount guard as ContourPlot: config/sizing changes must remount
+  // rather than let react-plotly call Plotly.react on contour traces.
+  const remountKey = useMemo(() => JSON.stringify({ config, sizing }), [config, sizing]);
 
   return (
     <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>
       <PlotlyChart
+        key={remountKey}
         data={allData}
         layout={layout}
         config={plotConfig}

--- a/packages/ui/src/components/charts/contour.tsx
+++ b/packages/ui/src/components/charts/contour.tsx
@@ -3,8 +3,10 @@
 import type { PlotData } from "plotly.js";
 import React, { useMemo } from "react";
 
+import { cn } from "../../lib/utils";
 import { PlotlyChart } from "./plotly-chart";
 import type { BaseChartProps, BaseSeries } from "./types";
+import { useChartSizing } from "./use-is-compact";
 import { createBaseLayout, createPlotlyConfig, getRenderer, getPlotType } from "./utils";
 
 export interface ContourSeriesData extends BaseSeries {
@@ -70,6 +72,7 @@ export function ContourPlot({
   error,
   fillMode = "none",
 }: ContourPlotProps) {
+  const [containerRef, sizing] = useChartSizing<HTMLDivElement>();
   const renderer = getRenderer(config.useWebGL);
   const plotType = getPlotType("contour", renderer);
 
@@ -153,18 +156,19 @@ export function ContourPlot({
     [data, plotType],
   );
 
-  const layout = useMemo(() => createBaseLayout(config), [config]);
-  const plotConfig = useMemo(() => createPlotlyConfig(config), [config]);
+  const layout = useMemo(() => createBaseLayout(config, sizing), [config, sizing]);
+  const plotConfig = useMemo(() => createPlotlyConfig(config, sizing), [config, sizing]);
 
   // When the configuration genuinely changes, `config` identity flips
   // and `layout` / `plotConfig` recompute; react-plotly would call
   // `Plotly.react` and crash. The only safe path is a clean unmount and
   // remount, driven by a key that hashes the full config snapshot. One
-  // frame of flicker per intentional change, no crash.
-  const remountKey = useMemo(() => JSON.stringify(config), [config]);
+  // frame of flicker per intentional change, no crash. Sizing-tier flips
+  // remount for the same reason.
+  const remountKey = useMemo(() => JSON.stringify({ config, sizing }), [config, sizing]);
 
   return (
-    <div className={className}>
+    <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>
       <PlotlyChart
         key={remountKey}
         data={plotData}
@@ -191,6 +195,7 @@ export function OverlayContour({
   loading,
   error,
 }: OverlayContourProps) {
+  const [containerRef, sizing] = useChartSizing<HTMLDivElement>();
   const renderer = getRenderer(config.useWebGL);
   const contourType = getPlotType("contour", renderer);
 
@@ -230,11 +235,11 @@ export function OverlayContour({
   // Combine base data with contour overlay
   const allData = [...baseData, ...contourPlotData];
 
-  const layout = createBaseLayout(config);
-  const plotConfig = createPlotlyConfig(config);
+  const layout = createBaseLayout(config, sizing);
+  const plotConfig = createPlotlyConfig(config, sizing);
 
   return (
-    <div className={className}>
+    <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>
       <PlotlyChart
         data={allData}
         layout={layout}

--- a/packages/ui/src/components/charts/contour.tsx
+++ b/packages/ui/src/components/charts/contour.tsx
@@ -235,10 +235,7 @@ export function OverlayContour({
     [contourData, contourType],
   );
 
-  const allData = useMemo(
-    () => [...baseData, ...contourPlotData],
-    [baseData, contourPlotData],
-  );
+  const allData = useMemo(() => [...baseData, ...contourPlotData], [baseData, contourPlotData]);
 
   const layout = useMemo(() => createBaseLayout(config, sizing), [config, sizing]);
   const plotConfig = useMemo(() => createPlotlyConfig(config, sizing), [config, sizing]);

--- a/packages/ui/src/components/charts/contour.tsx
+++ b/packages/ui/src/components/charts/contour.tsx
@@ -210,7 +210,7 @@ export function OverlayContour({
             name: series.name,
             type: contourType,
 
-            ncontours: series.ncontours || 15,
+            ncontours: series.ncontours ?? 15,
             contours: {
               ...series.contours,
               coloring: "lines",
@@ -219,7 +219,7 @@ export function OverlayContour({
 
             line: {
               color: series.line?.color || "black",
-              width: series.line?.width || 1,
+              width: series.line?.width ?? 1,
             },
 
             showscale: false, // Don't show colorbar for overlay

--- a/packages/ui/src/components/charts/correlation-matrix.tsx
+++ b/packages/ui/src/components/charts/correlation-matrix.tsx
@@ -3,9 +3,17 @@
 import type { PlotData } from "plotly.js";
 import React from "react";
 
+import { cn } from "../../lib/utils";
 import { PlotlyChart } from "./plotly-chart";
 import type { BaseChartProps } from "./types";
-import { createBaseLayout, createPlotlyConfig, getPlotType, getRenderer } from "./utils";
+import { useChartSizing } from "./use-is-compact";
+import {
+  createBaseLayout,
+  createPlotlyConfig,
+  getPlotType,
+  getRenderer,
+  truncateCategoryTicks,
+} from "./utils";
 
 export interface CorrelationMatrixProps extends BaseChartProps {
   correlationMatrix: number[][];
@@ -32,6 +40,7 @@ export function CorrelationMatrix({
   showColorbar = true,
   ...props
 }: CorrelationMatrixProps) {
+  const [containerRef, sizing] = useChartSizing<HTMLDivElement>();
   const renderer = getRenderer(props.config?.useWebGL);
   const plotType = getPlotType("heatmap", renderer);
 
@@ -67,7 +76,7 @@ export function CorrelationMatrix({
     },
   ] as unknown as PlotData[];
 
-  const layout = createBaseLayout(props.config || {});
+  const layout = createBaseLayout(props.config || {}, sizing);
 
   const enhancedLayout = {
     ...layout,
@@ -75,35 +84,44 @@ export function CorrelationMatrix({
       ...layout.title,
       text: props.config?.title || name,
     },
-    xaxis: {
-      ...layout.xaxis,
-      side: "bottom" as const,
-      tickangle: 45,
-      showgrid: false,
-      zeroline: false,
-      showline: false,
-      ticks: "" as const,
-      showticklabels: true,
-      type: "category" as const,
-    },
-    yaxis: {
-      ...layout.yaxis,
-      showgrid: false,
-      zeroline: false,
-      showline: false,
-      ticks: "" as const,
-      showticklabels: true,
-      autorange: "reversed" as const,
-      type: "category" as const,
-    },
+    // Truncate long column-name ticks so automargin cannot eat the plot area.
+    xaxis: truncateCategoryTicks(
+      {
+        ...layout.xaxis,
+        side: "bottom" as const,
+        tickangle: 45,
+        showgrid: false,
+        zeroline: false,
+        showline: false,
+        ticks: "" as const,
+        showticklabels: true,
+        type: "category" as const,
+      },
+      labels,
+      sizing,
+    ),
+    yaxis: truncateCategoryTicks(
+      {
+        ...layout.yaxis,
+        showgrid: false,
+        zeroline: false,
+        showline: false,
+        ticks: "" as const,
+        showticklabels: true,
+        autorange: "reversed" as const,
+        type: "category" as const,
+      },
+      labels,
+      sizing,
+    ),
     plot_bgcolor: "white",
     paper_bgcolor: "white",
   };
 
-  const plotConfig = createPlotlyConfig(props.config || {});
+  const plotConfig = createPlotlyConfig(props.config || {}, sizing);
 
   return (
-    <div className={props.className}>
+    <div ref={containerRef} className={cn("flex h-full w-full flex-col", props.className)}>
       <PlotlyChart
         data={plotData}
         layout={enhancedLayout}

--- a/packages/ui/src/components/charts/density.tsx
+++ b/packages/ui/src/components/charts/density.tsx
@@ -5,7 +5,7 @@ import React from "react";
 
 import { cn } from "../../lib/utils";
 import { PlotlyChart } from "./plotly-chart";
-import type { BaseChartProps, BaseSeries, SafeLayout } from "./types";
+import type { BaseChartProps, BaseSeries } from "./types";
 import { useChartSizing } from "./use-is-compact";
 import { createBaseLayout, createPlotlyConfig, getRenderer, getPlotType } from "./utils";
 
@@ -160,12 +160,14 @@ export function DensityPlot({
       bargap: 0,
       // Main plot axes
       xaxis: {
+        ...base.xaxis,
         domain: [0, 0.85],
         showgrid: false,
         zeroline: false,
         title: config.xAxisTitle ? { text: config.xAxisTitle } : undefined,
       },
       yaxis: {
+        ...base.yaxis,
         domain: [0, 0.85],
         showgrid: false,
         zeroline: false,
@@ -194,11 +196,13 @@ export function DensityPlot({
       hovermode: "closest",
       bargap: 0,
       xaxis: {
+        ...base.xaxis,
         showgrid: false,
         zeroline: false,
         title: config.xAxisTitle ? { text: config.xAxisTitle } : undefined,
       },
       yaxis: {
+        ...base.yaxis,
         showgrid: false,
         zeroline: false,
         title: config.yAxisTitle ? { text: config.yAxisTitle } : undefined,

--- a/packages/ui/src/components/charts/density.tsx
+++ b/packages/ui/src/components/charts/density.tsx
@@ -173,14 +173,17 @@ export function DensityPlot({
         zeroline: false,
         title: config.yAxisTitle ? { text: config.yAxisTitle } : undefined,
       },
-      // Marginal histogram axes
+      // Marginal histogram axes. Inherit the base tick font so their labels
+      // shrink with the tier like the main axes.
       xaxis2: {
+        tickfont: base.xaxis?.tickfont,
         domain: [0.85, 1],
         showgrid: false,
         zeroline: false,
         showticklabels: true,
       },
       yaxis2: {
+        tickfont: base.yaxis?.tickfont,
         domain: [0.85, 1],
         showgrid: false,
         zeroline: false,

--- a/packages/ui/src/components/charts/density.tsx
+++ b/packages/ui/src/components/charts/density.tsx
@@ -3,8 +3,10 @@
 import type { PlotData } from "plotly.js";
 import React from "react";
 
+import { cn } from "../../lib/utils";
 import { PlotlyChart } from "./plotly-chart";
 import type { BaseChartProps, BaseSeries, SafeLayout } from "./types";
+import { useChartSizing } from "./use-is-compact";
 import { createBaseLayout, createPlotlyConfig, getRenderer, getPlotType } from "./utils";
 
 export interface DensityPlotProps extends BaseChartProps {
@@ -58,6 +60,7 @@ export function DensityPlot({
   loading,
   error,
 }: DensityPlotProps) {
+  const [containerRef, sizing] = useChartSizing<HTMLDivElement>();
   const plotData: PlotData[] = [];
 
   if (showMarginalHistograms) {
@@ -142,15 +145,17 @@ export function DensityPlot({
     }
   }
 
+  // Tier margins replace the previous fixed 50/60 block.
+  const base = createBaseLayout(config, sizing);
+
   // Create layout based on whether marginal histograms are shown
   let layout;
   if (showMarginalHistograms) {
     // Layout with marginal subplots (like Plotly documentation)
     layout = {
-      ...createBaseLayout(config),
+      ...base,
       showlegend: false,
       autosize: true,
-      margin: { t: 50, l: 60, r: 60, b: 60 },
       hovermode: "closest",
       bargap: 0,
       // Main plot axes
@@ -183,10 +188,9 @@ export function DensityPlot({
   } else {
     // Use similar layout structure but without marginal axes
     layout = {
-      ...createBaseLayout(config),
+      ...base,
       showlegend: false,
       autosize: true,
-      margin: { t: 50, l: 60, r: 60, b: 60 },
       hovermode: "closest",
       bargap: 0,
       xaxis: {
@@ -202,10 +206,10 @@ export function DensityPlot({
     } as any; // Layout type allows flexible property assignment
   }
 
-  const plotConfig = createPlotlyConfig(config);
+  const plotConfig = createPlotlyConfig(config, sizing);
 
   return (
-    <div className={className}>
+    <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>
       <PlotlyChart
         data={plotData}
         layout={layout}
@@ -244,6 +248,7 @@ export function RidgePlot({
   colorScale = "Viridis",
   colorMode = "solid",
 }: RidgePlotProps) {
+  const [containerRef, sizing] = useChartSizing<HTMLDivElement>();
   const renderer = getRenderer(config.useWebGL);
   const plotType = getPlotType("scatter", renderer);
 
@@ -473,19 +478,20 @@ export function RidgePlot({
     }
   });
 
-  const plotConfig = createPlotlyConfig(config);
+  const plotConfig = createPlotlyConfig(config, sizing);
 
   // Create custom layout for ridge plots
+  const base = createBaseLayout(config, sizing);
   const layout = {
-    ...createBaseLayout(config),
+    ...base,
     xaxis: {
-      ...createBaseLayout(config).xaxis,
+      ...base.xaxis,
       autorange: true,
       type: "linear" as const,
       title: config.xAxisTitle ? { text: config.xAxisTitle } : undefined,
     },
     yaxis: {
-      ...createBaseLayout(config).yaxis,
+      ...base.yaxis,
       tickvals: data.map((_, index) => index * spacing),
       ticktext: data.map((series) => series.category),
       range: [-0.5, (data.length - 1) * spacing + 1],
@@ -494,7 +500,7 @@ export function RidgePlot({
   };
 
   return (
-    <div className={className}>
+    <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>
       <PlotlyChart
         data={plotData}
         layout={layout}

--- a/packages/ui/src/components/charts/dot-plot.tsx
+++ b/packages/ui/src/components/charts/dot-plot.tsx
@@ -7,7 +7,13 @@ import { cn } from "../../lib/utils";
 import { PlotlyChart } from "./plotly-chart";
 import type { BaseChartProps, BaseSeries, MarkerConfig } from "./types";
 import { useChartSizing } from "./use-is-compact";
-import { createBaseLayout, createPlotlyConfig, getRenderer, getPlotType } from "./utils";
+import {
+  createBaseLayout,
+  createPlotlyConfig,
+  getRenderer,
+  getPlotType,
+  truncateCategoryTicks,
+} from "./utils";
 
 export interface DotSeriesData extends BaseSeries {
   x?: (string | number | Date)[];
@@ -145,10 +151,11 @@ export function DotPlot({
   // Fix for horizontal dot plots - ensure categorical axis
   const hasHorizontalDots = data.some((series) => (series.orientation || orientation) === "h");
   if (hasHorizontalDots) {
-    dotLayout.yaxis = {
-      ...dotLayout.yaxis,
-      type: "category",
-    };
+    dotLayout.yaxis = truncateCategoryTicks(
+      { ...dotLayout.yaxis, type: "category" },
+      data.flatMap((series) => series.y ?? []),
+      sizing,
+    );
   }
 
   // Check if we have categorical x data (non-numeric strings)
@@ -156,10 +163,11 @@ export function DotPlot({
     (series) => series.x && series.x.some((val) => typeof val === "string" && isNaN(Number(val))),
   );
   if (hasCategoricalX && !hasHorizontalDots) {
-    dotLayout.xaxis = {
-      ...dotLayout.xaxis,
-      type: "category",
-    };
+    dotLayout.xaxis = truncateCategoryTicks(
+      { ...dotLayout.xaxis, type: "category" },
+      data.flatMap((series) => series.x ?? []),
+      sizing,
+    );
   }
 
   const plotConfig = createPlotlyConfig(config, sizing);

--- a/packages/ui/src/components/charts/heatmap.tsx
+++ b/packages/ui/src/components/charts/heatmap.tsx
@@ -3,9 +3,17 @@
 import type { PlotData } from "plotly.js";
 import React from "react";
 
+import { cn } from "../../lib/utils";
 import { PlotlyChart } from "./plotly-chart";
 import type { BaseChartProps, BaseSeries } from "./types";
-import { createBaseLayout, createPlotlyConfig, getRenderer, getPlotType } from "./utils";
+import { useChartSizing } from "./use-is-compact";
+import {
+  createBaseLayout,
+  createPlotlyConfig,
+  getRenderer,
+  getPlotType,
+  truncateCategoryTicks,
+} from "./utils";
 
 export interface HeatmapSeriesData extends BaseSeries {
   x?: (string | number | Date)[];
@@ -72,6 +80,7 @@ export function Heatmap({
   error,
   aspectRatio = "auto",
 }: HeatmapProps) {
+  const [containerRef, sizing] = useChartSizing<HTMLDivElement>();
   const renderer = getRenderer(config.useWebGL);
   const plotType = getPlotType("heatmap", renderer);
 
@@ -119,7 +128,7 @@ export function Heatmap({
     } as any as PlotData;
   });
 
-  const layout = createBaseLayout(config);
+  const layout = createBaseLayout(config, sizing);
 
   // Determine axis types based on data
   const firstSeries = data[0];
@@ -140,15 +149,18 @@ export function Heatmap({
         : "linear"
       : "linear";
 
-  layout.xaxis = {
-    ...layout.xaxis,
-    type: xAxisType,
-  };
+  // Bound long category labels so automargin can't eat the plot area.
+  layout.xaxis = truncateCategoryTicks(
+    { ...layout.xaxis, type: xAxisType },
+    firstSeries?.x ?? [],
+    sizing,
+  );
 
-  layout.yaxis = {
-    ...layout.yaxis,
-    type: yAxisType,
-  };
+  layout.yaxis = truncateCategoryTicks(
+    { ...layout.yaxis, type: yAxisType },
+    firstSeries?.y ?? [],
+    sizing,
+  );
 
   // Set aspect ratio if specified
   if (aspectRatio === "equal") {
@@ -159,10 +171,10 @@ export function Heatmap({
     };
   }
 
-  const plotConfig = createPlotlyConfig(config);
+  const plotConfig = createPlotlyConfig(config, sizing);
 
   return (
-    <div className={className}>
+    <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>
       <PlotlyChart
         data={plotData}
         layout={layout}

--- a/packages/ui/src/components/charts/histogram-2d.tsx
+++ b/packages/ui/src/components/charts/histogram-2d.tsx
@@ -3,8 +3,10 @@
 import type { PlotData } from "plotly.js";
 import React from "react";
 
+import { cn } from "../../lib/utils";
 import { PlotlyChart } from "./plotly-chart";
 import type { BaseChartProps, BaseSeries } from "./types";
+import { useChartSizing } from "./use-is-compact";
 import { createBaseLayout, createPlotlyConfig, getRenderer, getPlotType } from "./utils";
 
 export interface Histogram2DSeriesData extends BaseSeries {
@@ -66,6 +68,7 @@ export function Histogram2D({
   renderMode = "heatmap",
   contourFill = false,
 }: Histogram2DProps) {
+  const [containerRef, sizing] = useChartSizing<HTMLDivElement>();
   const renderer = getRenderer(config.useWebGL);
   // `histogram2dcontour` has no WebGL variant; `getPlotType` falls back
   // to the SVG path automatically.
@@ -117,11 +120,11 @@ export function Histogram2D({
       }) as any as PlotData,
   );
 
-  const layout = createBaseLayout(config);
-  const plotConfig = createPlotlyConfig(config);
+  const layout = createBaseLayout(config, sizing);
+  const plotConfig = createPlotlyConfig(config, sizing);
 
   return (
-    <div className={className}>
+    <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>
       <PlotlyChart
         data={plotData}
         layout={layout}

--- a/packages/ui/src/components/charts/histogram.tsx
+++ b/packages/ui/src/components/charts/histogram.tsx
@@ -314,6 +314,7 @@ export function Histogram({
       sharedYTitle: effectiveSharedYTitle,
       roworder: subplots.roworder,
       titleFontSize: cellTitleFontSize,
+      ultraCompactCells: sizing.cellUltraCompact,
     });
     Object.assign(layout, faceted);
   }
@@ -326,7 +327,7 @@ export function Histogram({
 
   applyReferenceLines(layout, config.referenceLines, { cells: subplots?.cells });
 
-  const plotConfig = createPlotlyConfig(config);
+  const plotConfig = createPlotlyConfig(config, sizing);
 
   return (
     <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>

--- a/packages/ui/src/components/charts/line-chart.tsx
+++ b/packages/ui/src/components/charts/line-chart.tsx
@@ -156,6 +156,7 @@ export function LineChart({
       sharedYTitle: effectiveSharedYTitle,
       roworder: subplots.roworder,
       titleFontSize: cellTitleFontSize,
+      ultraCompactCells: sizing.cellUltraCompact,
     });
     Object.assign(layout, faceted);
   }

--- a/packages/ui/src/components/charts/parallel-coordinates.tsx
+++ b/packages/ui/src/components/charts/parallel-coordinates.tsx
@@ -3,9 +3,17 @@
 import type { PlotData } from "plotly.js";
 import React from "react";
 
+import { cn } from "../../lib/utils";
 import { PlotlyChart } from "./plotly-chart";
 import type { BaseChartProps, BaseSeries } from "./types";
-import { createBaseLayout, createPlotlyConfig, getRenderer, getPlotType } from "./utils";
+import { useChartSizing } from "./use-is-compact";
+import {
+  createBaseLayout,
+  createPlotlyConfig,
+  getRenderer,
+  getPlotType,
+  tierAxisFontSizes,
+} from "./utils";
 
 export interface ParallelCoordinatesSeriesData extends BaseSeries {
   dimensions: Array<{
@@ -82,6 +90,8 @@ export function ParallelCoordinates({
   loading,
   error,
 }: ParallelCoordinatesProps) {
+  const [containerRef, sizing] = useChartSizing<HTMLDivElement>();
+  const fontSizes = tierAxisFontSizes(sizing);
   const renderer = getRenderer(config.useWebGL);
   const plotType = getPlotType("parcoords", renderer);
 
@@ -124,15 +134,16 @@ export function ParallelCoordinates({
               width: 1,
             },
 
-        // Label configuration
+        // Label configuration; defaults shrink with the container tier.
         labelangle: series.labelangle || 0,
         labelside: series.labelside || "top",
+        labelfont: { size: fontSizes.axisTitle },
         rangefont: series.rangefont || {
-          size: 12,
+          size: Math.min(12, fontSizes.tick),
           color: "#444",
         },
         tickfont: series.tickfont || {
-          size: 10,
+          size: Math.min(10, fontSizes.tick),
           color: "#444",
         },
 
@@ -145,11 +156,11 @@ export function ParallelCoordinates({
       }) as any as PlotData,
   );
 
-  const layout = createBaseLayout(config);
-  const plotConfig = createPlotlyConfig(config);
+  const layout = createBaseLayout(config, sizing);
+  const plotConfig = createPlotlyConfig(config, sizing);
 
   return (
-    <div className={className}>
+    <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>
       <PlotlyChart
         data={plotData}
         layout={layout}
@@ -213,6 +224,8 @@ export function ParallelCategories({
   loading,
   error,
 }: ParallelCategoriesProps) {
+  const [containerRef, sizing] = useChartSizing<HTMLDivElement>();
+  const fontSizes = tierAxisFontSizes(sizing);
   const renderer = getRenderer(config.useWebGL);
   const plotType = getPlotType("parcats", renderer);
 
@@ -253,11 +266,11 @@ export function ParallelCategories({
         bundlecolors: series.bundlecolors !== false,
         sortpaths: series.sortpaths || "forward",
         labelfont: series.labelfont || {
-          size: 14,
+          size: fontSizes.axisTitle,
           color: "#444",
         },
         tickfont: series.tickfont || {
-          size: 12,
+          size: fontSizes.tick,
           color: "#444",
         },
 
@@ -270,11 +283,11 @@ export function ParallelCategories({
       }) as any as PlotData,
   );
 
-  const layout = createBaseLayout(config);
-  const plotConfig = createPlotlyConfig(config);
+  const layout = createBaseLayout(config, sizing);
+  const plotConfig = createPlotlyConfig(config, sizing);
 
   return (
-    <div className={className}>
+    <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>
       <PlotlyChart
         data={plotData}
         layout={layout}
@@ -321,6 +334,7 @@ export interface AlluvialProps extends BaseChartProps {
 }
 
 export function Alluvial({ data, config = {}, className, loading, error }: AlluvialProps) {
+  const [containerRef, sizing] = useChartSizing<HTMLDivElement>();
   const renderer = getRenderer(config.useWebGL);
   const plotType = getPlotType("sankey", renderer);
 
@@ -368,11 +382,11 @@ export function Alluvial({ data, config = {}, className, loading, error }: Alluv
       }) as any as PlotData,
   );
 
-  const layout = createBaseLayout(config);
-  const plotConfig = createPlotlyConfig(config);
+  const layout = createBaseLayout(config, sizing);
+  const plotConfig = createPlotlyConfig(config, sizing);
 
   return (
-    <div className={className}>
+    <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>
       <PlotlyChart
         data={plotData}
         layout={layout}

--- a/packages/ui/src/components/charts/polar.tsx
+++ b/packages/ui/src/components/charts/polar.tsx
@@ -168,7 +168,6 @@ export function PolarPlot({
   // Tier-aware chrome + the polar config createBaseLayout cannot provide.
   const layout = {
     ...responsiveChrome(config, sizing),
-    plot_bgcolor: bgcolor,
 
     polar: {
       radialaxis: {

--- a/packages/ui/src/components/charts/polar.tsx
+++ b/packages/ui/src/components/charts/polar.tsx
@@ -3,9 +3,17 @@
 import type { PlotData } from "plotly.js";
 import React from "react";
 
+import { cn } from "../../lib/utils";
 import { PlotlyChart } from "./plotly-chart";
 import type { BaseChartProps, BaseSeries, MarkerConfig } from "./types";
-import { createPlotlyConfig, getRenderer, getPlotType, legendAnchorFor } from "./utils";
+import { useChartSizing } from "./use-is-compact";
+import {
+  createPlotlyConfig,
+  getRenderer,
+  getPlotType,
+  responsiveChrome,
+  tierAxisFontSizes,
+} from "./utils";
 
 export interface PolarSeriesData extends BaseSeries {
   r: number[];
@@ -98,6 +106,8 @@ export function PolarPlot({
   hole = 0,
   bgcolor = "white",
 }: PolarPlotProps) {
+  const [containerRef, sizing] = useChartSizing<HTMLDivElement>();
+  const fontSizes = tierAxisFontSizes(sizing);
   const renderer = getRenderer(config.useWebGL);
 
   const plotData: PlotData[] = data.map((series) => {
@@ -155,17 +165,15 @@ export function PolarPlot({
     } as any as PlotData;
   });
 
-  // Create polar layout with responsive sizing
+  // Tier-aware chrome + the polar config createBaseLayout cannot provide.
   const layout = {
-    title: config.title ? { text: config.title } : undefined,
-    // Remove fixed width/height to allow container-based sizing
-    paper_bgcolor: config.backgroundColor || "white",
+    ...responsiveChrome(config, sizing),
     plot_bgcolor: bgcolor,
-    autosize: true, // Enable responsive sizing
 
     polar: {
       radialaxis: {
-        title: radialAxis.title || "R",
+        title: { text: radialAxis.title || "R", font: { size: fontSizes.axisTitle } },
+        tickfont: { size: fontSizes.tick },
         range: radialAxis.range,
         tickmode: radialAxis.tickmode || "linear",
         tick0: radialAxis.tick0 || 0,
@@ -181,7 +189,8 @@ export function PolarPlot({
         showticklabels: radialAxis.showticklabels !== false,
       },
       angularaxis: {
-        title: angularAxis.title || "θ",
+        title: { text: angularAxis.title || "θ", font: { size: fontSizes.axisTitle } },
+        tickfont: { size: fontSizes.tick },
         tickmode: angularAxis.tickmode || "linear",
         tick0: angularAxis.tick0 || 0,
         dtick: angularAxis.dtick || 45,
@@ -204,15 +213,12 @@ export function PolarPlot({
       hole: hole,
       bgcolor: bgcolor,
     },
-
-    showlegend: config.showLegend !== false,
-    legend: legendAnchorFor(config.legendPosition ?? "right"),
   } as any;
 
-  const plotConfig = createPlotlyConfig(config);
+  const plotConfig = createPlotlyConfig(config, sizing);
 
   return (
-    <div className={className}>
+    <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>
       <PlotlyChart
         data={plotData}
         layout={layout}

--- a/packages/ui/src/components/charts/radar.tsx
+++ b/packages/ui/src/components/charts/radar.tsx
@@ -3,9 +3,17 @@
 import type { PlotData } from "plotly.js";
 import React from "react";
 
+import { cn } from "../../lib/utils";
 import { PlotlyChart } from "./plotly-chart";
 import type { BaseChartProps, BaseSeries } from "./types";
-import { createPlotlyConfig, getRenderer, getPlotType, legendAnchorFor } from "./utils";
+import { useChartSizing } from "./use-is-compact";
+import {
+  createPlotlyConfig,
+  getRenderer,
+  getPlotType,
+  responsiveChrome,
+  tierAxisFontSizes,
+} from "./utils";
 
 export interface RadarSeriesData extends BaseSeries {
   r: number[];
@@ -63,6 +71,8 @@ export function RadarPlot({
   radialAxisVisible = true,
   angularAxisVisible = true,
 }: RadarPlotProps) {
+  const [containerRef, sizing] = useChartSizing<HTMLDivElement>();
+  const fontSizes = tierAxisFontSizes(sizing);
   const renderer = getRenderer(config.useWebGL);
   const plotType = getPlotType("scatterpolar", renderer);
 
@@ -121,18 +131,16 @@ export function RadarPlot({
       }) as any as PlotData,
   );
 
-  // Create polar layout for radar chart with responsive sizing
+  // Tier-aware chrome + the polar config createBaseLayout cannot provide.
   const layout = {
-    title: config.title ? { text: config.title } : undefined,
-    // Remove fixed width/height to allow container-based sizing
-    paper_bgcolor: config.backgroundColor || "white",
-    autosize: true, // Enable responsive sizing
+    ...responsiveChrome(config, sizing),
 
     polar: {
       radialaxis: {
         visible: radialAxisVisible,
         range: rangeMode === "tozero" ? [0, undefined] : undefined,
         rangemode: rangeMode,
+        tickfont: { size: fontSizes.tick },
         gridcolor: "#E6E6E6",
         linecolor: "#444",
         showgrid: config.showGrid !== false,
@@ -148,6 +156,7 @@ export function RadarPlot({
             }
           : {}),
         tickangle: tickAngle,
+        tickfont: { size: fontSizes.tick },
         direction: "clockwise",
         period: 360,
         gridcolor: "#E6E6E6",
@@ -156,15 +165,12 @@ export function RadarPlot({
       },
       gridshape: gridShape,
     },
-
-    showlegend: config.showLegend !== false,
-    legend: legendAnchorFor(config.legendPosition ?? "right"),
   } as any;
 
-  const plotConfig = createPlotlyConfig(config);
+  const plotConfig = createPlotlyConfig(config, sizing);
 
   return (
-    <div className={className}>
+    <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>
       <PlotlyChart
         data={plotData}
         layout={layout}

--- a/packages/ui/src/components/charts/ridge-plot.tsx
+++ b/packages/ui/src/components/charts/ridge-plot.tsx
@@ -7,7 +7,7 @@ import { cn } from "../../lib/utils";
 import { PlotlyChart } from "./plotly-chart";
 import type { BaseChartProps } from "./types";
 import { useChartSizing } from "./use-is-compact";
-import { createBaseLayout, createPlotlyConfig } from "./utils";
+import { createBaseLayout, createPlotlyConfig, truncateTickLabel } from "./utils";
 
 /**
  * One ridge, pre-computed by the caller. The wrapper just shapes Plotly
@@ -84,7 +84,8 @@ export function RidgePlot({
     ...layout.yaxis,
     tickmode: "array",
     tickvals: categoryTicks.map((t) => t.value),
-    ticktext: categoryTicks.map((t) => t.label),
+    // Ellipsize lane labels per tier so they cannot grow the left margin.
+    ticktext: categoryTicks.map((t) => truncateTickLabel(t.label, sizing)),
     showgrid: false,
     zeroline: false,
   };

--- a/packages/ui/src/components/charts/spc-control.tsx
+++ b/packages/ui/src/components/charts/spc-control.tsx
@@ -3,8 +3,10 @@
 import type { PlotData } from "plotly.js";
 import React from "react";
 
+import { cn } from "../../lib/utils";
 import { PlotlyChart } from "./plotly-chart";
 import type { BaseChartProps, BaseSeries } from "./types";
+import { useChartSizing } from "./use-is-compact";
 import { createPlotlyConfig, getRenderer, getPlotType, createBaseLayout } from "./utils";
 
 export interface SPCSeriesData extends BaseSeries {
@@ -56,6 +58,7 @@ export function SPCControlCharts({
   showSpecLimits = true,
   showCenterLine = true,
 }: SPCControlChartsProps) {
+  const [containerRef, sizing] = useChartSizing<HTMLDivElement>();
   const renderer = getRenderer(config.useWebGL);
   const plotType = getPlotType("scatter", renderer);
 
@@ -219,11 +222,11 @@ export function SPCControlCharts({
       : []),
   ];
 
-  const layout = createBaseLayout(config);
-  const plotConfig = createPlotlyConfig(config);
+  const layout = createBaseLayout(config, sizing);
+  const plotConfig = createPlotlyConfig(config, sizing);
 
   return (
-    <div className={className}>
+    <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>
       <PlotlyChart
         data={plotData}
         layout={layout}

--- a/packages/ui/src/components/charts/ternary.tsx
+++ b/packages/ui/src/components/charts/ternary.tsx
@@ -22,7 +22,7 @@ function ternaryAxisTitle(
   fontSize: number,
 ): { text: string; font?: SafeFont } {
   const normalized = typeof title === "string" ? { text: title } : (title ?? { text: fallback });
-  return { font: { size: fontSize }, ...normalized };
+  return { ...normalized, font: { size: fontSize, ...normalized.font } };
 }
 
 export interface TernarySeriesData extends BaseSeries {

--- a/packages/ui/src/components/charts/ternary.tsx
+++ b/packages/ui/src/components/charts/ternary.tsx
@@ -3,9 +3,27 @@
 import type { PlotData } from "plotly.js";
 import React from "react";
 
+import { cn } from "../../lib/utils";
 import { PlotlyChart } from "./plotly-chart";
 import type { BaseChartProps, BaseSeries, MarkerConfig, SafeFont } from "./types";
-import { createPlotlyConfig, getRenderer, getPlotType, legendAnchorFor } from "./utils";
+import { useChartSizing } from "./use-is-compact";
+import {
+  createPlotlyConfig,
+  getRenderer,
+  getPlotType,
+  responsiveChrome,
+  tierAxisFontSizes,
+} from "./utils";
+
+// Normalise string-or-object axis titles; a caller-provided font wins over the tier font.
+function ternaryAxisTitle(
+  title: string | { text: string; font?: SafeFont } | undefined,
+  fallback: string,
+  fontSize: number,
+): { text: string; font?: SafeFont } {
+  const normalized = typeof title === "string" ? { text: title } : (title ?? { text: fallback });
+  return { font: { size: fontSize }, ...normalized };
+}
 
 export interface TernarySeriesData extends BaseSeries {
   a: number[];
@@ -113,6 +131,8 @@ export function TernaryPlot({
   sum = 1,
   bgcolor = "white",
 }: TernaryPlotProps) {
+  const [containerRef, sizing] = useChartSizing<HTMLDivElement>();
+  const fontSizes = tierAxisFontSizes(sizing);
   const renderer = getRenderer(config.useWebGL);
   const plotType = getPlotType("scatterternary", renderer);
 
@@ -198,18 +218,16 @@ export function TernaryPlot({
   // Combine all traces - boundaries first (background), then scatter points (foreground) for proper layering
   const allTraces = [...boundaryTraces, ...plotData];
 
-  // Create ternary-specific layout using responsive base layout
+  // Tier-aware chrome + the ternary config createBaseLayout cannot provide.
   const baseLayout = {
-    title: config.title ? { text: config.title } : undefined,
-    // Remove fixed width/height to allow container-based sizing
-    paper_bgcolor: config.backgroundColor || "white",
+    ...responsiveChrome(config, sizing),
     plot_bgcolor: bgcolor,
-    autosize: true, // Enable responsive sizing
 
     ternary: {
       sum: sum,
       aaxis: {
-        title: typeof aaxis.title === "string" ? { text: aaxis.title } : aaxis.title || "A",
+        title: ternaryAxisTitle(aaxis.title, "A", fontSizes.axisTitle),
+        tickfont: { size: fontSizes.tick },
         min: aaxis.min || 0,
         max: aaxis.max || sum,
         tick0: aaxis.tick0 || 0,
@@ -221,7 +239,8 @@ export function TernaryPlot({
         showticklabels: aaxis.showticklabels !== false,
       },
       baxis: {
-        title: typeof baxis.title === "string" ? { text: baxis.title } : baxis.title || "B",
+        title: ternaryAxisTitle(baxis.title, "B", fontSizes.axisTitle),
+        tickfont: { size: fontSizes.tick },
         min: baxis.min || 0,
         max: baxis.max || sum,
         tick0: baxis.tick0 || 0,
@@ -233,7 +252,8 @@ export function TernaryPlot({
         showticklabels: baxis.showticklabels !== false,
       },
       caxis: {
-        title: typeof caxis.title === "string" ? { text: caxis.title } : caxis.title || "C",
+        title: ternaryAxisTitle(caxis.title, "C", fontSizes.axisTitle),
+        tickfont: { size: fontSizes.tick },
         min: caxis.min || 0,
         max: caxis.max || sum,
         tick0: caxis.tick0 || 0,
@@ -246,15 +266,12 @@ export function TernaryPlot({
       },
       bgcolor: bgcolor,
     },
-
-    showlegend: config.showLegend !== false,
-    legend: legendAnchorFor(config.legendPosition ?? "right"),
   } as any; // Layout type allows flexible property assignment
 
-  const plotConfig = createPlotlyConfig(config);
+  const plotConfig = createPlotlyConfig(config, sizing);
 
   return (
-    <div className={className}>
+    <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>
       <PlotlyChart
         data={allTraces}
         layout={baseLayout}
@@ -312,6 +329,8 @@ export function TernaryContour({
   caxis = {},
   sum = 1,
 }: TernaryContourProps) {
+  const [containerRef, sizing] = useChartSizing<HTMLDivElement>();
+  const fontSizes = tierAxisFontSizes(sizing);
   const renderer = getRenderer(config.useWebGL);
   const plotType = getPlotType("contourternary", renderer);
 
@@ -360,17 +379,15 @@ export function TernaryContour({
       }) as any as PlotData,
   );
 
-  // Create ternary-specific layout (similar to TernaryPlot) with responsive sizing
+  // Tier-aware chrome + the ternary config createBaseLayout cannot provide.
   const layout = {
-    title: config.title ? { text: config.title } : undefined,
-    // Remove fixed width/height to allow container-based sizing
-    paper_bgcolor: config.backgroundColor || "white",
-    autosize: true, // Enable responsive sizing
+    ...responsiveChrome(config, sizing),
 
     ternary: {
       sum: sum,
       aaxis: {
-        title: aaxis.title || "A",
+        title: ternaryAxisTitle(aaxis.title, "A", fontSizes.axisTitle),
+        tickfont: { size: fontSizes.tick },
         min: aaxis.min || 0,
         max: aaxis.max || sum,
         tick0: aaxis.tick0 || 0,
@@ -381,7 +398,8 @@ export function TernaryContour({
         showline: aaxis.showline !== false,
       },
       baxis: {
-        title: baxis.title || "B",
+        title: ternaryAxisTitle(baxis.title, "B", fontSizes.axisTitle),
+        tickfont: { size: fontSizes.tick },
         min: baxis.min || 0,
         max: baxis.max || sum,
         tick0: baxis.tick0 || 0,
@@ -392,7 +410,8 @@ export function TernaryContour({
         showline: baxis.showline !== false,
       },
       caxis: {
-        title: caxis.title || "C",
+        title: ternaryAxisTitle(caxis.title, "C", fontSizes.axisTitle),
+        tickfont: { size: fontSizes.tick },
         min: caxis.min || 0,
         max: caxis.max || sum,
         tick0: caxis.tick0 || 0,
@@ -403,15 +422,12 @@ export function TernaryContour({
         showline: caxis.showline !== false,
       },
     },
-
-    showlegend: config.showLegend !== false,
-    legend: legendAnchorFor(config.legendPosition ?? "right"),
   } as any; // Layout type allows flexible property assignment
 
-  const plotConfig = createPlotlyConfig(config);
+  const plotConfig = createPlotlyConfig(config, sizing);
 
   return (
-    <div className={className}>
+    <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>
       <PlotlyChart
         data={plotData}
         layout={layout}

--- a/packages/ui/src/components/charts/utils.ts
+++ b/packages/ui/src/components/charts/utils.ts
@@ -181,15 +181,17 @@ export function truncateCategoryTicks(
   const categories: string[] = [];
   for (const v of values) {
     if (v == null || v === "") continue;
-    const s = v instanceof Date ? v.toISOString() : String(v as string | number);
+    const s = v instanceof Date ? v.toISOString() : String(v);
     if (seen.has(s)) continue;
     seen.add(s);
     categories.push(s);
   }
 
   const maxChars = tierMaxTickChars(options);
+  const cap = tierTickCap(options);
   const needsTruncation = categories.some((c) => c.length > maxChars);
-  if (!needsTruncation) return axis;
+  const overCap = cap !== undefined && categories.length > cap;
+  if (!needsTruncation && !overCap) return axis;
 
   // Sample in display order so array-mode ticks stay evenly spaced; tick
   // positions anchor by value, so order only affects sampling evenness.
@@ -199,7 +201,6 @@ export function truncateCategoryTicks(
     : categories;
   if (order === "category descending") displayOrdered.reverse();
 
-  const cap = tierTickCap(options);
   const step =
     cap !== undefined && displayOrdered.length > cap ? Math.ceil(displayOrdered.length / cap) : 1;
   const sampled = displayOrdered.filter((_, i) => i % step === 0);
@@ -772,11 +773,17 @@ export function createPlotlyConfig(
  * bottom row keeps them when X is shared) and which should hide their
  * Y-axis title (only the leftmost column keeps it).
  */
-function cellPosition(
+export function cellPosition(
   cellIndex: number,
   rows: number,
   columns: number,
-): { row: number; column: number; isLastRow: boolean; isFirstColumn: boolean } {
+): {
+  row: number;
+  column: number;
+  isLastRow: boolean;
+  isFirstColumn: boolean;
+  isLastColumn: boolean;
+} {
   const row = Math.floor(cellIndex / columns);
   const column = cellIndex % columns;
   return {
@@ -784,6 +791,7 @@ function cellPosition(
     column,
     isLastRow: row === rows - 1,
     isFirstColumn: column === 0,
+    isLastColumn: column === columns - 1,
   };
 }
 

--- a/packages/ui/src/components/charts/utils.ts
+++ b/packages/ui/src/components/charts/utils.ts
@@ -127,6 +127,91 @@ export function refineAxisType(
   return base;
 }
 
+/** Sizing-tier flags shared by the tier-aware layout helpers. */
+export interface ChartTierOptions {
+  snug?: boolean;
+  compact?: boolean;
+  veryCompact?: boolean;
+  ultraCompact?: boolean;
+  cellSnug?: boolean;
+  cellCompact?: boolean;
+  cellVeryCompact?: boolean;
+  cellUltraCompact?: boolean;
+  hasColorbar?: boolean;
+}
+
+/** Max tick-label characters per cell tier before ellipsis kicks in. */
+function tierMaxTickChars(options: ChartTierOptions): number {
+  const cellVeryCompact = options.cellVeryCompact ?? options.veryCompact ?? false;
+  const cellCompact = options.cellCompact ?? options.compact ?? cellVeryCompact;
+  const cellSnug = options.cellSnug ?? options.snug ?? cellCompact;
+  return cellVeryCompact ? 8 : cellCompact ? 12 : cellSnug ? 18 : 24;
+}
+
+/** Tick-count cap per cell tier; mirrors `createBaseLayout`'s `nticks`. */
+function tierTickCap(options: ChartTierOptions): number | undefined {
+  const cellVeryCompact = options.cellVeryCompact ?? options.veryCompact ?? false;
+  const cellCompact = options.cellCompact ?? options.compact ?? cellVeryCompact;
+  const cellSnug = options.cellSnug ?? options.snug ?? cellCompact;
+  return cellVeryCompact ? 5 : cellCompact ? 8 : cellSnug ? 12 : undefined;
+}
+
+/** Ellipsize one tick label to the tier's char budget (for charts that build their own ticktext). */
+export function truncateTickLabel(label: string, options: ChartTierOptions = {}): string {
+  const maxChars = tierMaxTickChars(options);
+  return label.length > maxChars ? `${label.slice(0, Math.max(1, maxChars - 1))}…` : label;
+}
+
+/**
+ * Ellipsize long category tick labels so automargin cannot grow until the
+ * plot area collapses. Array tick mode disables Plotly's nticks thinning,
+ * so past the tier's tick cap every Nth category is sampled. Hover reads
+ * point data, not ticktext. No-op on non-category axes, explicit ticks,
+ * or when every label fits.
+ */
+export function truncateCategoryTicks(
+  axis: Partial<LayoutAxis>,
+  values: ReadonlyArray<unknown>,
+  options: ChartTierOptions = {},
+): Partial<LayoutAxis> {
+  if (axis.type !== "category") return axis;
+  if (axis.tickvals !== undefined || axis.ticktext !== undefined) return axis;
+
+  const seen = new Set<string>();
+  const categories: string[] = [];
+  for (const v of values) {
+    if (v == null || v === "") continue;
+    const s = v instanceof Date ? v.toISOString() : String(v as string | number);
+    if (seen.has(s)) continue;
+    seen.add(s);
+    categories.push(s);
+  }
+
+  const maxChars = tierMaxTickChars(options);
+  const needsTruncation = categories.some((c) => c.length > maxChars);
+  if (!needsTruncation) return axis;
+
+  // Sample in display order so array-mode ticks stay evenly spaced; tick
+  // positions anchor by value, so order only affects sampling evenness.
+  const order = typeof axis.categoryorder === "string" ? axis.categoryorder : "";
+  const displayOrdered = order.startsWith("category")
+    ? [...categories].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+    : categories;
+  if (order === "category descending") displayOrdered.reverse();
+
+  const cap = tierTickCap(options);
+  const step =
+    cap !== undefined && displayOrdered.length > cap ? Math.ceil(displayOrdered.length / cap) : 1;
+  const sampled = displayOrdered.filter((_, i) => i % step === 0);
+
+  return {
+    ...axis,
+    tickmode: "array",
+    tickvals: sampled,
+    ticktext: sampled.map((c) => truncateTickLabel(c, options)),
+  };
+}
+
 /**
  * Creates base layout for all charts with PlotlyChartConfig.
  *
@@ -466,6 +551,59 @@ export function createBaseLayout(
 }
 
 /**
+ * Coordinate-agnostic chrome slice of `createBaseLayout` (title, legend,
+ * margins, autosize). Non-cartesian charts (polar / ternary / carpet)
+ * spread this into their layouts without inheriting `xaxis` / `yaxis`.
+ */
+export function responsiveChrome(
+  config: PlotlyChartConfig,
+  options: ChartTierOptions = {},
+): Partial<Layout> {
+  const {
+    title,
+    showlegend,
+    legend,
+    hoverlabel,
+    margin,
+    autosize,
+    width,
+    height,
+    paper_bgcolor,
+    font,
+    hovermode,
+    dragmode,
+  } = createBaseLayout(config, options);
+  return {
+    title,
+    showlegend,
+    legend,
+    hoverlabel,
+    margin,
+    autosize,
+    ...(width !== undefined ? { width } : {}),
+    ...(height !== undefined ? { height } : {}),
+    paper_bgcolor,
+    font,
+    hovermode,
+    dragmode,
+  };
+}
+
+/** Tick / axis-title font sizes for a tier; mirrors `createBaseLayout`'s axes. */
+export function tierAxisFontSizes(options: ChartTierOptions = {}): {
+  tick: number;
+  axisTitle: number;
+} {
+  const veryCompact = options.veryCompact ?? false;
+  const compact = options.compact ?? veryCompact;
+  const snug = options.snug ?? compact;
+  return {
+    tick: veryCompact ? 9 : compact ? 10 : snug ? 11 : 12,
+    axisTitle: veryCompact ? 10 : compact ? 11 : snug ? 13 : 14,
+  };
+}
+
+/**
  * Creates subplot layout configuration
  */
 export function createSubplotLayout(config: PlotlyChartConfig): Partial<Layout> {
@@ -714,6 +852,8 @@ export function extendLayoutForFacets(
      * full) so titles shrink as cells get smaller.
      */
     titleFontSize?: number;
+    /** cellUltraCompact tier: drop all axis / cell / shared titles, ticks only. */
+    ultraCompactCells?: boolean;
   },
 ): Partial<Layout> {
   const xTemplate = baseLayout.xaxis as Record<string, unknown> | undefined;
@@ -735,6 +875,7 @@ export function extendLayoutForFacets(
   // per-cell axis title so it doesn't render on top of the shared one.
   const sharedXTitleOn = options.sharedXTitle === true;
   const sharedYTitleOn = options.sharedYTitle === true;
+  const ultraCompactCells = options.ultraCompactCells === true;
   for (let i = 0; i < cells.length; i++) {
     const cell = cells[i];
     const { isLastRow, isFirstColumn } = cellPosition(i, options.rows, options.columns);
@@ -749,13 +890,13 @@ export function extendLayoutForFacets(
       // every cell that's in the bottom row of its own column. When
       // `sharedXTitle` is on, suppress entirely (the grid emits a
       // single annotation below the whole canvas instead).
-      title: sharedXTitleOn ? undefined : isLastRow ? xTitle : undefined,
+      title: sharedXTitleOn || ultraCompactCells ? undefined : isLastRow ? xTitle : undefined,
     };
     // Y axis: same pattern, leftmost column carries the labels and title.
     const yOverrides: FacetAxisOverrides = {
       matches: !isFirstCell && options.sharedY !== false ? "y" : undefined,
       showticklabels: options.sharedY !== false ? isFirstColumn : undefined,
-      title: sharedYTitleOn ? undefined : isFirstColumn ? yTitle : undefined,
+      title: sharedYTitleOn || ultraCompactCells ? undefined : isFirstColumn ? yTitle : undefined,
     };
     // The unsuffixed `xaxis` / `yaxis` keys hold cell 0's config; the
     // numbered keys take cells 1..N-1. Plotly's grid pattern reads both.
@@ -778,7 +919,7 @@ export function extendLayoutForFacets(
   const existingAnnotations =
     (baseLayout.annotations as Array<Record<string, unknown>> | undefined) ?? [];
   const cellTitleFontSize = options.titleFontSize ?? 12;
-  const cellTitles = cells
+  const cellTitles = (ultraCompactCells ? [] : cells)
     .filter((c) => c.title.length > 0)
     .map((cell) => ({
       text: cell.title,
@@ -802,7 +943,7 @@ export function extendLayoutForFacets(
   const xTitleFont = (xTitle?.font as Record<string, unknown> | undefined) ?? { size: 14 };
   const yTitleFont = (yTitle?.font as Record<string, unknown> | undefined) ?? { size: 14 };
   const sharedTitles: Array<Record<string, unknown>> = [];
-  if (sharedXTitleOn && xTitle?.text) {
+  if (!ultraCompactCells && sharedXTitleOn && xTitle?.text) {
     sharedTitles.push({
       text: xTitle.text,
       xref: "paper",
@@ -818,7 +959,7 @@ export function extendLayoutForFacets(
       font: xTitleFont,
     });
   }
-  if (sharedYTitleOn && yTitle?.text) {
+  if (!ultraCompactCells && sharedYTitleOn && yTitle?.text) {
     sharedTitles.push({
       text: yTitle.text,
       xref: "paper",
@@ -840,7 +981,7 @@ export function extendLayoutForFacets(
   // Bump margin floors so paper-anchored shared titles aren't clipped.
   // Plotly's annotations don't participate in `automargin`, so we have
   // to reserve the band ourselves.
-  if (sharedXTitleOn || sharedYTitleOn) {
+  if (!ultraCompactCells && (sharedXTitleOn || sharedYTitleOn)) {
     const existingMargin = (out.margin as Record<string, number> | undefined) ?? {};
     out.margin = {
       ...existingMargin,

--- a/packages/ui/src/components/charts/violin-plot.tsx
+++ b/packages/ui/src/components/charts/violin-plot.tsx
@@ -178,6 +178,7 @@ export function ViolinPlot({
       sharedYTitle: effectiveSharedYTitle,
       roworder: subplots.roworder,
       titleFontSize: cellTitleFontSize,
+      ultraCompactCells: sizing.cellUltraCompact,
     });
     Object.assign(layout, faceted);
   }
@@ -186,7 +187,7 @@ export function ViolinPlot({
 
   applyReferenceLines(layout, config.referenceLines, { cells: subplots?.cells });
 
-  const plotConfig = createPlotlyConfig(config);
+  const plotConfig = createPlotlyConfig(config, sizing);
 
   return (
     <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>

--- a/packages/ui/src/components/charts/wind-rose.tsx
+++ b/packages/ui/src/components/charts/wind-rose.tsx
@@ -3,9 +3,11 @@
 import type { PlotData } from "plotly.js";
 import React from "react";
 
+import { cn } from "../../lib/utils";
 import { PlotlyChart } from "./plotly-chart";
 import type { BaseChartProps, BaseSeries } from "./types";
-import { createPlotlyConfig, legendAnchorFor } from "./utils";
+import { useChartSizing } from "./use-is-compact";
+import { createPlotlyConfig, responsiveChrome, tierAxisFontSizes } from "./utils";
 
 /**
  * Wind-rose series. Each series represents one **value band** (e.g.
@@ -66,6 +68,8 @@ export function WindRose({
   directionTicks = DEFAULT_DIRECTION_TICKS,
   radialAxisTitle = "Frequency",
 }: WindRoseProps) {
+  const [containerRef, sizing] = useChartSizing<HTMLDivElement>();
+  const fontSizes = tierAxisFontSizes(sizing);
   const plotData: PlotData[] = data.map(
     (series) =>
       ({
@@ -104,12 +108,9 @@ export function WindRose({
   const tickText =
     directionLabels.length > 0 ? directionLabels : directionTicks.map((deg) => `${deg}°`);
 
+  // Tier-aware chrome + the polar config createBaseLayout cannot provide.
   const layout = {
-    title: config.title ? { text: config.title } : undefined,
-    paper_bgcolor: config.backgroundColor || "white",
-    autosize: true,
-    showlegend: config.showLegend !== false,
-    legend: legendAnchorFor(config.legendPosition ?? "right"),
+    ...responsiveChrome(config, sizing),
     // Stack value-band segments within each direction slice (the
     // canonical wind-rose rendering). `barmode: "stack"` is read by
     // both cartesian bar traces and barpolar.
@@ -117,7 +118,8 @@ export function WindRose({
     polar: {
       bgcolor: "white",
       radialaxis: {
-        title: { text: radialAxisTitle },
+        title: { text: radialAxisTitle, font: { size: fontSizes.axisTitle } },
+        tickfont: { size: fontSizes.tick },
         // East-pointing radial axis: avoids the north overlap with bars.
         angle: 0,
         tickangle: 0,
@@ -135,16 +137,17 @@ export function WindRose({
         tickmode: "array",
         tickvals: directionTicks,
         ticktext: tickText,
+        tickfont: { size: fontSizes.tick },
         gridcolor: "#E6E6E6",
         showgrid: config.showGrid !== false,
       },
     },
   } as unknown as Partial<import("plotly.js").Layout>;
 
-  const plotConfig = createPlotlyConfig(config);
+  const plotConfig = createPlotlyConfig(config, sizing);
 
   return (
-    <div className={className}>
+    <div ref={containerRef} className={cn("flex h-full w-full flex-col", className)}>
       <PlotlyChart
         data={plotData}
         layout={layout}


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

A batch of fixes for how charts render and stay correct on a dashboard, where they are small, dense, and driven by saved state rather than the live editor.

### Charts rescale to their container

Every non-cartesian and scientific wrapper (polar, radar, ternary, wind-rose, carpet, heatmap, correlation matrix, contour, density, ridge, parallel-coordinates/categories, alluvial, histogram-2d, SPC) now reads its container size and adapts to it; previously only cartesian charts did, so these rendered at fixed sizes and overflowed or clipped in dashboard cells. Two shared helpers back this: `responsiveChrome` (the coordinate-agnostic title/legend/margin/font slice of the base layout, so polar/ternary/carpet charts get tier-aware chrome without inheriting cartesian axes) and `tierAxisFontSizes` (per-tier tick and axis-title sizes). Long category tick labels are ellipsized per tier so Plotly's automargin can't grow until it eats the plot area, and past a tier's tick cap every Nth category is sampled. Faceted grids gain an ultra-compact tier that drops cell/axis/shared titles and keeps ticks only.

### WebGL context exhaustion

Grouped cartesian charts forced a WebGL trace per category, and a dashboard full of them exhausted the browser's WebGL context pool, making the data layer vanish on context loss. WebGL now auto-enables only past a point-count threshold, so small grouped charts stay on SVG and cost no context.

### Correlation matrix fetched wrong data from saved state

The corr aggregation was only seeded while editing, so a saved dashboard fetched raw rows and rendered an all-NaN matrix. The renderer now derives the pairwise corr functions itself, sharing one helper with the shelf so both agree on the projection.

### Contributor anonymization

Toggling anonymization re-pseudonymizes ids and names server-side. The update hook now invalidates the cached distinct-values and visualization-data reads so filters and charts refresh without a hard reload; a categorical filter drops a selected contributor id once the reloaded list no longer contains it (guarded to complete lists); and the color-map keys and labels overrides by contributor name so they keep matching what the chart looks up. STRUCT-to-name flattening is unified in one converter.

### Other correctness fixes

- Categorical color with multiple Y series: legendgroup keyed per (series × category) so every combo gets its own legend entry instead of collapsing to the first.
- Faceted dual-Y: secondary-axis series route onto a per-cell overlay axis instead of colliding with the primary grid axes.
- Numeric heatmap/contour and carpet axes sort ascending regardless of row order; shuffled rows previously scrambled iso-lines and non-monotonic carpet axes crashed Plotly's `contourcarpet`.
- Carpet `reverseScale` now reaches the trace and `showGrid` changes re-render (missing memo dependency).
