### PR TITLE
fix(mobile): keep experiment name and plot autoincrement stable on resume

### DIFF
--- a/apps/mobile/src/features/measurement-flow/domain/experiment-name.test.ts
+++ b/apps/mobile/src/features/measurement-flow/domain/experiment-name.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveExperimentName } from "./experiment-name";
+
+const experiments = [
+  { value: "exp-A", label: "Wheat Trial 2026" },
+  { value: "exp-B", label: "Rice Salinity" },
+];
+
+describe("resolveExperimentName", () => {
+  it("uses the live-query label when the experiment is in the loaded list", () => {
+    expect(
+      resolveExperimentName({
+        experimentLabel: undefined,
+        experiments,
+        experimentId: "exp-B",
+        fallback: "Experiment",
+      }),
+    ).toBe("Rice Salinity");
+  });
+
+  // Regression: the "experiment name disappears, just says 'Experiment'" bug.
+  // On cold resume / offline the query is empty, but the label captured at
+  // selection is persisted with the flow and must win.
+  it("prefers the persisted experimentLabel over an empty/stale live list", () => {
+    // The old live-only lookup loses the name when the query has not loaded.
+    const notLoaded: typeof experiments = [];
+    const buggy = notLoaded.find((e) => e.value === "exp-A")?.label ?? "Experiment";
+    expect(buggy).toBe("Experiment");
+
+    expect(
+      resolveExperimentName({
+        experimentLabel: "Wheat Trial 2026",
+        experiments: notLoaded,
+        experimentId: "exp-A",
+        fallback: "Experiment",
+      }),
+    ).toBe("Wheat Trial 2026");
+  });
+
+  it("treats a blank label as absent and falls back to the query", () => {
+    expect(
+      resolveExperimentName({
+        experimentLabel: "   ",
+        experiments,
+        experimentId: "exp-A",
+        fallback: "Experiment",
+      }),
+    ).toBe("Wheat Trial 2026");
+  });
+
+  it("falls back to the default only when neither label nor query has a name", () => {
+    expect(
+      resolveExperimentName({
+        experimentLabel: undefined,
+        experiments: [],
+        experimentId: "exp-A",
+        fallback: "Experiment",
+      }),
+    ).toBe("Experiment");
+  });
+});

--- a/apps/mobile/src/features/measurement-flow/domain/experiment-name.ts
+++ b/apps/mobile/src/features/measurement-flow/domain/experiment-name.ts
@@ -1,0 +1,21 @@
+// Prefer the label persisted with the flow (survives offline/cold resume) over
+// the live experiments query, which loses the name when its cache lacks
+// experimentId. Query then generic default are fallbacks for legacy flows.
+export interface ExperimentOption {
+  value: string;
+  label: string;
+}
+
+export function resolveExperimentName(args: {
+  experimentLabel: string | undefined;
+  experiments: ExperimentOption[];
+  experimentId: string | undefined;
+  fallback: string;
+}): string {
+  const { experimentLabel, experiments, experimentId, fallback } = args;
+  if (experimentLabel?.trim()) return experimentLabel;
+  const fromQuery = experimentId
+    ? experiments.find((e) => e.value === experimentId)?.label
+    : undefined;
+  return fromQuery ?? fallback;
+}

--- a/apps/mobile/src/features/measurement-flow/domain/iteration.test.ts
+++ b/apps/mobile/src/features/measurement-flow/domain/iteration.test.ts
@@ -2,10 +2,17 @@ import { describe, expect, it } from "vitest";
 import type { FlowNode } from "~/shared/measurements/flow-node";
 
 import type { AnswersSnapshot } from "./iteration";
-import { findNextMandatoryStep, firstManualQuestionNodeId } from "./iteration";
+import {
+  findNextMandatoryStep,
+  firstManualQuestionNodeId,
+  seedNextIterationAnswer,
+} from "./iteration";
 
 const makeQuestion = (id: string): FlowNode =>
   ({ id, type: "question", name: id, content: { kind: "text" } }) as FlowNode;
+
+const makeMultiChoice = (id: string, options: string[]): FlowNode =>
+  ({ id, type: "question", name: id, content: { kind: "multi_choice", options } }) as FlowNode;
 
 const makeInstruction = (id: string): FlowNode =>
   ({ id, type: "instruction", name: id, content: {} }) as FlowNode;
@@ -87,6 +94,37 @@ describe("findNextMandatoryStep", () => {
       makeQuestion("q3"),
     ];
     expect(next(0, nodes, 0, answers({ autoincrementSettings: { q2: true } }))).toBe(1);
+  });
+});
+
+describe("seedNextIterationAnswer (autoincrement)", () => {
+  const a = answers({ autoincrementSettings: { plot: true } });
+
+  it("rotates a multi_choice to the next option", () => {
+    const node = makeMultiChoice("plot", ["plot-1", "plot-2", "plot-3"]);
+    expect(
+      seedNextIterationAnswer({ node, answerValue: "plot-1", iterationCount: 0, answers: a }),
+    ).toEqual({ cycle: 1, name: "plot", value: "plot-2" });
+  });
+
+  it("wraps from the last option back to the first", () => {
+    const node = makeMultiChoice("plot", ["plot-1", "plot-2", "plot-3"]);
+    expect(
+      seedNextIterationAnswer({ node, answerValue: "plot-3", iterationCount: 0, answers: a }),
+    ).toEqual({ cycle: 1, name: "plot", value: "plot-1" });
+  });
+
+  // Regression: the "autoincrement jumps to a random plot elsewhere" bug. A
+  // stale/unrecognised prior answer must NOT wrap to options[0] (the first plot).
+  it("does not jump to the first plot when the current answer is not a known option", () => {
+    const node = makeMultiChoice("plot", ["plot-1", "plot-2", "plot-3"]);
+    const seed = seedNextIterationAnswer({
+      node,
+      answerValue: "plot-99",
+      iterationCount: 4,
+      answers: a,
+    });
+    expect(seed).toBeNull();
   });
 });
 

--- a/apps/mobile/src/features/measurement-flow/domain/iteration.test.ts
+++ b/apps/mobile/src/features/measurement-flow/domain/iteration.test.ts
@@ -126,6 +126,31 @@ describe("seedNextIterationAnswer (autoincrement)", () => {
     });
     expect(seed).toBeNull();
   });
+
+  it("carries a remembered non-choice answer into the next iteration", () => {
+    const node = makeQuestion("note");
+    const remembered = answers({ rememberAnswerSettings: { note: true } });
+    expect(
+      seedNextIterationAnswer({
+        node,
+        answerValue: "cloudy",
+        iterationCount: 2,
+        answers: remembered,
+      }),
+    ).toEqual({ cycle: 3, name: "note", value: "cloudy" });
+  });
+
+  it("returns null for a multi_choice without auto-increment enabled", () => {
+    const node = makeMultiChoice("plot", ["plot-1", "plot-2"]);
+    expect(
+      seedNextIterationAnswer({
+        node,
+        answerValue: "plot-1",
+        iterationCount: 0,
+        answers: answers(),
+      }),
+    ).toBeNull();
+  });
 });
 
 describe("firstManualQuestionNodeId", () => {

--- a/apps/mobile/src/features/measurement-flow/domain/iteration.ts
+++ b/apps/mobile/src/features/measurement-flow/domain/iteration.ts
@@ -59,7 +59,7 @@ export function findNextMandatoryStep(args: {
 }
 
 // Seed produced by committing `answerValue` on `node`: auto-increment rotates
-// a multi_choice to its next option, remember copies the value — both into
+// a multi_choice to its next option, remember copies the value; both into
 // the NEXT iteration. Null when nothing should carry.
 export function seedNextIterationAnswer(args: {
   node: FlowNode;
@@ -73,6 +73,9 @@ export function seedNextIterationAnswer(args: {
     if (isAutoincrementEnabled(answers, node.id) && answerValue) {
       const options: string[] = content.options ?? [];
       const currentIndex = options.indexOf(answerValue);
+      // Unknown/stale value: keep the manual answer rather than jumping to
+      // options[0]. Mirrors the idx<0 skip in carryForwardAnswers.
+      if (currentIndex < 0) return null;
       const nextIndex = (currentIndex + 1) % options.length;
       return { cycle: iterationCount + 1, name: node.id, value: options[nextIndex] };
     }

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
@@ -1,0 +1,136 @@
+import { render } from "@testing-library/react-native";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useFlowAnswersStore } from "~/features/measurement-flow/stores/use-flow-answers-store";
+import { useMeasurementFlowStore } from "~/features/measurement-flow/stores/use-measurement-flow-store";
+import type { AnalysisContent } from "~/shared/measurements/flow-node";
+
+import { AnalysisNode } from "./analysis-node";
+
+// Mock only the network/native edges and the heavy child components. The node
+// itself runs unmocked so its experiment-name resolution executes for real;
+// summaryProps captures the name the node hands to the summary card.
+const {
+  summaryProps,
+  useExperiments,
+  useSession,
+  useMeasurementUpload,
+  useMeasurements,
+  getSyncedUtcISO,
+  getSyncedLocalISO,
+  getTimeSyncState,
+} = vi.hoisted(() => ({
+  summaryProps: vi.fn(),
+  useExperiments: vi.fn(),
+  useSession: vi.fn(),
+  useMeasurementUpload: vi.fn(),
+  useMeasurements: vi.fn(),
+  getSyncedUtcISO: vi.fn(),
+  getSyncedLocalISO: vi.fn(),
+  getTimeSyncState: vi.fn(),
+}));
+
+vi.mock("~/features/experiments/hooks/use-experiments", () => ({
+  useExperiments: () => useExperiments(),
+}));
+vi.mock("~/features/auth/hooks/use-session", () => ({ useSession: () => useSession() }));
+vi.mock("~/features/recent-measurements/hooks/use-measurement-upload", () => ({
+  useMeasurementUpload: () => useMeasurementUpload(),
+}));
+vi.mock("~/features/recent-measurements/hooks/use-measurements", () => ({
+  useMeasurements: () => useMeasurements(),
+}));
+vi.mock("~/shared/time/time-sync", () => ({
+  getSyncedUtcISO: () => getSyncedUtcISO(),
+  getSyncedLocalISO: () => getSyncedLocalISO(),
+  getTimeSyncState: () => getTimeSyncState(),
+}));
+vi.mock("~/shared/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      key === "measurementFlow:analysis.node.defaultExperimentName" ? "Experiment" : key,
+  }),
+}));
+
+vi.mock("./analysis-summary-card", () => ({
+  AnalysisSummaryCard: (props: { experimentName: string }) => {
+    summaryProps(props);
+    return null;
+  },
+}));
+vi.mock("./analysis-macro-result", () => ({ AnalysisMacroResult: () => null }));
+vi.mock("./analysis-action-bar", () => ({
+  AnalysisActionBar: () => null,
+  useScrollToTop: () => ({
+    scrollViewRef: { current: null },
+    hasScrolled: false,
+    handleScroll: () => undefined,
+    scrollToTop: () => undefined,
+  }),
+}));
+vi.mock("~/shared/ui/measurement/comment-modal", () => ({ CommentModal: () => null }));
+vi.mock("~/shared/ui/measurement/measurement-questions-modal", () => ({
+  MeasurementQuestionsModal: () => null,
+}));
+
+const CONTENT = { params: {}, macroId: "macro-1" } as AnalysisContent;
+
+const resolvedName = () => summaryProps.mock.calls.at(-1)?.[0]?.experimentName as string;
+
+beforeEach(() => {
+  useMeasurementFlowStore.setState({
+    experimentId: undefined,
+    experimentLabel: undefined,
+    flowNodes: [],
+    currentFlowStep: 0,
+    iterationCount: 0,
+    scanResult: undefined,
+  });
+  useFlowAnswersStore.setState({
+    answersHistory: [{}],
+    autoincrementSettings: {},
+    rememberAnswerSettings: {},
+  });
+  summaryProps.mockClear();
+  useExperiments.mockReturnValue({ experiments: [{ value: "exp-1", label: "From Query" }] });
+  useSession.mockReturnValue({ session: { data: { user: { id: "user-1" } } } });
+  useMeasurementUpload.mockReturnValue({ isUploading: false, uploadMeasurement: vi.fn() });
+  useMeasurements.mockReturnValue({ updateMeasurementComment: vi.fn() });
+  getSyncedUtcISO.mockReturnValue("2026-04-20T10:00:00.000Z");
+  getSyncedLocalISO.mockReturnValue("2026-04-20T12:00:00.000+02:00");
+  getTimeSyncState.mockReturnValue({ timezone: "Europe/Amsterdam" });
+});
+
+describe("AnalysisNode experiment name", () => {
+  it("prefers the persisted experimentLabel over the live query label", () => {
+    useMeasurementFlowStore.setState({
+      experimentId: "exp-1",
+      experimentLabel: "Greenhouse Trial B",
+    });
+    render(<AnalysisNode content={CONTENT} />);
+    expect(resolvedName()).toBe("Greenhouse Trial B");
+  });
+
+  it("keeps the name when the experiments query is empty (offline / cold resume)", () => {
+    useExperiments.mockReturnValue({ experiments: [] });
+    useMeasurementFlowStore.setState({
+      experimentId: "exp-1",
+      experimentLabel: "Wheat Trial 2026",
+    });
+    render(<AnalysisNode content={CONTENT} />);
+    expect(resolvedName()).toBe("Wheat Trial 2026");
+  });
+
+  it("uses the live query label when no persisted label is present", () => {
+    useMeasurementFlowStore.setState({ experimentId: "exp-1", experimentLabel: undefined });
+    render(<AnalysisNode content={CONTENT} />);
+    expect(resolvedName()).toBe("From Query");
+  });
+
+  it("falls back to the default when neither label nor query resolves", () => {
+    useExperiments.mockReturnValue({ experiments: [] });
+    useMeasurementFlowStore.setState({ experimentId: "exp-missing", experimentLabel: undefined });
+    render(<AnalysisNode content={CONTENT} />);
+    expect(resolvedName()).toBe("Experiment");
+  });
+});

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.tsx
@@ -4,6 +4,7 @@ import React, { useMemo, useState } from "react";
 import { View, Text, ScrollView } from "react-native";
 import { useSession } from "~/features/auth/hooks/use-session";
 import { useExperiments } from "~/features/experiments/hooks/use-experiments";
+import { resolveExperimentName } from "~/features/measurement-flow/domain/experiment-name";
 import { flowProtocolId } from "~/features/measurement-flow/domain/flow-transitions";
 import { useFlowAnswersStore } from "~/features/measurement-flow/stores/use-flow-answers-store";
 import { useMeasurementFlowStore } from "~/features/measurement-flow/stores/use-measurement-flow-store";
@@ -34,8 +35,15 @@ export function AnalysisNode({ content }: AnalysisNodeProps) {
   const { t } = useTranslation("measurementFlow");
   // Resolved once at flow-load (hydrateFlowNodes): cell metadata + derived filename.
   const macro = content.macro;
-  const { scanResult, previousStep, nextStep, experimentId, iterationCount, flowNodes } =
-    useMeasurementFlowStore();
+  const {
+    scanResult,
+    previousStep,
+    nextStep,
+    experimentId,
+    experimentLabel,
+    iterationCount,
+    flowNodes,
+  } = useMeasurementFlowStore();
   const protocolId = flowProtocolId(flowNodes);
   const { experiments } = useExperiments();
   const { session } = useSession();
@@ -45,9 +53,12 @@ export function AnalysisNode({ content }: AnalysisNodeProps) {
     (n) => n.type === "measurement" && n.content?.protocolId === protocolId,
   )?.content?.protocol?.name as string | undefined;
 
-  const experimentName =
-    experiments.find((experiment) => experiment.value === experimentId)?.label ??
-    t("measurementFlow:analysis.node.defaultExperimentName");
+  const experimentName = resolveExperimentName({
+    experimentLabel,
+    experiments,
+    experimentId,
+    fallback: t("measurementFlow:analysis.node.defaultExperimentName"),
+  });
 
   const { getCycleAnswers } = useFlowAnswersStore();
   const [measurementComment, setMeasurementComment] = useState("");

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/questions-only-submit-node.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/questions-only-submit-node.tsx
@@ -4,6 +4,7 @@ import React, { useRef, useState } from "react";
 import { Text, TouchableOpacity, View } from "react-native";
 import { useSession } from "~/features/auth/hooks/use-session";
 import { useExperiments } from "~/features/experiments/hooks/use-experiments";
+import { resolveExperimentName } from "~/features/measurement-flow/domain/experiment-name";
 import { useFinishFlow } from "~/features/measurement-flow/hooks/use-finish-flow";
 import { useFlowAnswersStore } from "~/features/measurement-flow/stores/use-flow-answers-store";
 import { useMeasurementFlowStore } from "~/features/measurement-flow/stores/use-measurement-flow-store";
@@ -27,6 +28,7 @@ const log = createLogger("questions-submit");
 export function QuestionsOnlySubmitNode() {
   const {
     experimentId,
+    experimentLabel,
     iterationCount,
     flowNodes,
     dismissQuestionsSubmit,
@@ -49,9 +51,12 @@ export function QuestionsOnlySubmitNode() {
 
   const displayTimestamp = useRef<string>(getSyncedLocalISO()).current;
 
-  const experimentName =
-    experiments.find((e) => e.value === experimentId)?.label ??
-    t("measurementFlow:questionsSubmit.defaultExperimentName");
+  const experimentName = resolveExperimentName({
+    experimentLabel,
+    experiments,
+    experimentId,
+    fallback: t("measurementFlow:questionsSubmit.defaultExperimentName"),
+  });
 
   const cycleAnswers = getCycleAnswers(iterationCount);
   const questions = convertCycleAnswersToArray(cycleAnswers, flowNodes);

--- a/apps/mobile/src/features/measurement-flow/stores/flow-store-persistence.test.ts
+++ b/apps/mobile/src/features/measurement-flow/stores/flow-store-persistence.test.ts
@@ -5,12 +5,16 @@ import { useFlowAnswersStore } from "./use-flow-answers-store";
 import { useMeasurementFlowStore } from "./use-measurement-flow-store";
 
 // Characterization of the AsyncStorage wire format of both persisted flow
-// stores (pinned at version 0). A silent shape change wipes a field
-// researcher's paused flow on rehydrate. Update fixtures ONLY with a
-// deliberate change (additive/removal) or a version bump + migrate.
+// stores (pinned at version 1). A silent shape change wipes a field
+// researcher's paused flow on rehydrate. v1 deliberately discards pre-fix v0
+// payloads; update fixtures ONLY with a deliberate change or a version bump.
 
 const MEASUREMENT_KEY = "measurement-flow-storage";
 const ANSWERS_KEY = "flow-answers-storage";
+
+// A pre-fix v0 envelope for each store: rehydrating it must reset to defaults.
+const MEASUREMENT_V0 = `{ "state": { "experimentId": "old-exp", "iterationCount": 5 }, "version": 0 }`;
+const ANSWERS_V0 = `{ "state": { "answersHistory": [{ "plot": "old" }], "autoincrementSettings": { "plot": true }, "rememberAnswerSettings": {} }, "version": 0 }`;
 
 // v0 envelope for a paused mid-flow session, parked on the measurement node.
 // Every value differs from the store default so a key dropped from partialize
@@ -67,7 +71,7 @@ const MEASUREMENT_FIXTURE = `{
     "branchVisitCounts": { "node-b1": 2 },
     "branchReturnStack": [{ "landing": 3, "step": 1 }]
   },
-  "version": 0
+  "version": 1
 }`;
 
 // v0 envelope after two completed answer iterations with per-question
@@ -81,7 +85,7 @@ const ANSWERS_FIXTURE = `{
     "autoincrementSettings": { "plant_id": true, "leaf_count": false },
     "rememberAnswerSettings": { "leaf_count": true, "plant_id": false }
   },
-  "version": 0
+  "version": 1
 }`;
 
 const MEASUREMENT_STATE = (JSON.parse(MEASUREMENT_FIXTURE) as { state: Record<string, unknown> })
@@ -106,7 +110,7 @@ async function readEnvelope(key: string): Promise<Record<string, unknown>> {
   return JSON.parse(raw) as Record<string, unknown>;
 }
 
-describe("measurement-flow-storage v0 wire format", () => {
+describe("measurement-flow-storage v1 wire format", () => {
   beforeAll(async () => {
     await AsyncStorage.setItem(MEASUREMENT_KEY, MEASUREMENT_FIXTURE);
     await useMeasurementFlowStore.persist.rehydrate();
@@ -129,7 +133,7 @@ describe("measurement-flow-storage v0 wire format", () => {
     useMeasurementFlowStore.setState({}); // identity write still runs partialize + setItem
     const envelope = await readEnvelope(MEASUREMENT_KEY);
     expect(Object.keys(envelope).sort()).toEqual(["state", "version"]);
-    expect(envelope.version).toBe(0);
+    expect(envelope.version).toBe(1);
     expect(envelope.state).toEqual(EXPECTED_WRITTEN_STATE);
   });
 
@@ -158,7 +162,7 @@ describe("measurement-flow-storage v0 wire format", () => {
   });
 });
 
-describe("flow-answers-storage v0 wire format", () => {
+describe("flow-answers-storage v1 wire format", () => {
   beforeAll(async () => {
     await AsyncStorage.setItem(ANSWERS_KEY, ANSWERS_FIXTURE);
     await useFlowAnswersStore.persist.rehydrate();
@@ -174,7 +178,7 @@ describe("flow-answers-storage v0 wire format", () => {
     useFlowAnswersStore.setState({}); // identity write still runs partialize + setItem
     const envelope = await readEnvelope(ANSWERS_KEY);
     expect(Object.keys(envelope).sort()).toEqual(["state", "version"]);
-    expect(envelope.version).toBe(0);
+    expect(envelope.version).toBe(1);
     expect(envelope.state).toEqual(ANSWERS_STATE);
   });
 
@@ -188,5 +192,28 @@ describe("flow-answers-storage v0 wire format", () => {
       "autoincrementSettings",
       "rememberAnswerSettings",
     ]);
+  });
+});
+
+// The v0 -> v1 bump deliberately discards flows persisted by pre-fix builds
+// (they can hold a mis-seeded plot or a stale "Experiment" name). These run
+// last: rehydrating a v0 payload resets the singleton stores to defaults.
+describe("flow stores discard pre-fix v0 payloads on upgrade", () => {
+  it("resets the measurement flow store to initial state", async () => {
+    await AsyncStorage.setItem(MEASUREMENT_KEY, MEASUREMENT_V0);
+    await useMeasurementFlowStore.persist.rehydrate();
+    const state = useMeasurementFlowStore.getState();
+    expect(state.experimentId).toBeUndefined();
+    expect(state.iterationCount).toBe(0);
+    expect(state.flowNodes).toEqual([]);
+  });
+
+  it("clears the answer history", async () => {
+    await AsyncStorage.setItem(ANSWERS_KEY, ANSWERS_V0);
+    await useFlowAnswersStore.persist.rehydrate();
+    const state = useFlowAnswersStore.getState();
+    expect(state.answersHistory).toEqual([]);
+    expect(state.autoincrementSettings).toEqual({});
+    expect(state.rememberAnswerSettings).toEqual({});
   });
 });

--- a/apps/mobile/src/features/measurement-flow/stores/use-flow-answers-store.ts
+++ b/apps/mobile/src/features/measurement-flow/stores/use-flow-answers-store.ts
@@ -65,12 +65,14 @@ export const useFlowAnswersStore = create<FlowAnswersStore>()(
     {
       name: "flow-answers-storage",
       storage: createJSONStorage(() => AsyncStorage),
-      // The persisted shape is the v0 wire format, pinned by
-      // flow-store-persistence.test.ts. NEVER rename/remove a field here
-      // without bumping `version` and writing a real `migrate` — zustand
-      // silently DROPS persisted state on version mismatch.
-      version: 0,
-      migrate: (persisted) => persisted as FlowAnswersStore,
+      // v1 wire format, pinned by flow-store-persistence.test.ts. Bumped in
+      // tandem with the flow store so a pre-fix (v0) answer history is
+      // discarded on upgrade instead of resuming against a reset flow.
+      version: 1,
+      migrate: (persisted, version) =>
+        (version < 1
+          ? { answersHistory: [], autoincrementSettings: {}, rememberAnswerSettings: {} }
+          : persisted) as FlowAnswersStore,
       partialize: (state) => ({
         answersHistory: state.answersHistory,
         autoincrementSettings: state.autoincrementSettings,

--- a/apps/mobile/src/features/measurement-flow/stores/use-flow-answers-store.ts
+++ b/apps/mobile/src/features/measurement-flow/stores/use-flow-answers-store.ts
@@ -17,14 +17,21 @@ interface FlowAnswersStore {
   isRememberAnswerEnabled: (name: string) => boolean;
 }
 
+const EMPTY_ANSWERS: Pick<
+  FlowAnswersStore,
+  "answersHistory" | "autoincrementSettings" | "rememberAnswerSettings"
+> = {
+  answersHistory: [],
+  autoincrementSettings: {},
+  rememberAnswerSettings: {},
+};
+
 // Persisted alongside useMeasurementFlowStore: a paused flow needs its
 // answers to come back on resume after a kill/background.
 export const useFlowAnswersStore = create<FlowAnswersStore>()(
   persist(
     (set, get) => ({
-      answersHistory: [],
-      autoincrementSettings: {},
-      rememberAnswerSettings: {},
+      ...EMPTY_ANSWERS,
 
       setAnswer: (cycle: number, name: string, value: string) => {
         set((state) => {
@@ -44,7 +51,7 @@ export const useFlowAnswersStore = create<FlowAnswersStore>()(
       },
 
       clearHistory: () => {
-        set({ answersHistory: [], autoincrementSettings: {}, rememberAnswerSettings: {} });
+        set(EMPTY_ANSWERS);
       },
 
       getAnswer: (cycle, name) => get().answersHistory[cycle]?.[name],
@@ -70,9 +77,7 @@ export const useFlowAnswersStore = create<FlowAnswersStore>()(
       // discarded on upgrade instead of resuming against a reset flow.
       version: 1,
       migrate: (persisted, version) =>
-        (version < 1
-          ? { answersHistory: [], autoincrementSettings: {}, rememberAnswerSettings: {} }
-          : persisted) as FlowAnswersStore,
+        (version < 1 || !persisted ? EMPTY_ANSWERS : persisted) as FlowAnswersStore,
       partialize: (state) => ({
         answersHistory: state.answersHistory,
         autoincrementSettings: state.autoincrementSettings,

--- a/apps/mobile/src/features/measurement-flow/stores/use-measurement-flow-store.ts
+++ b/apps/mobile/src/features/measurement-flow/stores/use-measurement-flow-store.ts
@@ -128,12 +128,12 @@ export const useMeasurementFlowStore = create<MeasurementFlowStore>()(
     {
       name: "measurement-flow-storage",
       storage: createJSONStorage(() => AsyncStorage),
-      // v0 wire format, pinned by flow-store-persistence.test.ts. NEVER
-      // rename/remove a field without bumping `version` + a real `migrate`:
-      // zustand silently DROPS persisted state on version mismatch, wiping a
-      // researcher's paused flow.
-      version: 0,
-      migrate: (persisted) => persisted as MeasurementFlowStore,
+      // v1 wire format, pinned by flow-store-persistence.test.ts. v1 discards
+      // flows persisted by pre-fix (v0) builds, which can hold a mis-seeded
+      // plot or a stale "Experiment" name; the upgrade starts them clean.
+      version: 1,
+      migrate: (persisted, version) =>
+        (version < 1 ? initialFlowState : persisted) as MeasurementFlowStore,
       // protocolId was dropped from the persisted slice (now derived from
       // flowNodes via flowProtocolId); legacy payloads carrying it merge in
       // as an ignored extra key.


### PR DESCRIPTION
## What

Field report from a researcher measuring a burst of plots: the experiment name in the Recent list intermittently blanks to the literal word **"Experiment"**, and when it does, the auto-incrementing plot number **jumps to a random plot elsewhere**. The measurement data itself uploads fine (it carries `experimentId`), so only the display name and the next-plot seed are affected.

These are two independent defects that co-occur under the same field trigger (an app background/kill or foreground-refetch mid-burst, typically at low battery with patchy signal).

## Root causes

**1. Name reverts to "Experiment".** Both save nodes recomputed the name from the *live* `useExperiments()` query at save time:

```ts
experiments.find((e) => e.value === experimentId)?.label ?? "Experiment"
```

`useExperiments()` returns `[]` until it loads and refetches on mount/foreground with `filter: "member"`. Whenever the cached list does not currently contain the selected `experimentId` (cold resume before the query settles, or a membership/shape-divergent refetch), `.find()` misses and the measurement is saved with the literal `"Experiment"`. The correct name (`experimentLabel`) was already persisted with the flow at selection time but was never read.

**2. Plot autoincrement jumps to the first plot.** `seedNextIterationAnswer` did `options[(indexOf(answerValue) + 1) % length]`. When the prior answer is not byte-equal to an option (option drift, whitespace, or a stale carried value), `indexOf` returns `-1`, so `(-1 + 1) = 0` seeds `options[0]` — the first configured plot. The sibling `carryForwardAnswers` already guards this case; `seedNextIterationAnswer` did not.

## Fix

- New pure helper `domain/experiment-name.ts::resolveExperimentName` that prefers the persisted `experimentLabel`, then the live-query label, then the generic default. Both save nodes (`analysis-node.tsx`, `questions-only-submit-node.tsx`) route through it.
- `seedNextIterationAnswer`: `if (currentIndex < 0) return null` — an unrecognised value is a no-op (keeps the manual answer) instead of jumping to plot #1. Mirrors `carryForwardAnswers`.
- **Persist version bump (v0 → v1).** Both coupled flow stores (`measurement-flow-storage`, `flow-answers-storage`) bump to v1; `migrate` discards a v0 payload and resets to a clean slate. A flow persisted by a pre-fix build can hold a mis-seeded plot or a stale name, so on upgrade researchers start clean rather than resuming a corrupt flow. **In-progress flows are cleared on this update by design.**

## Tests

- `domain/experiment-name.test.ts` (new): prefers the persisted label over an empty/stale live list; blank label falls through; default only as last resort.
- `domain/iteration.test.ts`: `seedNextIterationAnswer` rotate/wrap cases plus the regression case (unknown option must not jump to `options[0]`). This case was red before the fix (received `plot-1`, expected `null`).
- `stores/flow-store-persistence.test.ts`: characterization updated to the v1 wire format, plus new cases asserting a pre-fix v0 payload is discarded (flow resets to initial, answer history clears) on rehydrate.

## Verification (local, mirrors PR CI)

- Tests + coverage: **780/780 pass**, coverage gate met
- `tsc --noEmit`: clean
- ESLint: clean
- Prettier: clean
- Workspace dep lint (sherif): clean
- Mobile styling guard: clean

## Follow-up (not in this PR)

The exact production trigger for the name miss (membership-scoped refetch vs body-shape divergence vs restore race) is worth confirming on-device; a one-line warn log at the fallback point would pin it. Optional hardening: normalise option matching (trim) in both iteration functions.
