### PR TITLE
feat(web): adds What’s New footer to mobile platform menu

### DIFF
--- a/apps/web/app/[locale]/platform/layout.tsx
+++ b/apps/web/app/[locale]/platform/layout.tsx
@@ -64,7 +64,7 @@ export default async function AppLayout({
         <SidebarEdgePeek />
         <SidebarFloatingReopen />
         <SidebarInset>
-          <NavigationTopbar locale={locale} user={session.user} />
+          <NavigationTopbar locale={locale} user={session.user} releaseNotes={releaseNotes} />
           <div className="3xl:px-10 4xl:px-14 flex flex-1 flex-col px-4 pb-6 pt-8 md:px-6">
             <PageContainer width="wide" className="flex flex-1 flex-col gap-4">
               <Breadcrumbs locale={locale} />

--- a/apps/web/components/navigation/navigation-topbar/navigation-topbar.test.tsx
+++ b/apps/web/components/navigation/navigation-topbar/navigation-topbar.test.tsx
@@ -1,3 +1,4 @@
+import { WHATS_NEW_OPEN_EVENT } from "@/components/whats-new/whats-new-shared";
 import { render, screen, userEvent, waitFor } from "@/test/test-utils";
 import { useFeatureFlagEnabled } from "posthog-js/react";
 import React from "react";
@@ -68,6 +69,21 @@ describe("NavigationTopbar", () => {
     await waitFor(() => {
       expect(screen.getByText("navigation.logout")).toBeInTheDocument();
     });
+  });
+
+  it("shows the whats-new footer in the mobile menu", async () => {
+    const handler = vi.fn();
+    const user = userEvent.setup();
+    window.addEventListener(WHATS_NEW_OPEN_EVENT, handler);
+
+    render(<NavigationTopbar locale="en" user={testUser} />);
+    await user.click(screen.getByLabelText("Open menu"));
+
+    const whatsNew = await screen.findByRole("button", { name: "whatsNew.navLabel" });
+    await user.click(whatsNew);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    window.removeEventListener(WHATS_NEW_OPEN_EVENT, handler);
   });
 
   it("signs out and navigates home via mobile menu", async () => {

--- a/apps/web/components/navigation/navigation-topbar/navigation-topbar.tsx
+++ b/apps/web/components/navigation/navigation-topbar/navigation-topbar.tsx
@@ -4,6 +4,7 @@ import { LanguageSwitcher } from "@/components/language-switcher";
 import { mainNavigation, userNavigation, iconMap } from "@/components/navigation/navigation-config";
 import { NavigationMobileNavItem } from "@/components/navigation/navigation-mobile-nav-item/navigation-mobile-nav-item";
 import { ActivityPopover } from "@/components/navigation/navigation-topbar/activity-popover";
+import { WhatsNewFooterItem } from "@/components/whats-new/whats-new-footer-item";
 import { Menu, Search, X } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -14,6 +15,7 @@ import { useSignOut } from "~/hooks/auth/useSignOut/useSignOut";
 
 import { FEATURE_FLAGS } from "@repo/analytics";
 import type { User } from "@repo/auth/types";
+import type { ComponentReleaseNoteFieldsFragment as ReleaseNoteFields } from "@repo/cms";
 import { useTranslation } from "@repo/i18n";
 import { Button } from "@repo/ui/components/button";
 import { ScrollArea } from "@repo/ui/components/scroll-area";
@@ -31,9 +33,10 @@ import { NavUser } from "../nav-user/nav-user";
 interface NavigationTopbarProps {
   locale: string;
   user: User;
+  releaseNotes?: ReleaseNoteFields[];
 }
 
-export function NavigationTopbar({ locale, user }: NavigationTopbarProps) {
+export function NavigationTopbar({ locale, user, releaseNotes = [] }: NavigationTopbarProps) {
   const { t } = useTranslation();
   const pathname = usePathname();
   const router = useRouter();
@@ -198,7 +201,7 @@ export function NavigationTopbar({ locale, user }: NavigationTopbarProps) {
                   </nav>
 
                   {/* Additional Navigation Links */}
-                  <div className="space-y-1 py-2">
+                  <div className="space-y-1 py-2 pb-8">
                     {Object.values(userNavigation).map((item) => (
                       <NavigationMobileNavItem
                         key={item.titleKey}
@@ -243,6 +246,13 @@ export function NavigationTopbar({ locale, user }: NavigationTopbarProps) {
                       </span>
                     </button>
                   </div>
+                </div>
+
+                <div className="border-t border-white/10 py-3">
+                  <WhatsNewFooterItem
+                    entries={releaseNotes}
+                    onOpen={() => setIsMobileMenuOpen(false)}
+                  />
                 </div>
               </div>
             </div>

--- a/apps/web/components/whats-new/whats-new-footer-item.tsx
+++ b/apps/web/components/whats-new/whats-new-footer-item.tsx
@@ -13,7 +13,13 @@ import { WHATS_NEW_OPEN_EVENT, countUnread } from "./whats-new-shared";
  * unread dot when there are new entries. Styled for the dark sidebar (white text), matching the
  * search button above it.
  */
-export function WhatsNewFooterItem({ entries }: { entries: ReleaseNoteFields[] }) {
+export function WhatsNewFooterItem({
+  entries,
+  onOpen,
+}: {
+  entries: ReleaseNoteFields[];
+  onOpen?: () => void;
+}) {
   const { t } = useTranslation("navigation");
   const lastSeen = useWhatsNewLastSeen();
   // Wait for the query to resolve — treating a loading `undefined` as "never seen" flashes every
@@ -25,7 +31,10 @@ export function WhatsNewFooterItem({ entries }: { entries: ReleaseNoteFields[] }
   return (
     <button
       type="button"
-      onClick={() => window.dispatchEvent(new Event(WHATS_NEW_OPEN_EVENT))}
+      onClick={() => {
+        onOpen?.();
+        window.dispatchEvent(new Event(WHATS_NEW_OPEN_EVENT));
+      }}
       aria-label={
         hasUnread ? `${label} (${t("whatsNew.unreadBadge", { count: unreadCount })})` : label
       }


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Adds the existing What’s New footer action to the mobile /platform navigation sheet, using the same release notes data as the desktop sidebar. The shared footer item now supports an optional onOpen callback so the mobile menu closes before opening the What’s New panel.