### PR TITLE
fix(mobile): pin @gorhom/bottom-sheet to 5.2.10 to restore bottom sheets

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -36,7 +36,7 @@
     "@contentful/rich-text-react-renderer": "16.0.2",
     "@contentful/rich-text-types": "17.0.1",
     "@expo/vector-icons": "^15.1.1",
-    "@gorhom/bottom-sheet": "^5.2.8",
+    "@gorhom/bottom-sheet": "5.2.10",
     "@photostructure/tz-lookup": "^10.0.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-navigation/bottom-tabs": "^7.15.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,8 +455,8 @@ importers:
         specifier: ^15.1.1
         version: 15.1.1(expo-font@55.0.8)(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
       '@gorhom/bottom-sheet':
-        specifier: ^5.2.8
-        version: 5.2.14(@types/react@19.2.14)(react-native-gesture-handler@2.30.1(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native-reanimated@4.2.3(react-native-worklets@0.7.4(@babel/core@7.29.7)(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
+        specifier: 5.2.10
+        version: 5.2.10(@types/react@19.2.14)(react-native-gesture-handler@2.30.1(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native-reanimated@4.2.3(react-native-worklets@0.7.4(@babel/core@7.29.7)(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
       '@photostructure/tz-lookup':
         specifier: ^10.0.0
         version: 10.0.0
@@ -4268,8 +4268,8 @@ packages:
   '@formatjs/intl-localematcher@0.6.2':
     resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
 
-  '@gorhom/bottom-sheet@5.2.14':
-    resolution: {integrity: sha512-uLQFlDjp9z+jrOFcMSEldPqL5JdaXL3vXOh+juhwoNvXgTsEorJLjHTugXu+YccAG/0KJnShzKCrb71MHBsvJg==}
+  '@gorhom/bottom-sheet@5.2.10':
+    resolution: {integrity: sha512-MnFddmVOlaoash0d9g1ClqFqX+32h/sV3PNEFz9A8XCvUbZGQM9OG6HHAzTb+eQfUGA8DkaurI+wfpNFyzj5Yw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-native': '*'
@@ -22141,7 +22141,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@gorhom/bottom-sheet@5.2.14(@types/react@19.2.14)(react-native-gesture-handler@2.30.1(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native-reanimated@4.2.3(react-native-worklets@0.7.4(@babel/core@7.29.7)(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)':
+  '@gorhom/bottom-sheet@5.2.10(@types/react@19.2.14)(react-native-gesture-handler@2.30.1(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native-reanimated@4.2.3(react-native-worklets@0.7.4(@babel/core@7.29.7)(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@gorhom/portal': 1.0.14(react-native@0.83.4(@babel/core@7.29.7)(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
       invariant: 2.2.4


### PR DESCRIPTION
## Type of PR

- [x] Bug Fix

## Summary

Since the lockfile regen in #1749, every bottom sheet in the mobile app is dead on `main`: the **device drawer does not open** and the **X to close a flow does nothing**. The app otherwise runs fine. This pins `@gorhom/bottom-sheet` to the last known-good release to restore them.

## Root cause

`#1749` regenerated the lockfile, which floated the caret `^5.2.8` up to **5.2.14**. That version carries an upstream regression introduced in **5.2.11** (modal-status rewrite):

- `handleDismiss` fails to early-exit when the modal status is `INITIAL`.
- Our shared controller [`use-bottom-sheet-controller.tsx`](apps/mobile/src/shared/ui/hooks/use-bottom-sheet-controller.tsx) uses the canonical `visible ? present() : dismiss()` effect. On first mount `visible` is `false`, so it calls `dismiss()` while status is still `INITIAL`.
- That strands the modal in `DISMISSING` forever, after which `handlePortalRender` silently refuses to render, so every later `present()` shows nothing.

Both the device drawer ([`device-sheet.tsx`](apps/mobile/src/features/connection/components/device-sheet/device-sheet.tsx)) and the flow exit sheet ([`exit-flow-sheet.tsx`](apps/mobile/src/features/measurement-flow/components/exit-flow-sheet.tsx)) present a `BottomSheetModal` through that one controller, so a single broken primitive kills both.

Upstream references: gorhom/react-native-bottom-sheet#2713, #2669. No fixed release exists yet (5.2.14 is `latest`).

## Fix

Pin `@gorhom/bottom-sheet` to exact **5.2.10**, the last release before the 5.2.11 rewrite. No `overrides`, no patch. Everything else stays on the #1749 latest (it resolves against the latest babel / gesture-handler / reanimated).

## Validation (on a cabled device)

- Clean-workspace reinstall on 5.2.14 reproduced the dead drawer.
- On 5.2.10: device drawer opens, the X closes it, and it reopens cleanly (open to close to open cycle).
- Flow-close X uses the same `BottomSheetModal.present()` path, so it is fixed by the same change.

## Follow-up

This is a temporary hold-back. When upstream ships a release above 5.2.14 with the `handleDismiss` `INITIAL` fix, bump forward and a caret can be restored. Worth tracking #2713.

