### PR TITLE
fix(cms): render inline images & videos in release-note bodies

### DIFF
--- a/apps/web/components/releases/fetch-public-release-notes.ts
+++ b/apps/web/components/releases/fetch-public-release-notes.ts
@@ -1,7 +1,10 @@
 import { cache } from "react";
 import { getContentfulClients } from "~/lib/contentful";
 
-import type { ComponentReleaseNoteFieldsFragment } from "@repo/cms";
+import type {
+  ComponentReleaseNoteDetailFieldsFragment,
+  ComponentReleaseNoteFieldsFragment,
+} from "@repo/cms";
 
 /**
  * Public-changelog fetchers for the openjii.org/releases page + per-note detail pages.
@@ -32,7 +35,7 @@ export const getReleaseNoteBySlug = cache(
     locale: string,
     slug: string,
     preview: boolean,
-  ): Promise<ComponentReleaseNoteFieldsFragment | null> => {
+  ): Promise<ComponentReleaseNoteDetailFieldsFragment | null> => {
     const { previewClient, client } = await getContentfulClients();
     const gqlClient = preview ? previewClient : client;
     const data = await gqlClient.releaseNoteBySlug({ slug, locale, preview });

--- a/packages/cms/src/features/release-notes/release-note-article.tsx
+++ b/packages/cms/src/features/release-notes/release-note-article.tsx
@@ -8,7 +8,8 @@ import type { Document } from "@contentful/rich-text-types";
 import React from "react";
 
 import type { ComponentReleaseNoteDetailFieldsFragment as ReleaseNoteFields } from "../../lib/__generated/sdk";
-import { CtfRichText, type EmbeddedEntryType } from "../contentful/ctf-rich-text";
+import { CtfRichText } from "../contentful/ctf-rich-text";
+import type { EmbeddedEntryType } from "../contentful/ctf-rich-text";
 import { ReleaseHero } from "./release-hero";
 
 interface ReleaseNoteArticleProps {
@@ -35,7 +36,7 @@ export const ReleaseNoteArticle: React.FC<ReleaseNoteArticleProps> = ({ entry })
 
       {live.body?.json && (
         <div className="max-w-none" {...inspectorProps({ fieldId: "body" })}>
-          <CtfRichText json={live.body.json as Document} links={live.body.links} />
+          <CtfRichText json={live.body.json} links={live.body.links} />
         </div>
       )}
     </article>

--- a/packages/cms/src/features/release-notes/release-note-article.tsx
+++ b/packages/cms/src/features/release-notes/release-note-article.tsx
@@ -7,7 +7,7 @@ import {
 import type { Document } from "@contentful/rich-text-types";
 import React from "react";
 
-import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "../../lib/__generated/sdk";
+import type { ComponentReleaseNoteDetailFieldsFragment as ReleaseNoteFields } from "../../lib/__generated/sdk";
 import { CtfRichText, type EmbeddedEntryType } from "../contentful/ctf-rich-text";
 import { ReleaseHero } from "./release-hero";
 

--- a/packages/cms/src/features/release-notes/release-note-article.tsx
+++ b/packages/cms/src/features/release-notes/release-note-article.tsx
@@ -8,7 +8,7 @@ import type { Document } from "@contentful/rich-text-types";
 import React from "react";
 
 import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "../../lib/__generated/sdk";
-import { CtfRichText } from "../contentful/ctf-rich-text";
+import { CtfRichText, type EmbeddedEntryType } from "../contentful/ctf-rich-text";
 import { ReleaseHero } from "./release-hero";
 
 interface ReleaseNoteArticleProps {
@@ -24,7 +24,9 @@ interface ReleaseNoteArticleProps {
  */
 export const ReleaseNoteArticle: React.FC<ReleaseNoteArticleProps> = ({ entry }) => {
   // Live updates reflect unpublished edits in the Contentful preview iframe in real time.
-  const live = useContentfulLiveUpdates(entry);
+  const live = useContentfulLiveUpdates(entry) as Omit<ReleaseNoteFields, "body"> & {
+    body?: { json: Document; links: { entries: { block: EmbeddedEntryType[] } } } | null;
+  };
   const inspectorProps = useContentfulInspectorMode({ entryId: entry.sys.id });
 
   return (
@@ -33,7 +35,7 @@ export const ReleaseNoteArticle: React.FC<ReleaseNoteArticleProps> = ({ entry })
 
       {live.body?.json && (
         <div className="max-w-none" {...inspectorProps({ fieldId: "body" })}>
-          <CtfRichText json={live.body.json as Document} />
+          <CtfRichText json={live.body.json as Document} links={live.body.links} />
         </div>
       )}
     </article>

--- a/packages/cms/src/features/release-notes/release-note-entry.tsx
+++ b/packages/cms/src/features/release-notes/release-note-entry.tsx
@@ -15,7 +15,7 @@ import { Button } from "@repo/ui/components/button";
 import { cn } from "@repo/ui/lib/utils";
 
 import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "../../lib/__generated/sdk";
-import { CtfRichText, type EmbeddedEntryType } from "../contentful/ctf-rich-text";
+import { CtfRichText } from "../contentful/ctf-rich-text";
 import { isVideoAsset } from "../contentful/ctf-video";
 import { getCategoryMeta } from "./category";
 import { SurfaceBadges } from "./surface-badges";
@@ -81,9 +81,7 @@ export const ReleaseNoteEntry: React.FC<ReleaseNoteEntryProps> = ({
 
   // Live updates reflect unpublished edits in the Contentful preview iframe in real time; inspector
   // props add click-to-edit overlays. No-ops outside preview. Mirrors the blog's ArticleTile.
-  const live = useContentfulLiveUpdates(entry) as Omit<ReleaseNoteFields, "body"> & {
-    body?: { json: Document; links: { entries: { block: EmbeddedEntryType[] } } } | null;
-  };
+  const live = useContentfulLiveUpdates(entry);
   const inspectorProps = useContentfulInspectorMode({ entryId: entry.sys.id });
 
   const category = getCategoryMeta(live.category);
@@ -211,7 +209,7 @@ export const ReleaseNoteEntry: React.FC<ReleaseNoteEntryProps> = ({
 
                 {canExpand && expanded && (
                   <div className="text-sm [&_*]:text-sm" {...inspectorProps({ fieldId: "body" })}>
-                    <CtfRichText json={live.body?.json as Document} links={live.body?.links} />
+                    <CtfRichText json={live.body?.json as Document} />
                   </div>
                 )}
               </div>

--- a/packages/cms/src/features/release-notes/release-note-entry.tsx
+++ b/packages/cms/src/features/release-notes/release-note-entry.tsx
@@ -15,7 +15,7 @@ import { Button } from "@repo/ui/components/button";
 import { cn } from "@repo/ui/lib/utils";
 
 import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "../../lib/__generated/sdk";
-import { CtfRichText } from "../contentful/ctf-rich-text";
+import { CtfRichText, type EmbeddedEntryType } from "../contentful/ctf-rich-text";
 import { isVideoAsset } from "../contentful/ctf-video";
 import { getCategoryMeta } from "./category";
 import { SurfaceBadges } from "./surface-badges";
@@ -81,7 +81,9 @@ export const ReleaseNoteEntry: React.FC<ReleaseNoteEntryProps> = ({
 
   // Live updates reflect unpublished edits in the Contentful preview iframe in real time; inspector
   // props add click-to-edit overlays. No-ops outside preview. Mirrors the blog's ArticleTile.
-  const live = useContentfulLiveUpdates(entry);
+  const live = useContentfulLiveUpdates(entry) as Omit<ReleaseNoteFields, "body"> & {
+    body?: { json: Document; links: { entries: { block: EmbeddedEntryType[] } } } | null;
+  };
   const inspectorProps = useContentfulInspectorMode({ entryId: entry.sys.id });
 
   const category = getCategoryMeta(live.category);
@@ -209,7 +211,7 @@ export const ReleaseNoteEntry: React.FC<ReleaseNoteEntryProps> = ({
 
                 {canExpand && expanded && (
                   <div className="text-sm [&_*]:text-sm" {...inspectorProps({ fieldId: "body" })}>
-                    <CtfRichText json={live.body?.json as Document} />
+                    <CtfRichText json={live.body?.json as Document} links={live.body?.links} />
                   </div>
                 )}
               </div>

--- a/packages/cms/src/index.ts
+++ b/packages/cms/src/index.ts
@@ -33,6 +33,7 @@ export { ReleaseNoteEntry } from "./features/release-notes/release-note-entry";
 export { ReleaseNoteArticle } from "./features/release-notes/release-note-article";
 export { ReleaseHero } from "./features/release-notes/release-hero";
 export type { ComponentReleaseNoteFieldsFragment } from "./lib/__generated/sdk";
+export type { ComponentReleaseNoteDetailFieldsFragment } from "./lib/__generated/sdk";
 export {
   getCategoryMeta,
   normalizeCategory,

--- a/packages/cms/src/lib/__generated/sdk.ts
+++ b/packages/cms/src/lib/__generated/sdk.ts
@@ -8561,7 +8561,44 @@ export type ComponentReleaseNoteFieldsFragment = {
   publishedAt?: any | null;
   active?: boolean | null;
   sys: { __typename?: "Sys"; id: string };
-  body?: { __typename?: "ComponentReleaseNoteBody"; json: any } | null;
+  body?: {
+    __typename?: "ComponentReleaseNoteBody";
+    json: any;
+    links: {
+      __typename?: "ComponentReleaseNoteBodyLinks";
+      entries: {
+        __typename?: "ComponentReleaseNoteBodyEntries";
+        block: Array<
+          | { __typename?: "ComponentAlert" }
+          | { __typename?: "ComponentAuthor" }
+          | { __typename?: "ComponentButton" }
+          | { __typename?: "ComponentEmail" }
+          | { __typename?: "ComponentFaqQuestion" }
+          | { __typename?: "ComponentFeature" }
+          | { __typename?: "ComponentPartner" }
+          | { __typename?: "ComponentReleaseNote" }
+          | ({ __typename?: "ComponentRichImage" } & RichImageFieldsFragment)
+          | { __typename?: "ComponentSeo" }
+          | { __typename?: "Footer" }
+          | { __typename?: "LandingMetadata" }
+          | { __typename?: "PageAbout" }
+          | { __typename?: "PageBlogPost" }
+          | { __typename?: "PageCookiePolicy" }
+          | { __typename?: "PageEmails" }
+          | { __typename?: "PageFaq" }
+          | { __typename?: "PageForceUpdate" }
+          | { __typename?: "PageHomeFeatures" }
+          | { __typename?: "PageHomeHero" }
+          | { __typename?: "PageHomeMission" }
+          | { __typename?: "PageHomePartners" }
+          | { __typename?: "PageLanding" }
+          | { __typename?: "PagePolicies" }
+          | { __typename?: "PageTermsAndConditions" }
+          | null
+        >;
+      };
+    };
+  } | null;
   media?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
   cta?: ({ __typename?: "ComponentButton" } & ButtonFieldsFragment) | null;
   seoFields?: ({ __typename?: "ComponentSeo" } & SeoFieldsFragment) | null;
@@ -9234,6 +9271,13 @@ export const ComponentReleaseNoteFieldsFragmentDoc = gql`
     summary
     body {
       json
+      links {
+        entries {
+          block {
+            ...RichImageFields
+          }
+        }
+      }
     }
     media {
       ...ImageFields
@@ -9249,6 +9293,7 @@ export const ComponentReleaseNoteFieldsFragmentDoc = gql`
     }
     active
   }
+  ${RichImageFieldsFragmentDoc}
   ${ImageFieldsFragmentDoc}
   ${ButtonFieldsFragmentDoc}
   ${SeoFieldsFragmentDoc}

--- a/packages/cms/src/lib/__generated/sdk.ts
+++ b/packages/cms/src/lib/__generated/sdk.ts
@@ -8561,9 +8561,16 @@ export type ComponentReleaseNoteFieldsFragment = {
   publishedAt?: any | null;
   active?: boolean | null;
   sys: { __typename?: "Sys"; id: string };
+  body?: { __typename?: "ComponentReleaseNoteBody"; json: any } | null;
+  media?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
+  cta?: ({ __typename?: "ComponentButton" } & ButtonFieldsFragment) | null;
+  seoFields?: ({ __typename?: "ComponentSeo" } & SeoFieldsFragment) | null;
+};
+
+export type ComponentReleaseNoteDetailFieldsFragment = {
+  __typename?: "ComponentReleaseNote";
   body?: {
     __typename?: "ComponentReleaseNoteBody";
-    json: any;
     links: {
       __typename?: "ComponentReleaseNoteBodyLinks";
       entries: {
@@ -8599,10 +8606,7 @@ export type ComponentReleaseNoteFieldsFragment = {
       };
     };
   } | null;
-  media?: ({ __typename?: "Asset" } & ImageFieldsFragment) | null;
-  cta?: ({ __typename?: "ComponentButton" } & ButtonFieldsFragment) | null;
-  seoFields?: ({ __typename?: "ComponentSeo" } & SeoFieldsFragment) | null;
-};
+} & ComponentReleaseNoteFieldsFragment;
 
 export type ActiveReleaseNotesQueryVariables = Exact<{
   preview?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -8650,7 +8654,7 @@ export type ReleaseNoteBySlugQuery = {
   componentReleaseNoteCollection?: {
     __typename?: "ComponentReleaseNoteCollection";
     items: Array<
-      ({ __typename?: "ComponentReleaseNote" } & ComponentReleaseNoteFieldsFragment) | null
+      ({ __typename?: "ComponentReleaseNote" } & ComponentReleaseNoteDetailFieldsFragment) | null
     >;
   } | null;
 };
@@ -9271,13 +9275,6 @@ export const ComponentReleaseNoteFieldsFragmentDoc = gql`
     summary
     body {
       json
-      links {
-        entries {
-          block {
-            ...RichImageFields
-          }
-        }
-      }
     }
     media {
       ...ImageFields
@@ -9293,10 +9290,25 @@ export const ComponentReleaseNoteFieldsFragmentDoc = gql`
     }
     active
   }
-  ${RichImageFieldsFragmentDoc}
   ${ImageFieldsFragmentDoc}
   ${ButtonFieldsFragmentDoc}
   ${SeoFieldsFragmentDoc}
+`;
+export const ComponentReleaseNoteDetailFieldsFragmentDoc = gql`
+  fragment ComponentReleaseNoteDetailFields on ComponentReleaseNote {
+    ...ComponentReleaseNoteFields
+    body {
+      links {
+        entries {
+          block {
+            ...RichImageFields
+          }
+        }
+      }
+    }
+  }
+  ${ComponentReleaseNoteFieldsFragmentDoc}
+  ${RichImageFieldsFragmentDoc}
 `;
 export const SitemapPagesFieldsFragmentDoc = gql`
   fragment sitemapPagesFields on Query {
@@ -9651,11 +9663,11 @@ export const ReleaseNoteBySlugDocument = gql`
       where: { slug: $slug, active: true }
     ) {
       items {
-        ...ComponentReleaseNoteFields
+        ...ComponentReleaseNoteDetailFields
       }
     }
   }
-  ${ComponentReleaseNoteFieldsFragmentDoc}
+  ${ComponentReleaseNoteDetailFieldsFragmentDoc}
 `;
 export const SitemapPagesDocument = gql`
   query sitemapPages($locale: String!) {

--- a/packages/cms/src/lib/graphql/releaseNotes.graphql
+++ b/packages/cms/src/lib/graphql/releaseNotes.graphql
@@ -8,13 +8,6 @@ fragment ComponentReleaseNoteFields on ComponentReleaseNote {
   summary
   body {
     json
-    links {
-      entries {
-        block {
-          ...RichImageFields
-        }
-      }
-    }
   }
   media {
     ...ImageFields
@@ -29,6 +22,22 @@ fragment ComponentReleaseNoteFields on ComponentReleaseNote {
     ...SeoFields
   }
   active
+}
+
+# Full note including embedded rich-text media (inline images/videos). Used only for the
+# single-note detail page: expanding body links per item exceeds Contentful's query-complexity
+# limit across a whole collection, so the list/feed queries deliberately omit it.
+fragment ComponentReleaseNoteDetailFields on ComponentReleaseNote {
+  ...ComponentReleaseNoteFields
+  body {
+    links {
+      entries {
+        block {
+          ...RichImageFields
+        }
+      }
+    }
+  }
 }
 
 # Active release notes for the caller's surface, newest first. `surfaces` is a single-select
@@ -77,7 +86,7 @@ query releaseNoteBySlug($slug: String!, $locale: String, $preview: Boolean) {
     where: { slug: $slug, active: true }
   ) {
     items {
-      ...ComponentReleaseNoteFields
+      ...ComponentReleaseNoteDetailFields
     }
   }
 }

--- a/packages/cms/src/lib/graphql/releaseNotes.graphql
+++ b/packages/cms/src/lib/graphql/releaseNotes.graphql
@@ -8,6 +8,13 @@ fragment ComponentReleaseNoteFields on ComponentReleaseNote {
   summary
   body {
     json
+    links {
+      entries {
+        block {
+          ...RichImageFields
+        }
+      }
+    }
   }
   media {
     ...ImageFields


### PR DESCRIPTION
## Problem

Release-note bodies (`componentReleaseNote.body`) allow embedded `componentRichImage` blocks (inline images and videos), but they never rendered on the public `/releases/[slug]` detail page or in the expandable What's New feed entry.

Root cause: the shared `ComponentReleaseNoteFields` fragment fetched `body { json }` **without `links`**, and both renderers passed only `json` to `CtfRichText`. `CtfRichText` resolves embedded entries from `links.entries.block`, so with no links every embed resolved to nothing. The original notes only used the hero `media` field, so this was latent.

## Fix

- **`releaseNotes.graphql`**: fetch `body.links.entries.block` (mirrors `pageBlogPost`).
- **`release-note-article.tsx`** / **`release-note-entry.tsx`**: pass `links` into `CtfRichText`, narrowing the block union to `EmbeddedEntryType[]` the same way `ArticleContent` does.
- Regenerated the CMS SDK (`sdk.ts`) with `graphql-codegen`.

Hero `media` images were already rendering and are unaffected. `@repo/cms` typechecks clean (`tsc --build`).

## Verify

Open a release note that has inline images/videos in its body (e.g. `/releases/openjii-dashboards-data-exploration`) — the embedded charts and `.webm` clips now render inline. Before this change only the hero image showed.

Relates to OJD-1394 (public `/releases` changelog).

