### PR TITLE
feat(iot): share sensor_family taxonomy across protocols and devices

### DIFF
--- a/apps/backend/src/protocols/core/repositories/protocol.repository.spec.ts
+++ b/apps/backend/src/protocols/core/repositories/protocol.repository.spec.ts
@@ -389,12 +389,12 @@ describe("ProtocolRepository", () => {
       });
       await testApp.createProtocol({
         name: "Quux probe",
-        family: "ambit",
+        family: "ambyte",
         createdBy: testUserId,
       });
 
       expect(await searchProtocolNames("multispeq")).toContain("Vorple leaf scan");
-      expect(await searchProtocolNames("ambit")).toContain("Quux probe");
+      expect(await searchProtocolNames("ambyte")).toContain("Quux probe");
     });
 
     it("should do prefix matching", async () => {

--- a/apps/backend/src/test/test-harness.ts
+++ b/apps/backend/src/test/test-harness.ts
@@ -439,7 +439,7 @@ export class TestHarness {
     name: string;
     description?: string;
     code?: Record<string, unknown>[];
-    family?: "multispeq" | "ambit" | "generic";
+    family?: "multispeq" | "ambyte" | "minipar" | "generic";
     createdBy: string;
   }) {
     const [protocol] = await this.database
@@ -463,7 +463,7 @@ export class TestHarness {
     serialNumber?: string;
     thingName?: string;
     name?: string;
-    deviceType?: string;
+    deviceType?: "multispeq" | "ambyte" | "minipar" | "generic";
     status?: "pending" | "active" | "rotating" | "revoked";
     certificateId?: string;
     certificateArn?: string;

--- a/apps/web/components/iot-devices/register-iot-device-dialog.test.tsx
+++ b/apps/web/components/iot-devices/register-iot-device-dialog.test.tsx
@@ -22,7 +22,8 @@ describe("RegisterIotDeviceDialog", () => {
       screen.getByPlaceholderText("iot.devices.dialog.serialPlaceholder"),
       "AA:BB:CC",
     );
-    await user.type(screen.getByPlaceholderText("iot.devices.dialog.typePlaceholder"), "ambyte");
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "Ambyte" }));
     await user.click(screen.getByRole("button", { name: "iot.devices.dialog.submit" }));
 
     await waitFor(() => expect(spy.called).toBe(true));
@@ -50,7 +51,8 @@ describe("RegisterIotDeviceDialog", () => {
 
     render(<RegisterIotDeviceDialog open onOpenChange={vi.fn()} />);
     await user.type(screen.getByPlaceholderText("iot.devices.dialog.serialPlaceholder"), "AA:BB");
-    await user.type(screen.getByPlaceholderText("iot.devices.dialog.typePlaceholder"), "ambyte");
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "Ambyte" }));
     await user.click(screen.getByRole("button", { name: "iot.devices.dialog.submit" }));
 
     await waitFor(() => expect(spy.called).toBe(true));

--- a/apps/web/components/iot-devices/register-iot-device-dialog.tsx
+++ b/apps/web/components/iot-devices/register-iot-device-dialog.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useRegisterIotDevice } from "@/hooks/iot/useRegisterIotDevice/useRegisterIotDevice";
+import { getSensorFamilyLabel } from "@/util/sensor-family";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2 } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { zRegisterIotDeviceBody } from "@repo/api/schemas/iot.schema";
+import { zSensorFamily } from "@repo/api/schemas/protocol.schema";
 import { useTranslation } from "@repo/i18n";
 import { Button } from "@repo/ui/components/button";
 import {
@@ -26,6 +28,13 @@ import {
   FormMessage,
 } from "@repo/ui/components/form";
 import { Input } from "@repo/ui/components/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui/components/select";
 import { toast } from "@repo/ui/hooks/use-toast";
 
 // Name stays optional without the contract's min(1) so an empty field is valid in the form;
@@ -47,7 +56,7 @@ export function RegisterIotDeviceDialog({ open, onOpenChange }: RegisterIotDevic
 
   const form = useForm<RegisterIotDeviceFormValues>({
     resolver: zodResolver(registerIotDeviceFormSchema),
-    defaultValues: { serialNumber: "", deviceType: "", name: "" },
+    defaultValues: { serialNumber: "", deviceType: undefined, name: "" },
   });
 
   const { mutate: registerIotDevice, isPending } = useRegisterIotDevice({
@@ -115,9 +124,20 @@ export function RegisterIotDeviceDialog({ open, onOpenChange }: RegisterIotDevic
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>{t("iot.devices.dialog.typeLabel")}</FormLabel>
-                  <FormControl>
-                    <Input placeholder={t("iot.devices.dialog.typePlaceholder")} {...field} trim />
-                  </FormControl>
+                  <Select onValueChange={field.onChange} value={field.value} disabled={isPending}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder={t("iot.devices.dialog.typePlaceholder")} />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {zSensorFamily.options.map((value) => (
+                        <SelectItem key={value} value={value}>
+                          {getSensorFamilyLabel(value)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                   <FormMessage />
                 </FormItem>
               )}

--- a/apps/web/components/iot/iot-protocol-runner.test.tsx
+++ b/apps/web/components/iot/iot-protocol-runner.test.tsx
@@ -435,7 +435,7 @@ describe("IotProtocolRunner", () => {
       const { rerender } = render(<IotProtocolRunner {...defaultProps} />);
 
       // Change sensor family
-      rerender(<IotProtocolRunner {...defaultProps} sensorFamily="ambit" />);
+      rerender(<IotProtocolRunner {...defaultProps} sensorFamily="ambyte" />);
 
       await waitFor(() => {
         expect(mockDisconnect).toHaveBeenCalled();
@@ -460,7 +460,7 @@ describe("IotProtocolRunner", () => {
       });
 
       // Change sensor family
-      rerender(<IotProtocolRunner {...defaultProps} sensorFamily="ambit" />);
+      rerender(<IotProtocolRunner {...defaultProps} sensorFamily="ambyte" />);
 
       await waitFor(() => {
         expect(screen.getByText("No result")).toBeInTheDocument();

--- a/apps/web/components/macro-settings/__tests__/macro-compatible-protocols-card.test.tsx
+++ b/apps/web/components/macro-settings/__tests__/macro-compatible-protocols-card.test.tsx
@@ -51,14 +51,19 @@ const mockCompatibleProtocols = [
   },
   {
     macroId: "00000000-0000-0000-0000-000000000001",
-    protocol: { id: PROTO_2_ID, name: "Humidity Protocol", family: "ambit", createdBy: CREATOR_ID },
+    protocol: {
+      id: PROTO_2_ID,
+      name: "Humidity Protocol",
+      family: "ambyte",
+      createdBy: CREATOR_ID,
+    },
     addedAt: "2024-01-01T00:00:00.000Z",
   },
 ];
 
 const mockAllProtocols = [
   createProtocol({ id: PROTO_1_ID, name: "Temperature Protocol", family: "multispeq" }),
-  createProtocol({ id: PROTO_2_ID, name: "Humidity Protocol", family: "ambit" }),
+  createProtocol({ id: PROTO_2_ID, name: "Humidity Protocol", family: "ambyte" }),
   createProtocol({ id: PROTO_3_ID, name: "Light Protocol", family: "multispeq" }),
 ];
 
@@ -105,7 +110,7 @@ describe("<MacroCompatibleProtocolsCard />", () => {
     });
     expect(screen.getByText("multispeq")).toBeInTheDocument();
     expect(screen.getByText("Humidity Protocol")).toBeInTheDocument();
-    expect(screen.getByText("ambit")).toBeInTheDocument();
+    expect(screen.getByText("ambyte")).toBeInTheDocument();
   });
 
   it("should render protocol links with correct hrefs", async () => {

--- a/apps/web/components/macro-settings/macro-compatible-protocols-card.tsx
+++ b/apps/web/components/macro-settings/macro-compatible-protocols-card.tsx
@@ -2,6 +2,7 @@
 
 import { useDebounce } from "@/hooks/useDebounce";
 import { useLocale } from "@/hooks/useLocale";
+import { getSensorFamilyBadgeColor } from "@/util/sensor-family";
 import { ExternalLink, FileJson2, X } from "lucide-react";
 import Link from "next/link";
 import { useMemo, useState } from "react";
@@ -24,17 +25,6 @@ import { useMacroCompatibleProtocols } from "../../hooks/macro/useMacroCompatibl
 import { useRemoveCompatibleProtocol } from "../../hooks/macro/useRemoveCompatibleProtocol/useRemoveCompatibleProtocol";
 import { useProtocolSearch } from "../../hooks/protocol/useProtocolSearch/useProtocolSearch";
 import { ProtocolSearchWithDropdown } from "../protocol-search-with-dropdown";
-
-const getFamilyColor = (family: string) => {
-  switch (family) {
-    case "multispeq":
-      return "bg-badge-published";
-    case "ambit":
-      return "bg-badge-active";
-    default:
-      return "bg-badge-archived";
-  }
-};
 
 interface MacroCompatibleProtocolsCardProps {
   macroId: string;
@@ -135,7 +125,9 @@ export function MacroCompatibleProtocolsCard({
                       <ExternalLink className="text-muted-foreground h-3.5 w-3.5" />
                     </Link>
                   </div>
-                  <Badge className={`${getFamilyColor(entry.protocol.family)} capitalize`}>
+                  <Badge
+                    className={`${getSensorFamilyBadgeColor(entry.protocol.family)} capitalize`}
+                  >
                     {entry.protocol.family}
                   </Badge>
                 </div>

--- a/apps/web/components/protocol-overview-cards.test.tsx
+++ b/apps/web/components/protocol-overview-cards.test.tsx
@@ -26,6 +26,16 @@ describe("ProtocolOverviewCards", () => {
     expect(screen.getByText("multispeq")).toBeInTheDocument();
   });
 
+  it("uses the active badge color for the ambyte family", () => {
+    render(
+      <ProtocolOverviewCards
+        protocols={[createProtocol({ name: "Ambyte Protocol", family: "ambyte" })]}
+      />,
+    );
+
+    expect(screen.getByText("ambyte")).toHaveClass("bg-badge-active");
+  });
+
   it("shows preferred badge for sorted protocols", () => {
     render(<ProtocolOverviewCards protocols={[createProtocol({ sortOrder: 1 })]} />);
     expect(screen.getByText("common.preferred")).toBeInTheDocument();

--- a/apps/web/components/protocol-overview-cards.tsx
+++ b/apps/web/components/protocol-overview-cards.tsx
@@ -1,5 +1,6 @@
 import { useProtocolCompatibleMacros } from "@/hooks/protocol/useProtocolCompatibleMacros/useProtocolCompatibleMacros";
 import { useLocale } from "@/hooks/useLocale";
+import { getSensorFamilyBadgeColor } from "@/util/sensor-family";
 import { ChevronRight } from "lucide-react";
 import Link from "next/link";
 import React, { useMemo, useState } from "react";
@@ -10,17 +11,6 @@ import { Badge } from "@repo/ui/components/badge";
 import { RichTextRenderer } from "@repo/ui/components/rich-text-renderer";
 import { Skeleton } from "@repo/ui/components/skeleton";
 import { cva } from "@repo/ui/lib/utils";
-
-const getFamilyColor = (family: string) => {
-  switch (family) {
-    case "multispeq":
-      return "bg-badge-published";
-    case "ambit":
-      return "bg-badge-active";
-    default:
-      return "bg-badge-archived";
-  }
-};
 
 const cardVariants = cva(
   "relative flex h-full min-h-[180px] flex-col gap-3 rounded-xl border p-5 transition-all hover:scale-[1.02] hover:shadow-lg",
@@ -77,7 +67,7 @@ function ProtocolCard({
     >
       <div className={cardVariants({ featured: isPreferred })}>
         <div className="inline-flex gap-1">
-          <Badge className={`${getFamilyColor(protocol.family)} capitalize`}>
+          <Badge className={`${getSensorFamilyBadgeColor(protocol.family)} capitalize`}>
             {protocol.family}
           </Badge>
           {isPreferred && (

--- a/apps/web/components/protocol-overview/__tests__/protocol-details-sidebar.test.tsx
+++ b/apps/web/components/protocol-overview/__tests__/protocol-details-sidebar.test.tsx
@@ -119,7 +119,7 @@ vi.mock("@repo/ui/components/select", async (importOriginal) => {
           }}
         >
           <option value="multispeq">MultispeQ</option>
-          <option value="ambit">Ambit</option>
+          <option value="ambyte">Ambyte</option>
         </select>
         {children}
       </div>
@@ -302,12 +302,12 @@ describe("ProtocolDetailsSidebar", () => {
     expect(screen.getByText("MultispeQ")).toBeInTheDocument();
   });
 
-  it("renders Ambit text when family is ambit and user is not the creator", () => {
+  it("renders Ambyte text when family is ambyte and user is not the creator", () => {
     vi.mocked(useSession).mockReturnValue({ data: { user: { id: "other-user" } } } as never);
     renderComponent({
-      protocol: { ...mockProtocol, family: "ambit" },
+      protocol: { ...mockProtocol, family: "ambyte" },
     });
-    expect(screen.getByText("Ambit")).toBeInTheDocument();
+    expect(screen.getByText("Ambyte")).toBeInTheDocument();
   });
 
   it("calls updateProtocol when family is changed", async () => {
@@ -316,12 +316,12 @@ describe("ProtocolDetailsSidebar", () => {
 
     const selectNative = screen.getByTestId("select-native");
     const user = userEvent.setup();
-    await user.selectOptions(selectNative, "ambit");
+    await user.selectOptions(selectNative, "ambyte");
 
     await waitFor(() => {
       expect(spy.called).toBe(true);
     });
-    expect(spy.body).toEqual({ family: "ambit" });
+    expect(spy.body).toEqual({ family: "ambyte" });
     expect(spy.params).toEqual({ id: "550e8400-e29b-41d4-a716-446655440000" });
   });
 
@@ -333,7 +333,7 @@ describe("ProtocolDetailsSidebar", () => {
 
     const selectNative = screen.getByTestId("select-native");
     const user = userEvent.setup();
-    await user.selectOptions(selectNative, "ambit");
+    await user.selectOptions(selectNative, "ambyte");
 
     await waitFor(() => {
       expect(toast).toHaveBeenCalledWith({
@@ -350,7 +350,7 @@ describe("ProtocolDetailsSidebar", () => {
 
     const selectNative = screen.getByTestId("select-native");
     const user = userEvent.setup();
-    await user.selectOptions(selectNative, "ambit");
+    await user.selectOptions(selectNative, "ambyte");
 
     await waitFor(
       () => {

--- a/apps/web/components/protocol-search-popover.test.tsx
+++ b/apps/web/components/protocol-search-popover.test.tsx
@@ -10,7 +10,7 @@ import { ProtocolSearchPopover } from "./protocol-search-popover";
 // Test data & helpers
 const protocols = [
   createProtocol({ name: "Fv/FM Baseline", family: "multispeq", createdByName: "Ada Lovelace" }),
-  createProtocol({ name: "Ambient Light", family: "ambit", createdByName: "Al Turing" }),
+  createProtocol({ name: "Ambient Light", family: "ambyte", createdByName: "Al Turing" }),
   createProtocol({
     name: "PAM Fluorometry",
     family: "multispeq",
@@ -73,7 +73,7 @@ describe("<ProtocolSearchPopover />", () => {
     expect(screen.getByText("PAM Fluorometry")).toBeInTheDocument();
 
     expect(screen.getAllByText("multispeq")).toHaveLength(2);
-    expect(screen.getByText("ambit")).toBeInTheDocument();
+    expect(screen.getByText("ambyte")).toBeInTheDocument();
   });
 
   it("displays protocol details correctly with created by info", () => {

--- a/apps/web/components/workbook/add-cell-button.tsx
+++ b/apps/web/components/workbook/add-cell-button.tsx
@@ -10,6 +10,7 @@ import {
   Terminal,
 } from "lucide-react";
 
+import type { SensorFamily } from "@repo/api/schemas/protocol.schema";
 import type { WorkbookCell } from "@repo/api/schemas/workbook-cells.schema";
 import { Button } from "@repo/ui/components/button";
 import {
@@ -30,7 +31,7 @@ interface AddCellButtonProps {
   onAdd: (type: CellType) => void;
   onAddCell?: (cell: WorkbookCell) => void;
   existingCells?: WorkbookCell[];
-  sensorFamily?: "multispeq" | "ambit" | "generic";
+  sensorFamily?: SensorFamily;
   variant?: "inline" | "bottom";
   showBranch?: boolean;
   accentColor?: string;

--- a/apps/web/components/workbook/cells/output-cell.test.tsx
+++ b/apps/web/components/workbook/cells/output-cell.test.tsx
@@ -453,7 +453,7 @@ describe("OutputCellComponent", () => {
       const proto = createProtocolCell();
       const cell = createOutputCell({ data: multispeqOutput(), producedBy: proto.id });
       useProtocolMock.mockReturnValue({
-        data: { body: { family: "ambit", code: multispeqProtocolCode() } },
+        data: { body: { family: "ambyte", code: multispeqProtocolCode() } },
         isLoading: false,
       });
       render(

--- a/apps/web/components/workbook/protocol-picker.tsx
+++ b/apps/web/components/workbook/protocol-picker.tsx
@@ -2,10 +2,12 @@
 
 import { useProtocolCreate } from "@/hooks/protocol/useProtocolCreate/useProtocolCreate";
 import { useProtocols } from "@/hooks/protocol/useProtocols/useProtocols";
+import { SENSOR_FAMILY_OPTIONS } from "@/util/sensor-family";
 import { Loader2, Microscope, Plus, Search } from "lucide-react";
 import type { ReactNode } from "react";
 import { useState } from "react";
 
+import type { SensorFamily } from "@repo/api/schemas/protocol.schema";
 import type { ProtocolCell } from "@repo/api/schemas/workbook-cells.schema";
 import { Badge } from "@repo/ui/components/badge";
 import { Button } from "@repo/ui/components/button";
@@ -19,13 +21,8 @@ import {
   SelectValue,
 } from "@repo/ui/components/select";
 
-type SensorFamily = "multispeq" | "ambit" | "generic";
-
-const familyLabels: Record<SensorFamily, string> = {
-  multispeq: "MultispeQ",
-  ambit: "Ambit",
-  generic: "Generic",
-};
+const isDisabledFamily = (family: SensorFamily) =>
+  SENSOR_FAMILY_OPTIONS.find((o) => o.value === family)?.disabled ?? false;
 
 interface ProtocolPickerProps {
   sensorFamily?: SensorFamily;
@@ -45,7 +42,10 @@ export function ProtocolPicker({
 
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState("");
-  const [newFamily, setNewFamily] = useState<SensorFamily>(sensorFamily);
+  // Protocols can only be created for a locally-runnable family; an ingest-only
+  // (disabled) sensorFamily falls back to the default creatable one.
+  const creatableFamily: SensorFamily = isDisabledFamily(sensorFamily) ? "multispeq" : sensorFamily;
+  const [newFamily, setNewFamily] = useState<SensorFamily>(creatableFamily);
   const [isCreating, setIsCreating] = useState(false);
   const createProtocol = useProtocolCreate();
 
@@ -65,7 +65,7 @@ export function ProtocolPicker({
   };
 
   const handleCreate = async () => {
-    if (!newName.trim()) return;
+    if (!newName.trim() || isDisabledFamily(newFamily)) return;
     setIsCreating(true);
     try {
       const result = await createProtocol.mutateAsync({
@@ -99,7 +99,7 @@ export function ProtocolPicker({
     setSearch("");
     setShowCreate(false);
     setNewName("");
-    setNewFamily(sensorFamily);
+    setNewFamily(creatableFamily);
   };
 
   return (
@@ -131,9 +131,9 @@ export function ProtocolPicker({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {(["multispeq", "ambit", "generic"] as const).map((f) => (
-                    <SelectItem key={f} value={f}>
-                      {familyLabels[f]}
+                  {SENSOR_FAMILY_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value} disabled={opt.disabled}>
+                      {opt.label}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.test.tsx
+++ b/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.test.tsx
@@ -260,7 +260,7 @@ describe("WorkbookUpgradeDialog", () => {
                 id: "prot-b",
                 name: "Proto B",
                 code: [{ b: 2 }],
-                family: "ambit",
+                family: "ambyte",
                 createdBy: "user-1",
               }),
         ),

--- a/apps/web/components/workbook/workbook-editor.tsx
+++ b/apps/web/components/workbook/workbook-editor.tsx
@@ -21,6 +21,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { GripVertical } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import type { SensorFamily } from "@repo/api/schemas/protocol.schema";
 import type { WorkbookCell } from "@repo/api/schemas/workbook-cells.schema";
 import type { EntitySnapshots } from "@repo/api/schemas/workbook-version.schema";
 import { cn } from "@repo/ui/lib/utils";
@@ -57,8 +58,8 @@ interface WorkbookEditorProps {
   isConnected?: boolean;
   isConnecting?: boolean;
   deviceInfo?: DeviceInfo | null;
-  sensorFamily?: "multispeq" | "ambit" | "generic";
-  onSensorFamilyChange?: (family: "multispeq" | "ambit" | "generic") => void;
+  sensorFamily?: SensorFamily;
+  onSensorFamilyChange?: (family: SensorFamily) => void;
   connectionType?: "bluetooth" | "serial";
   onConnectionTypeChange?: (type: "bluetooth" | "serial") => void;
   isRunningAll?: boolean;
@@ -76,7 +77,7 @@ interface WorkbookEditorProps {
 
 export function createDefaultCell(
   type: WorkbookCell["type"],
-  _sensorFamily: "multispeq" | "ambit" | "generic" = "multispeq",
+  _sensorFamily: SensorFamily = "multispeq",
 ): WorkbookCell {
   const id = crypto.randomUUID();
   const base = { id, isCollapsed: false };
@@ -194,7 +195,7 @@ interface SortableCellGroupProps {
   cells: WorkbookCell[];
   cellNumber?: number;
   executionStates?: Record<string, CellExecutionState>;
-  sensorFamily?: "multispeq" | "ambit" | "generic";
+  sensorFamily?: SensorFamily;
   readOnly?: boolean;
   entitySnapshots?: EntitySnapshots;
   onRunCell?: (cellId: string) => void;

--- a/apps/web/components/workbook/workbook-header.tsx
+++ b/apps/web/components/workbook/workbook-header.tsx
@@ -3,6 +3,7 @@
 import { AutosaveIndicator } from "@/components/shared/autosave/autosave-indicator";
 import { tsr } from "@/lib/tsr";
 import { decodeBase64 } from "@/util/base64";
+import { SENSOR_FAMILY_OPTIONS } from "@/util/sensor-family";
 import { ChevronDown, Circle, GitBranch, Play, Square, Trash2, Usb } from "lucide-react";
 import { useCallback } from "react";
 import { useIotBrowserSupport } from "~/hooks/iot/useIotBrowserSupport";
@@ -234,9 +235,11 @@ export function WorkbookHeader({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="multispeq">MultispeQ</SelectItem>
-              <SelectItem value="ambit">Ambit</SelectItem>
-              <SelectItem value="generic">Generic</SelectItem>
+              {SENSOR_FAMILY_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value} disabled={opt.disabled}>
+                  {opt.label}
+                </SelectItem>
+              ))}
             </SelectContent>
           </Select>
         )}

--- a/apps/web/hooks/iot/useIotBrowserSupport.test.ts
+++ b/apps/web/hooks/iot/useIotBrowserSupport.test.ts
@@ -104,13 +104,13 @@ describe("useIotBrowserSupport", () => {
       expect(result.current.any).toBe(true);
     });
 
-    it("keeps bluetooth enabled for ambit devices", () => {
+    it("keeps bluetooth enabled for ambyte devices", () => {
       Object.defineProperty(globalThis, "navigator", {
         value: { bluetooth: {}, serial: {}, userAgent: "test" },
         configurable: true,
       });
 
-      const { result } = renderHook(() => useIotBrowserSupport("ambit"));
+      const { result } = renderHook(() => useIotBrowserSupport("ambyte"));
 
       expect(result.current.bluetooth).toBe(true);
       expect(result.current.serial).toBe(true);

--- a/apps/web/hooks/iot/useIotCommunication/useIotCommunication.test.ts
+++ b/apps/web/hooks/iot/useIotCommunication/useIotCommunication.test.ts
@@ -107,8 +107,8 @@ describe("useIotCommunication", () => {
       expect(result.current).toBeDefined();
     });
 
-    it("supports ambit sensor family", () => {
-      const { result } = renderHook(() => useIotCommunication("ambit", "bluetooth"));
+    it("supports ambyte sensor family", () => {
+      const { result } = renderHook(() => useIotCommunication("ambyte", "bluetooth"));
       expect(result.current).toBeDefined();
     });
   });
@@ -147,8 +147,8 @@ describe("useIotCommunication", () => {
       });
     });
 
-    it("successfully connects with ambit sensor family via bluetooth", async () => {
-      const { result } = renderHook(() => useIotCommunication("ambit", "bluetooth"));
+    it("successfully connects with ambyte sensor family via bluetooth", async () => {
+      const { result } = renderHook(() => useIotCommunication("ambyte", "bluetooth"));
 
       void result.current.connect();
 
@@ -158,8 +158,8 @@ describe("useIotCommunication", () => {
       });
     });
 
-    it("successfully connects with ambit sensor family via serial", async () => {
-      const { result } = renderHook(() => useIotCommunication("ambit", "serial"));
+    it("successfully connects with ambyte sensor family via serial", async () => {
+      const { result } = renderHook(() => useIotCommunication("ambyte", "serial"));
 
       void result.current.connect();
 

--- a/apps/web/hooks/iot/useIotProtocolExecution/useIotProtocolExecution.test.ts
+++ b/apps/web/hooks/iot/useIotProtocolExecution/useIotProtocolExecution.test.ts
@@ -166,7 +166,7 @@ describe("useIotProtocolExecution", () => {
     });
   });
 
-  describe("generic/ambit execution", () => {
+  describe("generic/ambyte execution", () => {
     it("executes SET_CONFIG, RUN, GET_DATA steps in order", async () => {
       const mockExecute = vi
         .fn()
@@ -177,7 +177,7 @@ describe("useIotProtocolExecution", () => {
       const mockDriver: Partial<IDeviceDriver> = { execute: mockExecute };
 
       const { result } = renderHook(() =>
-        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambit"),
+        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambyte"),
       );
 
       const data = await result.current.executeProtocol([{ command: "test" }]);
@@ -201,7 +201,7 @@ describe("useIotProtocolExecution", () => {
       const mockDriver: Partial<IDeviceDriver> = { execute: mockExecute };
 
       const { result } = renderHook(() =>
-        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambit"),
+        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambyte"),
       );
 
       await expect(result.current.executeProtocol([{ command: "test" }])).rejects.toThrow(
@@ -221,7 +221,7 @@ describe("useIotProtocolExecution", () => {
       const mockDriver: Partial<IDeviceDriver> = { execute: mockExecute };
 
       const { result } = renderHook(() =>
-        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambit"),
+        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambyte"),
       );
 
       await expect(result.current.executeProtocol([{ command: "test" }])).rejects.toThrow(
@@ -242,7 +242,7 @@ describe("useIotProtocolExecution", () => {
       const mockDriver: Partial<IDeviceDriver> = { execute: mockExecute };
 
       const { result } = renderHook(() =>
-        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambit"),
+        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambyte"),
       );
 
       await expect(result.current.executeProtocol([{ command: "test" }])).rejects.toThrow(
@@ -260,7 +260,7 @@ describe("useIotProtocolExecution", () => {
       const mockDriver: Partial<IDeviceDriver> = { execute: mockExecute };
 
       const { result } = renderHook(() =>
-        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambit"),
+        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambyte"),
       );
 
       const data = await result.current.executeProtocol([{ command: "measure" }]);
@@ -277,7 +277,7 @@ describe("useIotProtocolExecution", () => {
       const mockDriver: Partial<IDeviceDriver> = { execute: mockExecute };
 
       const { result } = renderHook(() =>
-        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambit"),
+        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambyte"),
       );
 
       const data = await result.current.executeProtocol([{ command: "measure" }]);
@@ -295,7 +295,7 @@ describe("useIotProtocolExecution", () => {
       const mockDriver: Partial<IDeviceDriver> = { execute: mockExecute };
 
       const { result } = renderHook(() =>
-        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambit"),
+        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambyte"),
       );
 
       const data = await result.current.executeProtocol([{ command: "measure" }]);
@@ -311,7 +311,7 @@ describe("useIotProtocolExecution", () => {
       const mockDriver: Partial<IDeviceDriver> = { execute: mockExecute };
 
       const { result } = renderHook(() =>
-        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambit"),
+        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambyte"),
       );
 
       await expect(result.current.executeProtocol([{ command: "test" }])).rejects.toThrow(
@@ -328,7 +328,7 @@ describe("useIotProtocolExecution", () => {
       const mockDriver: Partial<IDeviceDriver> = { execute: mockExecute };
 
       const { result } = renderHook(() =>
-        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambit"),
+        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambyte"),
       );
 
       await expect(result.current.executeProtocol([{ command: "test" }])).rejects.toThrow(
@@ -349,7 +349,7 @@ describe("useIotProtocolExecution", () => {
       const mockDriver: Partial<IDeviceDriver> = { execute: mockExecute };
 
       const { result } = renderHook(() =>
-        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambit"),
+        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambyte"),
       );
 
       await expect(result.current.executeProtocol([{ command: "test" }])).rejects.toThrow(

--- a/apps/web/hooks/iot/useIotProtocolExecution/useIotProtocolExecution.ts
+++ b/apps/web/hooks/iot/useIotProtocolExecution/useIotProtocolExecution.ts
@@ -47,7 +47,7 @@ export function useIotProtocolExecution(
         return parseResponseData(unwrap(result, "Protocol execution failed"));
       }
 
-      // Generic / Ambit: load config → run → retrieve data
+      // Generic / Ambyte: load config → run → retrieve data
       unwrap(
         await driver.execute({ command: "SET_CONFIG", params: { protocol: protocolCode } }),
         "Failed to load protocol on device",

--- a/apps/web/hooks/iot/useRegisterIotDevice/useRegisterIotDevice.test.tsx
+++ b/apps/web/hooks/iot/useRegisterIotDevice/useRegisterIotDevice.test.tsx
@@ -4,10 +4,15 @@ import { renderHook, waitFor, act } from "@/test/test-utils";
 import { describe, it, expect, vi } from "vitest";
 
 import { contract } from "@repo/api/contract";
+import type { RegisterIotDeviceBody } from "@repo/api/schemas/iot.schema";
 
 import { useRegisterIotDevice } from "./useRegisterIotDevice";
 
-const body = { serialNumber: "E8:F6:0A:B1:1D:D4", deviceType: "ambyte", name: "Greenhouse 1" };
+const body: RegisterIotDeviceBody = {
+  serialNumber: "E8:F6:0A:B1:1D:D4",
+  deviceType: "ambyte",
+  name: "Greenhouse 1",
+};
 
 describe("useRegisterIotDevice", () => {
   it("sends the registration body", async () => {

--- a/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.test.ts
+++ b/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.test.ts
@@ -600,9 +600,9 @@ describe("useWorkbookExecution", () => {
     it("allows changing sensor family", () => {
       const { result } = renderExecution([]);
 
-      act(() => result.current.setSensorFamily("ambit"));
+      act(() => result.current.setSensorFamily("ambyte"));
 
-      expect(result.current.sensorFamily).toBe("ambit");
+      expect(result.current.sensorFamily).toBe("ambyte");
     });
   });
 });

--- a/apps/web/util/sensor-family.test.ts
+++ b/apps/web/util/sensor-family.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from "vitest";
 
 import { zSensorFamily } from "@repo/api/schemas/protocol.schema";
 
-import { SENSOR_FAMILY_OPTIONS, getSensorFamilyLabel } from "./sensor-family";
+import {
+  SENSOR_FAMILY_OPTIONS,
+  getSensorFamilyBadgeColor,
+  getSensorFamilyLabel,
+} from "./sensor-family";
 import type { SensorFamilyOption } from "./sensor-family";
 
 describe("SENSOR_FAMILY_OPTIONS", () => {
@@ -28,10 +32,16 @@ describe("SENSOR_FAMILY_OPTIONS", () => {
     }
   });
 
-  it("should mark ambit as disabled", () => {
-    const ambit = SENSOR_FAMILY_OPTIONS.find((o) => o.value === "ambit");
-    expect(ambit).toBeDefined();
-    expect(ambit?.disabled).toBe(true);
+  it("should mark ambyte as disabled", () => {
+    const ambyte = SENSOR_FAMILY_OPTIONS.find((o) => o.value === "ambyte");
+    expect(ambyte).toBeDefined();
+    expect(ambyte?.disabled).toBe(true);
+  });
+
+  it("should mark minipar as disabled", () => {
+    const minipar = SENSOR_FAMILY_OPTIONS.find((o) => o.value === "minipar");
+    expect(minipar).toBeDefined();
+    expect(minipar?.disabled).toBe(true);
   });
 
   it("should mark generic as enabled", () => {
@@ -54,7 +64,8 @@ describe("SENSOR_FAMILY_OPTIONS", () => {
 
     expect(byValue.generic.label).toBe("Generic");
     expect(byValue.multispeq.label).toBe("MultispeQ");
-    expect(byValue.ambit.label).toBe("Ambit");
+    expect(byValue.ambyte.label).toBe("Ambyte");
+    expect(byValue.minipar.label).toBe("MiniPAR");
   });
 });
 
@@ -67,7 +78,26 @@ describe("getSensorFamilyLabel", () => {
     expect(getSensorFamilyLabel("multispeq")).toBe("MultispeQ");
   });
 
-  it("should return 'Ambit' for ambit", () => {
-    expect(getSensorFamilyLabel("ambit")).toBe("Ambit");
+  it("should return 'Ambyte' for ambyte", () => {
+    expect(getSensorFamilyLabel("ambyte")).toBe("Ambyte");
+  });
+
+  it("should return 'MiniPAR' for minipar", () => {
+    expect(getSensorFamilyLabel("minipar")).toBe("MiniPAR");
+  });
+});
+
+describe("getSensorFamilyBadgeColor", () => {
+  it("should return the published badge for multispeq", () => {
+    expect(getSensorFamilyBadgeColor("multispeq")).toBe("bg-badge-published");
+  });
+
+  it("should return the active badge for ambyte", () => {
+    expect(getSensorFamilyBadgeColor("ambyte")).toBe("bg-badge-active");
+  });
+
+  it("should fall back to the archived badge for any other family", () => {
+    expect(getSensorFamilyBadgeColor("generic")).toBe("bg-badge-archived");
+    expect(getSensorFamilyBadgeColor("minipar")).toBe("bg-badge-archived");
   });
 });

--- a/apps/web/util/sensor-family.ts
+++ b/apps/web/util/sensor-family.ts
@@ -14,13 +14,14 @@ export interface SensorFamilyOption {
 const SENSOR_FAMILY_LABELS: Record<SensorFamily, string> = {
   generic: "Generic",
   multispeq: "MultispeQ",
-  ambit: "Ambit",
+  ambyte: "Ambyte",
+  minipar: "MiniPAR",
 };
 
 /**
- * Families that are not yet available for selection.
+ * Families that are not yet available for local connection (ingest-only).
  */
-const DISABLED_FAMILIES: ReadonlySet<SensorFamily> = new Set(["ambit"]);
+const DISABLED_FAMILIES: ReadonlySet<SensorFamily> = new Set(["ambyte", "minipar"]);
 
 /**
  * Selectable sensor family options derived from the API enum.
@@ -38,4 +39,19 @@ export const SENSOR_FAMILY_OPTIONS: SensorFamilyOption[] = zSensorFamily.options
  */
 export function getSensorFamilyLabel(family: SensorFamily): string {
   return SENSOR_FAMILY_LABELS[family];
+}
+
+/**
+ * Badge color class for a sensor family. Unknown values fall back to the
+ * neutral badge, so this accepts the raw `family` string carried on a protocol.
+ */
+export function getSensorFamilyBadgeColor(family: string): string {
+  switch (family) {
+    case "multispeq":
+      return "bg-badge-published";
+    case "ambyte":
+      return "bg-badge-active";
+    default:
+      return "bg-badge-archived";
+  }
 }

--- a/packages/api/src/schemas/experiment.schema.spec.ts
+++ b/packages/api/src/schemas/experiment.schema.spec.ts
@@ -1277,7 +1277,7 @@ describe("Experiment Schema", () => {
         protocol: {
           ...validPayload.protocol,
           description: "A test protocol",
-          family: "ambit",
+          family: "ambyte",
         },
         macro: {
           ...validPayload.macro,
@@ -1289,7 +1289,7 @@ describe("Experiment Schema", () => {
 
       const result = zProjectTransferWebhookPayload.parse(fullPayload);
       expect(result.experiment.locations).toHaveLength(1);
-      expect(result.protocol?.family).toBe("ambit");
+      expect(result.protocol?.family).toBe("ambyte");
       expect(result.macro?.language).toBe("python");
       expect(result.questions).toHaveLength(1);
     });

--- a/packages/api/src/schemas/iot.schema.ts
+++ b/packages/api/src/schemas/iot.schema.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { zSensorFamily } from "./protocol.schema";
+
 // --- Iot Credentials ---
 export const zIotCredentials = z.object({
   accessKeyId: z.string().describe("AWS Access Key ID for temporary credentials"),
@@ -22,13 +24,16 @@ export const zIotUploadUrl = z.object({
 // --- IoT IotDevices ---
 export const zIotDeviceStatus = z.enum(["pending", "active", "rotating", "revoked"]);
 
+// A device's class shares the canonical sensor-family taxonomy and maps to the ingest topic sensorType.
+export const zDeviceType = zSensorFamily;
+
 export const zIotDevice = z.object({
   id: z.string().uuid(),
   thingName: z.string(),
   thingArn: z.string(),
   serialNumber: z.string(),
   name: z.string().nullable(),
-  deviceType: z.string(),
+  deviceType: zDeviceType,
   status: zIotDeviceStatus,
   certificateId: z.string().nullable(),
   certificateArn: z.string().nullable(),
@@ -42,11 +47,7 @@ export const zIotDeviceList = z.array(zIotDevice);
 export const zRegisterIotDeviceBody = z.object({
   serialNumber: z.string().min(1).max(255).describe("Physical device identifier, e.g. MAC address"),
   name: z.string().min(1).max(255).optional(),
-  deviceType: z
-    .string()
-    .min(1)
-    .max(255)
-    .describe("IotDevice class, maps to the ingest topic sensorType"),
+  deviceType: zDeviceType.describe("IotDevice class, maps to the ingest topic sensorType"),
 });
 
 export const zRegisterIotDeviceResponse = zIotDevice;

--- a/packages/api/src/schemas/protocol.schema.spec.ts
+++ b/packages/api/src/schemas/protocol.schema.spec.ts
@@ -22,7 +22,7 @@ describe("Protocol Schema", () => {
   describe("zSensorFamily", () => {
     it("accepts valid enum values", () => {
       expect(zSensorFamily.parse("multispeq")).toBe("multispeq");
-      expect(zSensorFamily.parse("ambit")).toBe("ambit");
+      expect(zSensorFamily.parse("ambyte")).toBe("ambyte");
       expect(zSensorFamily.parse("generic")).toBe("generic");
     });
 

--- a/packages/api/src/schemas/protocol.schema.ts
+++ b/packages/api/src/schemas/protocol.schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const zSensorFamily = z.enum(["multispeq", "ambit", "generic"]);
+export const zSensorFamily = z.enum(["multispeq", "ambyte", "minipar", "generic"]);
 
 // Define Zod schemas for protocol models
 export const zProtocol = z.object({

--- a/packages/api/src/utils/validate-workbook.spec.ts
+++ b/packages/api/src/utils/validate-workbook.spec.ts
@@ -132,14 +132,14 @@ describe("validateWorkbook", () => {
     const cells = [protocolCell("p1", "prot-1"), protocolCell("p2", "prot-2")];
     const result = validateWorkbook(
       cells,
-      ctx({ "prot-1": { family: "multispeq" }, "prot-2": { family: "ambit" } }),
+      ctx({ "prot-1": { family: "multispeq" }, "prot-2": { family: "ambyte" } }),
     );
     expect(result.ok).toBe(true);
     expect(result.issues).toContainEqual(
       expect.objectContaining({
         level: "warning",
         code: "mixed-sensor-families",
-        detail: "ambit, multispeq",
+        detail: "ambyte, multispeq",
       }),
     );
   });

--- a/packages/database/drizzle/0037_last_doctor_spectrum.sql
+++ b/packages/database/drizzle/0037_last_doctor_spectrum.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "sensors" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
+DROP TABLE "sensors" CASCADE;--> statement-breakpoint
+ALTER TABLE "iot_devices" ALTER COLUMN "device_type" SET DATA TYPE text;--> statement-breakpoint
+ALTER TABLE "protocols" ALTER COLUMN "family" SET DATA TYPE text;--> statement-breakpoint
+DROP TYPE "public"."sensor_family";--> statement-breakpoint
+CREATE TYPE "public"."sensor_family" AS ENUM('multispeq', 'ambyte', 'minipar', 'generic');--> statement-breakpoint
+ALTER TABLE "iot_devices" ALTER COLUMN "device_type" SET DATA TYPE "public"."sensor_family" USING (CASE "device_type" WHEN 'ambit' THEN 'ambyte' ELSE "device_type" END)::"public"."sensor_family";--> statement-breakpoint
+ALTER TABLE "protocols" ALTER COLUMN "family" SET DATA TYPE "public"."sensor_family" USING (CASE "family" WHEN 'ambit' THEN 'ambyte' ELSE "family" END)::"public"."sensor_family";

--- a/packages/database/drizzle/meta/0037_snapshot.json
+++ b/packages/database/drizzle/meta/0037_snapshot.json
@@ -1,0 +1,2782 @@
+{
+  "id": "6b6ee61f-d305-4cf7-9974-6c53b49cf54e",
+  "prevId": "8441d129-32cc-4616-a327-cc9d3f8a0196",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_dashboards": {
+      "name": "experiment_dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"columns\":12,\"rowHeight\":80,\"gap\":16}'::jsonb"
+        },
+        "widgets": {
+          "name": "widgets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "experiment_dashboards_experiment_id_idx": {
+          "name": "experiment_dashboards_experiment_id_idx",
+          "columns": [
+            {
+              "expression": "experiment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiment_dashboards_experiment_id_experiments_id_fk": {
+          "name": "experiment_dashboards_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_dashboards",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_dashboards_created_by_users_id_fk": {
+          "name": "experiment_dashboards_created_by_users_id_fk",
+          "tableFrom": "experiment_dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_join_requests": {
+      "name": "experiment_join_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "join_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "experiment_join_requests_pending_uniq": {
+          "name": "experiment_join_requests_pending_uniq",
+          "columns": [
+            {
+              "expression": "experiment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"experiment_join_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "experiment_join_requests_experiment_idx": {
+          "name": "experiment_join_requests_experiment_idx",
+          "columns": [
+            {
+              "expression": "experiment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiment_join_requests_experiment_id_experiments_id_fk": {
+          "name": "experiment_join_requests_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_join_requests",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_join_requests_user_id_users_id_fk": {
+          "name": "experiment_join_requests_user_id_users_id_fk",
+          "tableFrom": "experiment_join_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_join_requests_decided_by_users_id_fk": {
+          "name": "experiment_join_requests_decided_by_users_id_fk",
+          "tableFrom": "experiment_join_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_locations": {
+      "name": "experiment_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "numeric(10, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "numeric(11, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "municipality": {
+          "name": "municipality",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_label": {
+          "name": "address_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_locations_experiment_id_experiments_id_fk": {
+          "name": "experiment_locations_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_locations",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_members": {
+      "name": "experiment_members",
+      "schema": "",
+      "columns": {
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "experiment_members_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_members_experiment_id_experiments_id_fk": {
+          "name": "experiment_members_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_members",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "experiment_members_user_id_users_id_fk": {
+          "name": "experiment_members_user_id_users_id_fk",
+          "tableFrom": "experiment_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "experiment_members_experiment_id_user_id_pk": {
+          "name": "experiment_members_experiment_id_user_id_pk",
+          "columns": [
+            "experiment_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_visualizations": {
+      "name": "experiment_visualizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chart_family": {
+          "name": "chart_family",
+          "type": "chart_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chart_type": {
+          "name": "chart_type",
+          "type": "chart_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_config": {
+          "name": "data_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_visualizations_experiment_id_experiments_id_fk": {
+          "name": "experiment_visualizations_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_visualizations",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_visualizations_created_by_users_id_fk": {
+          "name": "experiment_visualizations_created_by_users_id_fk",
+          "tableFrom": "experiment_visualizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiments": {
+      "name": "experiments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "experiment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "experiment_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "embargo_until": {
+          "name": "embargo_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "((now() AT TIME ZONE 'UTC') + interval '90 days')"
+        },
+        "anonymize_contributors": {
+          "name": "anonymize_contributors",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "workbook_id": {
+          "name": "workbook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workbook_version_id": {
+          "name": "workbook_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(\"experiments\".\"name\", '')), 'A') || setweight(to_tsvector('english', coalesce(\"experiments\".\"description\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiments_workbook_id_workbooks_id_fk": {
+          "name": "experiments_workbook_id_workbooks_id_fk",
+          "tableFrom": "experiments",
+          "tableTo": "workbooks",
+          "columnsFrom": [
+            "workbook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "experiments_workbook_version_id_workbook_versions_id_fk": {
+          "name": "experiments_workbook_version_id_workbook_versions_id_fk",
+          "tableFrom": "experiments",
+          "tableTo": "workbook_versions",
+          "columnsFrom": [
+            "workbook_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "experiments_created_by_users_id_fk": {
+          "name": "experiments_created_by_users_id_fk",
+          "tableFrom": "experiments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "experiments_name_unique": {
+          "name": "experiments_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flows": {
+      "name": "flows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "flows_experiment_id_experiments_id_fk": {
+          "name": "flows_experiment_id_experiments_id_fk",
+          "tableFrom": "flows",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flows_experiment_id_unique": {
+          "name": "flows_experiment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "experiment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "invitation_resource_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_invited_by_users_id_fk": {
+          "name": "invitations_invited_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "resource_id_check": {
+          "name": "resource_id_check",
+          "value": "(\"invitations\".\"resource_type\" = 'platform' AND \"invitations\".\"resource_id\" IS NULL) OR (\"invitations\".\"resource_type\" != 'platform' AND \"invitations\".\"resource_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.iot_devices": {
+      "name": "iot_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thing_name": {
+          "name": "thing_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thing_arn": {
+          "name": "thing_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "sensor_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "certificate_id": {
+          "name": "certificate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_arn": {
+          "name": "certificate_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "iot_devices_created_by_idx": {
+          "name": "iot_devices_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "iot_devices_created_by_users_id_fk": {
+          "name": "iot_devices_created_by_users_id_fk",
+          "tableFrom": "iot_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "iot_devices_thing_name_unique": {
+          "name": "iot_devices_thing_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "thing_name"
+          ]
+        },
+        "iot_devices_serial_number_unique": {
+          "name": "iot_devices_serial_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "serial_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.macros": {
+      "name": "macros",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "macro_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forked_from": {
+          "name": "forked_from",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(\"macros\".\"name\", '')), 'A') || setweight(to_tsvector('english', coalesce(\"macros\".\"description\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "macros_created_by_users_id_fk": {
+          "name": "macros_created_by_users_id_fk",
+          "tableFrom": "macros",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "macros_forked_from_macros_id_fk": {
+          "name": "macros_forked_from_macros_id_fk",
+          "tableFrom": "macros",
+          "tableTo": "macros",
+          "columnsFrom": [
+            "forked_from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "macros_name_unique": {
+          "name": "macros_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "macros_filename_unique": {
+          "name": "macros_filename_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "filename"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_invitations": {
+      "name": "organization_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_invitations_organization_id_organizations_id_fk": {
+          "name": "organization_invitations_organization_id_organizations_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_inviter_id_users_id_fk": {
+          "name": "organization_invitations_inviter_id_users_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_team_id_teams_id_fk": {
+          "name": "organization_invitations_team_id_teams_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_members": {
+      "name": "organization_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "organization_members_org_user_uniq": {
+          "name": "organization_members_org_user_uniq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "organization_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated": {
+          "name": "activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whats_new_last_seen_at": {
+          "name": "whats_new_last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_user_id_users_id_fk": {
+          "name": "profiles_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_user_id_unique": {
+          "name": "profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.protocol_macros": {
+      "name": "protocol_macros",
+      "schema": "",
+      "columns": {
+        "protocol_id": {
+          "name": "protocol_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "macro_id": {
+          "name": "macro_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "protocol_macros_protocol_id_protocols_id_fk": {
+          "name": "protocol_macros_protocol_id_protocols_id_fk",
+          "tableFrom": "protocol_macros",
+          "tableTo": "protocols",
+          "columnsFrom": [
+            "protocol_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "protocol_macros_macro_id_macros_id_fk": {
+          "name": "protocol_macros_macro_id_macros_id_fk",
+          "tableFrom": "protocol_macros",
+          "tableTo": "macros",
+          "columnsFrom": [
+            "macro_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "protocol_macros_protocol_id_macro_id_pk": {
+          "name": "protocol_macros_protocol_id_macro_id_pk",
+          "columns": [
+            "protocol_id",
+            "macro_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.protocols": {
+      "name": "protocols",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "sensor_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forked_from": {
+          "name": "forked_from",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(\"protocols\".\"name\", '')), 'A') || setweight(to_tsvector('english', coalesce(\"protocols\".\"description\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "protocols_created_by_users_id_fk": {
+          "name": "protocols_created_by_users_id_fk",
+          "tableFrom": "protocols",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "protocols_forked_from_protocols_id_fk": {
+          "name": "protocols_forked_from_protocols_id_fk",
+          "tableFrom": "protocols",
+          "tableTo": "protocols",
+          "columnsFrom": [
+            "forked_from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "protocols_name_unique": {
+          "name": "protocols_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rate_limits_key_unique": {
+          "name": "rate_limits_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_team_id": {
+          "name": "active_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_organizations_id_fk": {
+          "name": "sessions_active_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_active_team_id_teams_id_fk": {
+          "name": "sessions_active_team_id_teams_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "active_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "team_members_team_user_uniq": {
+          "name": "team_members_team_user_uniq",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_members_user_idx": {
+          "name": "team_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "teams_organization_idx": {
+          "name": "teams_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_organization_id_organizations_id_fk": {
+          "name": "teams_organization_id_organizations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered": {
+          "name": "registered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workbook_versions": {
+      "name": "workbook_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workbook_id": {
+          "name": "workbook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cells": {
+          "name": "cells",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "entity_snapshots": {
+          "name": "entity_snapshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"protocols\":{},\"macros\":{}}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workbook_versions_workbook_id_idx": {
+          "name": "workbook_versions_workbook_id_idx",
+          "columns": [
+            {
+              "expression": "workbook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workbook_versions_workbook_id_workbooks_id_fk": {
+          "name": "workbook_versions_workbook_id_workbooks_id_fk",
+          "tableFrom": "workbook_versions",
+          "tableTo": "workbooks",
+          "columnsFrom": [
+            "workbook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workbook_versions_created_by_users_id_fk": {
+          "name": "workbook_versions_created_by_users_id_fk",
+          "tableFrom": "workbook_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workbook_versions_workbook_version_uniq": {
+          "name": "workbook_versions_workbook_version_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workbook_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workbooks": {
+      "name": "workbooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cells": {
+          "name": "cells",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forked_from": {
+          "name": "forked_from",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(\"workbooks\".\"name\", '')), 'A') || setweight(to_tsvector('english', coalesce(\"workbooks\".\"description\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "workbooks_created_by_idx": {
+          "name": "workbooks_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workbooks_created_by_users_id_fk": {
+          "name": "workbooks_created_by_users_id_fk",
+          "tableFrom": "workbooks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workbooks_forked_from_workbooks_id_fk": {
+          "name": "workbooks_forked_from_workbooks_id_fk",
+          "tableFrom": "workbooks",
+          "tableTo": "workbooks",
+          "columnsFrom": [
+            "forked_from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.chart_family": {
+      "name": "chart_family",
+      "schema": "public",
+      "values": [
+        "basic",
+        "scientific",
+        "3d",
+        "statistical"
+      ]
+    },
+    "public.chart_type": {
+      "name": "chart_type",
+      "schema": "public",
+      "values": [
+        "line",
+        "scatter",
+        "bar",
+        "pie",
+        "area",
+        "dot-plot",
+        "bubble",
+        "lollipop",
+        "box-plot",
+        "histogram",
+        "violin-plot",
+        "density-plot",
+        "ridge-plot",
+        "histogram-2d",
+        "density-plot-2d",
+        "spc-control-chart",
+        "heatmap",
+        "contour",
+        "carpet",
+        "ternary",
+        "parallel-coordinates",
+        "wind-rose",
+        "radar",
+        "polar",
+        "correlation-matrix",
+        "alluvial"
+      ]
+    },
+    "public.device_status": {
+      "name": "device_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "rotating",
+        "revoked"
+      ]
+    },
+    "public.experiment_members_role": {
+      "name": "experiment_members_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member"
+      ]
+    },
+    "public.experiment_status": {
+      "name": "experiment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "stale",
+        "archived",
+        "published"
+      ]
+    },
+    "public.experiment_visibility": {
+      "name": "experiment_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "public"
+      ]
+    },
+    "public.invitation_resource_type": {
+      "name": "invitation_resource_type",
+      "schema": "public",
+      "values": [
+        "platform",
+        "experiment"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "revoked"
+      ]
+    },
+    "public.join_request_status": {
+      "name": "join_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "cancelled"
+      ]
+    },
+    "public.macro_language": {
+      "name": "macro_language",
+      "schema": "public",
+      "values": [
+        "python",
+        "r",
+        "javascript"
+      ]
+    },
+    "public.organization_type": {
+      "name": "organization_type",
+      "schema": "public",
+      "values": [
+        "research_institute",
+        "non_profit",
+        "private_company",
+        "government_agency",
+        "university"
+      ]
+    },
+    "public.sensor_family": {
+      "name": "sensor_family",
+      "schema": "public",
+      "values": [
+        "multispeq",
+        "ambyte",
+        "minipar",
+        "generic"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1783940279830,
       "tag": "0036_burly_cargill",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1784036223478,
+      "tag": "0037_last_doctor_spectrum",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/scripts/seed.ts
+++ b/packages/database/scripts/seed.ts
@@ -143,11 +143,11 @@ async function main() {
 
   console.log(`  Created user: ${user.id}`);
 
-  // 2. Create protocols (10 total — 6 multispeq, 4 ambit; some with sortOrder)
+  // 2. Create protocols (10 total — 6 multispeq, 4 ambyte; some with sortOrder)
   const protocolData: {
     name: string;
     description: string;
-    family: "multispeq" | "ambit";
+    family: "multispeq" | "ambyte";
     code: Record<string, unknown>[];
     sortOrder?: number;
   }[] = [
@@ -202,16 +202,16 @@ async function main() {
     {
       name: "[Seed] Soil Moisture Probe",
       description:
-        "Ambit-based soil moisture and temperature measurement at configurable depth intervals.",
-      family: "ambit",
+        "Ambyte-based soil moisture and temperature measurement at configurable depth intervals.",
+      family: "ambyte",
       code: [{ _protocol_set: [{ label: "SoilMoisture", interval: 5, depth_cm: 15 }] }],
       sortOrder: 1,
     },
     {
       name: "[Seed] Ambient Light & Temperature",
       description:
-        "Reads ambient PAR, UV index, and air temperature using an Ambit environmental sensor array.",
-      family: "ambit",
+        "Reads ambient PAR, UV index, and air temperature using an Ambyte environmental sensor array.",
+      family: "ambyte",
       code: [{ _protocol_set: [{ label: "AmbientEnv", sample_rate: 10 }] }],
       sortOrder: 2,
     },
@@ -219,7 +219,7 @@ async function main() {
       name: "[Seed] Soil EC & pH Logger",
       description:
         "Logs electrical conductivity and pH in soil solution for nutrient availability monitoring.",
-      family: "ambit",
+      family: "ambyte",
       code: [{ _protocol_set: [{ label: "SoilEC", interval: 30 }] }],
       sortOrder: 3,
     },
@@ -227,7 +227,7 @@ async function main() {
       name: "[Seed] Canopy Temperature Monitor",
       description:
         "Infrared canopy temperature monitoring for crop water stress index calculations.",
-      family: "ambit",
+      family: "ambyte",
       code: [{ _protocol_set: [{ label: "CanopyTemp", ir_emissivity: 0.95, interval: 60 }] }],
       sortOrder: 4,
     },

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -113,7 +113,12 @@ export const organizationTypeEnum = pgEnum("organization_type", [
 ]);
 
 // Sensor Family Enum
-export const sensorFamilyEnum = pgEnum("sensor_family", ["multispeq", "ambit", "generic"]);
+export const sensorFamilyEnum = pgEnum("sensor_family", [
+  "multispeq",
+  "ambyte",
+  "minipar",
+  "generic",
+]);
 
 // Profiles Table
 export const profiles = pgTable("profiles", {
@@ -229,17 +234,6 @@ export const teamMembers = pgTable(
     index("team_members_user_idx").on(t.userId),
   ],
 );
-
-// Sensors Table
-export const sensors = pgTable("sensors", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  serialNumber: varchar("serial_number", { length: 100 }).unique().notNull(),
-  name: text("name").notNull(),
-  family: sensorFamilyEnum("family").notNull(),
-  location: text("location"),
-  isActive: boolean("is_active").default(true).notNull(),
-  ...timestamps,
-});
 
 // Experiments Table
 // Experiment Status Enum
@@ -620,7 +614,7 @@ export const iotDevices = pgTable(
     thingArn: text("thing_arn").notNull(),
     serialNumber: text("serial_number").notNull().unique(),
     name: varchar("name", { length: 255 }),
-    deviceType: text("device_type").notNull(),
+    deviceType: sensorFamilyEnum("device_type").notNull(),
     status: deviceStatusEnum("status").default("pending").notNull(),
     certificateId: text("certificate_id"),
     certificateArn: text("certificate_arn"),

--- a/packages/i18n/locales/de-DE/experiments.json
+++ b/packages/i18n/locales/de-DE/experiments.json
@@ -308,7 +308,7 @@
     },
     "fileUpload": {
       "title": "Ambyte-Daten hochladen",
-      "description": "Wählen Sie einen Ambyte-Ordner (z. B. \"Ambyte_10\") oder einzelne Ambit-Unterordner (z. B. \"1\", \"2\", \"3\", \"4\"). Der Ordner sollte .txt-Messdateien enthalten.",
+      "description": "Wählen Sie einen Ambyte-Ordner (z. B. \"Ambyte_10\") oder einzelne Ambyte-Unterordner (z. B. \"1\", \"2\", \"3\", \"4\"). Der Ordner sollte .txt-Messdateien enthalten.",
       "selectFolder": "Ambyte-Ordner auswählen",
       "changeSelection": "Ordnerauswahl ändern",
       "browseInstruction": "Klicken Sie hier, um nach einem Ambyte-Datenordner zu suchen",

--- a/packages/i18n/locales/de-DE/iot.json
+++ b/packages/i18n/locales/de-DE/iot.json
@@ -107,7 +107,7 @@
         "serialLabel": "Seriennummer",
         "serialPlaceholder": "E8:F6:0A:B1:1D:D4",
         "typeLabel": "Gerätetyp",
-        "typePlaceholder": "ambyte",
+        "typePlaceholder": "Gerätetyp auswählen",
         "nameLabel": "Name (optional)",
         "namePlaceholder": "Gewächshaus-Sensor 1",
         "submit": "Registrieren",

--- a/packages/i18n/locales/en-US/experiments.json
+++ b/packages/i18n/locales/en-US/experiments.json
@@ -362,7 +362,7 @@
     },
     "fileUpload": {
       "title": "Upload Ambyte Data",
-      "description": "Select an Ambyte folder (e.g., \"Ambyte_10\") or individual ambit subfolders (e.g., \"1\", \"2\", \"3\", \"4\"). The folder should contain .txt measurement files.",
+      "description": "Select an Ambyte folder (e.g., \"Ambyte_10\") or individual ambyte subfolders (e.g., \"1\", \"2\", \"3\", \"4\"). The folder should contain .txt measurement files.",
       "selectFolder": "Select Ambyte folder",
       "changeSelection": "Change folder selection",
       "browseInstruction": "Click to browse for an Ambyte data folder",

--- a/packages/i18n/locales/en-US/iot.json
+++ b/packages/i18n/locales/en-US/iot.json
@@ -107,7 +107,7 @@
         "serialLabel": "Serial number",
         "serialPlaceholder": "E8:F6:0A:B1:1D:D4",
         "typeLabel": "Device type",
-        "typePlaceholder": "ambyte",
+        "typePlaceholder": "Select a device type",
         "nameLabel": "Name (optional)",
         "namePlaceholder": "Greenhouse sensor 1",
         "submit": "Register",

--- a/packages/i18n/locales/nl-NL/experiments.json
+++ b/packages/i18n/locales/nl-NL/experiments.json
@@ -227,7 +227,7 @@
     },
     "fileUpload": {
       "title": "Ambyte-gegevens uploaden",
-      "description": "Selecteer een Ambyte-map (bijv. \"Ambyte_10\") of afzonderlijke ambit-submappen (bijv. \"1\", \"2\", \"3\", \"4\"). De map moet .txt-meetbestanden bevatten.",
+      "description": "Selecteer een Ambyte-map (bijv. \"Ambyte_10\") of afzonderlijke ambyte-submappen (bijv. \"1\", \"2\", \"3\", \"4\"). De map moet .txt-meetbestanden bevatten.",
       "selectFolder": "Selecteer Ambyte-map",
       "changeSelection": "Mapselectie wijzigen",
       "browseInstruction": "Klik om te bladeren naar een Ambyte-gegevensmap",


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Unifies the sensor-family taxonomy across protocols and IoT devices into a single source of truth. The `ambit` family is renamed to `ambyte` (matching the actual hardware name), a new `minipar` family is added, and a device's `deviceType` now reuses the shared `sensor_family` enum instead of being an unconstrained string.

The `zSensorFamily` enum is now `multispeq | ambyte | minipar | generic`, and both the API `deviceType` schema and the `iot_devices.device_type` column derive from it. Device registration is therefore constrained to known families: the register-device dialog swaps its free-text input for a select populated from the enum, and `ambyte` and `minipar` are surfaced as disabled options since they are ingest-only and not yet available for local (bluetooth/serial) connection. The workbook family pickers are consolidated onto the same shared `SENSOR_FAMILY_OPTIONS` list rather than each hardcoding their own.

## OJD-1602