### PR TITLE
fix(dashboards): key filter context on filter-widget content so rich-text keystrokes don't re-render every chart

### DIFF
--- a/apps/web/components/experiment-dashboards/dashboard-filters-context.test.tsx
+++ b/apps/web/components/experiment-dashboards/dashboard-filters-context.test.tsx
@@ -1,10 +1,10 @@
-import { createFilterWidget } from "@/test/factories";
+import { createFilterWidget, createRichTextWidget } from "@/test/factories";
 import { render, screen, act } from "@/test/test-utils";
 import { renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
 
-import type { DashboardWidget } from "@repo/api/schemas/experiment.schema";
+import type { DashboardWidget, DataFilter } from "@repo/api/schemas/experiment.schema";
 
 import {
   DashboardFiltersProvider,
@@ -232,5 +232,51 @@ describe("useDashboardFilterWidget", () => {
     expect(result.current.merged).toEqual([
       { column: "device_id", operator: "equals", value: "D9" },
     ]);
+  });
+
+  it("keeps the merged-filter identity stable when a non-filter widget churns", () => {
+    const filterWidget = createFilterWidget({
+      config: {
+        tableName: "raw_data",
+        column: "device_id",
+        operator: "equals",
+        defaultValue: "D1",
+      },
+    });
+    const richText = createRichTextWidget({ config: { html: "<p>a</p>" } });
+
+    function Harness({ widgets }: { widgets: DashboardWidget[] }) {
+      return (
+        <DashboardFiltersProvider widgets={widgets}>
+          <Probe />
+        </DashboardFiltersProvider>
+      );
+    }
+    const captured: DataFilter[][] = [];
+    function Probe() {
+      captured.push(useDashboardFiltersForTable("raw_data"));
+      return null;
+    }
+
+    const { rerender } = render(<Harness widgets={[filterWidget, richText]} />);
+    // Simulate an editor keystroke: fresh array + fresh widget objects, only
+    // the rich-text html changed.
+    rerender(
+      <Harness widgets={[{ ...filterWidget }, { ...richText, config: { html: "<p>ab</p>" } }]} />,
+    );
+    expect(captured.length).toBeGreaterThanOrEqual(2);
+    expect(captured.at(-1)).toBe(captured[0]);
+
+    // Control: a filter-widget change must still invalidate.
+    rerender(
+      <Harness
+        widgets={[
+          { ...filterWidget, config: { ...filterWidget.config, defaultValue: "D2" } },
+          richText,
+        ]}
+      />,
+    );
+    expect(captured.at(-1)).not.toBe(captured[0]);
+    expect(captured.at(-1)).toEqual([{ column: "device_id", operator: "equals", value: "D2" }]);
   });
 });

--- a/apps/web/components/experiment-dashboards/dashboard-filters-context.tsx
+++ b/apps/web/components/experiment-dashboards/dashboard-filters-context.tsx
@@ -40,7 +40,7 @@ interface DashboardFiltersProviderProps {
 export function DashboardFiltersProvider({ widgets, children }: DashboardFiltersProviderProps) {
   const [overrides, setOverrides] = useState<OverrideMap>({});
 
-  const filterWidgetsById = useMemo(() => indexFilterWidgets(widgets), [widgets]);
+  const filterWidgetsById = useFilterWidgetIndex(widgets);
 
   useGarbageCollectStaleOverrides(filterWidgetsById, setOverrides);
 
@@ -147,6 +147,23 @@ function indexFilterWidgets(widgets: DashboardWidget[]): Map<string, FilterWidge
     }
   }
   return map;
+}
+
+/**
+ * Index keyed on filter-widget CONTENT, not `widgets` identity. The editor
+ * form emits a fresh widgets array on every keystroke in any widget (e.g.
+ * rich-text html); an identity-keyed memo would rebuild the index, churn the
+ * context value, and re-render every chart on the dashboard per input.
+ */
+function useFilterWidgetIndex(widgets: DashboardWidget[]): Map<string, FilterWidget> {
+  const filterWidgets = widgets.filter((widget) => widget.type === "filter");
+  const signature = JSON.stringify(filterWidgets);
+
+  const indexRef = useRef<{ signature: string; map: Map<string, FilterWidget> } | null>(null);
+  if (indexRef.current?.signature !== signature) {
+    indexRef.current = { signature, map: indexFilterWidgets(filterWidgets) };
+  }
+  return indexRef.current.map;
 }
 
 function resolveWidgetValue(


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)