### PR TITLE
feat(workbooks): legible & safe version upgrades, inline rename, rollback

### DIFF
--- a/apps/backend/src/experiments/application/use-cases/set-workbook-version/set-workbook-version.spec.ts
+++ b/apps/backend/src/experiments/application/use-cases/set-workbook-version/set-workbook-version.spec.ts
@@ -88,6 +88,16 @@ describe("SetWorkbookVersionUseCase", () => {
     expect(access.value.experiment?.workbookVersionId).toBe(v1Id);
   });
 
+  it("rejects when the experiment has no attached workbook", async () => {
+    const { experiment } = await testApp.createExperiment({
+      name: "No workbook experiment",
+      userId: adminUserId,
+    });
+    const result = await setUseCase.execute(experiment.id, v1Id, adminUserId);
+    assertFailure(result);
+    expect(result.error.statusCode).toBe(400);
+  });
+
   it("rejects a non-admin", async () => {
     const result = await setUseCase.execute(experimentId, v1Id, memberUserId);
     assertFailure(result);

--- a/apps/backend/src/experiments/application/use-cases/set-workbook-version/set-workbook-version.spec.ts
+++ b/apps/backend/src/experiments/application/use-cases/set-workbook-version/set-workbook-version.spec.ts
@@ -1,8 +1,9 @@
-import { assertFailure, assertSuccess } from "../../../../common/utils/fp-utils";
+import { assertFailure, assertSuccess, failure, AppError } from "../../../../common/utils/fp-utils";
 import { TestHarness } from "../../../../test/test-harness";
 import { PublishVersionUseCase } from "../../../../workbooks/application/use-cases/publish-version/publish-version";
 import { WorkbookRepository } from "../../../../workbooks/core/repositories/workbook.repository";
 import { ExperimentRepository } from "../../../core/repositories/experiment.repository";
+import { FlowRepository } from "../../../core/repositories/flow.repository";
 import { AttachWorkbookUseCase } from "../attach-workbook/attach-workbook";
 import { UpgradeWorkbookVersionUseCase } from "../upgrade-workbook-version/upgrade-workbook-version";
 import { SetWorkbookVersionUseCase } from "./set-workbook-version";
@@ -15,6 +16,7 @@ describe("SetWorkbookVersionUseCase", () => {
   let publishUseCase: PublishVersionUseCase;
   let workbookRepo: WorkbookRepository;
   let experimentRepo: ExperimentRepository;
+  let flowRepo: FlowRepository;
 
   let adminUserId: string;
   let memberUserId: string;
@@ -38,6 +40,7 @@ describe("SetWorkbookVersionUseCase", () => {
     publishUseCase = testApp.module.get(PublishVersionUseCase);
     workbookRepo = testApp.module.get(WorkbookRepository);
     experimentRepo = testApp.module.get(ExperimentRepository);
+    flowRepo = testApp.module.get(FlowRepository);
 
     const { experiment } = await testApp.createExperiment({
       name: "Test Experiment",
@@ -96,6 +99,19 @@ describe("SetWorkbookVersionUseCase", () => {
     const result = await setUseCase.execute(experiment.id, v1Id, adminUserId);
     assertFailure(result);
     expect(result.error.statusCode).toBe(400);
+  });
+
+  it("leaves the experiment on its current version when the flow refresh fails", async () => {
+    vi.spyOn(flowRepo, "upsert").mockResolvedValue(failure(AppError.internal("flow upsert boom")));
+
+    const result = await setUseCase.execute(experimentId, v1Id, adminUserId);
+    assertFailure(result);
+    expect(result.error.statusCode).toBe(500);
+
+    // Experiment must NOT have been re-pinned since the flow never updated.
+    const access = await experimentRepo.checkAccess(experimentId, adminUserId);
+    assertSuccess(access);
+    expect(access.value.experiment?.workbookVersionId).toBe(v2Id);
   });
 
   it("rejects a non-admin", async () => {

--- a/apps/backend/src/experiments/application/use-cases/set-workbook-version/set-workbook-version.spec.ts
+++ b/apps/backend/src/experiments/application/use-cases/set-workbook-version/set-workbook-version.spec.ts
@@ -71,6 +71,7 @@ describe("SetWorkbookVersionUseCase", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     testApp.afterEach();
   });
 

--- a/apps/backend/src/experiments/application/use-cases/set-workbook-version/set-workbook-version.spec.ts
+++ b/apps/backend/src/experiments/application/use-cases/set-workbook-version/set-workbook-version.spec.ts
@@ -1,0 +1,110 @@
+import { assertFailure, assertSuccess } from "../../../../common/utils/fp-utils";
+import { TestHarness } from "../../../../test/test-harness";
+import { PublishVersionUseCase } from "../../../../workbooks/application/use-cases/publish-version/publish-version";
+import { WorkbookRepository } from "../../../../workbooks/core/repositories/workbook.repository";
+import { ExperimentRepository } from "../../../core/repositories/experiment.repository";
+import { AttachWorkbookUseCase } from "../attach-workbook/attach-workbook";
+import { UpgradeWorkbookVersionUseCase } from "../upgrade-workbook-version/upgrade-workbook-version";
+import { SetWorkbookVersionUseCase } from "./set-workbook-version";
+
+describe("SetWorkbookVersionUseCase", () => {
+  const testApp = TestHarness.App;
+  let attachUseCase: AttachWorkbookUseCase;
+  let upgradeUseCase: UpgradeWorkbookVersionUseCase;
+  let setUseCase: SetWorkbookVersionUseCase;
+  let publishUseCase: PublishVersionUseCase;
+  let workbookRepo: WorkbookRepository;
+  let experimentRepo: ExperimentRepository;
+
+  let adminUserId: string;
+  let memberUserId: string;
+  let experimentId: string;
+  let workbookId: string;
+  let v1Id: string;
+  let v2Id: string;
+
+  beforeAll(async () => {
+    await testApp.setup();
+  });
+
+  beforeEach(async () => {
+    await testApp.beforeEach();
+    adminUserId = await testApp.createTestUser({});
+    memberUserId = await testApp.createTestUser({ email: "member@test.com" });
+
+    attachUseCase = testApp.module.get(AttachWorkbookUseCase);
+    upgradeUseCase = testApp.module.get(UpgradeWorkbookVersionUseCase);
+    setUseCase = testApp.module.get(SetWorkbookVersionUseCase);
+    publishUseCase = testApp.module.get(PublishVersionUseCase);
+    workbookRepo = testApp.module.get(WorkbookRepository);
+    experimentRepo = testApp.module.get(ExperimentRepository);
+
+    const { experiment } = await testApp.createExperiment({
+      name: "Test Experiment",
+      userId: adminUserId,
+    });
+    experimentId = experiment.id;
+    await testApp.addExperimentMember(experimentId, memberUserId, "member");
+
+    const workbook = await testApp.createWorkbook({
+      name: "Test Workbook",
+      cells: [{ id: "md1", type: "markdown", content: "v1", isCollapsed: false }],
+      createdBy: adminUserId,
+    });
+    workbookId = workbook.id;
+
+    // Attach publishes + pins v1.
+    const attach = await attachUseCase.execute(experimentId, workbookId, adminUserId);
+    assertSuccess(attach);
+    v1Id = attach.value.workbookVersionId;
+
+    // Change cells and upgrade to mint + pin v2.
+    await workbookRepo.update(workbookId, {
+      cells: [{ id: "md1", type: "markdown", content: "v2", isCollapsed: false }],
+    });
+    const upgrade = await upgradeUseCase.execute(experimentId, adminUserId);
+    assertSuccess(upgrade);
+    v2Id = upgrade.value.workbookVersionId;
+  });
+
+  afterEach(() => {
+    testApp.afterEach();
+  });
+
+  afterAll(async () => {
+    await testApp.teardown();
+  });
+
+  it("rolls the experiment back to an earlier version without publishing", async () => {
+    expect(v2Id).not.toBe(v1Id);
+
+    const result = await setUseCase.execute(experimentId, v1Id, adminUserId);
+    assertSuccess(result);
+    expect(result.value.workbookVersionId).toBe(v1Id);
+    expect(result.value.version).toBe(1);
+
+    const access = await experimentRepo.checkAccess(experimentId, adminUserId);
+    assertSuccess(access);
+    expect(access.value.experiment?.workbookVersionId).toBe(v1Id);
+  });
+
+  it("rejects a non-admin", async () => {
+    const result = await setUseCase.execute(experimentId, v1Id, memberUserId);
+    assertFailure(result);
+    expect(result.error.statusCode).toBe(403);
+  });
+
+  it("rejects a version that belongs to a different workbook", async () => {
+    const otherWorkbook = await testApp.createWorkbook({
+      name: "Other Workbook",
+      cells: [{ id: "md1", type: "markdown", content: "x", isCollapsed: false }],
+      createdBy: adminUserId,
+    });
+    const foreign = await publishUseCase.execute(otherWorkbook.id, adminUserId);
+    assertSuccess(foreign);
+
+    const result = await setUseCase.execute(experimentId, foreign.value.id, adminUserId);
+    assertFailure(result);
+    expect(result.error.statusCode).toBe(404);
+  });
+});

--- a/apps/backend/src/experiments/application/use-cases/set-workbook-version/set-workbook-version.ts
+++ b/apps/backend/src/experiments/application/use-cases/set-workbook-version/set-workbook-version.ts
@@ -69,17 +69,19 @@ export class SetWorkbookVersionUseCase {
           );
         }
 
-        const updateResult = await this.experimentRepository.update(experimentId, {
-          workbookVersionId: target.id,
-        });
-        if (updateResult.isFailure()) return updateResult;
-
-        // Refresh the materialised flow row so mobile reads the pinned graph.
+        // Refresh the materialised flow row first, then re-pin. If the flow
+        // upsert fails, the experiment stays on the old (consistent) version
+        // rather than pointing at a version whose flow never updated.
         const flowResult = await this.flowRepository.upsert(
           experimentId,
           cellsToFlowGraph(target.cells),
         );
         if (flowResult.isFailure()) return flowResult;
+
+        const updateResult = await this.experimentRepository.update(experimentId, {
+          workbookVersionId: target.id,
+        });
+        if (updateResult.isFailure()) return updateResult;
 
         this.logger.log({
           msg: "Experiment pinned to a specific workbook version",

--- a/apps/backend/src/experiments/application/use-cases/set-workbook-version/set-workbook-version.ts
+++ b/apps/backend/src/experiments/application/use-cases/set-workbook-version/set-workbook-version.ts
@@ -1,0 +1,101 @@
+import { Injectable, Logger } from "@nestjs/common";
+
+import { cellsToFlowGraph } from "@repo/api/utils/cells-to-flow";
+
+import { Result, failure, success, AppError } from "../../../../common/utils/fp-utils";
+import { WorkbookVersionRepository } from "../../../../workbooks/core/repositories/workbook-version.repository";
+import type { ExperimentDto } from "../../../core/models/experiment.model";
+import { ExperimentRepository } from "../../../core/repositories/experiment.repository";
+import { FlowRepository } from "../../../core/repositories/flow.repository";
+
+export interface SetWorkbookVersionResult {
+  workbookId: string;
+  workbookVersionId: string;
+  version: number;
+}
+
+/**
+ * Pins an experiment to a SPECIFIC existing published version (rollback or
+ * roll-forward). Unlike upgrade, it never publishes a new version; the target
+ * must already belong to the experiment's workbook.
+ */
+@Injectable()
+export class SetWorkbookVersionUseCase {
+  private readonly logger = new Logger(SetWorkbookVersionUseCase.name);
+
+  constructor(
+    private readonly experimentRepository: ExperimentRepository,
+    private readonly workbookVersionRepository: WorkbookVersionRepository,
+    private readonly flowRepository: FlowRepository,
+  ) {}
+
+  async execute(
+    experimentId: string,
+    versionId: string,
+    userId: string,
+  ): Promise<Result<SetWorkbookVersionResult>> {
+    const accessResult = await this.experimentRepository.checkAccess(experimentId, userId);
+
+    return accessResult.chain(
+      async ({ experiment, isAdmin }: { experiment: ExperimentDto | null; isAdmin: boolean }) => {
+        if (!experiment) {
+          return failure(AppError.notFound(`Experiment with ID ${experimentId} not found`));
+        }
+
+        if (!isAdmin) {
+          return failure(AppError.forbidden("Only admins can change the workbook version"));
+        }
+
+        if (!experiment.workbookId) {
+          return failure(
+            AppError.badRequest(
+              "Experiment does not have an attached workbook. Attach a workbook first.",
+            ),
+          );
+        }
+
+        const versionsResult = await this.workbookVersionRepository.findByWorkbookId(
+          experiment.workbookId,
+        );
+        if (versionsResult.isFailure()) return versionsResult;
+
+        // Restrict the target to a version of THIS experiment's workbook.
+        const target = versionsResult.value.find((v) => v.id === versionId);
+        if (!target) {
+          return failure(
+            AppError.notFound(
+              `Version ${versionId} does not belong to workbook ${experiment.workbookId}`,
+            ),
+          );
+        }
+
+        const updateResult = await this.experimentRepository.update(experimentId, {
+          workbookVersionId: target.id,
+        });
+        if (updateResult.isFailure()) return updateResult;
+
+        // Refresh the materialised flow row so mobile reads the pinned graph.
+        const flowResult = await this.flowRepository.upsert(
+          experimentId,
+          cellsToFlowGraph(target.cells),
+        );
+        if (flowResult.isFailure()) return flowResult;
+
+        this.logger.log({
+          msg: "Experiment pinned to a specific workbook version",
+          operation: "setWorkbookVersion",
+          experimentId,
+          workbookId: experiment.workbookId,
+          workbookVersionId: target.id,
+          version: target.version,
+        });
+
+        return success({
+          workbookId: experiment.workbookId,
+          workbookVersionId: target.id,
+          version: target.version,
+        });
+      },
+    );
+  }
+}

--- a/apps/backend/src/experiments/experiment.module.ts
+++ b/apps/backend/src/experiments/experiment.module.ts
@@ -74,6 +74,7 @@ import { ListExperimentsUseCase } from "./application/use-cases/list-experiments
 import { CreateTransferRequestUseCase } from "./application/use-cases/project-transfer-requests/create-transfer-request/create-transfer-request";
 import { ListTransferRequestsUseCase } from "./application/use-cases/project-transfer-requests/list-transfer-requests/list-transfer-requests";
 import { ExecuteProjectTransferUseCase } from "./application/use-cases/project-transfer/execute-project-transfer";
+import { SetWorkbookVersionUseCase } from "./application/use-cases/set-workbook-version/set-workbook-version";
 import { UpdateExperimentUseCase } from "./application/use-cases/update-experiment/update-experiment";
 import { UpgradeWorkbookVersionUseCase } from "./application/use-cases/upgrade-workbook-version/upgrade-workbook-version";
 import { ANALYTICS_PORT } from "./core/ports/analytics.port";
@@ -249,6 +250,7 @@ import { ProjectTransferWebhookController } from "./presentation/project-transfe
     AttachWorkbookUseCase,
     DetachWorkbookUseCase,
     UpgradeWorkbookVersionUseCase,
+    SetWorkbookVersionUseCase,
 
     // Experiment data annotation use cases
     AddAnnotationsUseCase,

--- a/apps/backend/src/experiments/presentation/experiment-workbooks.controller.spec.ts
+++ b/apps/backend/src/experiments/presentation/experiment-workbooks.controller.spec.ts
@@ -7,6 +7,7 @@ import { success, failure, AppError } from "../../common/utils/fp-utils";
 import { TestHarness } from "../../test/test-harness";
 import { AttachWorkbookUseCase } from "../application/use-cases/attach-workbook/attach-workbook";
 import { DetachWorkbookUseCase } from "../application/use-cases/detach-workbook/detach-workbook";
+import { SetWorkbookVersionUseCase } from "../application/use-cases/set-workbook-version/set-workbook-version";
 import { UpgradeWorkbookVersionUseCase } from "../application/use-cases/upgrade-workbook-version/upgrade-workbook-version";
 
 describe("ExperimentWorkbooksController", () => {
@@ -15,6 +16,7 @@ describe("ExperimentWorkbooksController", () => {
   let attachUseCase: AttachWorkbookUseCase;
   let detachUseCase: DetachWorkbookUseCase;
   let upgradeUseCase: UpgradeWorkbookVersionUseCase;
+  let setVersionUseCase: SetWorkbookVersionUseCase;
 
   beforeAll(async () => {
     await testApp.setup({ mock: { AnalyticsAdapter: true } });
@@ -27,6 +29,7 @@ describe("ExperimentWorkbooksController", () => {
     attachUseCase = testApp.module.get(AttachWorkbookUseCase);
     detachUseCase = testApp.module.get(DetachWorkbookUseCase);
     upgradeUseCase = testApp.module.get(UpgradeWorkbookVersionUseCase);
+    setVersionUseCase = testApp.module.get(SetWorkbookVersionUseCase);
 
     vi.restoreAllMocks();
   });
@@ -188,6 +191,84 @@ describe("ExperimentWorkbooksController", () => {
         id: expId,
       });
       await testApp.post(path).withAuth(testUserId).expect(StatusCodes.BAD_REQUEST);
+    });
+  });
+
+  describe("setWorkbookVersion", () => {
+    it("should re-pin the experiment to the requested version", async () => {
+      const workbookId = faker.string.uuid();
+      const versionId = faker.string.uuid();
+      vi.spyOn(setVersionUseCase, "execute").mockResolvedValue(
+        success({ workbookId, workbookVersionId: versionId, version: 1 }),
+      );
+
+      const expId = faker.string.uuid();
+      const path = testApp.resolvePath(contract.experiments.setWorkbookVersion.path, { id: expId });
+      const response = await testApp
+        .post(path)
+        .withAuth(testUserId)
+        .send({ versionId })
+        .expect(StatusCodes.OK);
+
+      expect(response.body).toMatchObject({
+        workbookId,
+        workbookVersionId: versionId,
+        version: 1,
+      });
+    });
+
+    it("should return 400 for invalid body (missing versionId)", async () => {
+      const expId = faker.string.uuid();
+      const path = testApp.resolvePath(contract.experiments.setWorkbookVersion.path, { id: expId });
+      await testApp.post(path).withAuth(testUserId).send({}).expect(StatusCodes.BAD_REQUEST);
+    });
+
+    it("should return 400 for a non-uuid versionId", async () => {
+      const expId = faker.string.uuid();
+      const path = testApp.resolvePath(contract.experiments.setWorkbookVersion.path, { id: expId });
+      await testApp
+        .post(path)
+        .withAuth(testUserId)
+        .send({ versionId: "not-a-uuid" })
+        .expect(StatusCodes.BAD_REQUEST);
+    });
+
+    it("should return 401 without auth", async () => {
+      const expId = faker.string.uuid();
+      const path = testApp.resolvePath(contract.experiments.setWorkbookVersion.path, { id: expId });
+      await testApp
+        .post(path)
+        .withoutAuth()
+        .send({ versionId: faker.string.uuid() })
+        .expect(StatusCodes.UNAUTHORIZED);
+    });
+
+    it("should return 403 when user lacks admin access", async () => {
+      vi.spyOn(setVersionUseCase, "execute").mockResolvedValue(
+        failure(AppError.forbidden("Only admins can change the workbook version")),
+      );
+
+      const expId = faker.string.uuid();
+      const path = testApp.resolvePath(contract.experiments.setWorkbookVersion.path, { id: expId });
+      await testApp
+        .post(path)
+        .withAuth(testUserId)
+        .send({ versionId: faker.string.uuid() })
+        .expect(StatusCodes.FORBIDDEN);
+    });
+
+    it("should return 404 when the target version is not found", async () => {
+      vi.spyOn(setVersionUseCase, "execute").mockResolvedValue(
+        failure(AppError.notFound("Workbook version not found")),
+      );
+
+      const expId = faker.string.uuid();
+      const path = testApp.resolvePath(contract.experiments.setWorkbookVersion.path, { id: expId });
+      await testApp
+        .post(path)
+        .withAuth(testUserId)
+        .send({ versionId: faker.string.uuid() })
+        .expect(StatusCodes.NOT_FOUND);
     });
   });
 });

--- a/apps/backend/src/experiments/presentation/experiment-workbooks.controller.ts
+++ b/apps/backend/src/experiments/presentation/experiment-workbooks.controller.ts
@@ -10,6 +10,7 @@ import { formatDates } from "../../common/utils/date-formatter";
 import { handleFailure } from "../../common/utils/fp-utils";
 import { AttachWorkbookUseCase } from "../application/use-cases/attach-workbook/attach-workbook";
 import { DetachWorkbookUseCase } from "../application/use-cases/detach-workbook/detach-workbook";
+import { SetWorkbookVersionUseCase } from "../application/use-cases/set-workbook-version/set-workbook-version";
 import { UpgradeWorkbookVersionUseCase } from "../application/use-cases/upgrade-workbook-version/upgrade-workbook-version";
 
 @Controller()
@@ -20,6 +21,7 @@ export class ExperimentWorkbooksController {
     private readonly attachWorkbookUseCase: AttachWorkbookUseCase,
     private readonly detachWorkbookUseCase: DetachWorkbookUseCase,
     private readonly upgradeWorkbookVersionUseCase: UpgradeWorkbookVersionUseCase,
+    private readonly setWorkbookVersionUseCase: SetWorkbookVersionUseCase,
   ) {}
 
   @TsRestHandler(contract.experiments.attachWorkbook)
@@ -62,6 +64,26 @@ export class ExperimentWorkbooksController {
   upgradeWorkbookVersion(@Session() session: UserSession) {
     return tsRestHandler(contract.experiments.upgradeWorkbookVersion, async ({ params }) => {
       const result = await this.upgradeWorkbookVersionUseCase.execute(params.id, session.user.id);
+
+      if (result.isSuccess()) {
+        return {
+          status: StatusCodes.OK as const,
+          body: result.value,
+        };
+      }
+
+      return handleFailure(result, this.logger);
+    });
+  }
+
+  @TsRestHandler(contract.experiments.setWorkbookVersion)
+  setWorkbookVersion(@Session() session: UserSession) {
+    return tsRestHandler(contract.experiments.setWorkbookVersion, async ({ params, body }) => {
+      const result = await this.setWorkbookVersionUseCase.execute(
+        params.id,
+        body.versionId,
+        session.user.id,
+      );
 
       if (result.isSuccess()) {
         return {

--- a/apps/backend/src/test/test-harness.ts
+++ b/apps/backend/src/test/test-harness.ts
@@ -28,6 +28,10 @@ import {
   macros,
   workbooks,
   workbookVersions,
+  accounts,
+  experimentDashboards,
+  experimentVisualizations,
+  experimentJoinRequests,
 } from "@repo/database";
 
 import { AppModule } from "../app.module";
@@ -121,8 +125,10 @@ export class TestHarness {
       await this.clearDatabase();
       this.resetMockAdapters();
     } catch (e) {
-      console.log("Failed to clean up database for integration tests.", e);
-      // Don't throw the error to allow tests to continue
+      // Fail loudly: a swallowed cleanup error leaves the shared test DB
+      // polluted, which surfaces later as confusing duplicate-key failures.
+      console.error("Failed to clean up database for integration tests.", e);
+      throw e;
     }
   }
 
@@ -181,8 +187,12 @@ export class TestHarness {
     // Clean up test data in correct order (respecting foreign key constraints)
     await this.database.delete(auditLogs).execute();
     await this.database.delete(invitations).execute();
+    await this.database.delete(experimentJoinRequests).execute();
     await this.database.delete(experimentMembers).execute();
     await this.database.delete(experimentLocations).execute();
+    // Dashboards/visualizations reference experiments, delete before experiments
+    await this.database.delete(experimentVisualizations).execute();
+    await this.database.delete(experimentDashboards).execute();
     await this.database.delete(workbookVersions).execute();
     await this.database.delete(workbooks).execute();
     // Flows reference experiments, so delete flows before experiments
@@ -195,8 +205,9 @@ export class TestHarness {
     await this.database.delete(organizations).execute();
     // IoT devices reference users, delete before users
     await this.database.delete(iotDevices).execute();
-    // Sessions reference users, delete before users
+    // Sessions/accounts reference users, delete before users
     await this.database.delete(sessions).execute();
+    await this.database.delete(accounts).execute();
     await this.database.delete(users).execute();
   }
 

--- a/apps/backend/src/workbooks/application/use-cases/is-workbook-upgradable/shared-entity-propagation.spec.ts
+++ b/apps/backend/src/workbooks/application/use-cases/is-workbook-upgradable/shared-entity-propagation.spec.ts
@@ -1,0 +1,286 @@
+import { assertSuccess } from "../../../../common/utils/fp-utils";
+import { UpdateMacroUseCase } from "../../../../macros/application/use-cases/update-macro/update-macro";
+import { MacroRepository } from "../../../../macros/core/repositories/macro.repository";
+import { UpdateProtocolUseCase } from "../../../../protocols/application/use-cases/update-protocol/update-protocol";
+import { ProtocolRepository } from "../../../../protocols/core/repositories/protocol.repository";
+import { TestHarness } from "../../../../test/test-harness";
+import { WorkbookVersionRepository } from "../../../core/repositories/workbook-version.repository";
+import { WorkbookRepository } from "../../../core/repositories/workbook.repository";
+import { PublishVersionUseCase } from "../publish-version/publish-version";
+import { IsWorkbookUpgradableUseCase } from "./is-workbook-upgradable";
+
+function expectValue<T>(v: T | null | undefined): T {
+  if (v == null) throw new Error("expected non-null value");
+  return v;
+}
+
+/**
+ * Protocols and macros are single shared rows referenced by id from workbook
+ * cells; there is no per-workbook copy. This suite pins down what that means
+ * across two workbooks that reference the same entity: the "if I edit my
+ * protocol, what happens to the other workbook / to experiments?" question.
+ *
+ * The load-bearing facts it proves:
+ *  - Editing the entity mutates the one shared row, so EVERY workbook that
+ *    references it (even one owned by someone else, whose owner did nothing)
+ *    immediately reports drift (isUpgradable === true).
+ *  - Editing "from the workbook page" and editing the entity "directly" are the
+ *    same UpdateProtocolUseCase call; there is no workbook-scoped sandbox.
+ *  - Published version snapshots stay frozen on the old code, so experiments
+ *    pinned to them are NOT mutated until someone upgrades.
+ *  - Upgrading one workbook advances only that workbook; the other still lags.
+ *  - Re-running a workbook (output cells + per-run runtime fields) is NOT drift.
+ */
+describe("shared entity propagation across workbooks (integration)", () => {
+  const testApp = TestHarness.App;
+  let isUpgradableUseCase: IsWorkbookUpgradableUseCase;
+  let publishVersion: PublishVersionUseCase;
+  let updateProtocol: UpdateProtocolUseCase;
+  let updateMacro: UpdateMacroUseCase;
+  let workbookRepo: WorkbookRepository;
+  let versionRepo: WorkbookVersionRepository;
+  let protocolRepo: ProtocolRepository;
+  let macroRepo: MacroRepository;
+
+  // Owner of the shared entity + workbook WA; `otherId` owns only workbook WB.
+  let ownerId: string;
+  let otherId: string;
+
+  beforeAll(async () => {
+    await testApp.setup();
+  });
+
+  beforeEach(async () => {
+    await testApp.beforeEach();
+    ownerId = await testApp.createTestUser({});
+    otherId = await testApp.createTestUser({});
+    isUpgradableUseCase = testApp.module.get(IsWorkbookUpgradableUseCase);
+    publishVersion = testApp.module.get(PublishVersionUseCase);
+    updateProtocol = testApp.module.get(UpdateProtocolUseCase);
+    updateMacro = testApp.module.get(UpdateMacroUseCase);
+    workbookRepo = testApp.module.get(WorkbookRepository);
+    versionRepo = testApp.module.get(WorkbookVersionRepository);
+    protocolRepo = testApp.module.get(ProtocolRepository);
+    macroRepo = testApp.module.get(MacroRepository);
+  });
+
+  afterEach(() => {
+    testApp.afterEach();
+  });
+
+  afterAll(async () => {
+    await testApp.teardown();
+  });
+
+  const protocolCell = (protocolId: string, id = "p1") => ({
+    id,
+    type: "protocol" as const,
+    isCollapsed: false,
+    payload: { protocolId, version: 1 },
+  });
+
+  const macroCell = (macroId: string, id = "m1") => ({
+    id,
+    type: "macro" as const,
+    isCollapsed: false,
+    payload: { macroId, language: "python" as const },
+  });
+
+  /** Publish the workbook's current cells + live entity code as a new version. */
+  async function publish(workbookId: string, userId: string) {
+    const result = await publishVersion.execute(workbookId, userId);
+    assertSuccess(result);
+    return result.value;
+  }
+
+  /** isUpgradable is computed against the live draft + live entity code. */
+  async function isUpgradable(workbookId: string): Promise<boolean> {
+    const wb = await workbookRepo.findById(workbookId);
+    assertSuccess(wb);
+    const result = await isUpgradableUseCase.execute(expectValue(wb.value));
+    assertSuccess(result);
+    return result.value;
+  }
+
+  async function latestVersion(workbookId: string) {
+    const result = await versionRepo.getLatestVersion(workbookId);
+    assertSuccess(result);
+    return expectValue(result.value);
+  }
+
+  async function protocolSnapshotCode(workbookId: string, protocolId: string) {
+    const version = await latestVersion(workbookId);
+    return (version.entitySnapshots.protocols[protocolId] as { code: unknown } | undefined)?.code;
+  }
+
+  async function macroSnapshotCode(workbookId: string, macroId: string) {
+    const version = await latestVersion(workbookId);
+    return (version.entitySnapshots.macros[macroId] as { code: string } | undefined)?.code;
+  }
+
+  const OLD_CODE = [{ label: "Phi2", pulses: [10, 20] }];
+  const NEW_CODE = [{ label: "Phi2", pulses: [10, 30] }];
+
+  it("editing a shared protocol flags every referencing workbook and freezes all snapshots", async () => {
+    const protocol = await testApp.createProtocol({
+      name: "Shared protocol",
+      code: OLD_CODE,
+      createdBy: ownerId,
+    });
+    // WA is owned by the protocol owner; WB by a different user. Both reference
+    // the same protocol and are each published to v1.
+    const wa = await testApp.createWorkbook({
+      name: "WA (owner)",
+      cells: [protocolCell(protocol.id)],
+      createdBy: ownerId,
+    });
+    const wb = await testApp.createWorkbook({
+      name: "WB (other user)",
+      cells: [protocolCell(protocol.id)],
+      createdBy: otherId,
+    });
+    await publish(wa.id, ownerId);
+    await publish(wb.id, otherId);
+
+    expect(await isUpgradable(wa.id)).toBe(false);
+    expect(await isUpgradable(wb.id)).toBe(false);
+
+    // Edit the protocol. This is the SAME call the protocol cell autosave makes
+    // "from the workbook page" and the standalone protocol page makes
+    // "directly": there is no workbook-scoped copy.
+    assertSuccess(await updateProtocol.execute(protocol.id, { code: NEW_CODE }));
+
+    // The single shared row now holds the new code.
+    const live = await protocolRepo.findOne(protocol.id);
+    assertSuccess(live);
+    expect(expectValue(live.value).code).toEqual(NEW_CODE);
+
+    // BOTH workbooks report drift, including WB, whose owner did nothing.
+    expect(await isUpgradable(wa.id)).toBe(true);
+    expect(await isUpgradable(wb.id)).toBe(true);
+
+    // BOTH published snapshots stay frozen on the old code, so any experiment
+    // pinned to v1 keeps running the old protocol until it is upgraded.
+    expect(await protocolSnapshotCode(wa.id, protocol.id)).toEqual(OLD_CODE);
+    expect(await protocolSnapshotCode(wb.id, protocol.id)).toEqual(OLD_CODE);
+
+    // The entity edit mints no workbook version on its own.
+    expect((await latestVersion(wa.id)).version).toBe(1);
+    expect((await latestVersion(wb.id)).version).toBe(1);
+  });
+
+  it("upgrading one workbook advances only it; the other still lags", async () => {
+    const protocol = await testApp.createProtocol({
+      name: "Shared protocol",
+      code: OLD_CODE,
+      createdBy: ownerId,
+    });
+    const wa = await testApp.createWorkbook({
+      name: "WA (owner)",
+      cells: [protocolCell(protocol.id)],
+      createdBy: ownerId,
+    });
+    const wb = await testApp.createWorkbook({
+      name: "WB (other user)",
+      cells: [protocolCell(protocol.id)],
+      createdBy: otherId,
+    });
+    await publish(wa.id, ownerId);
+    await publish(wb.id, otherId);
+    assertSuccess(await updateProtocol.execute(protocol.id, { code: NEW_CODE }));
+
+    // The owner upgrades WA (what the experiment design page / upgrade banner
+    // does): a new version snapshots the current live code.
+    await publish(wa.id, ownerId);
+
+    expect((await latestVersion(wa.id)).version).toBe(2);
+    expect(await isUpgradable(wa.id)).toBe(false);
+    expect(await protocolSnapshotCode(wa.id, protocol.id)).toEqual(NEW_CODE);
+
+    // WB is untouched: still on v1, still frozen on the old code, still drifted.
+    expect((await latestVersion(wb.id)).version).toBe(1);
+    expect(await isUpgradable(wb.id)).toBe(true);
+    expect(await protocolSnapshotCode(wb.id, protocol.id)).toEqual(OLD_CODE);
+  });
+
+  it("re-running a workbook (output cells + per-run fields) is not drift", async () => {
+    const protocol = await testApp.createProtocol({
+      name: "Shared protocol",
+      code: OLD_CODE,
+      createdBy: ownerId,
+    });
+    const question = {
+      id: "q1",
+      type: "question" as const,
+      isCollapsed: false,
+      isAnswered: false,
+      name: "reading",
+      question: { kind: "open_ended" as const, text: "Value?", required: false },
+    };
+    const wb = await testApp.createWorkbook({
+      name: "WB",
+      cells: [protocolCell(protocol.id), question],
+      createdBy: ownerId,
+    });
+    await publish(wb.id, ownerId);
+    expect(await isUpgradable(wb.id)).toBe(false);
+
+    // Mirror exactly what a run leaves in `cells`: an appended output cell and
+    // per-run runtime fields on the question. designOf() strips both, so this
+    // must NOT register as an upgrade (OJD-1626).
+    await workbookRepo.update(wb.id, {
+      cells: [
+        protocolCell(protocol.id),
+        { ...question, isAnswered: true, answer: "42" },
+        {
+          id: "out1",
+          type: "output",
+          isCollapsed: false,
+          producedBy: "p1",
+          data: { value: 42 },
+          executionTime: 12,
+          messages: [],
+        },
+      ],
+    });
+
+    expect(await isUpgradable(wb.id)).toBe(false);
+  });
+
+  it("editing a shared macro behaves identically to a shared protocol", async () => {
+    const macro = await testApp.createMacro({
+      name: "Shared macro",
+      code: btoa("print('v0')"),
+      createdBy: ownerId,
+    });
+    const wa = await testApp.createWorkbook({
+      name: "WA (owner)",
+      cells: [macroCell(macro.id)],
+      createdBy: ownerId,
+    });
+    const wb = await testApp.createWorkbook({
+      name: "WB (other user)",
+      cells: [macroCell(macro.id)],
+      createdBy: otherId,
+    });
+    await publish(wa.id, ownerId);
+    await publish(wb.id, otherId);
+
+    expect(await isUpgradable(wa.id)).toBe(false);
+    expect(await isUpgradable(wb.id)).toBe(false);
+
+    const newCode = btoa("print('v1')");
+    // Macro updates are owner-gated, so the edit runs as the macro's owner.
+    assertSuccess(await updateMacro.execute(macro.id, { code: newCode }, ownerId));
+
+    const live = await macroRepo.findById(macro.id);
+    assertSuccess(live);
+    expect(expectValue(live.value).code).toBe(newCode);
+
+    expect(await isUpgradable(wa.id)).toBe(true);
+    expect(await isUpgradable(wb.id)).toBe(true);
+
+    expect(await macroSnapshotCode(wa.id, macro.id)).toBe(btoa("print('v0')"));
+    expect(await macroSnapshotCode(wb.id, macro.id)).toBe(btoa("print('v0')"));
+  });
+});

--- a/apps/web/app/[locale]/platform/experiments/[id]/design/page.test.tsx
+++ b/apps/web/app/[locale]/platform/experiments/[id]/design/page.test.tsx
@@ -256,7 +256,7 @@ describe("ExperimentDesignPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/v2 is available/)).toBeInTheDocument();
-      expect(screen.getByText(/flow\.upgradeToLatest/)).toBeInTheDocument();
+      expect(screen.getByText(/flow\.reviewAndUpgrade/)).toBeInTheDocument();
     });
   });
 

--- a/apps/web/components/experiment-flow/linked-workbook-card.flicker.test.tsx
+++ b/apps/web/components/experiment-flow/linked-workbook-card.flicker.test.tsx
@@ -17,7 +17,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LinkedWorkbookCard } from "./linked-workbook-card";
 
 const { syncState } = vi.hoisted(() => ({
-  syncState: { workbook: 0, versions: 0, mutating: 0, upgrading: 0 },
+  syncState: { workbook: 0, versions: 0, mutating: 0, upgrading: 0, setting: 0 },
 }));
 
 vi.mock("@tanstack/react-query", async (importActual) => {
@@ -35,6 +35,7 @@ vi.mock("@tanstack/react-query", async (importActual) => {
       const key = filters?.mutationKey;
       if (key?.[0] === "workbook" && key[2] === "update") return syncState.mutating;
       if (key?.[0] === "experiment" && key[2] === "upgradeWorkbook") return syncState.upgrading;
+      if (key?.[0] === "experiment" && key[2] === "setWorkbookVersion") return syncState.setting;
       return 0;
     },
   };
@@ -93,6 +94,7 @@ describe("LinkedWorkbookCard upgrade banner (anti-flicker)", () => {
     syncState.versions = 0;
     syncState.mutating = 0;
     syncState.upgrading = 0;
+    syncState.setting = 0;
     mockUseWorkbookVersions.mockReturnValue({ data: { body: [pinnedVersion] } });
   });
 
@@ -139,6 +141,26 @@ describe("LinkedWorkbookCard upgrade banner (anti-flicker)", () => {
 
     // Upgrade settles and re-pins; isUpgradable is false again. Never flashed.
     syncState.upgrading = 0;
+    setUpgradable(false);
+    rerender(card());
+    expect(upgradeButton()).not.toBeInTheDocument();
+  });
+
+  it("does not flash the banner while a history restore/roll-forward is in flight", () => {
+    // Settled, not upgradable (just re-pinned): no banner.
+    setUpgradable(false);
+    const { rerender } = render(card());
+    expect(upgradeButton()).not.toBeInTheDocument();
+
+    // A version restore re-pins the experiment; its refetch transiently reads
+    // isUpgradable=true before settling. Stay frozen (hidden).
+    syncState.setting = 1;
+    setUpgradable(true);
+    rerender(card());
+    expect(upgradeButton()).not.toBeInTheDocument();
+
+    // Restore settles; isUpgradable is false again. Never flashed.
+    syncState.setting = 0;
     setUpgradable(false);
     rerender(card());
     expect(upgradeButton()).not.toBeInTheDocument();

--- a/apps/web/components/experiment-flow/linked-workbook-card.flicker.test.tsx
+++ b/apps/web/components/experiment-flow/linked-workbook-card.flicker.test.tsx
@@ -85,7 +85,7 @@ function setUpgradable(isUpgradable: boolean) {
 }
 
 const card = () => <LinkedWorkbookCard {...props} />;
-const upgradeButton = () => screen.queryByRole("button", { name: /flow\.upgradeToLatest/i });
+const upgradeButton = () => screen.queryByRole("button", { name: /flow\.reviewAndUpgrade/i });
 
 describe("LinkedWorkbookCard upgrade banner (anti-flicker)", () => {
   beforeEach(() => {

--- a/apps/web/components/experiment-flow/linked-workbook-card.test.tsx
+++ b/apps/web/components/experiment-flow/linked-workbook-card.test.tsx
@@ -64,6 +64,17 @@ describe("LinkedWorkbookCard", () => {
     await waitFor(() => expect(screen.getByText("v1")).toBeInTheDocument());
   });
 
+  it("opens the version history dialog from the history button", async () => {
+    mountDefaults();
+    render(<LinkedWorkbookCard {...defaultProps} />);
+    await waitFor(() => expect(screen.getByText("Test Workbook")).toBeInTheDocument());
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "flow.versionHistory.open" }));
+
+    expect(await screen.findByText("flow.versionHistory.title")).toBeInTheDocument();
+  });
+
   it("shows upgrade banner when a newer version is available", async () => {
     mountDefaults();
     render(<LinkedWorkbookCard {...defaultProps} />);

--- a/apps/web/components/experiment-flow/linked-workbook-card.test.tsx
+++ b/apps/web/components/experiment-flow/linked-workbook-card.test.tsx
@@ -25,6 +25,19 @@ function mountDefaults() {
   server.mount(contract.workbooks.getWorkbook, { body: workbook });
   server.mount(contract.workbooks.listWorkbookVersions, { body: [v2, v1] });
   server.mount(contract.workbooks.listWorkbooks, { body: [workbook, otherWorkbook] });
+  // The upgrade review dialog fetches the pinned version to diff against live.
+  server.mount(contract.workbooks.getWorkbookVersion, {
+    body: {
+      id: "ver-1",
+      workbookId: "wb-1",
+      version: 1,
+      cells: [],
+      metadata: {},
+      entitySnapshots: { protocols: {}, macros: {} },
+      createdAt: "2025-01-01T00:00:00.000Z",
+      createdBy: "user-1",
+    },
+  });
 }
 
 describe("LinkedWorkbookCard", () => {
@@ -163,13 +176,12 @@ describe("LinkedWorkbookCard", () => {
     render(<LinkedWorkbookCard {...defaultProps} />);
     await waitFor(() => expect(screen.getByText(/v2 is available/)).toBeInTheDocument());
 
-    await user.click(screen.getByRole("button", { name: /flow\.upgradeToLatest/ }));
+    await user.click(screen.getByRole("button", { name: /flow\.reviewAndUpgrade/ }));
 
-    const confirmBtn = screen
-      .getAllByText("flow.confirmUpgrade")
-      .find((el) => el.closest("[role='alertdialog']"));
-    expect(confirmBtn).toBeDefined();
-    if (confirmBtn) await user.click(confirmBtn);
+    // The review dialog opens; confirm once it has loaded the diff.
+    const confirmBtn = await screen.findByRole("button", { name: /flow\.confirmUpgrade/ });
+    await waitFor(() => expect(confirmBtn).not.toBeDisabled());
+    await user.click(confirmBtn);
 
     await waitFor(() => expect(spy.called).toBe(true));
     // The "upgraded" toast was intentionally removed; no success toast fires.
@@ -183,12 +195,11 @@ describe("LinkedWorkbookCard", () => {
     render(<LinkedWorkbookCard {...defaultProps} />);
     await waitFor(() => expect(screen.getByText(/v2 is available/)).toBeInTheDocument());
 
-    await user.click(screen.getByRole("button", { name: /flow\.upgradeToLatest/ }));
+    await user.click(screen.getByRole("button", { name: /flow\.reviewAndUpgrade/ }));
 
-    const confirmBtn = screen
-      .getAllByText("flow.confirmUpgrade")
-      .find((el) => el.closest("[role='alertdialog']"));
-    if (confirmBtn) await user.click(confirmBtn);
+    const confirmBtn = await screen.findByRole("button", { name: /flow\.confirmUpgrade/ });
+    await waitFor(() => expect(confirmBtn).not.toBeDisabled());
+    await user.click(confirmBtn);
 
     await waitFor(() =>
       expect(toast).toHaveBeenCalledWith({

--- a/apps/web/components/experiment-flow/linked-workbook-card.tsx
+++ b/apps/web/components/experiment-flow/linked-workbook-card.tsx
@@ -86,7 +86,13 @@ export function LinkedWorkbookCard({
   const upgradingWorkbook = useIsMutating({
     mutationKey: ["experiment", experimentId, "upgradeWorkbook"],
   });
-  const isSyncing = fetchingWorkbook + fetchingVersions + savingWorkbook + upgradingWorkbook > 0;
+  // History restore/roll-forward repins the version too; freeze the banner while
+  // it is in flight so `isUpgradable` does not flicker mid-mutation.
+  const settingVersion = useIsMutating({
+    mutationKey: ["experiment", experimentId, "setWorkbookVersion"],
+  });
+  const isSyncing =
+    fetchingWorkbook + fetchingVersions + savingWorkbook + upgradingWorkbook + settingVersion > 0;
 
   const liveHasUpgrade = hasNewerPublished || workbook?.isUpgradable === true;
   const settledHasUpgradeRef = useRef(liveHasUpgrade);

--- a/apps/web/components/experiment-flow/linked-workbook-card.tsx
+++ b/apps/web/components/experiment-flow/linked-workbook-card.tsx
@@ -13,6 +13,7 @@ import {
   ArrowUpCircle,
   Check,
   ExternalLink,
+  History,
   LinkIcon,
   Loader2,
   Pencil,
@@ -40,6 +41,8 @@ import { Input } from "@repo/ui/components/input";
 import { toast } from "@repo/ui/hooks/use-toast";
 import { cn } from "@repo/ui/lib/utils";
 
+import { WorkbookUpgradeDialog } from "../workbook/upgrade/workbook-upgrade-dialog";
+import { WorkbookVersionHistoryDialog } from "../workbook/upgrade/workbook-version-history-dialog";
 import { WorkbookSelect } from "../workbook/workbook-select";
 
 interface LinkedWorkbookCardProps {
@@ -160,6 +163,8 @@ export function LinkedWorkbookCard({
 
   const upgradeVersion = useUpgradeWorkbookVersion(experimentId);
   const [upgradeState, setUpgradeState] = useState<"idle" | "upgrading" | "success">("idle");
+  const [reviewOpen, setReviewOpen] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(false);
 
   useEffect(() => {
     if (upgradeState === "success") {
@@ -174,6 +179,7 @@ export function LinkedWorkbookCard({
       { params: { id: experimentId } },
       {
         onSuccess: () => {
+          setReviewOpen(false);
           setUpgradeState("success");
         },
         onError: () => {
@@ -248,6 +254,17 @@ export function LinkedWorkbookCard({
                         showUpgrade={false}
                       />
                     </span>
+                  )}
+                  {pinnedVersion && (
+                    <button
+                      type="button"
+                      onClick={() => setHistoryOpen(true)}
+                      aria-label={t("flow.versionHistory.open")}
+                      title={t("flow.versionHistory.open")}
+                      className="text-muted-foreground hover:text-foreground shrink-0 rounded p-0.5 transition-colors"
+                    >
+                      <History className="h-3.5 w-3.5" />
+                    </button>
                   )}
                   {canRename && (
                     <button
@@ -330,42 +347,25 @@ export function LinkedWorkbookCard({
               )}
             </p>
           </div>
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-7 gap-1.5 text-xs font-medium text-emerald-700 hover:bg-emerald-100 hover:text-emerald-800"
-                disabled={upgradeState === "upgrading"}
-              >
-                {upgradeState === "upgrading" ? (
-                  <>
-                    <Loader2 className="h-3 w-3 animate-spin" />
-                    Upgrading…
-                  </>
-                ) : (
-                  <>
-                    <ArrowUpCircle className="h-3 w-3" />
-                    {hasNewerPublished
-                      ? t("flow.upgradeToLatest", { version: latestVersion.version })
-                      : t("flow.upgradeToLatest", { version: pinnedVersion.version + 1 })}
-                  </>
-                )}
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>{t("flow.confirmUpgradeTitle")}</AlertDialogTitle>
-                <AlertDialogDescription>{t("flow.confirmUpgradeMessage")}</AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
-                <AlertDialogAction onClick={handleUpgrade}>
-                  {t("flow.confirmUpgrade")}
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 gap-1.5 text-xs font-medium text-emerald-700 hover:bg-emerald-100 hover:text-emerald-800"
+            disabled={upgradeState === "upgrading"}
+            onClick={() => setReviewOpen(true)}
+          >
+            {upgradeState === "upgrading" ? (
+              <>
+                <Loader2 className="h-3 w-3 animate-spin" />
+                {t("flow.upgradeDiff.upgrading")}
+              </>
+            ) : (
+              <>
+                <ArrowUpCircle className="h-3 w-3" />
+                {t("flow.reviewAndUpgrade")}
+              </>
+            )}
+          </Button>
         </div>
       )}
 
@@ -416,6 +416,28 @@ export function LinkedWorkbookCard({
           </Button>
         </div>
       )}
+
+      {pinnedVersion && (
+        <WorkbookUpgradeDialog
+          open={reviewOpen}
+          onOpenChange={setReviewOpen}
+          workbookId={workbookId}
+          pinnedVersionId={workbookVersionId}
+          currentVersion={pinnedVersion.version}
+          targetVersionLabel={`v${hasNewerPublished ? latestVersion.version : pinnedVersion.version + 1}`}
+          onConfirm={handleUpgrade}
+          isUpgrading={upgradeState === "upgrading"}
+        />
+      )}
+
+      <WorkbookVersionHistoryDialog
+        open={historyOpen}
+        onOpenChange={setHistoryOpen}
+        experimentId={experimentId}
+        workbookId={workbookId}
+        currentVersionId={workbookVersionId}
+        canManage={hasAccess}
+      />
     </div>
   );
 }

--- a/apps/web/components/workbook/cell-title.test.tsx
+++ b/apps/web/components/workbook/cell-title.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, userEvent, waitFor } from "@/test/test-utils";
+import { describe, it, expect, vi } from "vitest";
+
+import { CellTitle } from "./cell-title";
+
+const labels = { rename: "Rename", save: "Save name", cancel: "Cancel" };
+
+describe("CellTitle", () => {
+  it("renders plain text with no controls when rename is not allowed", () => {
+    render(<CellTitle name="My Protocol" canRename={false} onRename={vi.fn()} labels={labels} />);
+    expect(screen.getByText("My Protocol")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Rename")).not.toBeInTheDocument();
+  });
+
+  it("commits a trimmed new name on save", async () => {
+    const onRename = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<CellTitle name="Old" canRename onRename={onRename} labels={labels} />);
+
+    await user.click(screen.getByLabelText("Rename"));
+    await user.clear(screen.getByLabelText("Rename"));
+    await user.type(screen.getByLabelText("Rename"), "  New name  ");
+    await user.click(screen.getByLabelText("Save name"));
+
+    expect(onRename).toHaveBeenCalledWith("New name");
+  });
+
+  it("does not call onRename when the name is unchanged or empty", async () => {
+    const onRename = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<CellTitle name="Same" canRename onRename={onRename} labels={labels} />);
+
+    await user.click(screen.getByLabelText("Rename"));
+    await user.click(screen.getByLabelText("Save name"));
+    expect(onRename).not.toHaveBeenCalled();
+
+    await user.click(screen.getByLabelText("Rename"));
+    await user.clear(screen.getByLabelText("Rename"));
+    await user.click(screen.getByLabelText("Save name"));
+    expect(onRename).not.toHaveBeenCalled();
+  });
+
+  it("cancels editing on Escape without saving", async () => {
+    const onRename = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<CellTitle name="Keep" canRename onRename={onRename} labels={labels} />);
+
+    await user.click(screen.getByLabelText("Rename"));
+    await user.type(screen.getByLabelText("Rename"), "discarded");
+    await user.keyboard("{Escape}");
+
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.getByText("Keep")).toBeInTheDocument();
+  });
+
+  it("keeps the editor open when onRename rejects", async () => {
+    const onRename = vi.fn().mockRejectedValue(new Error("taken"));
+    const user = userEvent.setup();
+    render(<CellTitle name="Old" canRename onRename={onRename} labels={labels} />);
+
+    await user.click(screen.getByLabelText("Rename"));
+    await user.clear(screen.getByLabelText("Rename"));
+    await user.type(screen.getByLabelText("Rename"), "New");
+    await user.click(screen.getByLabelText("Save name"));
+
+    await waitFor(() => expect(onRename).toHaveBeenCalled());
+    expect(screen.getByLabelText("Save name")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/workbook/cell-title.test.tsx
+++ b/apps/web/components/workbook/cell-title.test.tsx
@@ -40,6 +40,31 @@ describe("CellTitle", () => {
     expect(onRename).not.toHaveBeenCalled();
   });
 
+  it("commits the new name on Enter", async () => {
+    const onRename = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<CellTitle name="Old" canRename onRename={onRename} labels={labels} />);
+
+    await user.click(screen.getByLabelText("Rename"));
+    await user.clear(screen.getByLabelText("Rename"));
+    await user.type(screen.getByLabelText("Rename"), "Via Enter{Enter}");
+
+    await waitFor(() => expect(onRename).toHaveBeenCalledWith("Via Enter"));
+  });
+
+  it("cancels editing via the cancel button", async () => {
+    const onRename = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<CellTitle name="Keep" canRename onRename={onRename} labels={labels} />);
+
+    await user.click(screen.getByLabelText("Rename"));
+    await user.type(screen.getByLabelText("Rename"), "discarded");
+    await user.click(screen.getByLabelText("Cancel"));
+
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.getByText("Keep")).toBeInTheDocument();
+  });
+
   it("cancels editing on Escape without saving", async () => {
     const onRename = vi.fn().mockResolvedValue(undefined);
     const user = userEvent.setup();

--- a/apps/web/components/workbook/cell-title.tsx
+++ b/apps/web/components/workbook/cell-title.tsx
@@ -102,7 +102,7 @@ export function CellTitle({
           setDraft(name);
           setEditing(true);
         }}
-        className="shrink-0 opacity-0 transition-opacity group-hover/title:opacity-100"
+        className="shrink-0 opacity-0 transition-opacity focus-visible:opacity-100 group-hover/title:opacity-100"
       >
         <Pencil className="h-3 w-3" />
       </button>

--- a/apps/web/components/workbook/cell-title.tsx
+++ b/apps/web/components/workbook/cell-title.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Check, Pencil, X } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@repo/ui/components/button";
+import { Input } from "@repo/ui/components/input";
+
+interface CellTitleProps {
+  name: string;
+  /** Owner + editable host. When false the title is plain, non-interactive text. */
+  canRename?: boolean;
+  /** Persist the new name. Rejects to keep the editor open (e.g. on a name clash). */
+  onRename?: (next: string) => Promise<void>;
+  isPending?: boolean;
+  labels: { rename: string; save: string; cancel: string };
+}
+
+/**
+ * Compact inline-editable title for a workbook cell header. Rendered inside the
+ * CellWrapper's colored pill, so it inherits the accent color/size and only
+ * owns the pencil affordance + edit state machine.
+ */
+export function CellTitle({
+  name,
+  canRename = false,
+  onRename,
+  isPending,
+  labels,
+}: CellTitleProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(name);
+
+  if (!canRename || !onRename) return <>{name}</>;
+
+  const commit = async () => {
+    const next = draft.trim();
+    if (!next || next === name) {
+      setEditing(false);
+      return;
+    }
+    try {
+      await onRename(next);
+      setEditing(false);
+    } catch {
+      // Keep the editor open so the user can adjust a rejected name.
+    }
+  };
+
+  if (editing) {
+    return (
+      <span className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+        <Input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              void commit();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              setEditing(false);
+            }
+          }}
+          disabled={isPending}
+          autoFocus
+          aria-label={labels.rename}
+          className="h-6 w-44 text-[13px] font-semibold"
+        />
+        <Button
+          size="icon"
+          variant="ghost"
+          className="h-6 w-6 shrink-0"
+          disabled={isPending}
+          aria-label={labels.save}
+          onClick={() => void commit()}
+        >
+          <Check className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          size="icon"
+          variant="ghost"
+          className="h-6 w-6 shrink-0"
+          disabled={isPending}
+          aria-label={labels.cancel}
+          onClick={() => setEditing(false)}
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      </span>
+    );
+  }
+
+  return (
+    <span className="group/title inline-flex min-w-0 items-center gap-1">
+      <span className="truncate">{name}</span>
+      <button
+        type="button"
+        aria-label={labels.rename}
+        onClick={(e) => {
+          e.stopPropagation();
+          setDraft(name);
+          setEditing(true);
+        }}
+        className="shrink-0 opacity-0 transition-opacity group-hover/title:opacity-100"
+      >
+        <Pencil className="h-3 w-3" />
+      </button>
+    </span>
+  );
+}

--- a/apps/web/components/workbook/cells/macro-cell.test.tsx
+++ b/apps/web/components/workbook/cells/macro-cell.test.tsx
@@ -373,4 +373,52 @@ describe("MacroCellComponent", () => {
       typeof useSession
     >);
   });
+
+  describe("inline rename", () => {
+    it("renames the macro and repoints the cell label for the owner", async () => {
+      vi.mocked(useSession).mockReturnValue({
+        data: { user: { id: "user-1" } },
+        isPending: false,
+      } as ReturnType<typeof useSession>);
+      const updateSpy = server.mount(contract.macros.updateMacro, {
+        body: createMacro({ id: "macro-1", name: "Renamed Macro" }),
+      });
+      const onUpdate = vi.fn();
+      renderMacroCell({ onUpdate });
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByLabelText("cells.rename"));
+      const input = screen.getByLabelText("cells.rename");
+      await user.clear(input);
+      await user.type(input, "Renamed Macro");
+      await user.click(screen.getByLabelText("cells.renameSave"));
+
+      await waitFor(() => expect(updateSpy.called).toBe(true));
+      expect(updateSpy.body).toEqual({ name: "Renamed Macro" });
+      await waitFor(() =>
+        expect(onUpdate).toHaveBeenCalledWith(
+          expect.objectContaining({ payload: expect.objectContaining({ name: "Renamed Macro" }) }),
+        ),
+      );
+
+      vi.mocked(useSession).mockReturnValue({ data: null, isPending: false } as ReturnType<
+        typeof useSession
+      >);
+    });
+
+    it("does not offer rename to non-owners", async () => {
+      vi.mocked(useSession).mockReturnValue({
+        data: { user: { id: "viewer" } },
+        isPending: false,
+      } as ReturnType<typeof useSession>);
+      renderMacroCell({}, { createdBy: "other-user" });
+
+      await screen.findByText("My Macro");
+      expect(screen.queryByLabelText("cells.rename")).not.toBeInTheDocument();
+
+      vi.mocked(useSession).mockReturnValue({ data: null, isPending: false } as ReturnType<
+        typeof useSession
+      >);
+    });
+  });
 });

--- a/apps/web/components/workbook/cells/macro-cell.test.tsx
+++ b/apps/web/components/workbook/cells/macro-cell.test.tsx
@@ -406,6 +406,49 @@ describe("MacroCellComponent", () => {
       >);
     });
 
+    it("merges a concurrent language change into the resolved rename", async () => {
+      vi.mocked(useSession).mockReturnValue({
+        data: { user: { id: "user-1" } },
+        isPending: false,
+      } as ReturnType<typeof useSession>);
+      server.mount(contract.macros.getMacro, { body: baseMacro });
+      server.mount(contract.macros.updateMacro, {
+        body: createMacro({ id: "macro-1", name: "Renamed Macro" }),
+        delay: 100,
+      });
+      const onUpdate = vi.fn();
+
+      const user = userEvent.setup();
+      const { rerender } = render(
+        <MacroCellComponent cell={cell} onUpdate={onUpdate} onDelete={vi.fn()} />,
+      );
+
+      await user.click(await screen.findByLabelText("cells.rename"));
+      const input = screen.getByLabelText("cells.rename");
+      await user.clear(input);
+      await user.type(input, "Renamed Macro");
+      await user.click(screen.getByLabelText("cells.renameSave"));
+
+      // A language switch lands while the rename save is still in flight.
+      rerender(
+        <MacroCellComponent
+          cell={{ ...cell, payload: { ...cell.payload, language: "r" } }}
+          onUpdate={onUpdate}
+          onDelete={vi.fn()}
+        />,
+      );
+
+      await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+      const updated = onUpdate.mock.lastCall?.[0] as MacroCell;
+      // The rename must preserve the concurrent language switch, not revert it.
+      expect(updated.payload.language).toBe("r");
+      expect(updated.payload.name).toBe("Renamed Macro");
+
+      vi.mocked(useSession).mockReturnValue({ data: null, isPending: false } as ReturnType<
+        typeof useSession
+      >);
+    });
+
     it("shows the conflict toast and keeps the editor open on a duplicate name", async () => {
       vi.mocked(useSession).mockReturnValue({
         data: { user: { id: "user-1" } },

--- a/apps/web/components/workbook/cells/macro-cell.test.tsx
+++ b/apps/web/components/workbook/cells/macro-cell.test.tsx
@@ -1,6 +1,8 @@
 import { createMacro, createMacroCell } from "@/test/factories";
+import { API_URL } from "@/test/msw/mount";
 import { server } from "@/test/msw/server";
 import { render, screen, waitFor, userEvent } from "@/test/test-utils";
+import { http, HttpResponse } from "msw";
 import { describe, it, expect, vi } from "vitest";
 
 import { contract } from "@repo/api/contract";
@@ -398,6 +400,81 @@ describe("MacroCellComponent", () => {
       await waitFor(() => expect(onUpdate).toHaveBeenCalled());
       const updated = onUpdate.mock.lastCall?.[0] as MacroCell;
       expect(updated.payload.name).toBe("Renamed Macro");
+
+      vi.mocked(useSession).mockReturnValue({ data: null, isPending: false } as ReturnType<
+        typeof useSession
+      >);
+    });
+
+    it("shows the conflict toast and keeps the editor open on a duplicate name", async () => {
+      vi.mocked(useSession).mockReturnValue({
+        data: { user: { id: "user-1" } },
+        isPending: false,
+      } as ReturnType<typeof useSession>);
+      // The update contract has no typed 409; the backend signals a name clash
+      // via a REPOSITORY_DUPLICATE code on a 400 body.
+      server.use(
+        http.put(`${API_URL}/api/v1/macros/:id`, () =>
+          HttpResponse.json(
+            { code: "REPOSITORY_DUPLICATE", message: "duplicate", statusCode: 400 },
+            { status: 400 },
+          ),
+        ),
+      );
+      const { toast } = await import("@repo/ui/hooks/use-toast");
+      const onUpdate = vi.fn();
+      renderMacroCell({ onUpdate });
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByLabelText("cells.rename"));
+      const input = screen.getByLabelText("cells.rename");
+      await user.clear(input);
+      await user.type(input, "Taken Name");
+      await user.click(screen.getByLabelText("cells.renameSave"));
+
+      await waitFor(() =>
+        expect(toast).toHaveBeenCalledWith({
+          description: "cells.renameConflict",
+          variant: "destructive",
+        }),
+      );
+      // Editor stays open so the user can pick another name, and the cell label
+      // is never repointed to the rejected name.
+      expect(screen.getByLabelText("cells.renameSave")).toBeInTheDocument();
+      expect(onUpdate).not.toHaveBeenCalled();
+
+      vi.mocked(useSession).mockReturnValue({ data: null, isPending: false } as ReturnType<
+        typeof useSession
+      >);
+    });
+
+    it("shows a generic failure toast when rename fails without a conflict code", async () => {
+      vi.mocked(useSession).mockReturnValue({
+        data: { user: { id: "user-1" } },
+        isPending: false,
+      } as ReturnType<typeof useSession>);
+      server.mount(contract.macros.updateMacro, {
+        status: 400,
+        body: { message: "boom", statusCode: 400 },
+      });
+      const { toast } = await import("@repo/ui/hooks/use-toast");
+      const onUpdate = vi.fn();
+      renderMacroCell({ onUpdate });
+
+      const user = userEvent.setup();
+      await user.click(await screen.findByLabelText("cells.rename"));
+      const input = screen.getByLabelText("cells.rename");
+      await user.clear(input);
+      await user.type(input, "Another Name");
+      await user.click(screen.getByLabelText("cells.renameSave"));
+
+      await waitFor(() =>
+        expect(toast).toHaveBeenCalledWith({
+          description: "boom",
+          variant: "destructive",
+        }),
+      );
+      expect(onUpdate).not.toHaveBeenCalled();
 
       vi.mocked(useSession).mockReturnValue({ data: null, isPending: false } as ReturnType<
         typeof useSession

--- a/apps/web/components/workbook/cells/macro-cell.test.tsx
+++ b/apps/web/components/workbook/cells/macro-cell.test.tsx
@@ -395,11 +395,9 @@ describe("MacroCellComponent", () => {
 
       await waitFor(() => expect(updateSpy.called).toBe(true));
       expect(updateSpy.body).toEqual({ name: "Renamed Macro" });
-      await waitFor(() =>
-        expect(onUpdate).toHaveBeenCalledWith(
-          expect.objectContaining({ payload: expect.objectContaining({ name: "Renamed Macro" }) }),
-        ),
-      );
+      await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+      const updated = onUpdate.mock.lastCall?.[0] as MacroCell;
+      expect(updated.payload.name).toBe("Renamed Macro");
 
       vi.mocked(useSession).mockReturnValue({ data: null, isPending: false } as ReturnType<
         typeof useSession

--- a/apps/web/components/workbook/cells/macro-cell.tsx
+++ b/apps/web/components/workbook/cells/macro-cell.tsx
@@ -32,6 +32,7 @@ import {
 } from "@repo/ui/components/tooltip";
 import { toast } from "@repo/ui/hooks/use-toast";
 
+import { CellTitle } from "../cell-title";
 import { CellWrapper } from "../cell-wrapper";
 import { WorkbookCodeEditor } from "../workbook-code-editor";
 import { useWorkbookEntitySaved } from "../workbook-entity-saved-context";
@@ -169,12 +170,51 @@ export function MacroCellComponent({
 
   const [langSelectOpen, setLangSelectOpen] = useState(false);
 
+  // Rename the shared macro row and repoint the cell label at the new name.
+  // Renaming a fork resolves the auto-generated "Copy of ..." name in place.
+  const [isRenaming, setIsRenaming] = useState(false);
+  const handleRename = useCallback(
+    async (next: string) => {
+      setIsRenaming(true);
+      try {
+        const res = await saveMacro({ params: { id: macroId }, body: { name: next } });
+        onUpdate({ ...cell, payload: { ...cell.payload, name: res.body.name } });
+      } catch (err) {
+        const parsed = parseApiError(err);
+        toast({
+          description:
+            parsed?.code === "REPOSITORY_DUPLICATE"
+              ? t("cells.renameConflict")
+              : (parsed?.message ?? t("cells.renameFailed")),
+          variant: "destructive",
+        });
+        throw err;
+      } finally {
+        setIsRenaming(false);
+      }
+    },
+    [macroId, saveMacro, onUpdate, cell, t],
+  );
+
   const displayName = cell.payload.name ?? macroName ?? "Macro";
 
   return (
     <CellWrapper
       icon={<Code className="h-3.5 w-3.5" />}
-      label={displayName}
+      label={
+        <CellTitle
+          name={displayName}
+          canRename={isEditable}
+          onRename={handleRename}
+          isPending={isRenaming}
+          labels={{
+            rename: t("cells.rename"),
+            save: t("cells.renameSave"),
+            cancel: t("cells.renameCancel"),
+          }}
+        />
+      }
+      labelText={displayName}
       accentColor="#6C5CE7"
       isCollapsed={cell.isCollapsed}
       onToggleCollapse={(collapsed) => onUpdate({ ...cell, isCollapsed: collapsed })}

--- a/apps/web/components/workbook/cells/macro-cell.tsx
+++ b/apps/web/components/workbook/cells/macro-cell.tsx
@@ -9,7 +9,7 @@ import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { decodeBase64, encodeBase64 } from "@/util/base64";
 import { Check, Code, Copy, ExternalLink, GitFork, Loader2 } from "lucide-react";
 import Link from "next/link";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { parseApiError } from "~/util/apiError";
 
 import type { MacroLanguage } from "@repo/api/schemas/macro.schema";
@@ -170,6 +170,12 @@ export function MacroCellComponent({
 
   const [langSelectOpen, setLangSelectOpen] = useState(false);
 
+  // Track the latest cell so the async rename merges its result into current
+  // state rather than a stale snapshot captured when the save began (e.g. a
+  // concurrent language change or collapse toggle would otherwise be clobbered).
+  const cellRef = useRef(cell);
+  cellRef.current = cell;
+
   // Rename the shared macro row and repoint the cell label at the new name.
   // Renaming a fork resolves the auto-generated "Copy of ..." name in place.
   const [isRenaming, setIsRenaming] = useState(false);
@@ -178,7 +184,8 @@ export function MacroCellComponent({
       setIsRenaming(true);
       try {
         const res = await saveMacro({ params: { id: macroId }, body: { name: next } });
-        onUpdate({ ...cell, payload: { ...cell.payload, name: res.body.name } });
+        const latest = cellRef.current;
+        onUpdate({ ...latest, payload: { ...latest.payload, name: res.body.name } });
       } catch (err) {
         const parsed = parseApiError(err);
         toast({
@@ -193,7 +200,7 @@ export function MacroCellComponent({
         setIsRenaming(false);
       }
     },
-    [macroId, saveMacro, onUpdate, cell, t],
+    [macroId, saveMacro, onUpdate, t],
   );
 
   const displayName = cell.payload.name ?? macroName ?? "Macro";

--- a/apps/web/components/workbook/cells/macro-cell.tsx
+++ b/apps/web/components/workbook/cells/macro-cell.tsx
@@ -9,7 +9,7 @@ import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { decodeBase64, encodeBase64 } from "@/util/base64";
 import { Check, Code, Copy, ExternalLink, GitFork, Loader2 } from "lucide-react";
 import Link from "next/link";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { parseApiError } from "~/util/apiError";
 
 import type { MacroLanguage } from "@repo/api/schemas/macro.schema";
@@ -170,11 +170,13 @@ export function MacroCellComponent({
 
   const [langSelectOpen, setLangSelectOpen] = useState(false);
 
-  // Track the latest cell so the async rename merges its result into current
-  // state rather than a stale snapshot captured when the save began (e.g. a
-  // concurrent language change or collapse toggle would otherwise be clobbered).
+  // Track the latest cell so the async rename merges into current state, not a
+  // stale snapshot from when the save began. Sync in a layout effect (not during
+  // render) so a speculative render never leaks into the ref.
   const cellRef = useRef(cell);
-  cellRef.current = cell;
+  useLayoutEffect(() => {
+    cellRef.current = cell;
+  }, [cell]);
 
   // Rename the shared macro row and repoint the cell label at the new name.
   // Renaming a fork resolves the auto-generated "Copy of ..." name in place.

--- a/apps/web/components/workbook/cells/protocol-cell.test.tsx
+++ b/apps/web/components/workbook/cells/protocol-cell.test.tsx
@@ -641,6 +641,52 @@ describe("ProtocolCellComponent", () => {
       expect(updated.payload.name).toBe("Fluorescence");
     });
 
+    it("merges a concurrent cell change into the resolved rename", async () => {
+      server.mount(contract.protocols.getProtocol, {
+        body: createProtocol({
+          id: "p1",
+          name: "Light Sensor",
+          code: [{ measurement: "light" }],
+          createdBy: OWNER_ID,
+        }),
+      });
+      mockedUseSession.mockReturnValue({
+        data: { user: { id: OWNER_ID } },
+        isPending: false,
+      } as ReturnType<typeof useSession>);
+      server.mount(contract.protocols.updateProtocol, {
+        body: createProtocol({ id: "p1", name: "Fluorescence" }),
+        delay: 100,
+      });
+      const onUpdate = vi.fn();
+
+      const user = userEvent.setup();
+      const { rerender } = render(
+        <ProtocolCellComponent cell={makeProtocolCell()} onUpdate={onUpdate} onDelete={vi.fn()} />,
+      );
+
+      await user.click(await screen.findByLabelText("cells.rename"));
+      const input = screen.getByLabelText("cells.rename");
+      await user.clear(input);
+      await user.type(input, "Fluorescence");
+      await user.click(screen.getByLabelText("cells.renameSave"));
+
+      // A collapse toggle lands while the rename save is still in flight.
+      rerender(
+        <ProtocolCellComponent
+          cell={makeProtocolCell({ isCollapsed: true })}
+          onUpdate={onUpdate}
+          onDelete={vi.fn()}
+        />,
+      );
+
+      await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+      const updated = onUpdate.mock.lastCall?.[0] as ProtocolCell;
+      // The rename must preserve the concurrent collapse, not revert it.
+      expect(updated.isCollapsed).toBe(true);
+      expect(updated.payload.name).toBe("Fluorescence");
+    });
+
     it("does not offer rename to non-owners", async () => {
       server.mount(contract.protocols.getProtocol, {
         body: createProtocol({ id: "p1", code: [{ measurement: "light" }], createdBy: "someone" }),

--- a/apps/web/components/workbook/cells/protocol-cell.test.tsx
+++ b/apps/web/components/workbook/cells/protocol-cell.test.tsx
@@ -603,4 +603,94 @@ describe("ProtocolCellComponent", () => {
     const link = await screen.findByRole("link", { name: "cells.forkedFrom" });
     expect(link).toHaveAttribute("href", "/platform/protocols/p-src");
   });
+
+  describe("inline rename", () => {
+    it("renames the protocol and repoints the cell label for the owner", async () => {
+      server.mount(contract.protocols.getProtocol, {
+        body: createProtocol({
+          id: "p1",
+          name: "Light Sensor",
+          code: [{ measurement: "light" }],
+          createdBy: OWNER_ID,
+        }),
+      });
+      mockedUseSession.mockReturnValue({
+        data: { user: { id: OWNER_ID } },
+        isPending: false,
+      } as ReturnType<typeof useSession>);
+      const updateSpy = server.mount(contract.protocols.updateProtocol, {
+        body: createProtocol({ id: "p1", name: "Fluorescence" }),
+      });
+      const onUpdate = vi.fn();
+
+      const user = userEvent.setup();
+      render(
+        <ProtocolCellComponent cell={makeProtocolCell()} onUpdate={onUpdate} onDelete={vi.fn()} />,
+      );
+
+      await user.click(await screen.findByLabelText("cells.rename"));
+      const input = screen.getByLabelText("cells.rename");
+      await user.clear(input);
+      await user.type(input, "Fluorescence");
+      await user.click(screen.getByLabelText("cells.renameSave"));
+
+      await waitFor(() => expect(updateSpy.called).toBe(true));
+      expect(updateSpy.body).toEqual({ name: "Fluorescence" });
+      await waitFor(() =>
+        expect(onUpdate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            payload: expect.objectContaining({ name: "Fluorescence" }),
+          }),
+        ),
+      );
+    });
+
+    it("does not offer rename to non-owners", async () => {
+      server.mount(contract.protocols.getProtocol, {
+        body: createProtocol({ id: "p1", code: [{ measurement: "light" }], createdBy: "someone" }),
+      });
+      mockedUseSession.mockReturnValue({
+        data: { user: { id: "viewer" } },
+        isPending: false,
+      } as ReturnType<typeof useSession>);
+
+      render(
+        <ProtocolCellComponent cell={makeProtocolCell()} onUpdate={vi.fn()} onDelete={vi.fn()} />,
+      );
+
+      await waitFor(() =>
+        expect(screen.getByTestId("code-editor-wrapper")).toHaveAttribute("data-readonly", "true"),
+      );
+      expect(screen.queryByLabelText("cells.rename")).not.toBeInTheDocument();
+    });
+
+    it("keeps the editor open and does not repoint the cell when the rename fails", async () => {
+      server.mount(contract.protocols.getProtocol, {
+        body: createProtocol({ id: "p1", code: [{ measurement: "light" }], createdBy: OWNER_ID }),
+      });
+      mockedUseSession.mockReturnValue({
+        data: { user: { id: OWNER_ID } },
+        isPending: false,
+      } as ReturnType<typeof useSession>);
+      const updateSpy = server.mount(contract.protocols.updateProtocol, {
+        status: 500,
+        body: { message: "boom", statusCode: 500 },
+      });
+      const onUpdate = vi.fn();
+
+      const user = userEvent.setup();
+      render(
+        <ProtocolCellComponent cell={makeProtocolCell()} onUpdate={onUpdate} onDelete={vi.fn()} />,
+      );
+
+      await user.click(await screen.findByLabelText("cells.rename"));
+      await user.clear(screen.getByLabelText("cells.rename"));
+      await user.type(screen.getByLabelText("cells.rename"), "Taken");
+      await user.click(screen.getByLabelText("cells.renameSave"));
+
+      await waitFor(() => expect(updateSpy.called).toBe(true));
+      expect(onUpdate).not.toHaveBeenCalled();
+      expect(screen.getByLabelText("cells.renameSave")).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/components/workbook/cells/protocol-cell.test.tsx
+++ b/apps/web/components/workbook/cells/protocol-cell.test.tsx
@@ -1,7 +1,9 @@
 import { __resetProtocolCodeRegistry, getLiveProtocolCode } from "@/lib/protocol-code-registry";
 import { createProtocol } from "@/test/factories";
+import { API_URL } from "@/test/msw/mount";
 import { server } from "@/test/msw/server";
 import { render, screen, userEvent, waitFor } from "@/test/test-utils";
+import { http, HttpResponse } from "msw";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { contract } from "@repo/api/contract";
@@ -733,6 +735,47 @@ describe("ProtocolCellComponent", () => {
       await waitFor(() => expect(updateSpy.called).toBe(true));
       expect(onUpdate).not.toHaveBeenCalled();
       expect(screen.getByLabelText("cells.renameSave")).toBeInTheDocument();
+    });
+
+    it("shows the conflict toast and keeps the editor open on a duplicate name", async () => {
+      server.mount(contract.protocols.getProtocol, {
+        body: createProtocol({ id: "p1", code: [{ measurement: "light" }], createdBy: OWNER_ID }),
+      });
+      mockedUseSession.mockReturnValue({
+        data: { user: { id: OWNER_ID } },
+        isPending: false,
+      } as ReturnType<typeof useSession>);
+      // The update contract has no typed 409; the backend signals a name clash
+      // via a REPOSITORY_DUPLICATE code on a 400 body.
+      server.use(
+        http.patch(`${API_URL}/api/v1/protocols/:id`, () =>
+          HttpResponse.json(
+            { code: "REPOSITORY_DUPLICATE", message: "duplicate", statusCode: 400 },
+            { status: 400 },
+          ),
+        ),
+      );
+      const { toast } = await import("@repo/ui/hooks/use-toast");
+      const onUpdate = vi.fn();
+
+      const user = userEvent.setup();
+      render(
+        <ProtocolCellComponent cell={makeProtocolCell()} onUpdate={onUpdate} onDelete={vi.fn()} />,
+      );
+
+      await user.click(await screen.findByLabelText("cells.rename"));
+      await user.clear(screen.getByLabelText("cells.rename"));
+      await user.type(screen.getByLabelText("cells.rename"), "Taken Name");
+      await user.click(screen.getByLabelText("cells.renameSave"));
+
+      await waitFor(() =>
+        expect(toast).toHaveBeenCalledWith({
+          description: "cells.renameConflict",
+          variant: "destructive",
+        }),
+      );
+      expect(screen.getByLabelText("cells.renameSave")).toBeInTheDocument();
+      expect(onUpdate).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/components/workbook/cells/protocol-cell.test.tsx
+++ b/apps/web/components/workbook/cells/protocol-cell.test.tsx
@@ -636,13 +636,9 @@ describe("ProtocolCellComponent", () => {
 
       await waitFor(() => expect(updateSpy.called).toBe(true));
       expect(updateSpy.body).toEqual({ name: "Fluorescence" });
-      await waitFor(() =>
-        expect(onUpdate).toHaveBeenCalledWith(
-          expect.objectContaining({
-            payload: expect.objectContaining({ name: "Fluorescence" }),
-          }),
-        ),
-      );
+      await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+      const updated = onUpdate.mock.lastCall?.[0] as ProtocolCell;
+      expect(updated.payload.name).toBe("Fluorescence");
     });
 
     it("does not offer rename to non-owners", async () => {

--- a/apps/web/components/workbook/cells/protocol-cell.tsx
+++ b/apps/web/components/workbook/cells/protocol-cell.tsx
@@ -193,6 +193,12 @@ export function ProtocolCellComponent({
     }
   }, [protocolData, forkProtocol, onUpdate, cell]);
 
+  // Track the latest cell so the async rename merges its result into current
+  // state rather than a stale snapshot captured when the save began (e.g. a
+  // concurrent collapse toggle would otherwise be clobbered).
+  const cellRef = useRef(cell);
+  cellRef.current = cell;
+
   // Rename the shared protocol row and repoint the cell label at the new name.
   // Renaming a fork resolves the auto-generated "Copy of ..." name in place.
   const [isRenaming, setIsRenaming] = useState(false);
@@ -201,7 +207,8 @@ export function ProtocolCellComponent({
       setIsRenaming(true);
       try {
         const res = await saveProtocol({ params: { id: protocolId }, body: { name: next } });
-        onUpdate({ ...cell, payload: { ...cell.payload, name: res.body.name } });
+        const latest = cellRef.current;
+        onUpdate({ ...latest, payload: { ...latest.payload, name: res.body.name } });
       } catch (err) {
         const parsed = parseApiError(err);
         toast({
@@ -216,7 +223,7 @@ export function ProtocolCellComponent({
         setIsRenaming(false);
       }
     },
-    [protocolId, saveProtocol, onUpdate, cell, tWorkbook],
+    [protocolId, saveProtocol, onUpdate, tWorkbook],
   );
 
   const displayName = cell.payload.name ?? protocolName ?? "Protocol";

--- a/apps/web/components/workbook/cells/protocol-cell.tsx
+++ b/apps/web/components/workbook/cells/protocol-cell.tsx
@@ -27,6 +27,7 @@ import {
 } from "@repo/ui/components/tooltip";
 import { toast } from "@repo/ui/hooks/use-toast";
 
+import { CellTitle } from "../cell-title";
 import { CellWrapper } from "../cell-wrapper";
 import { WorkbookCodeEditor } from "../workbook-code-editor";
 import { useWorkbookEntitySaved } from "../workbook-entity-saved-context";
@@ -192,12 +193,51 @@ export function ProtocolCellComponent({
     }
   }, [protocolData, forkProtocol, onUpdate, cell]);
 
+  // Rename the shared protocol row and repoint the cell label at the new name.
+  // Renaming a fork resolves the auto-generated "Copy of ..." name in place.
+  const [isRenaming, setIsRenaming] = useState(false);
+  const handleRename = useCallback(
+    async (next: string) => {
+      setIsRenaming(true);
+      try {
+        const res = await saveProtocol({ params: { id: protocolId }, body: { name: next } });
+        onUpdate({ ...cell, payload: { ...cell.payload, name: res.body.name } });
+      } catch (err) {
+        const parsed = parseApiError(err);
+        toast({
+          description:
+            parsed?.code === "REPOSITORY_DUPLICATE"
+              ? tWorkbook("cells.renameConflict")
+              : (parsed?.message ?? tWorkbook("cells.renameFailed")),
+          variant: "destructive",
+        });
+        throw err;
+      } finally {
+        setIsRenaming(false);
+      }
+    },
+    [protocolId, saveProtocol, onUpdate, cell, tWorkbook],
+  );
+
   const displayName = cell.payload.name ?? protocolName ?? "Protocol";
 
   return (
     <CellWrapper
       icon={<Microscope className="h-3.5 w-3.5" />}
-      label={displayName}
+      label={
+        <CellTitle
+          name={displayName}
+          canRename={isEditable}
+          onRename={handleRename}
+          isPending={isRenaming}
+          labels={{
+            rename: tWorkbook("cells.rename"),
+            save: tWorkbook("cells.renameSave"),
+            cancel: tWorkbook("cells.renameCancel"),
+          }}
+        />
+      }
+      labelText={displayName}
       accentColor="#2D3142"
       isCollapsed={cell.isCollapsed}
       onToggleCollapse={(collapsed) => onUpdate({ ...cell, isCollapsed: collapsed })}

--- a/apps/web/components/workbook/cells/protocol-cell.tsx
+++ b/apps/web/components/workbook/cells/protocol-cell.tsx
@@ -10,7 +10,7 @@ import { registerProtocolCodeSource } from "@/lib/protocol-code-registry";
 import { getSensorFamilyLabel } from "@/util/sensor-family";
 import { Check, Copy, ExternalLink, GitFork, Hand, Loader2, Microscope } from "lucide-react";
 import Link from "next/link";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { parseApiError } from "~/util/apiError";
 
 import type { SensorFamily } from "@repo/api/schemas/protocol.schema";
@@ -193,11 +193,13 @@ export function ProtocolCellComponent({
     }
   }, [protocolData, forkProtocol, onUpdate, cell]);
 
-  // Track the latest cell so the async rename merges its result into current
-  // state rather than a stale snapshot captured when the save began (e.g. a
-  // concurrent collapse toggle would otherwise be clobbered).
+  // Track the latest cell so the async rename merges into current state, not a
+  // stale snapshot from when the save began. Sync in a layout effect (not during
+  // render) so a speculative render never leaks into the ref.
   const cellRef = useRef(cell);
-  cellRef.current = cell;
+  useLayoutEffect(() => {
+    cellRef.current = cell;
+  }, [cell]);
 
   // Rename the shared protocol row and repoint the cell label at the new name.
   // Renaming a fork resolves the auto-generated "Copy of ..." name in place.

--- a/apps/web/components/workbook/upgrade/code-diff.tsx
+++ b/apps/web/components/workbook/upgrade/code-diff.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { lineDiff } from "@/lib/line-diff";
+import { useMemo } from "react";
+
+import { cn } from "@repo/ui/lib/utils";
+
+interface CodeDiffProps {
+  oldText: string;
+  newText: string;
+}
+
+const linePrefix = { same: " ", add: "+", del: "-" } as const;
+
+/** Compact red/green line diff of two text blocks. */
+export function CodeDiff({ oldText, newText }: CodeDiffProps) {
+  const lines = useMemo(() => lineDiff(oldText, newText), [oldText, newText]);
+
+  return (
+    <pre className="max-h-64 overflow-auto rounded-md border bg-[#0B0F14]/[0.02] p-2 text-[11px] leading-relaxed">
+      {lines.map((line, i) => (
+        <div
+          key={i}
+          className={cn(
+            "whitespace-pre-wrap break-words px-1",
+            line.type === "add" && "bg-emerald-500/10 text-emerald-800 dark:text-emerald-300",
+            line.type === "del" && "bg-red-500/10 text-red-800 dark:text-red-300",
+            line.type === "same" && "text-muted-foreground",
+          )}
+        >
+          <span className="select-none opacity-60">{linePrefix[line.type]} </span>
+          {line.text || " "}
+        </div>
+      ))}
+    </pre>
+  );
+}

--- a/apps/web/components/workbook/upgrade/entity-diff-row.tsx
+++ b/apps/web/components/workbook/upgrade/entity-diff-row.tsx
@@ -2,6 +2,7 @@
 
 import { useMacro } from "@/hooks/macro/useMacro/useMacro";
 import { useProtocol } from "@/hooks/protocol/useProtocol/useProtocol";
+import { contract, getContractError } from "@/lib/tsr";
 import { decodeBase64 } from "@/util/base64";
 import { formatDate } from "@/util/date";
 import { useEffect, useRef } from "react";
@@ -17,6 +18,8 @@ export interface ResolvedEntity {
   kind: "protocol" | "macro";
   exists: boolean;
   family?: SensorFamily;
+  /** The lookup failed for a non-404 reason (network/server); status is unknown, not "removed". */
+  loadFailed?: boolean;
 }
 
 type EntityStatus = "added" | "changed" | "unchanged" | "removed";
@@ -93,16 +96,20 @@ export function ProtocolDiffRow({ id, oldCode, fallbackName, onResolved }: RowPr
   const body = query.data?.body;
   const settled = !query.isLoading;
   const exists = !!body;
+  // A 404 means the protocol was genuinely deleted (removed); any other error
+  // (5xx, network) is transient and must not be reported as "removed".
+  const notFound = getContractError(contract.protocols.getProtocol, query.error)?.status === 404;
+  const loadFailed = !!query.error && !notFound;
 
   const reported = useRef(false);
   useEffect(() => {
     if (settled && !reported.current) {
       reported.current = true;
-      onResolved({ id, kind: "protocol", exists, family: body?.family });
+      onResolved({ id, kind: "protocol", exists, family: body?.family, loadFailed });
     }
-  }, [settled, exists, body?.family, id, onResolved]);
+  }, [settled, exists, body?.family, loadFailed, id, onResolved]);
 
-  if (!settled) return null;
+  if (!settled || loadFailed) return null;
 
   const oldText = oldCode != null ? JSON.stringify(oldCode, null, 2) : "";
   const newText = body?.code != null ? JSON.stringify(body.code, null, 2) : "";
@@ -130,19 +137,23 @@ export function ProtocolDiffRow({ id, oldCode, fallbackName, onResolved }: RowPr
 }
 
 export function MacroDiffRow({ id, oldCode, fallbackName, onResolved }: RowProps) {
-  const { data: body, isLoading } = useMacro(id);
+  const { data: body, isLoading, error } = useMacro(id);
   const settled = !isLoading;
   const exists = !!body;
+  // A 404 means the macro was genuinely deleted (removed); any other error
+  // (5xx, network) is transient and must not be reported as "removed".
+  const notFound = getContractError(contract.macros.getMacro, error)?.status === 404;
+  const loadFailed = !!error && !notFound;
 
   const reported = useRef(false);
   useEffect(() => {
     if (settled && !reported.current) {
       reported.current = true;
-      onResolved({ id, kind: "macro", exists });
+      onResolved({ id, kind: "macro", exists, loadFailed });
     }
-  }, [settled, exists, id, onResolved]);
+  }, [settled, exists, loadFailed, id, onResolved]);
 
-  if (!settled) return null;
+  if (!settled || loadFailed) return null;
 
   const oldText = typeof oldCode === "string" ? decodeBase64(oldCode) : "";
   const newText = body?.code ? decodeBase64(body.code) : "";

--- a/apps/web/components/workbook/upgrade/entity-diff-row.tsx
+++ b/apps/web/components/workbook/upgrade/entity-diff-row.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useMacro } from "@/hooks/macro/useMacro/useMacro";
+import { useProtocol } from "@/hooks/protocol/useProtocol/useProtocol";
+import { decodeBase64 } from "@/util/base64";
+import { formatDate } from "@/util/date";
+import { useEffect, useRef } from "react";
+
+import type { SensorFamily } from "@repo/api/schemas/protocol.schema";
+import { useTranslation } from "@repo/i18n";
+import { Badge } from "@repo/ui/components/badge";
+
+import { CodeDiff } from "./code-diff";
+
+export interface ResolvedEntity {
+  id: string;
+  kind: "protocol" | "macro";
+  exists: boolean;
+  family?: SensorFamily;
+}
+
+type EntityStatus = "added" | "changed" | "unchanged" | "removed";
+
+const statusVariant: Record<EntityStatus, "default" | "secondary" | "destructive" | "outline"> = {
+  added: "default",
+  changed: "default",
+  unchanged: "secondary",
+  removed: "destructive",
+};
+
+function EntityDiffShell({
+  name,
+  kind,
+  status,
+  updatedAt,
+  oldText,
+  newText,
+}: {
+  name: string;
+  kind: "protocol" | "macro";
+  status: EntityStatus;
+  updatedAt?: string;
+  oldText: string;
+  newText: string;
+}) {
+  const { t } = useTranslation("experiments");
+  const showDiff = status === "added" || status === "changed";
+
+  return (
+    <div className="rounded-md border p-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="text-muted-foreground shrink-0 text-[11px] uppercase tracking-wide">
+            {t(`flow.upgradeDiff.kind.${kind}`)}
+          </span>
+          <span className="truncate text-sm font-medium">{name}</span>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {updatedAt && status !== "removed" ? (
+            <span className="text-muted-foreground text-[11px]">
+              {t("flow.upgradeDiff.lastChanged", { when: formatDate(updatedAt) })}
+            </span>
+          ) : null}
+          <Badge variant={statusVariant[status]} className="text-[10px]">
+            {t(`flow.upgradeDiff.status.${status}`)}
+          </Badge>
+        </div>
+      </div>
+      {showDiff ? (
+        <details className="mt-2">
+          <summary className="text-muted-foreground hover:text-foreground cursor-pointer text-xs">
+            {t("flow.upgradeDiff.viewDiff")}
+          </summary>
+          <div className="mt-2">
+            <CodeDiff oldText={oldText} newText={newText} />
+          </div>
+        </details>
+      ) : null}
+    </div>
+  );
+}
+
+interface RowProps {
+  id: string;
+  /** Frozen code from the pinned version snapshot; absent when the cell was added since. */
+  oldCode?: unknown;
+  fallbackName?: string;
+  onResolved: (r: ResolvedEntity) => void;
+}
+
+export function ProtocolDiffRow({ id, oldCode, fallbackName, onResolved }: RowProps) {
+  const query = useProtocol(id);
+  const body = query.data?.body;
+  const settled = !query.isLoading;
+  const exists = !!body;
+
+  const reported = useRef(false);
+  useEffect(() => {
+    if (settled && !reported.current) {
+      reported.current = true;
+      onResolved({ id, kind: "protocol", exists, family: body?.family });
+    }
+  }, [settled, exists, body?.family, id, onResolved]);
+
+  if (!settled) return null;
+
+  const oldText = oldCode != null ? JSON.stringify(oldCode, null, 2) : "";
+  const newText = body?.code != null ? JSON.stringify(body.code, null, 2) : "";
+  const status: EntityStatus = !exists
+    ? "removed"
+    : oldCode == null
+      ? "added"
+      : oldText !== newText
+        ? "changed"
+        : "unchanged";
+
+  // Unchanged entities still report for the verdict but are not listed.
+  if (status === "unchanged") return null;
+
+  return (
+    <EntityDiffShell
+      name={body?.name ?? fallbackName ?? id}
+      kind="protocol"
+      status={status}
+      updatedAt={body?.updatedAt}
+      oldText={oldText}
+      newText={newText}
+    />
+  );
+}
+
+export function MacroDiffRow({ id, oldCode, fallbackName, onResolved }: RowProps) {
+  const { data: body, isLoading } = useMacro(id);
+  const settled = !isLoading;
+  const exists = !!body;
+
+  const reported = useRef(false);
+  useEffect(() => {
+    if (settled && !reported.current) {
+      reported.current = true;
+      onResolved({ id, kind: "macro", exists });
+    }
+  }, [settled, exists, id, onResolved]);
+
+  if (!settled) return null;
+
+  const oldText = typeof oldCode === "string" ? decodeBase64(oldCode) : "";
+  const newText = body?.code ? decodeBase64(body.code) : "";
+  const status: EntityStatus = !exists
+    ? "removed"
+    : oldCode == null
+      ? "added"
+      : oldText !== newText
+        ? "changed"
+        : "unchanged";
+
+  // Unchanged entities still report for the verdict but are not listed.
+  if (status === "unchanged") return null;
+
+  return (
+    <EntityDiffShell
+      name={body?.name ?? fallbackName ?? id}
+      kind="macro"
+      status={status}
+      updatedAt={body?.updatedAt}
+      oldText={oldText}
+      newText={newText}
+    />
+  );
+}

--- a/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.test.tsx
+++ b/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.test.tsx
@@ -1,12 +1,15 @@
 import {
+  createBranchCell,
   createMacro,
   createMacroCell,
   createProtocol,
   createProtocolCell,
   createWorkbook,
 } from "@/test/factories";
+import { API_URL } from "@/test/msw/mount";
 import { server } from "@/test/msw/server";
 import { render, screen, userEvent, waitFor } from "@/test/test-utils";
+import { http, HttpResponse } from "msw";
 import { describe, it, expect, vi } from "vitest";
 
 import { contract } from "@repo/api/contract";
@@ -138,6 +141,124 @@ describe("WorkbookUpgradeDialog", () => {
     await waitFor(() =>
       expect(screen.getByText("flow.upgradeDiff.verdict.errors")).toBeInTheDocument(),
     );
+  });
+
+  it("lists a missing macro and dangling branch references as blocking errors", async () => {
+    const macroCell = createMacroCell({
+      id: "cell-m",
+      payload: { macroId: "mac-gone", language: "python", name: "Gone Macro" },
+    });
+    const branchCell = createBranchCell({
+      id: "cell-b",
+      paths: [
+        {
+          id: "path-1",
+          label: "Yes",
+          color: "#22c55e",
+          gotoCellId: "ghost-goto",
+          conditions: [
+            {
+              id: "cond-1",
+              sourceCellId: "ghost-src",
+              field: "answer",
+              operator: "eq",
+              value: "x",
+            },
+          ],
+        },
+      ],
+    });
+    const version: WorkbookVersion = {
+      id: PINNED_VERSION_ID,
+      workbookId: WORKBOOK_ID,
+      version: 1,
+      cells: [macroCell],
+      metadata: {},
+      entitySnapshots: { protocols: {}, macros: { "mac-gone": { code: btoa("print(1)") } } },
+      createdAt: "2025-01-01T00:00:00.000Z",
+      createdBy: "user-1",
+    };
+    server.mount(contract.workbooks.getWorkbookVersion, { body: version });
+    server.mount(contract.workbooks.getWorkbook, {
+      body: createWorkbook({ id: WORKBOOK_ID, cells: [macroCell, branchCell] }),
+    });
+    // The referenced macro no longer exists.
+    server.mount(contract.macros.getMacro, {
+      status: 404,
+      body: { message: "gone", statusCode: 404 },
+    });
+
+    renderDialog();
+
+    await waitFor(() =>
+      expect(screen.getByText("flow.upgradeDiff.verdict.errors")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("flow.upgradeDiff.issue.missingMacro")).toBeInTheDocument();
+    expect(screen.getByText("flow.upgradeDiff.issue.danglingSource")).toBeInTheDocument();
+    expect(screen.getByText("flow.upgradeDiff.issue.danglingGoto")).toBeInTheDocument();
+  });
+
+  it("warns on mixed sensor families, shows an added cell, and cancels", async () => {
+    const protoA = createProtocolCell({
+      id: "cell-a",
+      payload: { protocolId: "prot-a", version: 1, name: "Proto A" },
+    });
+    const protoB = createProtocolCell({
+      id: "cell-b2",
+      payload: { protocolId: "prot-b", version: 1, name: "Proto B" },
+    });
+    const version: WorkbookVersion = {
+      id: PINNED_VERSION_ID,
+      workbookId: WORKBOOK_ID,
+      version: 1,
+      // Pinned had only Proto A; Proto B is new since -> an "added" cell change.
+      cells: [protoA],
+      metadata: {},
+      entitySnapshots: {
+        protocols: { "prot-a": { code: [{ a: 1 }], family: "multispeq" } },
+        macros: {},
+      },
+      createdAt: "2025-01-01T00:00:00.000Z",
+      createdBy: "user-1",
+    };
+    server.mount(contract.workbooks.getWorkbookVersion, { body: version });
+    server.mount(contract.workbooks.getWorkbook, {
+      body: createWorkbook({ id: WORKBOOK_ID, cells: [protoA, protoB] }),
+    });
+    // Two families across the two protocols -> mixed-family warning.
+    server.use(
+      http.get(`${API_URL}/api/v1/protocols/:id`, ({ params }) =>
+        HttpResponse.json(
+          params.id === "prot-a"
+            ? createProtocol({
+                id: "prot-a",
+                name: "Proto A",
+                code: [{ a: 1 }],
+                family: "multispeq",
+                createdBy: "user-1",
+              })
+            : createProtocol({
+                id: "prot-b",
+                name: "Proto B",
+                code: [{ b: 2 }],
+                family: "ambit",
+                createdBy: "user-1",
+              }),
+        ),
+      ),
+    );
+
+    const { props } = renderDialog();
+
+    await waitFor(() =>
+      expect(screen.getByText("flow.upgradeDiff.verdict.warnings")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("flow.upgradeDiff.issue.mixedFamilies")).toBeInTheDocument();
+    expect(screen.getByText("flow.upgradeDiff.change.added")).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "cancel" }));
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
   });
 
   it("shows an error state instead of spinning forever when a fetch fails", async () => {

--- a/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.test.tsx
+++ b/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.test.tsx
@@ -1,4 +1,10 @@
-import { createProtocol, createProtocolCell, createWorkbook } from "@/test/factories";
+import {
+  createMacro,
+  createMacroCell,
+  createProtocol,
+  createProtocolCell,
+  createWorkbook,
+} from "@/test/factories";
 import { server } from "@/test/msw/server";
 import { render, screen, userEvent, waitFor } from "@/test/test-utils";
 import { describe, it, expect, vi } from "vitest";
@@ -80,6 +86,40 @@ describe("WorkbookUpgradeDialog", () => {
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: /flow\.confirmUpgrade/ }));
     expect(props.onConfirm).toHaveBeenCalled();
+  });
+
+  it("shows a changed macro in the code diff", async () => {
+    const macroCell = createMacroCell({
+      id: "cell-m",
+      payload: { macroId: "mac-1", language: "python", name: "My Macro" },
+    });
+    const version: WorkbookVersion = {
+      id: PINNED_VERSION_ID,
+      workbookId: WORKBOOK_ID,
+      version: 1,
+      cells: [macroCell],
+      metadata: {},
+      entitySnapshots: { protocols: {}, macros: { "mac-1": { code: btoa("print('v0')") } } },
+      createdAt: "2025-01-01T00:00:00.000Z",
+      createdBy: "user-1",
+    };
+    server.mount(contract.workbooks.getWorkbookVersion, { body: version });
+    server.mount(contract.workbooks.getWorkbook, {
+      body: createWorkbook({ id: WORKBOOK_ID, cells: [macroCell] }),
+    });
+    server.mount(contract.macros.getMacro, {
+      body: createMacro({
+        id: "mac-1",
+        name: "My Macro",
+        code: btoa("print('v1')"),
+        createdBy: "user-1",
+      }),
+    });
+
+    renderDialog();
+
+    expect(await screen.findByText("My Macro")).toBeInTheDocument();
+    expect(await screen.findByText("flow.upgradeDiff.status.changed")).toBeInTheDocument();
   });
 
   it("flags a missing protocol as a blocking error", async () => {

--- a/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.test.tsx
+++ b/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.test.tsx
@@ -1,0 +1,117 @@
+import { createProtocol, createProtocolCell, createWorkbook } from "@/test/factories";
+import { server } from "@/test/msw/server";
+import { render, screen, userEvent, waitFor } from "@/test/test-utils";
+import { describe, it, expect, vi } from "vitest";
+
+import { contract } from "@repo/api/contract";
+import type { WorkbookVersion } from "@repo/api/schemas/workbook-version.schema";
+
+import { WorkbookUpgradeDialog } from "./workbook-upgrade-dialog";
+
+const WORKBOOK_ID = "wb-1";
+const PINNED_VERSION_ID = "ver-1";
+const PROTOCOL_ID = "prot-1";
+
+const protocolCell = createProtocolCell({
+  id: "cell-1",
+  payload: { protocolId: PROTOCOL_ID, version: 1, name: "My Protocol" },
+});
+
+function mountPinned(entityCode: unknown) {
+  const version: WorkbookVersion = {
+    id: PINNED_VERSION_ID,
+    workbookId: WORKBOOK_ID,
+    version: 1,
+    cells: [protocolCell],
+    metadata: {},
+    entitySnapshots: {
+      protocols: { [PROTOCOL_ID]: { code: entityCode, family: "multispeq" } },
+      macros: {},
+    },
+    createdAt: "2025-01-01T00:00:00.000Z",
+    createdBy: "user-1",
+  };
+  server.mount(contract.workbooks.getWorkbookVersion, { body: version });
+}
+
+function renderDialog(overrides: Partial<Parameters<typeof WorkbookUpgradeDialog>[0]> = {}) {
+  const props = {
+    open: true,
+    onOpenChange: vi.fn(),
+    workbookId: WORKBOOK_ID,
+    pinnedVersionId: PINNED_VERSION_ID,
+    currentVersion: 1,
+    targetVersionLabel: "v2",
+    onConfirm: vi.fn(),
+    isUpgrading: false,
+    ...overrides,
+  };
+  return { ...render(<WorkbookUpgradeDialog {...props} />), props };
+}
+
+describe("WorkbookUpgradeDialog", () => {
+  it("shows a changed protocol and a clean verdict, and confirms the upgrade", async () => {
+    mountPinned([{ a: 1 }]);
+    server.mount(contract.workbooks.getWorkbook, {
+      body: createWorkbook({ id: WORKBOOK_ID, cells: [protocolCell] }),
+    });
+    server.mount(contract.protocols.getProtocol, {
+      body: createProtocol({
+        id: PROTOCOL_ID,
+        name: "My Protocol",
+        code: [{ a: 2 }],
+        family: "multispeq",
+        createdBy: "user-1",
+      }),
+    });
+
+    const { props } = renderDialog();
+
+    // Protocol code drifted -> a "changed" row for the protocol.
+    expect(await screen.findByText("My Protocol")).toBeInTheDocument();
+    expect(await screen.findByText("flow.upgradeDiff.status.changed")).toBeInTheDocument();
+    // No cell-structure changes (same single cell).
+    expect(screen.getByText("flow.upgradeDiff.noCellChanges")).toBeInTheDocument();
+    // Single existing protocol, one family -> no structural issues.
+    await waitFor(() =>
+      expect(screen.getByText("flow.upgradeDiff.verdict.ok")).toBeInTheDocument(),
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /flow\.confirmUpgrade/ }));
+    expect(props.onConfirm).toHaveBeenCalled();
+  });
+
+  it("flags a missing protocol as a blocking error", async () => {
+    mountPinned([{ a: 1 }]);
+    server.mount(contract.workbooks.getWorkbook, {
+      body: createWorkbook({ id: WORKBOOK_ID, cells: [protocolCell] }),
+    });
+    // The live protocol no longer exists.
+    server.mount(contract.protocols.getProtocol, {
+      status: 404,
+      body: { message: "not found", statusCode: 404 },
+    });
+
+    renderDialog();
+
+    await waitFor(() =>
+      expect(screen.getByText("flow.upgradeDiff.verdict.errors")).toBeInTheDocument(),
+    );
+  });
+
+  it("shows an error state instead of spinning forever when a fetch fails", async () => {
+    server.mount(contract.workbooks.getWorkbookVersion, {
+      status: 404,
+      body: { message: "gone", statusCode: 404 },
+    });
+    server.mount(contract.workbooks.getWorkbook, {
+      body: createWorkbook({ id: WORKBOOK_ID, cells: [] }),
+    });
+
+    renderDialog();
+
+    expect(await screen.findByText("flow.upgradeDiff.loadError")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /flow\.confirmUpgrade/ })).toBeDisabled();
+  });
+});

--- a/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.test.tsx
+++ b/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.test.tsx
@@ -143,6 +143,25 @@ describe("WorkbookUpgradeDialog", () => {
     );
   });
 
+  it("shows a load error (not a false missing block) when an entity lookup fails transiently", async () => {
+    mountPinned([{ a: 1 }]);
+    server.mount(contract.workbooks.getWorkbook, {
+      body: createWorkbook({ id: WORKBOOK_ID, cells: [protocolCell] }),
+    });
+    // A 500 is transient, not a genuine deletion: the dialog must not conclude
+    // the protocol is missing.
+    server.mount(contract.protocols.getProtocol, {
+      status: 500,
+      body: { message: "boom", statusCode: 500 },
+    });
+
+    renderDialog();
+
+    expect(await screen.findByText("flow.upgradeDiff.loadError")).toBeInTheDocument();
+    expect(screen.queryByText("flow.upgradeDiff.verdict.errors")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /flow\.confirmUpgrade/ })).toBeDisabled();
+  });
+
   it("lists a missing macro and dangling branch references as blocking errors", async () => {
     const macroCell = createMacroCell({
       id: "cell-m",

--- a/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.tsx
+++ b/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.tsx
@@ -124,10 +124,15 @@ export function WorkbookUpgradeDialog({
     return validateWorkbook(liveCells, ctx);
   }, [pinned, live, resolved, totalRefs, liveCells]);
 
+  // A referenced entity that failed to load (non-404) means we cannot trust the
+  // verdict: validateWorkbook would see it as missing and emit a false blocking
+  // error. Surface it as a load failure instead.
+  const entityLoadFailed = Object.values(resolved).some((r) => r.loadFailed);
   const errors = verdict?.issues.filter((i) => i.level === "error") ?? [];
   const warnings = verdict?.issues.filter((i) => i.level === "warning") ?? [];
   const ready = !!pinned && !!live;
-  const loading = !loadError && !ready && (pinnedLoading || liveLoading);
+  const failed = !!loadError || entityLoadFailed;
+  const loading = !failed && !ready && (pinnedLoading || liveLoading);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -139,7 +144,7 @@ export function WorkbookUpgradeDialog({
           </DialogDescription>
         </DialogHeader>
 
-        {loadError ? (
+        {failed ? (
           <div className="text-destructive flex items-center gap-2 py-8 text-sm">
             <XCircle className="h-4 w-4 shrink-0" />
             {t("flow.upgradeDiff.loadError")}
@@ -256,7 +261,7 @@ export function WorkbookUpgradeDialog({
           </Button>
           <Button
             onClick={onConfirm}
-            disabled={isUpgrading || !ready || verdict == null || errors.length > 0}
+            disabled={isUpgrading || !ready || failed || verdict == null || errors.length > 0}
           >
             {isUpgrading ? (
               <>

--- a/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.tsx
+++ b/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.tsx
@@ -254,7 +254,10 @@ export function WorkbookUpgradeDialog({
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isUpgrading}>
             {t("cancel")}
           </Button>
-          <Button onClick={onConfirm} disabled={isUpgrading || !ready}>
+          <Button
+            onClick={onConfirm}
+            disabled={isUpgrading || !ready || verdict == null || errors.length > 0}
+          >
             {isUpgrading ? (
               <>
                 <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
@@ -312,7 +315,9 @@ function IssueList({
   return (
     <ul className="mt-1.5 list-disc space-y-0.5 pl-5 text-xs">
       {issues.map((issue, i) => (
-        <li key={`${issue.code}-${issue.cellId ?? i}`}>{issueMessage(t, issue)}</li>
+        <li key={`${issue.code}-${issue.cellId ?? ""}-${issue.ref ?? ""}-${i}`}>
+          {issueMessage(t, issue)}
+        </li>
       ))}
     </ul>
   );

--- a/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.tsx
+++ b/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import { useWorkbook } from "@/hooks/workbook/useWorkbook/useWorkbook";
+import { useWorkbookVersion } from "@/hooks/workbook/useWorkbookVersion/useWorkbookVersion";
+import { diffCells } from "@/lib/workbook-diff";
+import { AlertTriangle, ArrowUpCircle, CheckCircle2, Loader2, XCircle } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type { WorkbookCell } from "@repo/api/schemas/workbook-cells.schema";
+import type { WorkbookIssue } from "@repo/api/utils/validate-workbook";
+import { validateWorkbook } from "@repo/api/utils/validate-workbook";
+import { useTranslation } from "@repo/i18n";
+import { Badge } from "@repo/ui/components/badge";
+import { Button } from "@repo/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/components/dialog";
+import { cn } from "@repo/ui/lib/utils";
+
+import { MacroDiffRow, ProtocolDiffRow } from "./entity-diff-row";
+import type { ResolvedEntity } from "./entity-diff-row";
+
+interface WorkbookUpgradeDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  workbookId: string;
+  /** The version the experiment is currently pinned to. */
+  pinnedVersionId: string;
+  currentVersion: number;
+  /** Human label for the version the upgrade will move to (e.g. "v4"). */
+  targetVersionLabel: string;
+  onConfirm: () => void;
+  isUpgrading: boolean;
+}
+
+function issueMessage(
+  t: (key: string, opts?: Record<string, unknown>) => string,
+  issue: WorkbookIssue,
+): string {
+  const label = issue.cellLabel ?? issue.ref ?? "";
+  switch (issue.code) {
+    case "missing-protocol":
+      return t("flow.upgradeDiff.issue.missingProtocol", { label });
+    case "missing-macro":
+      return t("flow.upgradeDiff.issue.missingMacro", { label });
+    case "dangling-branch-source":
+      return t("flow.upgradeDiff.issue.danglingSource", { ref: issue.ref ?? "" });
+    case "dangling-branch-goto":
+      return t("flow.upgradeDiff.issue.danglingGoto", { ref: issue.ref ?? "" });
+    case "macro-without-input":
+      return t("flow.upgradeDiff.issue.macroWithoutInput", { label });
+    case "mixed-sensor-families":
+      return t("flow.upgradeDiff.issue.mixedFamilies", { detail: issue.detail ?? "" });
+  }
+}
+
+export function WorkbookUpgradeDialog({
+  open,
+  onOpenChange,
+  workbookId,
+  pinnedVersionId,
+  currentVersion,
+  targetVersionLabel,
+  onConfirm,
+  isUpgrading,
+}: WorkbookUpgradeDialogProps) {
+  const { t } = useTranslation("experiments");
+
+  const {
+    data: pinned,
+    isLoading: pinnedLoading,
+    error: pinnedError,
+  } = useWorkbookVersion(workbookId, pinnedVersionId, { enabled: open });
+  const {
+    data: live,
+    isLoading: liveLoading,
+    error: liveError,
+  } = useWorkbook(workbookId, { enabled: open });
+  const loadError = pinnedError ?? liveError;
+
+  const liveCells: WorkbookCell[] = useMemo(() => live?.cells ?? [], [live]);
+  const cellChanges = useMemo(
+    () => (pinned ? diffCells(pinned.cells, liveCells) : []),
+    [pinned, liveCells],
+  );
+
+  // Unique protocol/macro ids referenced by the target (live) workbook.
+  const referenced = useMemo(() => {
+    const protocols = new Map<string, string | undefined>();
+    const macros = new Map<string, string | undefined>();
+    for (const cell of liveCells) {
+      if (cell.type === "protocol") protocols.set(cell.payload.protocolId, cell.payload.name);
+      if (cell.type === "macro") macros.set(cell.payload.macroId, cell.payload.name);
+    }
+    return { protocols, macros };
+  }, [liveCells]);
+  const totalRefs = referenced.protocols.size + referenced.macros.size;
+
+  const [resolved, setResolved] = useState<Record<string, ResolvedEntity>>({});
+  useEffect(() => {
+    if (!open) setResolved({});
+  }, [open]);
+  const handleResolved = useCallback((r: ResolvedEntity) => {
+    setResolved((prev) => (r.id in prev ? prev : { ...prev, [r.id]: r }));
+  }, []);
+
+  const verdict = useMemo(() => {
+    if (!pinned || !live) return null;
+    if (Object.keys(resolved).length < totalRefs) return null;
+    const ctx = {
+      protocols: {} as Record<string, { family?: ResolvedEntity["family"] }>,
+      macros: {} as Record<string, unknown>,
+    };
+    for (const r of Object.values(resolved)) {
+      if (!r.exists) continue;
+      if (r.kind === "protocol") ctx.protocols[r.id] = { family: r.family };
+      else ctx.macros[r.id] = {};
+    }
+    return validateWorkbook(liveCells, ctx);
+  }, [pinned, live, resolved, totalRefs, liveCells]);
+
+  const errors = verdict?.issues.filter((i) => i.level === "error") ?? [];
+  const warnings = verdict?.issues.filter((i) => i.level === "warning") ?? [];
+  const ready = !!pinned && !!live;
+  const loading = !loadError && !ready && (pinnedLoading || liveLoading);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{t("flow.upgradeDiff.title")}</DialogTitle>
+          <DialogDescription>
+            {t("flow.upgradeDiff.subtitle", { from: currentVersion, to: targetVersionLabel })}
+          </DialogDescription>
+        </DialogHeader>
+
+        {loadError ? (
+          <div className="text-destructive flex items-center gap-2 py-8 text-sm">
+            <XCircle className="h-4 w-4 shrink-0" />
+            {t("flow.upgradeDiff.loadError")}
+          </div>
+        ) : loading || !ready ? (
+          <div className="flex items-center justify-center py-10">
+            <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
+          </div>
+        ) : (
+          <div className="max-h-[55vh] space-y-4 overflow-y-auto pr-1">
+            {/* Compatibility verdict */}
+            <section>
+              {verdict == null ? (
+                <div className="text-muted-foreground flex items-center gap-2 text-sm">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  {t("flow.upgradeDiff.checking")}
+                </div>
+              ) : errors.length > 0 ? (
+                <VerdictBlock
+                  tone="error"
+                  icon={<XCircle className="h-4 w-4" />}
+                  title={t("flow.upgradeDiff.verdict.errors")}
+                >
+                  <IssueList t={t} issues={errors} />
+                </VerdictBlock>
+              ) : warnings.length > 0 ? (
+                <VerdictBlock
+                  tone="warning"
+                  icon={<AlertTriangle className="h-4 w-4" />}
+                  title={t("flow.upgradeDiff.verdict.warnings")}
+                >
+                  <IssueList t={t} issues={warnings} />
+                </VerdictBlock>
+              ) : (
+                <VerdictBlock
+                  tone="ok"
+                  icon={<CheckCircle2 className="h-4 w-4" />}
+                  title={t("flow.upgradeDiff.verdict.ok")}
+                />
+              )}
+              <p className="text-muted-foreground mt-1.5 text-[11px]">
+                {t("flow.upgradeDiff.macroCaveat")}
+              </p>
+            </section>
+
+            {/* Cell-level changes */}
+            <section>
+              <h4 className="text-muted-foreground mb-1.5 text-xs font-semibold uppercase tracking-wide">
+                {t("flow.upgradeDiff.cellChanges")}
+              </h4>
+              {cellChanges.length === 0 ? (
+                <p className="text-muted-foreground text-sm">
+                  {t("flow.upgradeDiff.noCellChanges")}
+                </p>
+              ) : (
+                <ul className="space-y-1">
+                  {cellChanges.map((change) => (
+                    <li key={change.cellId} className="flex items-center gap-2 text-sm">
+                      <Badge
+                        variant={change.type === "removed" ? "destructive" : "secondary"}
+                        className="w-16 justify-center text-[10px] capitalize"
+                      >
+                        {t(`flow.upgradeDiff.change.${change.type}`)}
+                      </Badge>
+                      <span className="text-muted-foreground text-xs capitalize">
+                        {change.cellType}
+                      </span>
+                      {change.label ? <span className="truncate">{change.label}</span> : null}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+
+            {/* Entity code changes */}
+            {totalRefs > 0 ? (
+              <section>
+                <h4 className="text-muted-foreground mb-1.5 text-xs font-semibold uppercase tracking-wide">
+                  {t("flow.upgradeDiff.codeChanges")}
+                </h4>
+                <div className="space-y-2">
+                  {[...referenced.protocols].map(([id, name]) => (
+                    <ProtocolDiffRow
+                      key={id}
+                      id={id}
+                      oldCode={
+                        (pinned.entitySnapshots.protocols[id] as { code?: unknown } | undefined)
+                          ?.code
+                      }
+                      fallbackName={name}
+                      onResolved={handleResolved}
+                    />
+                  ))}
+                  {[...referenced.macros].map(([id, name]) => (
+                    <MacroDiffRow
+                      key={id}
+                      id={id}
+                      oldCode={
+                        (pinned.entitySnapshots.macros[id] as { code?: string } | undefined)?.code
+                      }
+                      fallbackName={name}
+                      onResolved={handleResolved}
+                    />
+                  ))}
+                </div>
+              </section>
+            ) : null}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isUpgrading}>
+            {t("cancel")}
+          </Button>
+          <Button onClick={onConfirm} disabled={isUpgrading || !ready}>
+            {isUpgrading ? (
+              <>
+                <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                {t("flow.upgradeDiff.upgrading")}
+              </>
+            ) : (
+              <>
+                <ArrowUpCircle className="mr-1.5 h-4 w-4" />
+                {t("flow.confirmUpgrade")}
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function VerdictBlock({
+  tone,
+  icon,
+  title,
+  children,
+}: {
+  tone: "ok" | "warning" | "error";
+  icon: React.ReactNode;
+  title: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-md border p-2.5",
+        tone === "ok" && "border-emerald-200 bg-emerald-50 text-emerald-800",
+        tone === "warning" && "border-amber-200 bg-amber-50 text-amber-800",
+        tone === "error" && "border-red-200 bg-red-50 text-red-800",
+      )}
+    >
+      <div className="flex items-center gap-2 text-sm font-medium">
+        {icon}
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function IssueList({
+  t,
+  issues,
+}: {
+  t: (key: string, opts?: Record<string, unknown>) => string;
+  issues: WorkbookIssue[];
+}) {
+  return (
+    <ul className="mt-1.5 list-disc space-y-0.5 pl-5 text-xs">
+      {issues.map((issue, i) => (
+        <li key={`${issue.code}-${issue.cellId ?? i}`}>{issueMessage(t, issue)}</li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/components/workbook/upgrade/workbook-version-history-dialog.test.tsx
+++ b/apps/web/components/workbook/upgrade/workbook-version-history-dialog.test.tsx
@@ -33,6 +33,17 @@ describe("WorkbookVersionHistoryDialog", () => {
     expect(screen.getByText("flow.versionHistory.current")).toBeInTheDocument();
   });
 
+  it("shows a load error instead of the empty state when the fetch fails", async () => {
+    server.mount(contract.workbooks.listWorkbookVersions, {
+      status: 500,
+      body: { message: "boom", statusCode: 500 },
+    });
+    render(<WorkbookVersionHistoryDialog {...baseProps} />);
+
+    expect(await screen.findByText("flow.versionHistory.loadError")).toBeInTheDocument();
+    expect(screen.queryByText("flow.versionHistory.empty")).not.toBeInTheDocument();
+  });
+
   it("restores an earlier version after confirmation", async () => {
     const spy = server.mount(contract.experiments.setWorkbookVersion, {
       status: 200,

--- a/apps/web/components/workbook/upgrade/workbook-version-history-dialog.test.tsx
+++ b/apps/web/components/workbook/upgrade/workbook-version-history-dialog.test.tsx
@@ -74,6 +74,24 @@ describe("WorkbookVersionHistoryDialog", () => {
     );
   });
 
+  it("dismisses the restore confirmation via cancel without restoring", async () => {
+    const spy = server.mount(contract.experiments.setWorkbookVersion, {
+      status: 200,
+      body: { workbookId: "wb-1", workbookVersionId: "ver-1", version: 1 },
+    });
+    const user = userEvent.setup();
+    render(<WorkbookVersionHistoryDialog {...baseProps} />);
+
+    await waitFor(() => expect(screen.getByText("v1")).toBeInTheDocument());
+    await user.click(screen.getByRole("button", { name: "flow.versionHistory.restore" }));
+
+    const confirm = await screen.findByRole("alertdialog");
+    await user.click(within(confirm).getByRole("button", { name: "cancel" }));
+
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
+    expect(spy.called).toBe(false);
+  });
+
   it("hides restore controls for non-managers", async () => {
     render(<WorkbookVersionHistoryDialog {...baseProps} canManage={false} />);
     await waitFor(() => expect(screen.getByText("v1")).toBeInTheDocument());

--- a/apps/web/components/workbook/upgrade/workbook-version-history-dialog.test.tsx
+++ b/apps/web/components/workbook/upgrade/workbook-version-history-dialog.test.tsx
@@ -1,0 +1,84 @@
+import { createWorkbookVersionSummary } from "@/test/factories";
+import { server } from "@/test/msw/server";
+import { render, screen, userEvent, waitFor, within } from "@/test/test-utils";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { contract } from "@repo/api/contract";
+import { toast } from "@repo/ui/hooks/use-toast";
+
+import { WorkbookVersionHistoryDialog } from "./workbook-version-history-dialog";
+
+const v1 = createWorkbookVersionSummary({ id: "ver-1", workbookId: "wb-1", version: 1 });
+const v2 = createWorkbookVersionSummary({ id: "ver-2", workbookId: "wb-1", version: 2 });
+
+const baseProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+  experimentId: "exp-1",
+  workbookId: "wb-1",
+  currentVersionId: "ver-2",
+  canManage: true,
+};
+
+describe("WorkbookVersionHistoryDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    server.mount(contract.workbooks.listWorkbookVersions, { body: [v2, v1] });
+  });
+
+  it("lists versions and marks the pinned one as current", async () => {
+    render(<WorkbookVersionHistoryDialog {...baseProps} />);
+    await waitFor(() => expect(screen.getByText("v2")).toBeInTheDocument());
+    expect(screen.getByText("v1")).toBeInTheDocument();
+    expect(screen.getByText("flow.versionHistory.current")).toBeInTheDocument();
+  });
+
+  it("restores an earlier version after confirmation", async () => {
+    const spy = server.mount(contract.experiments.setWorkbookVersion, {
+      status: 200,
+      body: { workbookId: "wb-1", workbookVersionId: "ver-1", version: 1 },
+    });
+    const user = userEvent.setup();
+    render(<WorkbookVersionHistoryDialog {...baseProps} />);
+
+    await waitFor(() => expect(screen.getByText("v1")).toBeInTheDocument());
+    // Only the non-current version (v1) offers Restore.
+    await user.click(screen.getByRole("button", { name: "flow.versionHistory.restore" }));
+
+    const confirm = await screen.findByRole("alertdialog");
+    await user.click(within(confirm).getByRole("button", { name: "flow.versionHistory.restore" }));
+
+    await waitFor(() => expect(spy.called).toBe(true));
+    expect(spy.body).toEqual({ versionId: "ver-1" });
+    await waitFor(() => expect(baseProps.onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it("shows a destructive toast when restore fails", async () => {
+    server.mount(contract.experiments.setWorkbookVersion, {
+      status: 500,
+      body: { message: "boom" },
+    });
+    const user = userEvent.setup();
+    render(<WorkbookVersionHistoryDialog {...baseProps} />);
+
+    await waitFor(() => expect(screen.getByText("v1")).toBeInTheDocument());
+    await user.click(screen.getByRole("button", { name: "flow.versionHistory.restore" }));
+    const confirm = await screen.findByRole("alertdialog");
+    await user.click(within(confirm).getByRole("button", { name: "flow.versionHistory.restore" }));
+
+    await waitFor(() =>
+      expect(toast).toHaveBeenCalledWith({
+        description: "flow.versionHistory.restoreFailed",
+        variant: "destructive",
+      }),
+    );
+  });
+
+  it("hides restore controls for non-managers", async () => {
+    render(<WorkbookVersionHistoryDialog {...baseProps} canManage={false} />);
+    await waitFor(() => expect(screen.getByText("v1")).toBeInTheDocument());
+    expect(
+      screen.queryByRole("button", { name: "flow.versionHistory.restore" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/workbook/upgrade/workbook-version-history-dialog.tsx
+++ b/apps/web/components/workbook/upgrade/workbook-version-history-dialog.tsx
@@ -60,7 +60,10 @@ export function WorkbookVersionHistoryDialog({
   const setVersion = useSetWorkbookVersion(experimentId);
   const [pending, setPending] = useState<VersionSummary | null>(null);
 
-  const handleRestore = () => {
+  const handleRestore = (e: React.MouseEvent) => {
+    // Keep the alert open while the mutation runs so the pending spinner shows;
+    // AlertDialogAction would otherwise close it on click.
+    e.preventDefault();
     if (!pending) return;
     const target = pending;
     setVersion.mutate(
@@ -73,6 +76,7 @@ export function WorkbookVersionHistoryDialog({
         },
         onError: () => {
           toast({ description: t("flow.versionHistory.restoreFailed"), variant: "destructive" });
+          setPending(null);
         },
       },
     );

--- a/apps/web/components/workbook/upgrade/workbook-version-history-dialog.tsx
+++ b/apps/web/components/workbook/upgrade/workbook-version-history-dialog.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useSetWorkbookVersion } from "@/hooks/experiment/useSetWorkbookVersion/useSetWorkbookVersion";
+import { useWorkbookVersions } from "@/hooks/workbook/useWorkbookVersions/useWorkbookVersions";
+import { formatDate } from "@/util/date";
+import { History, Loader2, RotateCcw } from "lucide-react";
+import { useState } from "react";
+
+import { useTranslation } from "@repo/i18n";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@repo/ui/components/alert-dialog";
+import { Badge } from "@repo/ui/components/badge";
+import { Button } from "@repo/ui/components/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@repo/ui/components/dialog";
+import { toast } from "@repo/ui/hooks/use-toast";
+
+interface VersionSummary {
+  id: string;
+  version: number;
+  createdAt: string;
+}
+
+interface WorkbookVersionHistoryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  experimentId: string;
+  workbookId: string;
+  /** The version the experiment is currently pinned to. */
+  currentVersionId: string;
+  /** Experiment admins may restore a version; everyone else views only. */
+  canManage: boolean;
+}
+
+export function WorkbookVersionHistoryDialog({
+  open,
+  onOpenChange,
+  experimentId,
+  workbookId,
+  currentVersionId,
+  canManage,
+}: WorkbookVersionHistoryDialogProps) {
+  const { t } = useTranslation("experiments");
+  const { data, isLoading } = useWorkbookVersions(workbookId, { enabled: open });
+  const versions = (data?.body ?? []) as VersionSummary[];
+
+  const setVersion = useSetWorkbookVersion(experimentId);
+  const [pending, setPending] = useState<VersionSummary | null>(null);
+
+  const handleRestore = () => {
+    if (!pending) return;
+    const target = pending;
+    setVersion.mutate(
+      { params: { id: experimentId }, body: { versionId: target.id } },
+      {
+        onSuccess: () => {
+          toast({ description: t("flow.versionHistory.restored", { version: target.version }) });
+          setPending(null);
+          onOpenChange(false);
+        },
+        onError: () => {
+          toast({ description: t("flow.versionHistory.restoreFailed"), variant: "destructive" });
+        },
+      },
+    );
+  };
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <History className="h-4 w-4" />
+              {t("flow.versionHistory.title")}
+            </DialogTitle>
+            <DialogDescription>{t("flow.versionHistory.subtitle")}</DialogDescription>
+          </DialogHeader>
+
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
+            </div>
+          ) : versions.length === 0 ? (
+            <p className="text-muted-foreground py-6 text-center text-sm">
+              {t("flow.versionHistory.empty")}
+            </p>
+          ) : (
+            <ul className="max-h-[55vh] space-y-1 overflow-y-auto pr-1">
+              {versions.map((v) => {
+                const isCurrent = v.id === currentVersionId;
+                return (
+                  <li
+                    key={v.id}
+                    className="flex items-center justify-between gap-2 rounded-md border p-2"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 text-sm font-medium">
+                        v{v.version}
+                        {isCurrent ? (
+                          <Badge variant="secondary" className="text-[10px]">
+                            {t("flow.versionHistory.current")}
+                          </Badge>
+                        ) : null}
+                      </div>
+                      <div className="text-muted-foreground text-xs">{formatDate(v.createdAt)}</div>
+                    </div>
+                    {canManage && !isCurrent ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="shrink-0"
+                        onClick={() => setPending(v)}
+                        disabled={setVersion.isPending}
+                      >
+                        <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+                        {t("flow.versionHistory.restore")}
+                      </Button>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={!!pending} onOpenChange={(o) => !o && setPending(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("flow.versionHistory.restoreConfirmTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("flow.versionHistory.restoreConfirmMessage", { version: pending?.version ?? 0 })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={setVersion.isPending}>{t("cancel")}</AlertDialogCancel>
+            <AlertDialogAction onClick={handleRestore} disabled={setVersion.isPending}>
+              {setVersion.isPending ? (
+                <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+              ) : (
+                <RotateCcw className="mr-1.5 h-4 w-4" />
+              )}
+              {t("flow.versionHistory.restore")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/web/components/workbook/upgrade/workbook-version-history-dialog.tsx
+++ b/apps/web/components/workbook/upgrade/workbook-version-history-dialog.tsx
@@ -3,7 +3,7 @@
 import { useSetWorkbookVersion } from "@/hooks/experiment/useSetWorkbookVersion/useSetWorkbookVersion";
 import { useWorkbookVersions } from "@/hooks/workbook/useWorkbookVersions/useWorkbookVersions";
 import { formatDate } from "@/util/date";
-import { History, Loader2, RotateCcw } from "lucide-react";
+import { History, Loader2, RotateCcw, XCircle } from "lucide-react";
 import { useState } from "react";
 
 import { useTranslation } from "@repo/i18n";
@@ -54,7 +54,7 @@ export function WorkbookVersionHistoryDialog({
   canManage,
 }: WorkbookVersionHistoryDialogProps) {
   const { t } = useTranslation("experiments");
-  const { data, isLoading } = useWorkbookVersions(workbookId, { enabled: open });
+  const { data, isLoading, error } = useWorkbookVersions(workbookId, { enabled: open });
   const versions = (data?.body ?? []) as VersionSummary[];
 
   const setVersion = useSetWorkbookVersion(experimentId);
@@ -97,6 +97,11 @@ export function WorkbookVersionHistoryDialog({
           {isLoading ? (
             <div className="flex items-center justify-center py-8">
               <Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
+            </div>
+          ) : error ? (
+            <div className="text-destructive flex items-center gap-2 py-6 text-sm">
+              <XCircle className="h-4 w-4 shrink-0" />
+              {t("flow.versionHistory.loadError")}
             </div>
           ) : versions.length === 0 ? (
             <p className="text-muted-foreground py-6 text-center text-sm">

--- a/apps/web/hooks/experiment/useSetWorkbookVersion/useSetWorkbookVersion.ts
+++ b/apps/web/hooks/experiment/useSetWorkbookVersion/useSetWorkbookVersion.ts
@@ -1,0 +1,24 @@
+import { tsr } from "@/lib/tsr";
+
+/**
+ * Pin the experiment to a specific existing workbook version (rollback or
+ * roll-forward). Mirrors the upgrade hook's invalidation so the design page and
+ * the linked-workbook banner react to the new pinned version.
+ */
+export const useSetWorkbookVersion = (experimentId?: string) => {
+  const queryClient = tsr.useQueryClient();
+
+  return tsr.experiments.setWorkbookVersion.useMutation({
+    mutationKey: ["experiment", experimentId, "setWorkbookVersion"],
+    onSettled: async (data, _error, variables) => {
+      await queryClient.invalidateQueries({ queryKey: ["experiment", variables.params.id] });
+      await queryClient.invalidateQueries({ queryKey: ["experimentAccess", variables.params.id] });
+      await queryClient.invalidateQueries({ queryKey: ["experiments"] });
+      const workbookId = data?.body.workbookId;
+      if (workbookId) {
+        await queryClient.invalidateQueries({ queryKey: ["workbook", workbookId] });
+        await queryClient.invalidateQueries({ queryKey: ["workbookVersions", workbookId] });
+      }
+    },
+  });
+};

--- a/apps/web/lib/line-diff.test.ts
+++ b/apps/web/lib/line-diff.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+
+import { lineDiff, hasChanges } from "./line-diff";
+
+describe("lineDiff", () => {
+  it("marks identical text as unchanged", () => {
+    const result = lineDiff("a\nb\nc", "a\nb\nc");
+    expect(result.every((l) => l.type === "same")).toBe(true);
+    expect(hasChanges(result)).toBe(false);
+  });
+
+  it("detects an inserted line", () => {
+    const result = lineDiff("a\nc", "a\nb\nc");
+    expect(result).toEqual([
+      { type: "same", text: "a" },
+      { type: "add", text: "b" },
+      { type: "same", text: "c" },
+    ]);
+    expect(hasChanges(result)).toBe(true);
+  });
+
+  it("detects a removed line", () => {
+    const result = lineDiff("a\nb\nc", "a\nc");
+    expect(result).toEqual([
+      { type: "same", text: "a" },
+      { type: "del", text: "b" },
+      { type: "same", text: "c" },
+    ]);
+  });
+
+  it("represents an edit as a delete + add", () => {
+    const result = lineDiff("hello", "world");
+    expect(result).toEqual([
+      { type: "del", text: "hello" },
+      { type: "add", text: "world" },
+    ]);
+  });
+
+  it("treats empty text as zero lines", () => {
+    expect(lineDiff("", "a")).toEqual([{ type: "add", text: "a" }]);
+    expect(lineDiff("a", "")).toEqual([{ type: "del", text: "a" }]);
+    expect(lineDiff("", "")).toEqual([]);
+  });
+});

--- a/apps/web/lib/line-diff.ts
+++ b/apps/web/lib/line-diff.ts
@@ -1,0 +1,51 @@
+export type DiffLineType = "same" | "add" | "del";
+
+export interface DiffLine {
+  type: DiffLineType;
+  text: string;
+}
+
+/**
+ * Standard LCS line diff between two blocks of text. Returns the merged line
+ * sequence tagged as unchanged / added / removed, suitable for a red-green
+ * rendering. Empty input is treated as zero lines (not one blank line).
+ */
+export function lineDiff(oldText: string, newText: string): DiffLine[] {
+  const a = oldText.length ? oldText.split("\n") : [];
+  const b = newText.length ? newText.split("\n") : [];
+  const m = a.length;
+  const n = b.length;
+
+  // lcs[i][j] = length of the longest common subsequence of a[i:] and b[j:].
+  const lcs: number[][] = Array.from({ length: m + 1 }, () => new Array<number>(n + 1).fill(0));
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      lcs[i][j] = a[i] === b[j] ? lcs[i + 1][j + 1] + 1 : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
+  }
+
+  const out: DiffLine[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < m && j < n) {
+    if (a[i] === b[j]) {
+      out.push({ type: "same", text: a[i] });
+      i++;
+      j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      out.push({ type: "del", text: a[i] });
+      i++;
+    } else {
+      out.push({ type: "add", text: b[j] });
+      j++;
+    }
+  }
+  while (i < m) out.push({ type: "del", text: a[i++] });
+  while (j < n) out.push({ type: "add", text: b[j++] });
+  return out;
+}
+
+/** Whether a diff contains any add/del lines. */
+export function hasChanges(lines: DiffLine[]): boolean {
+  return lines.some((l) => l.type !== "same");
+}

--- a/apps/web/lib/workbook-diff.test.ts
+++ b/apps/web/lib/workbook-diff.test.ts
@@ -53,6 +53,20 @@ describe("diffCells", () => {
     ]);
   });
 
+  it("reports a changed markdown cell with no label", () => {
+    const markdown = (id: string, content: string): WorkbookCell => ({
+      id,
+      type: "markdown",
+      isCollapsed: false,
+      content,
+    });
+    const changes = diffCells([markdown("m1", "before")], [markdown("m1", "after")]);
+    expect(changes).toEqual([
+      expect.objectContaining({ type: "changed", cellId: "m1", cellType: "markdown" }),
+    ]);
+    expect(changes[0].label).toBeUndefined();
+  });
+
   it("ignores runtime fields and output cells (a re-run is not a change)", () => {
     const before = [protocol("p1"), question("q1", "reading")];
     const answered: WorkbookCell = {

--- a/apps/web/lib/workbook-diff.test.ts
+++ b/apps/web/lib/workbook-diff.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+
+import type { WorkbookCell } from "@repo/api/schemas/workbook-cells.schema";
+
+import { diffCells } from "./workbook-diff";
+
+const protocol = (id: string, name = "P"): WorkbookCell => ({
+  id,
+  type: "protocol",
+  isCollapsed: false,
+  payload: { protocolId: `${id}-prot`, version: 1, name },
+});
+
+const question = (id: string, name: string): WorkbookCell => ({
+  id,
+  type: "question",
+  isCollapsed: false,
+  isAnswered: false,
+  name,
+  question: { kind: "open_ended", text: "?", required: false },
+});
+
+const output = (id: string, producedBy: string): WorkbookCell => ({
+  id,
+  type: "output",
+  isCollapsed: false,
+  producedBy,
+  data: { v: 1 },
+});
+
+describe("diffCells", () => {
+  it("returns no changes for identical designs", () => {
+    const cells = [protocol("p1"), question("q1", "reading")];
+    expect(diffCells(cells, cells)).toEqual([]);
+  });
+
+  it("detects added and removed cells", () => {
+    const before = [protocol("p1")];
+    const after = [protocol("p1"), question("q1", "reading")];
+    expect(diffCells(before, after)).toContainEqual(
+      expect.objectContaining({ type: "added", cellId: "q1" }),
+    );
+    expect(diffCells(after, before)).toContainEqual(
+      expect.objectContaining({ type: "removed", cellId: "q1" }),
+    );
+  });
+
+  it("detects an edited cell payload", () => {
+    const before = [protocol("p1", "Old name")];
+    const after = [protocol("p1", "New name")];
+    expect(diffCells(before, after)).toEqual([
+      expect.objectContaining({ type: "changed", cellId: "p1" }),
+    ]);
+  });
+
+  it("ignores runtime fields and output cells (a re-run is not a change)", () => {
+    const before = [protocol("p1"), question("q1", "reading")];
+    const answered: WorkbookCell = {
+      id: "q1",
+      type: "question",
+      isCollapsed: false,
+      isAnswered: true,
+      answer: "42",
+      name: "reading",
+      question: { kind: "open_ended", text: "?", required: false },
+    };
+    const afterRun: WorkbookCell[] = [protocol("p1"), answered, output("out1", "p1")];
+    expect(diffCells(before, afterRun)).toEqual([]);
+  });
+
+  it("detects a reordered cell", () => {
+    const before = [protocol("p1"), question("q1", "reading"), protocol("p2")];
+    const after = [question("q1", "reading"), protocol("p1"), protocol("p2")];
+    const changes = diffCells(before, after);
+    expect(changes.some((c) => c.type === "moved")).toBe(true);
+    expect(changes.every((c) => c.type === "moved")).toBe(true);
+  });
+});

--- a/apps/web/lib/workbook-diff.ts
+++ b/apps/web/lib/workbook-diff.ts
@@ -18,10 +18,11 @@ function stableStringify(value: unknown): string {
   const deepSort = (v: unknown): unknown => {
     if (Array.isArray(v)) return v.map(deepSort);
     if (v !== null && typeof v === "object") {
-      return Object.keys(v as Record<string, unknown>)
+      const obj = v as Record<string, unknown>;
+      return Object.keys(obj)
         .sort()
         .reduce<Record<string, unknown>>((acc, key) => {
-          acc[key] = deepSort((v as Record<string, unknown>)[key]);
+          acc[key] = deepSort(obj[key]);
           return acc;
         }, {});
     }

--- a/apps/web/lib/workbook-diff.ts
+++ b/apps/web/lib/workbook-diff.ts
@@ -1,0 +1,131 @@
+import type { WorkbookCell } from "@repo/api/schemas/workbook-cells.schema";
+
+// Mirrors the backend drift projection (is-workbook-upgradable `designOf`): the
+// upgrade diff must ignore the same runtime/UI artifacts so a re-run never shows
+// as a change. Kept local + display-only; the backend stays the source of truth
+// for the drift *decision*.
+const RUNTIME_CELL_FIELDS = new Set([
+  "isCollapsed",
+  "isAnswered",
+  "answer",
+  "evaluatedPathId",
+  "data",
+  "executionTime",
+  "messages",
+]);
+
+function stableStringify(value: unknown): string {
+  const deepSort = (v: unknown): unknown => {
+    if (Array.isArray(v)) return v.map(deepSort);
+    if (v !== null && typeof v === "object") {
+      return Object.keys(v as Record<string, unknown>)
+        .sort()
+        .reduce<Record<string, unknown>>((acc, key) => {
+          acc[key] = deepSort((v as Record<string, unknown>)[key]);
+          return acc;
+        }, {});
+    }
+    return v;
+  };
+  return JSON.stringify(deepSort(value));
+}
+
+function designCell(cell: WorkbookCell): string {
+  return stableStringify(
+    Object.fromEntries(Object.entries(cell).filter(([k]) => !RUNTIME_CELL_FIELDS.has(k))),
+  );
+}
+
+function labelOf(cell: WorkbookCell): string | undefined {
+  switch (cell.type) {
+    case "protocol":
+    case "macro":
+      return cell.payload.name;
+    case "question":
+      return cell.name;
+    default:
+      return undefined;
+  }
+}
+
+export type CellChangeType = "added" | "removed" | "changed" | "moved";
+
+export interface CellChange {
+  type: CellChangeType;
+  cellId: string;
+  cellType: WorkbookCell["type"];
+  label?: string;
+}
+
+/** Ids of `a` that survive in `b` in the same relative order (LCS of id sequences). */
+function lcsIds(a: string[], b: string[]): Set<string> {
+  const m = a.length;
+  const n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array<number>(n + 1).fill(0));
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  const keep = new Set<string>();
+  let i = 0;
+  let j = 0;
+  while (i < m && j < n) {
+    if (a[i] === b[j]) {
+      keep.add(a[i]);
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      i++;
+    } else {
+      j++;
+    }
+  }
+  return keep;
+}
+
+/**
+ * Compares two cell arrays (a pinned version vs the live/target workbook) and
+ * returns the design-level changes: cells added, removed, edited, or reordered.
+ * Output cells and runtime state are ignored.
+ */
+export function diffCells(oldCells: WorkbookCell[], newCells: WorkbookCell[]): CellChange[] {
+  const oldD = oldCells.filter((c) => c.type !== "output");
+  const newD = newCells.filter((c) => c.type !== "output");
+  const oldById = new Map(oldD.map((c) => [c.id, c]));
+  const newById = new Map(newD.map((c) => [c.id, c]));
+
+  const changes: CellChange[] = [];
+
+  for (const c of oldD) {
+    if (!newById.has(c.id)) {
+      changes.push({ type: "removed", cellId: c.id, cellType: c.type, label: labelOf(c) });
+    }
+  }
+
+  const changedOrAdded = new Set<string>();
+  for (const c of newD) {
+    const prev = oldById.get(c.id);
+    if (!prev) {
+      changes.push({ type: "added", cellId: c.id, cellType: c.type, label: labelOf(c) });
+      changedOrAdded.add(c.id);
+    } else if (designCell(prev) !== designCell(c)) {
+      changes.push({ type: "changed", cellId: c.id, cellType: c.type, label: labelOf(c) });
+      changedOrAdded.add(c.id);
+    }
+  }
+
+  // Reordering: among cells present on both sides, those off the LCS moved.
+  const commonOldIds = oldD.filter((c) => newById.has(c.id)).map((c) => c.id);
+  const commonNewIds = newD.filter((c) => oldById.has(c.id)).map((c) => c.id);
+  const stable = lcsIds(commonOldIds, commonNewIds);
+  for (const c of newD) {
+    if (!oldById.has(c.id)) continue;
+    if (changedOrAdded.has(c.id)) continue;
+    if (!stable.has(c.id)) {
+      changes.push({ type: "moved", cellId: c.id, cellType: c.type, label: labelOf(c) });
+    }
+  }
+
+  return changes;
+}

--- a/packages/api/src/contracts/experiment.contract.ts
+++ b/packages/api/src/contracts/experiment.contract.ts
@@ -85,7 +85,11 @@ import {
   zUpdateExperimentDashboardResponse,
 } from "../schemas/experiment.schema";
 import { zWebhookAuthHeader, zWebhookErrorResponse } from "../schemas/user.schema";
-import { zAttachWorkbookBody, zAttachWorkbookResponse } from "../schemas/workbook-version.schema";
+import {
+  zAttachWorkbookBody,
+  zAttachWorkbookResponse,
+  zSetWorkbookVersionBody,
+} from "../schemas/workbook-version.schema";
 
 const c = initContract();
 
@@ -465,7 +469,7 @@ export const experimentContract = c.router({
     method: "POST",
     path: "/api/v1/experiments/:id/workbook/version",
     pathParams: zIdPathParam,
-    body: z.object({ versionId: z.string().uuid() }),
+    body: zSetWorkbookVersionBody,
     responses: {
       200: zAttachWorkbookResponse,
       400: zErrorResponse,

--- a/packages/api/src/contracts/experiment.contract.ts
+++ b/packages/api/src/contracts/experiment.contract.ts
@@ -461,6 +461,22 @@ export const experimentContract = c.router({
       "Publishes the latest workbook cells as a new version (or reuses the latest if unchanged) and updates the experiment to reference it.",
   },
 
+  setWorkbookVersion: {
+    method: "POST",
+    path: "/api/v1/experiments/:id/workbook/version",
+    pathParams: zIdPathParam,
+    body: z.object({ versionId: z.string().uuid() }),
+    responses: {
+      200: zAttachWorkbookResponse,
+      400: zErrorResponse,
+      403: zErrorResponse,
+      404: zErrorResponse,
+    },
+    summary: "Pin the experiment to a specific workbook version",
+    description:
+      "Repins the experiment to an existing published version (rollback or roll-forward) without publishing a new one.",
+  },
+
   uploadData: {
     method: "POST",
     path: "/api/v1/experiments/:id/uploads",

--- a/packages/api/src/schemas/workbook-version.schema.ts
+++ b/packages/api/src/schemas/workbook-version.schema.ts
@@ -49,6 +49,10 @@ export const zAttachWorkbookBody = z.object({
   workbookId: z.string().uuid(),
 });
 
+export const zSetWorkbookVersionBody = z.object({
+  versionId: z.string().uuid(),
+});
+
 export const zAttachWorkbookResponse = z.object({
   workbookId: z.string().uuid(),
   workbookVersionId: z.string().uuid(),
@@ -59,5 +63,6 @@ export type WorkbookVersion = z.infer<typeof zWorkbookVersion>;
 export type WorkbookVersionSummary = z.infer<typeof zWorkbookVersionSummary>;
 export type WorkbookVersionList = z.infer<typeof zWorkbookVersionList>;
 export type AttachWorkbookBody = z.infer<typeof zAttachWorkbookBody>;
+export type SetWorkbookVersionBody = z.infer<typeof zSetWorkbookVersionBody>;
 export type AttachWorkbookResponse = z.infer<typeof zAttachWorkbookResponse>;
 export type EntitySnapshots = z.infer<typeof zEntitySnapshots>;

--- a/packages/api/src/utils/validate-workbook.spec.ts
+++ b/packages/api/src/utils/validate-workbook.spec.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+
+import type { WorkbookCell } from "../schemas/workbook-cells.schema";
+import { validateWorkbook } from "./validate-workbook";
+import type { WorkbookValidationContext } from "./validate-workbook";
+
+const protocolCell = (id: string, protocolId: string): WorkbookCell => ({
+  id,
+  type: "protocol",
+  isCollapsed: false,
+  payload: { protocolId, version: 1, name: "Protocol" },
+});
+
+const macroCell = (id: string, macroId: string): WorkbookCell => ({
+  id,
+  type: "macro",
+  isCollapsed: false,
+  payload: { macroId, language: "python", name: "Macro" },
+});
+
+const questionCell = (id: string): WorkbookCell => ({
+  id,
+  type: "question",
+  isCollapsed: false,
+  isAnswered: false,
+  name: "reading",
+  question: { kind: "open_ended", text: "Value?", required: false },
+});
+
+const branchCell = (id: string, sourceCellId: string, gotoCellId?: string): WorkbookCell => ({
+  id,
+  type: "branch",
+  isCollapsed: false,
+  paths: [
+    {
+      id: "path-1",
+      label: "High",
+      color: "#000000",
+      conditions: [{ id: "c1", sourceCellId, field: "answer", operator: "gt", value: "1" }],
+      gotoCellId,
+    },
+  ],
+});
+
+const ctx = (
+  protocols: WorkbookValidationContext["protocols"],
+  macros: WorkbookValidationContext["macros"] = {},
+): WorkbookValidationContext => ({ protocols, macros });
+
+describe("validateWorkbook", () => {
+  it("reports no issues for a well-formed workbook", () => {
+    const cells = [protocolCell("p1", "prot-1"), macroCell("m1", "mac-1")];
+    const result = validateWorkbook(
+      cells,
+      ctx({ "prot-1": { family: "multispeq" } }, { "mac-1": {} }),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.issues).toEqual([]);
+  });
+
+  it("flags a protocol cell whose entity no longer exists", () => {
+    const cells = [protocolCell("p1", "gone")];
+    const result = validateWorkbook(cells, ctx({}));
+    expect(result.ok).toBe(false);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        code: "missing-protocol",
+        cellId: "p1",
+        ref: "gone",
+      }),
+    );
+  });
+
+  it("flags a macro cell whose entity no longer exists", () => {
+    const cells = [protocolCell("p1", "prot-1"), macroCell("m1", "gone")];
+    const result = validateWorkbook(cells, ctx({ "prot-1": { family: "multispeq" } }, {}));
+    expect(result.ok).toBe(false);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({ level: "error", code: "missing-macro", cellId: "m1", ref: "gone" }),
+    );
+  });
+
+  it("flags dangling branch source and goto references", () => {
+    const cells = [questionCell("q1"), branchCell("b1", "removed-source", "removed-target")];
+    const result = validateWorkbook(cells, ctx({}));
+    expect(result.ok).toBe(false);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        code: "dangling-branch-source",
+        cellId: "b1",
+        ref: "removed-source",
+      }),
+    );
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        code: "dangling-branch-goto",
+        cellId: "b1",
+        ref: "removed-target",
+      }),
+    );
+  });
+
+  it("accepts branch references that resolve to existing cells", () => {
+    const cells = [questionCell("q1"), branchCell("b1", "q1", "q1")];
+    const result = validateWorkbook(cells, ctx({}));
+    expect(result.issues).toEqual([]);
+  });
+
+  it("warns (not errors) when a macro has no upstream measurement", () => {
+    const cells = [macroCell("m1", "mac-1"), protocolCell("p1", "prot-1")];
+    const result = validateWorkbook(
+      cells,
+      ctx({ "prot-1": { family: "multispeq" } }, { "mac-1": {} }),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({ level: "warning", code: "macro-without-input", cellId: "m1" }),
+    );
+  });
+
+  it("warns for every macro in a chain with no protocol upstream", () => {
+    const cells = [macroCell("m1", "mac-1"), macroCell("m2", "mac-2")];
+    const result = validateWorkbook(cells, ctx({}, { "mac-1": {}, "mac-2": {} }));
+    const flagged = result.issues
+      .filter((i) => i.code === "macro-without-input")
+      .map((i) => i.cellId);
+    expect(flagged).toEqual(expect.arrayContaining(["m1", "m2"]));
+  });
+
+  it("warns when a workbook mixes sensor families", () => {
+    const cells = [protocolCell("p1", "prot-1"), protocolCell("p2", "prot-2")];
+    const result = validateWorkbook(
+      cells,
+      ctx({ "prot-1": { family: "multispeq" }, "prot-2": { family: "ambit" } }),
+    );
+    expect(result.ok).toBe(true);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        level: "warning",
+        code: "mixed-sensor-families",
+        detail: "ambit, multispeq",
+      }),
+    );
+  });
+});

--- a/packages/api/src/utils/validate-workbook.ts
+++ b/packages/api/src/utils/validate-workbook.ts
@@ -66,9 +66,14 @@ export function validateWorkbook(
   const cellIds = new Set(cells.map((c) => c.id));
   const families = new Set<SensorFamily>();
   const seenBranchRefs = new Set<string>();
+  // A macro ultimately consumes the output of an upstream measurement. Approximate
+  // that as "some protocol cell precedes it in document order" so a protocol-less
+  // macro chain flags every macro, not just the first. Tracked in one pass (O(n)).
+  let sawProtocol = false;
 
   for (const cell of cells) {
     if (cell.type === "protocol") {
+      sawProtocol = true;
       const protocol = ctx.protocols[cell.payload.protocolId];
       if (!protocol) {
         issues.push({
@@ -83,14 +88,24 @@ export function validateWorkbook(
       }
     }
 
-    if (cell.type === "macro" && !(cell.payload.macroId in ctx.macros)) {
-      issues.push({
-        level: "error",
-        code: "missing-macro",
-        cellId: cell.id,
-        cellLabel: cellLabelOf(cell),
-        ref: cell.payload.macroId,
-      });
+    if (cell.type === "macro") {
+      if (!(cell.payload.macroId in ctx.macros)) {
+        issues.push({
+          level: "error",
+          code: "missing-macro",
+          cellId: cell.id,
+          cellLabel: cellLabelOf(cell),
+          ref: cell.payload.macroId,
+        });
+      }
+      if (!sawProtocol) {
+        issues.push({
+          level: "warning",
+          code: "macro-without-input",
+          cellId: cell.id,
+          cellLabel: cellLabelOf(cell),
+        });
+      }
     }
 
     if (cell.type === "branch") {
@@ -122,22 +137,6 @@ export function validateWorkbook(
       }
     }
   }
-
-  // A macro ultimately consumes the output of an upstream measurement.
-  // Approximate that as "some protocol cell precedes it in document order" so a
-  // protocol-less macro chain flags every macro, not just the first.
-  cells.forEach((cell, index) => {
-    if (cell.type !== "macro") return;
-    const hasUpstream = cells.slice(0, index).some((c) => c.type === "protocol");
-    if (!hasUpstream) {
-      issues.push({
-        level: "warning",
-        code: "macro-without-input",
-        cellId: cell.id,
-        cellLabel: cellLabelOf(cell),
-      });
-    }
-  });
 
   if (families.size > 1) {
     issues.push({

--- a/packages/api/src/utils/validate-workbook.ts
+++ b/packages/api/src/utils/validate-workbook.ts
@@ -1,0 +1,151 @@
+import type { SensorFamily } from "../schemas/protocol.schema";
+import type { WorkbookCell } from "../schemas/workbook-cells.schema";
+
+export type WorkbookIssueLevel = "error" | "warning";
+
+export type WorkbookIssueCode =
+  | "missing-protocol"
+  | "missing-macro"
+  | "dangling-branch-source"
+  | "dangling-branch-goto"
+  | "mixed-sensor-families"
+  | "macro-without-input";
+
+export interface WorkbookIssue {
+  level: WorkbookIssueLevel;
+  code: WorkbookIssueCode;
+  /** Cell the issue is anchored to; absent for workbook-wide issues. */
+  cellId?: string;
+  /** Display label for the offending cell, when it has one. */
+  cellLabel?: string;
+  /** Unresolved reference (entity id or target cell id). */
+  ref?: string;
+  /** Extra value for message interpolation (e.g. the family list). */
+  detail?: string;
+}
+
+export interface WorkbookValidationContext {
+  /** Referenced protocols by id with sensor family. A missing id means the protocol no longer exists. */
+  protocols: Record<string, { family?: SensorFamily } | undefined>;
+  /** Referenced macros by id. A missing id means the macro no longer exists. */
+  macros: Record<string, unknown>;
+}
+
+export interface WorkbookValidationResult {
+  issues: WorkbookIssue[];
+  /** True when there are no blocking errors (warnings are allowed). */
+  ok: boolean;
+}
+
+function cellLabelOf(cell: WorkbookCell): string | undefined {
+  switch (cell.type) {
+    case "protocol":
+    case "macro":
+      return cell.payload.name;
+    case "question":
+      return cell.name;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Static, device-free structural checks for a workbook's cells. Catches the
+ * breakages a shared-entity edit or a version upgrade can introduce: references
+ * to cells/entities that no longer exist, more than one sensor family in a
+ * single flow, and a macro with nothing upstream to run on. It intentionally
+ * does NOT (and cannot) verify macro logic, protocol output shape, or device
+ * behaviour, so a clean result is "no structural problems", not "guaranteed to
+ * run".
+ */
+export function validateWorkbook(
+  cells: WorkbookCell[],
+  ctx: WorkbookValidationContext,
+): WorkbookValidationResult {
+  const issues: WorkbookIssue[] = [];
+  const cellIds = new Set(cells.map((c) => c.id));
+  const families = new Set<SensorFamily>();
+  const seenBranchRefs = new Set<string>();
+
+  for (const cell of cells) {
+    if (cell.type === "protocol") {
+      const protocol = ctx.protocols[cell.payload.protocolId];
+      if (!protocol) {
+        issues.push({
+          level: "error",
+          code: "missing-protocol",
+          cellId: cell.id,
+          cellLabel: cellLabelOf(cell),
+          ref: cell.payload.protocolId,
+        });
+      } else if (protocol.family) {
+        families.add(protocol.family);
+      }
+    }
+
+    if (cell.type === "macro" && !(cell.payload.macroId in ctx.macros)) {
+      issues.push({
+        level: "error",
+        code: "missing-macro",
+        cellId: cell.id,
+        cellLabel: cellLabelOf(cell),
+        ref: cell.payload.macroId,
+      });
+    }
+
+    if (cell.type === "branch") {
+      for (const path of cell.paths) {
+        for (const cond of path.conditions) {
+          const key = `s:${cell.id}:${cond.sourceCellId}`;
+          if (cond.sourceCellId && !cellIds.has(cond.sourceCellId) && !seenBranchRefs.has(key)) {
+            seenBranchRefs.add(key);
+            issues.push({
+              level: "error",
+              code: "dangling-branch-source",
+              cellId: cell.id,
+              cellLabel: cellLabelOf(cell),
+              ref: cond.sourceCellId,
+            });
+          }
+        }
+        const gotoKey = `g:${cell.id}:${path.gotoCellId}`;
+        if (path.gotoCellId && !cellIds.has(path.gotoCellId) && !seenBranchRefs.has(gotoKey)) {
+          seenBranchRefs.add(gotoKey);
+          issues.push({
+            level: "error",
+            code: "dangling-branch-goto",
+            cellId: cell.id,
+            cellLabel: cellLabelOf(cell),
+            ref: path.gotoCellId,
+          });
+        }
+      }
+    }
+  }
+
+  // A macro ultimately consumes the output of an upstream measurement.
+  // Approximate that as "some protocol cell precedes it in document order" so a
+  // protocol-less macro chain flags every macro, not just the first.
+  cells.forEach((cell, index) => {
+    if (cell.type !== "macro") return;
+    const hasUpstream = cells.slice(0, index).some((c) => c.type === "protocol");
+    if (!hasUpstream) {
+      issues.push({
+        level: "warning",
+        code: "macro-without-input",
+        cellId: cell.id,
+        cellLabel: cellLabelOf(cell),
+      });
+    }
+  });
+
+  if (families.size > 1) {
+    issues.push({
+      level: "warning",
+      code: "mixed-sensor-families",
+      detail: [...families].sort().join(", "),
+    });
+  }
+
+  return { issues, ok: !issues.some((i) => i.level === "error") };
+}

--- a/packages/i18n/locales/de-DE/experiments.json
+++ b/packages/i18n/locales/de-DE/experiments.json
@@ -96,7 +96,8 @@
       "restoreConfirmMessage": "Dies setzt das Experiment wieder auf v{{version}} und ändert das Messprotokoll für künftige Messungen. Vorhandene Daten bleiben erhalten.",
       "restored": "Auf v{{version}} zurückgesetzt",
       "restoreFailed": "Version konnte nicht wiederhergestellt werden",
-      "empty": "Noch keine veröffentlichten Versionen."
+      "empty": "Noch keine veröffentlichten Versionen.",
+      "loadError": "Versionsverlauf konnte nicht geladen werden. Bitte erneut versuchen."
     },
     "upgradeDiff": {
       "title": "Änderungen vor dem Aktualisieren prüfen",

--- a/packages/i18n/locales/de-DE/experiments.json
+++ b/packages/i18n/locales/de-DE/experiments.json
@@ -84,7 +84,59 @@
     "editingTitle": "Arbeitsbuch dieses Experiments bearbeiten",
     "editAutoApplyNotice": "Jede Änderung, die du hier speicherst, wird automatisch auf dieses Experiment angewendet.",
     "editIsolatedHint": "Wenn du Änderungen ausprobieren möchtest, ohne dieses Experiment zu beeinflussen, bearbeite über die Arbeitsbuch-Seite; diese Änderungen bleiben getrennt, bis du die Version aktualisierst.",
-    "editOpenWorkbookLink": "Arbeitsbuch-Seite öffnen"
+    "editOpenWorkbookLink": "Arbeitsbuch-Seite öffnen",
+    "reviewAndUpgrade": "Prüfen & aktualisieren",
+    "versionHistory": {
+      "open": "Versionsverlauf",
+      "title": "Versionsverlauf",
+      "subtitle": "Jede Version, die beim Anhängen oder Aktualisieren dieses Arbeitsbuchs veröffentlicht wurde.",
+      "current": "Aktuell",
+      "restore": "Wiederherstellen",
+      "restoreConfirmTitle": "Diese Version wiederherstellen?",
+      "restoreConfirmMessage": "Dies setzt das Experiment wieder auf v{{version}} und ändert das Messprotokoll für künftige Messungen. Vorhandene Daten bleiben erhalten.",
+      "restored": "Auf v{{version}} zurückgesetzt",
+      "restoreFailed": "Version konnte nicht wiederhergestellt werden",
+      "empty": "Noch keine veröffentlichten Versionen."
+    },
+    "upgradeDiff": {
+      "title": "Änderungen vor dem Aktualisieren prüfen",
+      "subtitle": "Dieses Experiment wird von v{{from}} auf {{to}} umgestellt.",
+      "checking": "Kompatibilität wird geprüft...",
+      "loadError": "Änderungen konnten nicht geladen werden. Schließen und erneut versuchen.",
+      "upgrading": "Wird aktualisiert...",
+      "cellChanges": "Ablaufänderungen",
+      "noCellChanges": "Keine Änderungen an der Ablaufstruktur.",
+      "codeChanges": "Protokoll- & Makro-Änderungen",
+      "viewDiff": "Unterschiede anzeigen",
+      "macroCaveat": "Nur strukturelle Prüfungen. Makro-Logik wird nicht überprüft; testen Sie den Ablauf nach der Aktualisierung.",
+      "lastChanged": "geändert {{when}}",
+      "kind": { "protocol": "Protokoll", "macro": "Makro" },
+      "status": {
+        "added": "Hinzugefügt",
+        "changed": "Geändert",
+        "unchanged": "Unverändert",
+        "removed": "Entfernt"
+      },
+      "change": {
+        "added": "Hinzugefügt",
+        "removed": "Entfernt",
+        "changed": "Bearbeitet",
+        "moved": "Verschoben"
+      },
+      "verdict": {
+        "ok": "Keine strukturellen Probleme gefunden",
+        "warnings": "Aktualisierung möglich, mit Warnungen",
+        "errors": "Die Aktualisierung könnte dieses Arbeitsbuch beschädigen"
+      },
+      "issue": {
+        "missingProtocol": "Protokoll \"{{label}}\" existiert nicht mehr",
+        "missingMacro": "Makro \"{{label}}\" existiert nicht mehr",
+        "danglingSource": "Eine Verzweigungsbedingung verweist auf eine nicht mehr vorhandene Zelle ({{ref}})",
+        "danglingGoto": "Eine Verzweigung springt zu einer nicht mehr vorhandenen Zelle ({{ref}})",
+        "macroWithoutInput": "Makro \"{{label}}\" hat keine vorangehende Messung zum Ausführen",
+        "mixedFamilies": "Dieses Arbeitsbuch mischt Sensorfamilien ({{detail}}); ein Durchlauf zielt auf ein einzelnes Gerät"
+      }
+    }
   },
   "overview": "Übersicht",
   "data": "Daten",

--- a/packages/i18n/locales/de-DE/workbook.json
+++ b/packages/i18n/locales/de-DE/workbook.json
@@ -73,7 +73,7 @@
     "expand": "Ausgabe ausklappen",
     "collapse": "Ausgabe einklappen",
     "clear": "Ausgabe löschen",
-    "empty": "Keine Messdaten verfügbar — führen Sie zuerst eine Protokollzelle aus",
+    "empty": "Keine Messdaten verfügbar - führen Sie zuerst eine Protokollzelle aus",
     "noData": "Keine Ausgabedaten",
     "tabTable": "Tabelle",
     "tabJson": "JSON",
@@ -92,6 +92,11 @@
     "protocolReadOnly": "Schreibgeschützt. Zum Bearbeiten forken.",
     "macroReadOnly": "Schreibgeschützt. Zum Bearbeiten forken.",
     "fork": "Zum Bearbeiten forken",
-    "forkedFrom": "Geforkt von"
+    "forkedFrom": "Geforkt von",
+    "rename": "Umbenennen",
+    "renameSave": "Namen speichern",
+    "renameCancel": "Abbrechen",
+    "renameConflict": "Dieser Name ist bereits vergeben",
+    "renameFailed": "Umbenennen fehlgeschlagen"
   }
 }

--- a/packages/i18n/locales/en-US/experiments.json
+++ b/packages/i18n/locales/en-US/experiments.json
@@ -110,7 +110,54 @@
     "editingTitle": "Editing this experiment's workbook",
     "editAutoApplyNotice": "Every change you save here is applied to this experiment automatically.",
     "editIsolatedHint": "To try changes without affecting this experiment, edit from the workbook page instead; edits there stay separate until you upgrade the version.",
-    "editOpenWorkbookLink": "Open the workbook page"
+    "editOpenWorkbookLink": "Open the workbook page",
+    "reviewAndUpgrade": "Review & upgrade",
+    "versionHistory": {
+      "open": "Version history",
+      "title": "Version history",
+      "subtitle": "Every version published when this workbook was attached or upgraded.",
+      "current": "Current",
+      "restore": "Restore",
+      "restoreConfirmTitle": "Restore this version?",
+      "restoreConfirmMessage": "This re-pins the experiment to v{{version}}, changing its measurement protocol for future measurements. Existing data is preserved.",
+      "restored": "Restored to v{{version}}",
+      "restoreFailed": "Failed to restore version",
+      "empty": "No published versions yet."
+    },
+    "upgradeDiff": {
+      "title": "Review changes before upgrading",
+      "subtitle": "Moving this experiment from v{{from}} to {{to}}.",
+      "checking": "Checking compatibility...",
+      "loadError": "Couldn't load the changes. Close and try again.",
+      "upgrading": "Upgrading...",
+      "cellChanges": "Flow changes",
+      "noCellChanges": "No changes to the flow structure.",
+      "codeChanges": "Protocol & macro changes",
+      "viewDiff": "View diff",
+      "macroCaveat": "Structural checks only. Macro logic is not verified, so test the flow after upgrading.",
+      "lastChanged": "updated {{when}}",
+      "kind": { "protocol": "Protocol", "macro": "Macro" },
+      "status": {
+        "added": "Added",
+        "changed": "Changed",
+        "unchanged": "Unchanged",
+        "removed": "Removed"
+      },
+      "change": { "added": "Added", "removed": "Removed", "changed": "Edited", "moved": "Moved" },
+      "verdict": {
+        "ok": "No structural issues found",
+        "warnings": "Upgrade is possible, with warnings",
+        "errors": "Upgrading may break this workbook"
+      },
+      "issue": {
+        "missingProtocol": "Protocol \"{{label}}\" no longer exists",
+        "missingMacro": "Macro \"{{label}}\" no longer exists",
+        "danglingSource": "A branch condition points at a cell that no longer exists ({{ref}})",
+        "danglingGoto": "A branch jumps to a cell that no longer exists ({{ref}})",
+        "macroWithoutInput": "Macro \"{{label}}\" has no measurement before it to run on",
+        "mixedFamilies": "This workbook mixes sensor families ({{detail}}); one run targets a single device"
+      }
+    }
   },
   "overview": "Overview",
   "data": "Data",

--- a/packages/i18n/locales/en-US/experiments.json
+++ b/packages/i18n/locales/en-US/experiments.json
@@ -122,7 +122,8 @@
       "restoreConfirmMessage": "This re-pins the experiment to v{{version}}, changing its measurement protocol for future measurements. Existing data is preserved.",
       "restored": "Restored to v{{version}}",
       "restoreFailed": "Failed to restore version",
-      "empty": "No published versions yet."
+      "empty": "No published versions yet.",
+      "loadError": "Could not load version history. Try again."
     },
     "upgradeDiff": {
       "title": "Review changes before upgrading",

--- a/packages/i18n/locales/en-US/workbook.json
+++ b/packages/i18n/locales/en-US/workbook.json
@@ -73,7 +73,7 @@
     "expand": "Expand output",
     "collapse": "Collapse output",
     "clear": "Clear output",
-    "empty": "No measurement data available — run a protocol cell first",
+    "empty": "No measurement data available - run a protocol cell first",
     "noData": "No output data",
     "tabTable": "Table",
     "tabJson": "JSON",
@@ -92,6 +92,11 @@
     "protocolReadOnly": "Read-only. Fork it to edit.",
     "macroReadOnly": "Read-only. Fork it to edit.",
     "fork": "Fork to edit",
-    "forkedFrom": "Forked from"
+    "forkedFrom": "Forked from",
+    "rename": "Rename",
+    "renameSave": "Save name",
+    "renameCancel": "Cancel",
+    "renameConflict": "That name is already taken",
+    "renameFailed": "Rename failed"
   }
 }

--- a/packages/i18n/locales/nl-NL/experiments.json
+++ b/packages/i18n/locales/nl-NL/experiments.json
@@ -81,7 +81,59 @@
     "editingTitle": "Het werkboek van dit experiment bewerken",
     "editAutoApplyNotice": "Elke wijziging die je hier opslaat, wordt automatisch toegepast op dit experiment.",
     "editIsolatedHint": "Wil je wijzigingen uitproberen zonder dit experiment te beïnvloeden, bewerk dan via de werkboekpagina; die wijzigingen blijven gescheiden totdat je de versie bijwerkt.",
-    "editOpenWorkbookLink": "Open de werkboekpagina"
+    "editOpenWorkbookLink": "Open de werkboekpagina",
+    "reviewAndUpgrade": "Controleren & upgraden",
+    "versionHistory": {
+      "open": "Versiegeschiedenis",
+      "title": "Versiegeschiedenis",
+      "subtitle": "Elke versie die is gepubliceerd bij het koppelen of upgraden van dit werkboek.",
+      "current": "Huidig",
+      "restore": "Herstellen",
+      "restoreConfirmTitle": "Deze versie herstellen?",
+      "restoreConfirmMessage": "Dit koppelt het experiment terug aan v{{version}} en wijzigt het meetprotocol voor toekomstige metingen. Bestaande gegevens blijven behouden.",
+      "restored": "Hersteld naar v{{version}}",
+      "restoreFailed": "Herstellen van versie mislukt",
+      "empty": "Nog geen gepubliceerde versies."
+    },
+    "upgradeDiff": {
+      "title": "Bekijk wijzigingen voor het upgraden",
+      "subtitle": "Dit experiment gaat van v{{from}} naar {{to}}.",
+      "checking": "Compatibiliteit controleren...",
+      "loadError": "Kon de wijzigingen niet laden. Sluit en probeer opnieuw.",
+      "upgrading": "Bezig met upgraden...",
+      "cellChanges": "Flow-wijzigingen",
+      "noCellChanges": "Geen wijzigingen in de flow-structuur.",
+      "codeChanges": "Protocol- & macrowijzigingen",
+      "viewDiff": "Verschillen tonen",
+      "macroCaveat": "Alleen structurele controles. Macrologica wordt niet geverifieerd; test de flow na het upgraden.",
+      "lastChanged": "gewijzigd {{when}}",
+      "kind": { "protocol": "Protocol", "macro": "Macro" },
+      "status": {
+        "added": "Toegevoegd",
+        "changed": "Gewijzigd",
+        "unchanged": "Ongewijzigd",
+        "removed": "Verwijderd"
+      },
+      "change": {
+        "added": "Toegevoegd",
+        "removed": "Verwijderd",
+        "changed": "Bewerkt",
+        "moved": "Verplaatst"
+      },
+      "verdict": {
+        "ok": "Geen structurele problemen gevonden",
+        "warnings": "Upgraden is mogelijk, met waarschuwingen",
+        "errors": "Upgraden kan dit werkboek breken"
+      },
+      "issue": {
+        "missingProtocol": "Protocol \"{{label}}\" bestaat niet meer",
+        "missingMacro": "Macro \"{{label}}\" bestaat niet meer",
+        "danglingSource": "Een branchvoorwaarde verwijst naar een cel die niet meer bestaat ({{ref}})",
+        "danglingGoto": "Een branch springt naar een cel die niet meer bestaat ({{ref}})",
+        "macroWithoutInput": "Macro \"{{label}}\" heeft geen voorafgaande meting om op te draaien",
+        "mixedFamilies": "Dit werkboek mengt sensorfamilies ({{detail}}); een run richt zich op één apparaat"
+      }
+    }
   },
   "overview": "Overzicht",
   "data": "Gegevens",

--- a/packages/i18n/locales/nl-NL/experiments.json
+++ b/packages/i18n/locales/nl-NL/experiments.json
@@ -93,7 +93,8 @@
       "restoreConfirmMessage": "Dit koppelt het experiment terug aan v{{version}} en wijzigt het meetprotocol voor toekomstige metingen. Bestaande gegevens blijven behouden.",
       "restored": "Hersteld naar v{{version}}",
       "restoreFailed": "Herstellen van versie mislukt",
-      "empty": "Nog geen gepubliceerde versies."
+      "empty": "Nog geen gepubliceerde versies.",
+      "loadError": "Kan versiegeschiedenis niet laden. Probeer het opnieuw."
     },
     "upgradeDiff": {
       "title": "Bekijk wijzigingen voor het upgraden",

--- a/packages/i18n/locales/nl-NL/workbook.json
+++ b/packages/i18n/locales/nl-NL/workbook.json
@@ -73,7 +73,7 @@
     "expand": "Uitvoer uitvouwen",
     "collapse": "Uitvoer samenvouwen",
     "clear": "Uitvoer wissen",
-    "empty": "Geen meetgegevens beschikbaar — voer eerst een protocolcel uit",
+    "empty": "Geen meetgegevens beschikbaar - voer eerst een protocolcel uit",
     "noData": "Geen uitvoergegevens",
     "tabTable": "Tabel",
     "tabJson": "JSON",
@@ -92,6 +92,11 @@
     "protocolReadOnly": "Alleen-lezen. Fork het om te bewerken.",
     "macroReadOnly": "Alleen-lezen. Fork het om te bewerken.",
     "fork": "Forken om te bewerken",
-    "forkedFrom": "Geforkt van"
+    "forkedFrom": "Geforkt van",
+    "rename": "Naam wijzigen",
+    "renameSave": "Naam opslaan",
+    "renameCancel": "Annuleren",
+    "renameConflict": "Die naam is al in gebruik",
+    "renameFailed": "Naam wijzigen mislukt"
   }
 }


### PR DESCRIPTION
Refs OJD-1674

## Context

Follow-up to the workbook fork/edit thread (Tom's feedback on #1771). Protocols and macros are single shared rows referenced by workbook cells, and versions are only minted when an experiment attaches/upgrades. That model is fine, but it left three sharp edges:

1. **Editing "your" protocol changes it for everyone** — there's no per-workbook copy, so editing an entity (from a workbook page or its own page) mutates the one shared row. Live workbooks see it immediately; experiments keep their frozen snapshot until upgraded.
2. **Upgrade was a blind button** — you couldn't see *what* changed or whether the workbook would *still run* after upgrading.
3. **Versions were invisible** — no history, no rollback.

## What's in here

**Integration test — proves the propagation model** (`shared-entity-propagation.spec.ts`)
Two workbooks share one protocol (one owned by the protocol owner, one by another user). Asserts: editing the entity flags *both* workbooks upgradable and freezes *both* published snapshots; upgrading one advances only it; and a re-run (output cells + per-run fields) is **not** drift. Macro parity included.

**Inline rename from the cell** — resolves the ugly `Copy of X <uuid>` fork name in place. Renames the shared entity + repoints the cell label; friendly "name taken" on a 409.

**Review-before-upgrade dialog** — replaces the blind confirm on the experiment design page:
- **What changed**: cell-level added/removed/reordered/edited (ignores the runtime layer, so a re-run shows nothing) + per-protocol/macro code diff + "last changed {updatedAt}".
- **Compatibility verdict**: a new pure `validateWorkbook` (`@repo/api/utils`) flags dangling branch refs, missing entities, sensor-family mixing, and a macro with no upstream input. Honest caveat: structural only, macro logic isn't verified.

**Version history + rollback** — a history dialog off the version badge; a new `POST /experiments/:id/workbook/version` endpoint re-pins to any existing version (rollback or roll-forward) without publishing.

## Testing
- Backend integration (real DB): shared-entity propagation (4) + set-workbook-version (3) + upgrade/upgradable regression — all green.
- Web: cell rename, CellTitle, upgrade dialog, diff utils, and updated linked-workbook-card/design-page tests — all green.
- `@repo/api`: validateWorkbook unit tests.
- tsc + eslint clean across web / backend / @repo/api for all touched files.

## Notes
- No DB migration.
- `validateWorkbook` is reusable at save/attach/run later.
- The rename edits the shared entity (same "affects everyone" property as editing code); gated to entities you own.

## Videos
[1_rename.webm](https://github.com/user-attachments/assets/2ec53614-7126-4afa-bfb6-50976399a157)

[2_upgrade.webm](https://github.com/user-attachments/assets/e7ce35e6-469b-4186-864f-63ed2b1e174b)

[3_rollback.webm](https://github.com/user-attachments/assets/09a4bab9-72eb-45fe-b75f-17961048ee70)
