### PR TITLE
fix(ci): use merge-base for Linear release base_ref

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -102,6 +102,14 @@ jobs:
           echo "Found previous release branch: ${PREVIOUS_BRANCH:-none}"
           echo "previous_branch=$PREVIOUS_BRANCH" >> $GITHUB_OUTPUT
 
+          if [[ -n "$PREVIOUS_BRANCH" ]]; then
+            BASE_REF=$(git merge-base HEAD "$PREVIOUS_BRANCH")
+          else
+            BASE_REF=""
+          fi
+          echo "Using base_ref: ${BASE_REF:-none}"
+          echo "base_ref=$BASE_REF" >> $GITHUB_OUTPUT
+
       - name: Sync Linear release
         uses: linear/linear-release-action@v0
         with:
@@ -109,7 +117,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           command: sync
           version: ${{ inputs.ref || github.ref_name }}
-          base_ref: ${{ steps.prev.outputs.previous_branch }}
+          base_ref: ${{ steps.prev.outputs.base_ref }}
           stage: production
           include_paths: "apps/web/**,apps/backend/**,apps/data/**,infrastructure/**"
           dry_run: ${{ inputs.dry_run }}


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description
Linear release sync was crashing with "base-ref is not an ancestor of HEAD" because we passed the previous release branch's tip directly as base_ref. Release branches diverge over time from hotfixes, so that tip isn't always an ancestor.

Fix: use git merge-base between the branches instead — it's always a valid ancestor, so this can't happen again.
<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #
- Related to #

## Testing Instructions

<!-- Provide steps to test your changes and any relevant environments tested -->

- [ ] Test case 1
- [ ] Test case 2

## Changes Made

<!-- List the key changes made in this PR -->

-
-

## Checklist

- [ ] I have added/updated tests for my changes
- [ ] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [ ] I have tested these changes locally
- [ ] My changes generate no new warnings
- [ ] I have reviewed my own code

## Screenshots/Recordings

<!-- If applicable, add screenshots or recordings to demonstrate your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
