### PR TITLE
fix(data): drop persist in parquet upload, unsupported on serverless compute

### DIFF
--- a/apps/data/src/tasks/data_upload_task.py
+++ b/apps/data/src/tasks/data_upload_task.py
@@ -245,13 +245,10 @@ def process_parquet_upload() -> dict:
     except Exception:
         pass
 
-    # count() and write() are separate actions; cache so the sources are read once.
-    result.persist()
-    try:
-        row_count = result.count()
-        result.write.mode("overwrite").parquet(output_path)
-    finally:
-        result.unpersist()
+    result.write.mode("overwrite").parquet(output_path)
+    # Count the written output instead of result: a second action on the plan
+    # would recompute it, and persist/cache is unsupported on serverless compute.
+    row_count = spark.read.parquet(output_path).count()
 
     logger.info(f"Saved {row_count} rows to {output_path}")
     return {


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## OJD-1490