### PR TITLE
chore(data): bump urllib3 to 2.7.0

### DIFF
--- a/apps/data/poetry.lock
+++ b/apps/data/poetry.lock
@@ -235,7 +235,7 @@ description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
-markers = "python_full_version < \"3.10.2\""
+markers = "python_version == \"3.10\" and python_full_version < \"3.10.2\""
 files = [
     {file = "importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151"},
     {file = "importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb"},
@@ -551,7 +551,7 @@ description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
-markers = "python_version < \"3.11\""
+markers = "python_version == \"3.10\""
 files = [
     {file = "tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867"},
     {file = "tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9"},
@@ -616,14 +616,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
-    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]
@@ -657,7 +657,7 @@ description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
-markers = "python_full_version < \"3.10.2\""
+markers = "python_version == \"3.10\" and python_full_version < \"3.10.2\""
 files = [
     {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
     {file = "zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
@@ -673,5 +673,5 @@ type = ["pytest-mypy"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.9"
-content-hash = "1101fba8eb3bcbde520a59d383b1a9818fefc60302d09cde8cbe949769b69a87"
+python-versions = "^3.10"
+content-hash = "8c9cf5690824b98c5d614a395493725ae1c36bdc5c8f4d11fe7d7b957ffb1f34"

--- a/apps/data/pyproject.toml
+++ b/apps/data/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 package-mode = false
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 pandas = "^2.0.0"
 numpy = "^1.24.0"
 scipy = "^1.10.0"


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description

Fixes Dependabot alerts #240 and #241 (both urllib3 2.6.3 in apps/data).

- Decompression DoS: urllib3 <2.7.0 could fully decompress highly compressed
  responses in one op (Brotli read + drain_conn), causing excessive CPU/memory.
- Redirect header leak: sensitive headers forwarded on cross-origin redirects
  via the low-level ProxyManager path.

urllib3 2.7.0 requires Python >=3.10, so the pyproject floor is raised
^3.9 -> ^3.10. This matches CI (deploy-databricks.yml already uses 3.10) and
fully removes 2.6.3 from the lock. Validated with `poetry check --lock`.