### PR TITLE
feat(web): public site logo, footer, and padding tweaks

### DIFF
--- a/apps/web/app/[locale]/(info)/layout.tsx
+++ b/apps/web/app/[locale]/(info)/layout.tsx
@@ -32,7 +32,7 @@ export default async function InfoGroupLayout({ children, params }: InfoLayoutPr
     <>
       <UnifiedNavbar locale={locale} session={session} />
       <div className="mx-auto flex w-full max-w-7xl justify-center">
-        <main className="flex min-h-screen w-full flex-col px-4">{children}</main>
+        <main className="flex min-h-screen w-full flex-col px-2">{children}</main>
       </div>
       {footerData && <HomeFooter footerData={footerData} preview={preview} locale={locale} />}
       <Toaster />

--- a/apps/web/components/navigation/unified-navbar/unified-navbar.tsx
+++ b/apps/web/components/navigation/unified-navbar/unified-navbar.tsx
@@ -241,17 +241,22 @@ export function UnifiedNavbar({ locale, session, isHomePage = false }: UnifiedNa
 
   const showSolid = (isHomePage && !isIntersecting) || isGreenMode;
 
+  // Home nav sits over the dark hero (white logo); every other page uses the yellow platform logo
+  const logoSrc = isHomePage
+    ? "/openJII-logo-BW-horizontal-white.png"
+    : "/openJII_logo_RGB_horizontal_yellow_transparentBG.png";
+
   return (
     <header
       className="pointer-events-auto sticky left-0 z-50 w-full"
       style={{ top: "var(--banner-offset, 0px)" }}
     >
-      {/* Gradient layer — hero/dark mode */}
+      {/* Gradient layer - hero/dark mode */}
       <div
         aria-hidden="true"
-        className={`absolute inset-0 -z-10 bg-gradient-to-b from-black/80 to-transparent transition-opacity duration-300 ${showSolid ? "opacity-0" : "opacity-100"}`}
+        className={`bg-linear-to-b absolute inset-0 -z-10 from-black/80 to-transparent transition-opacity duration-300 ${showSolid ? "opacity-0" : "opacity-100"}`}
       />
-      {/* Solid layer — green/nav mode */}
+      {/* Solid layer - green/nav mode */}
       <div
         aria-hidden="true"
         className={`bg-sidebar absolute inset-0 -z-10 border-b border-white/40 shadow-lg transition-opacity duration-300 ${showSolid ? "opacity-100" : "opacity-0"}`}
@@ -260,11 +265,11 @@ export function UnifiedNavbar({ locale, session, isHomePage = false }: UnifiedNa
         {/* Logo/Brand */}
         <div className="col-start-1 col-end-2 flex items-center">
           <Image
-            src="/openJII-logo-BW-vertical-white.png"
+            src={logoSrc}
             alt="openJII logo"
-            width={210}
-            height={52}
-            className="h-11 w-auto"
+            width={isHomePage ? 94 : 150}
+            height={44}
+            className="h-11 w-auto max-w-none shrink-0"
           />
         </div>
 

--- a/packages/cms/src/features/footer.tsx
+++ b/packages/cms/src/features/footer.tsx
@@ -72,12 +72,12 @@ export const HomeFooter: React.FC<HomeFooterProps> = ({ footerData, preview, loc
           {/* openJII Brand/Description aligned left */}
           <div className="flex flex-col items-start">
             <Image
-              src="/openJII-logo-BW-horizontal-white.png"
+              src="/openJII_logo_RGB_horizontal_yellow_transparentBG.png"
               alt="openJII Logo"
-              width={140}
-              height={80}
+              width={170}
+              height={50}
               priority
-              className="-ml-2 -mt-3"
+              className="mb-3 h-12 w-auto"
             />
             <p
               className="mb-4 leading-relaxed text-white"
@@ -121,6 +121,13 @@ export const HomeFooter: React.FC<HomeFooterProps> = ({ footerData, preview, loc
             <p className="text-sm text-white" {...inspectorProps({ fieldId: "copyright" })}>
               {currentFooter.copyright}
             </p>
+            <span className="hidden text-white sm:inline">•</span>
+            <Link
+              href={buildHref("/releases")}
+              className="hover:text-jii-bright-green text-sm text-white transition-colors"
+            >
+              Releases
+            </Link>
             <span className="hidden text-white sm:inline">•</span>
             <Link
               href={buildHref("/cookie-settings")}

--- a/packages/cms/src/shared/container.tsx
+++ b/packages/cms/src/shared/container.tsx
@@ -3,5 +3,5 @@ import type { HTMLProps } from "react";
 import { cn } from "@repo/ui/lib/utils";
 
 export const Container = ({ className, ...props }: HTMLProps<HTMLDivElement>) => {
-  return <div className={cn("max-w-8xl mx-auto px-4", className)} {...props} />;
+  return <div className={cn("max-w-8xl mx-auto", className)} {...props} />;
 };


### PR DESCRIPTION
## What

Small visual tweaks to the public (logged-out) marketing pages.

- **Footer logo** now uses the yellow platform variant (was the white one), matching the authenticated platform sidebar.
- **Navbar logo**: the horizontal wordmark now lives in the nav. The home page keeps **white** (the nav floats over the dark hero); every other page uses **yellow** (solid green bar).
- **Mobile navbar logo** no longer squishes on narrow screens. Tailwind's `img { max-width: 100% }` plus the 3-column grid capped the width while the height stayed fixed; `max-w-none` lets it keep its aspect ratio.
- **Padding**: the `(info)` layout `<main>` and the shared `Container` both applied `px-4`, double-padding every info page. Removed `px-4` from `Container` and tightened `<main>` to `px-2`, so content keeps a single slim gutter.
- **Releases** is now linked from the footer's bottom row.

## Files

- `apps/web/app/[locale]/(info)/layout.tsx` - main padding `px-4` -> `px-2`
- `apps/web/components/navigation/unified-navbar/unified-navbar.tsx` - per-page logo variant + mobile squish fix
- `packages/cms/src/features/footer.tsx` - yellow logo + Releases link
- `packages/cms/src/shared/container.tsx` - drop the duplicate `px-4`

## Before / after

### 1. Footer logo (white -> yellow)

<table>
<tr><th align="left">Before</th><th align="left">After</th></tr>
<tr>
<td><img src="https://raw.githubusercontent.com/Jan-IngenHousz-Institute/open-jii/pr-assets/public-ui-tweaks/shots/footer_before.png" width="430"></td>
<td><img src="https://raw.githubusercontent.com/Jan-IngenHousz-Institute/open-jii/pr-assets/public-ui-tweaks/shots/footer_after.png" width="430"></td>
</tr>
</table>

### 2. Navbar on the home page (keeps white, over the hero)

<table>
<tr><th align="left">Before</th><th align="left">After</th></tr>
<tr>
<td><img src="https://raw.githubusercontent.com/Jan-IngenHousz-Institute/open-jii/pr-assets/public-ui-tweaks/shots/navhome_before.png" width="430"></td>
<td><img src="https://raw.githubusercontent.com/Jan-IngenHousz-Institute/open-jii/pr-assets/public-ui-tweaks/shots/navhome_after.png" width="430"></td>
</tr>
</table>

### 3. Navbar on every other page (yellow)

<table>
<tr><th align="left">Before</th><th align="left">After</th></tr>
<tr>
<td><img src="https://raw.githubusercontent.com/Jan-IngenHousz-Institute/open-jii/pr-assets/public-ui-tweaks/shots/navother_before.png" width="430"></td>
<td><img src="https://raw.githubusercontent.com/Jan-IngenHousz-Institute/open-jii/pr-assets/public-ui-tweaks/shots/navother_after.png" width="430"></td>
</tr>
</table>

### 4. Mobile navbar logo (no longer squished)

<table>
<tr><th align="left">Before</th><th align="left">After</th></tr>
<tr>
<td><img src="https://raw.githubusercontent.com/Jan-IngenHousz-Institute/open-jii/pr-assets/public-ui-tweaks/shots/mobilelogo_before.png" width="300"></td>
<td><img src="https://raw.githubusercontent.com/Jan-IngenHousz-Institute/open-jii/pr-assets/public-ui-tweaks/shots/mobilelogo_after.png" width="300"></td>
</tr>
</table>

### 5. Padding on info pages, mobile /releases (single slim gutter)

<table>
<tr><th align="left">Before</th><th align="left">After</th></tr>
<tr>
<td><img src="https://raw.githubusercontent.com/Jan-IngenHousz-Institute/open-jii/pr-assets/public-ui-tweaks/shots/padding_before.png" width="250"></td>
<td><img src="https://raw.githubusercontent.com/Jan-IngenHousz-Institute/open-jii/pr-assets/public-ui-tweaks/shots/padding_after.png" width="250"></td>
</tr>
</table>

### 6. Releases link in the footer

<table>
<tr><th align="left">Before</th><th align="left">After</th></tr>
<tr>
<td><img src="https://raw.githubusercontent.com/Jan-IngenHousz-Institute/open-jii/pr-assets/public-ui-tweaks/shots/footerlink_before.png" width="430"></td>
<td><img src="https://raw.githubusercontent.com/Jan-IngenHousz-Institute/open-jii/pr-assets/public-ui-tweaks/shots/footerlink_after.png" width="430"></td>
</tr>
</table>

## Testing

- `pnpm --filter web typecheck` passes.
- Captured in Chromium via Playwright against a local build. Mobile logo verified from 320px to 768px with no horizontal scroll.

> Note: screenshots are hosted on the `pr-assets/public-ui-tweaks` branch so they stay out of this diff. Safe to delete that branch after merge.
