### PR TITLE
fix(data): write xlsx exports via Files API on serverless

### DIFF
--- a/apps/data/src/tasks/data_export_task.py
+++ b/apps/data/src/tasks/data_export_task.py
@@ -7,6 +7,7 @@
 
 # DBTITLE 1,Imports
 import json
+import io
 import uuid
 from datetime import datetime
 from typing import Optional
@@ -20,7 +21,7 @@ import sys
 sys.path.append("/Workspace/Repos/open-jii/apps/data/src/lib/openjii")
 from openjii.helpers import load_experiment_table
 
-# Use print() for logging — Databricks captures stdout/stderr from the
+# Use print() for logging - Databricks captures stdout/stderr from the
 # driver on the compute cluster, but the Python logging module is often
 # swallowed (especially when running as a Databricks task/workflow).
 def log(msg: str, level: str = "INFO"):
@@ -192,7 +193,7 @@ def export_data(df, row_count):
             df.coalesce(1).write.mode("overwrite").json(OUTPUT_PATH)
         elif FORMAT == "json-array":
             # Write as a proper JSON array: [{}, {}, ...]
-            # Collects all rows to the driver — suitable for reasonably sized exports.
+            # Collects all rows to the driver - suitable for reasonably sized exports.
             # We write into a Spark-style partitioned directory so the output layout
             # (single data file + _SUCCESS marker) matches csv/ndjson/parquet, which
             # keeps get_export_file_path() and the downstream download flow consistent.
@@ -213,8 +214,17 @@ def export_data(df, row_count):
                     f"Export has {column_count} columns, which exceeds Excel's {EXCEL_MAX_COLUMNS}-column "
                     "limit per sheet. Use CSV or Parquet for tables this wide."
                 )
+            # Serverless has no Spark Excel writer; build the workbook in memory and upload it
+            # via the Files API (binary-safe, uses the volume's UC grant like csv/parquet).
+            from databricks.sdk import WorkspaceClient
+            w = WorkspaceClient()
             df = flatten_complex_columns(df)
-            df.coalesce(1).write.mode("overwrite").format("excel").option("header", True).save(OUTPUT_PATH)
+            buf = io.BytesIO()
+            df.toPandas().to_excel(buf, index=False, engine="openpyxl")
+            buf.seek(0)
+            w.files.create_directory(OUTPUT_PATH)
+            w.files.upload(f"{OUTPUT_PATH}/{TABLE_NAME}.xlsx", buf, overwrite=True)
+            w.files.upload(f"{OUTPUT_PATH}/_SUCCESS", io.BytesIO(b""), overwrite=True)
         else:
             raise ValueError(f"Unsupported format: {FORMAT}")
         

--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -1084,7 +1084,9 @@ module "data_export_job" {
       spec = {
         environment_version = "4"
         dependencies = [
-          "/Workspace/Shared/.bundle/open-jii/${var.environment}/artifacts/.internal/openjii-0.1.0-py3-none-any.whl"
+          "/Workspace/Shared/.bundle/open-jii/${var.environment}/artifacts/.internal/openjii-0.1.0-py3-none-any.whl",
+          # openpyxl backs the pandas Excel writer used for xlsx exports
+          "openpyxl==3.1.5"
         ]
       }
     }

--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -1009,7 +1009,9 @@ module "data_export_job" {
       spec = {
         environment_version = "4"
         dependencies = [
-          "/Workspace/Shared/.bundle/open-jii/${var.environment}/artifacts/.internal/openjii-0.1.0-py3-none-any.whl"
+          "/Workspace/Shared/.bundle/open-jii/${var.environment}/artifacts/.internal/openjii-0.1.0-py3-none-any.whl",
+          # openpyxl backs the pandas Excel writer used for xlsx exports
+          "openpyxl==3.1.5"
         ]
       }
     }


### PR DESCRIPTION
## Type of PR

- [x] Bug Fix

## Description

XLSX experiment-data exports have never worked on the serverless `Data-Export-Job`. The task wrote Excel with Spark's `df.write.format("excel")`, but serverless Databricks has no Spark Excel writer, so every xlsx export failed with `EXCEL_DATA_WRITER_NOT_ENABLED`. CSV / NDJSON / JSON-array / Parquet were unaffected because they use native Spark writers (or `dbutils.fs.put` for the JSON array).

The fix builds the workbook in memory with pandas/openpyxl and uploads it to the Unity Catalog volume through the **Files API** (`WorkspaceClient().files`), which is binary-safe and uses the volume's own UC write grant — the same one Spark already uses to write csv/parquet there.

Getting the binary onto the volume was the hard part on serverless. For the record, these all fail and are *not* viable:

| Approach | Fails with |
|---|---|
| `df.write.format("excel")` | `EXCEL_DATA_WRITER_NOT_ENABLED`. Writer is gated behind `spark.databricks.sql.excel.enabled`, which serverless won't let us set; and even enabled, Databricks requires Excel to be written to local disk then copied (UC volumes reject non-sequential writes), so it hits the same walls below |
| pandas `to_excel` → `/Volumes/...` FUSE path | `OSError [Errno 5]` (FUSE rejects openpyxl's seeking writes) |
| `/tmp` + `dbutils.fs.cp("file:...", volume)` | `INSUFFICIENT_PERMISSIONS: SELECT on any file` (cp from local needs the broad `ANY FILE` grant) |
| `dbutils.fs.put` | text-only; corrupts the binary workbook |
| **Files API `w.files.create_directory` + `w.files.upload`** | ✅ works |

## Related Issues

- Related to OJD-1469 (bug in the xlsx export added there)

## Changes Made

- `apps/data/src/tasks/data_export_task.py`: xlsx branch now serialises to an in-memory buffer and writes it (plus the `_SUCCESS` marker) via the Files API instead of the Spark Excel writer. Existing row/column caps keep the driver-side collect bounded to Excel's sheet limits.
- `infrastructure/env/{dev,prod}/main.tf`: added `openpyxl==3.1.5` to the `data_export_job` serverless environment dependencies (databricks-sdk is already preinstalled on serverless).

## Testing Instructions

- [x] Validated end-to-end on **dev**: hand-deployed the fixed notebook + patched the job env with `openpyxl`, then ran an xlsx export for a real experiment — the job completes green and writes `raw_data.xlsx` + `_SUCCESS` to the `data-exports` volume, and the file downloads/opens correctly from the app.
- [x] Verified the Files API `create_directory` (recursive) + `upload` mechanism directly against the `data-exports` volume before relying on it.

## Additional Notes

The dev validation was a temporary hand-swap (creates Terraform drift on the job env until this merges); merging normalises it via the CI bundle deploy + tofu apply. No DB migration. No `OJD` ticket, so tagged `no-linear` — happy to swap in a reference if one exists.

