### PR TITLE
feat(infra): IoT thing type, group & task-role IAM and env vars for device registry

### DIFF
--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -1840,6 +1840,14 @@ module "backend_ecs" {
       value = join(",", module.iot_core.iot_policy_names)
     },
     {
+      name  = "AWS_IOT_DEVICE_THING_TYPE_NAME"
+      value = module.iot_core.device_thing_type_name
+    },
+    {
+      name  = "AWS_IOT_DEVICE_THING_GROUP_NAME"
+      value = module.iot_core.device_thing_group_name
+    },
+    {
       name  = "EMAIL_BASE_URL"
       value = "https://${module.route53.environment_domain}"
     },

--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -1802,6 +1802,14 @@ module "backend_ecs" {
       value = join(",", module.iot_core.iot_policy_names)
     },
     {
+      name  = "AWS_IOT_DEVICE_THING_TYPE_NAME"
+      value = module.iot_core.device_thing_type_name
+    },
+    {
+      name  = "AWS_IOT_DEVICE_THING_GROUP_NAME"
+      value = module.iot_core.device_thing_group_name
+    },
+    {
       name  = "POSTHOG_KEY"
       value = var.posthog_key
     },

--- a/infrastructure/modules/ecs/main.tf
+++ b/infrastructure/modules/ecs/main.tf
@@ -122,8 +122,15 @@ resource "aws_iam_role_policy" "ecs_task_cognito_policy" {
         Resource = var.cognito_identity_pool_arn
       },
       {
-        Effect   = "Allow"
-        Action   = ["iot:AttachPolicy"]
+        Effect = "Allow"
+        Action = [
+          "iot:AttachPolicy",
+          "iot:CreateThing",
+          "iot:DeleteThing",
+          "iot:DescribeThing",
+          "iot:AddThingToThingGroup",
+          "iot:RemoveThingFromThingGroup"
+        ]
         Resource = "*"
       }
     ]

--- a/infrastructure/modules/iot-core/main.tf
+++ b/infrastructure/modules/iot-core/main.tf
@@ -118,6 +118,29 @@ resource "aws_iot_policy" "iot_policy" {
   })
 }
 
+# --------------------------------------------------
+# Managed device registry (Thing type + group)
+# --------------------------------------------------
+# Devices registered through the platform are created as Things of this type and
+# added to the managed-devices group. Certificates and their scoped policy are
+# attached in a later slice; nothing here issues credentials.
+resource "aws_iot_thing_type" "device" {
+  name = "open_jii_${var.environment}_device"
+
+  properties {
+    description           = "Platform-managed IoT device"
+    searchable_attributes = ["deviceType", "serialNumber"]
+  }
+}
+
+resource "aws_iot_thing_group" "managed_devices" {
+  name = "open_jii_${var.environment}_managed_devices"
+
+  properties {
+    description = "All platform-registered IoT devices"
+  }
+}
+
 # --------------------------------------------
 # IAM Role and Policy for Kinesis Integration
 # --------------------------------------------

--- a/infrastructure/modules/iot-core/outputs.tf
+++ b/infrastructure/modules/iot-core/outputs.tf
@@ -9,6 +9,16 @@ output "iot_topic_rule_names" {
   value       = [for rule in aws_iot_topic_rule.iot_rules : rule.name]
 }
 
+output "device_thing_type_name" {
+  description = "Name of the IoT Thing type applied to platform-managed devices"
+  value       = aws_iot_thing_type.device.name
+}
+
+output "device_thing_group_name" {
+  description = "Name of the IoT Thing group that holds all platform-managed devices"
+  value       = aws_iot_thing_group.managed_devices.name
+}
+
 output "iot_kinesis_role_arn" {
   description = "ARN of the IoT Kinesis IAM Role"
   value       = aws_iam_role.iot_kinesis_role.arn


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description
 
Adds the infrastructure foundation for a platform-managed IoT device registry, so the backend can register devices under a consistent Thing type and group. This is the first slice: it provisions the registry primitives and grants the backend permission to manage Things. No certificates or scoped device policies are issued here.

The `iot-core` module now defines a `Thing type` (`open_jii_<env>_device`) with `deviceType` and `serialNumber` as searchable attributes, and a `Thing group` (`open_jii_<env>_managed_devices`) that will hold every device registered through the platform. Both names are exported as module outputs and wired into the backend ECS task as `AWS_IOT_DEVICE_THING_TYPE_NAME` and `AWS_IOT_DEVICE_THING_GROUP_NAME` in dev and prod.

The ECS task role, previously limited to `iot:AttachPolicy`, gains the Thing lifecycle actions the backend needs to drive registration: `CreateThing`, `DeleteThing`, `DescribeThing`, `AddThingToThingGroup`, and `RemoveThingFromThingGroup`.

## OJD-1607
