### PR TITLE
feat(workbooks): inline command cell

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -115,6 +115,7 @@
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "catalog:",
     "uuid": "^14.0.0",
+    "yaml": "2.8.3",
     "zod": "catalog:",
     "zustand": "^5.0.12"
   },

--- a/apps/mobile/src/features/measurement-flow/domain/flow-transitions.test.ts
+++ b/apps/mobile/src/features/measurement-flow/domain/flow-transitions.test.ts
@@ -20,6 +20,15 @@ const makeQuestion = (id: string): FlowNode =>
 const makeMeasurement = (id: string): FlowNode =>
   ({ id, type: "measurement", name: id, content: { params: {}, protocolId: "p" } }) as FlowNode;
 
+// A command cell also rides a "measurement" node but carries no protocolId.
+const makeCommand = (id: string): FlowNode =>
+  ({
+    id,
+    type: "measurement",
+    name: id,
+    content: { command: { format: "string", content: "battery" } },
+  }) as FlowNode;
+
 const inFlow = (overrides: Partial<FlowState> = {}): FlowState => ({
   ...initialFlowState,
   experimentId: "exp-1",
@@ -34,6 +43,14 @@ describe("flowProtocolId", () => {
 
   it("is undefined for questions-only flows", () => {
     expect(flowProtocolId([makeQuestion("q1"), makeQuestion("q2")])).toBeUndefined();
+  });
+
+  it("skips a leading command node so the real protocol still resolves", () => {
+    expect(flowProtocolId([makeCommand("c1"), makeMeasurement("m1")])).toBe("p");
+  });
+
+  it("is undefined for a command-only flow (no protocol to upload against)", () => {
+    expect(flowProtocolId([makeCommand("c1")])).toBeUndefined();
   });
 });
 

--- a/apps/mobile/src/features/measurement-flow/domain/flow-transitions.ts
+++ b/apps/mobile/src/features/measurement-flow/domain/flow-transitions.ts
@@ -92,7 +92,13 @@ function firstMeasurementStep(flowNodes: FlowNode[]): number {
 // assumes at most one). Derived from the persisted flowNodes, so it
 // survives pause/resume and can never go stale across flows.
 export function flowProtocolId(flowNodes: FlowNode[]): string | undefined {
-  const node = flowNodes.find((n) => n.type === "measurement");
+  // A command cell also rides a "measurement" node but carries no protocolId, so
+  // match the first node that actually has one; otherwise a leading command node
+  // would shadow the real protocol and the upload would fail with "Missing protocol id".
+  const node = flowNodes.find(
+    (n) =>
+      n.type === "measurement" && (n.content as { protocolId?: string } | undefined)?.protocolId,
+  );
   return (node?.content as { protocolId?: string } | undefined)?.protocolId;
 }
 

--- a/apps/mobile/src/features/measurement-flow/domain/flow-transitions.ts
+++ b/apps/mobile/src/features/measurement-flow/domain/flow-transitions.ts
@@ -32,6 +32,9 @@ export interface FlowState {
   isFlowFinished: boolean;
   isQuestionsSubmitPending: boolean;
   scanResult?: ScanResult;
+  // Cell id of the producer (protocol or command) that yielded scanResult;
+  // keys the synthetic output cell in hydrateCells for branch evaluation.
+  producerCellId?: string;
   isFromOverview: boolean;
   // Workbook-derived data for on-device branch evaluation; empty for legacy
   // flow-only experiments. Persisted so a resumed branching flow keeps routing.
@@ -52,6 +55,7 @@ export const initialFlowState: FlowState = {
   isFlowFinished: false,
   isQuestionsSubmitPending: false,
   scanResult: undefined,
+  producerCellId: undefined,
   isFromOverview: false,
   cells: [],
   edges: [],
@@ -147,6 +151,7 @@ export function previousStepState(state: FlowState): Partial<FlowState> {
       isFlowFinished: false,
       isQuestionsSubmitPending: false,
       scanResult: undefined,
+      producerCellId: undefined,
       cells: [],
       edges: [],
       ...clearedBranchIteration,
@@ -165,6 +170,7 @@ export function startNewIterationState(state: FlowState): Partial<FlowState> {
     iterationCount: state.iterationCount + 1,
     isQuestionsSubmitPending: false,
     scanResult: undefined,
+    producerCellId: undefined,
     isFromOverview: false,
     ...clearedBranchIteration,
   };
@@ -175,6 +181,7 @@ export function retryIterationState(): Partial<FlowState> {
     currentFlowStep: 0,
     isQuestionsSubmitPending: false,
     scanResult: undefined,
+    producerCellId: undefined,
     isFromOverview: false,
     ...clearedBranchIteration,
   };
@@ -195,6 +202,7 @@ export function dismissQuestionsSubmitState(state: FlowState): Partial<FlowState
     currentFlowStep: 0,
     iterationCount: state.iterationCount + 1,
     scanResult: undefined,
+    producerCellId: undefined,
     ...clearedBranchIteration,
   };
 }

--- a/apps/mobile/src/features/measurement-flow/hooks/use-load-experiment-flow.ts
+++ b/apps/mobile/src/features/measurement-flow/hooks/use-load-experiment-flow.ts
@@ -64,9 +64,7 @@ export function useLoadExperimentFlow(experimentId: string | undefined): {
 
   const isLoading =
     !noWorkbook &&
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     (isExperimentsLoading ||
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       isVersionLoading ||
       (!!experimentId && experimentsData == null && !experimentsError));
   const error =

--- a/apps/mobile/src/features/measurement-flow/hooks/use-measurement-capture.ts
+++ b/apps/mobile/src/features/measurement-flow/hooks/use-measurement-capture.ts
@@ -16,7 +16,8 @@ const log = createLogger("measurement-capture");
 // View-model for MeasurementNode: owns the scan lifecycle (preconditions +
 // user feedback, execution, store wiring, disconnect cleanup) so the
 // component is a pure render switch over the returned state.
-export function useMeasurementCapture(content: MeasurementContent) {
+// nodeId (== cell id) attributes the recorded result to its producing cell.
+export function useMeasurementCapture(content: MeasurementContent, nodeId?: string) {
   const { t } = useTranslation("measurementFlow");
   // Resolved once at flow-load (hydrateFlowNodes): snapshot code + cell name.
   const protocol = content.protocol;
@@ -92,7 +93,7 @@ export function useMeasurementCapture(content: MeasurementContent) {
         const result = await executeScan(protocol);
         // executeScan types its payload as plain `object`; the device output
         // is JSON, so the structural ScanResult cast is safe at this seam.
-        setScanResult(result as ScanResult | undefined);
+        setScanResult(result as ScanResult | undefined, nodeId);
         // Play system notification sound when measurement completes
         await playSound();
         nextStep();

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/experiment-selection-step.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/experiment-selection-step.tsx
@@ -62,7 +62,6 @@ export function ExperimentSelectionStep() {
     const q = search.trim().toLowerCase();
     if (!q) return sorted;
     return sorted.filter(
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       (e) => e.label.toLowerCase().includes(q) || (e.description ?? "").toLowerCase().includes(q),
     );
   }, [sorted, search]);

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
@@ -1,9 +1,9 @@
-import { render } from "@testing-library/react-native";
+import { act, render } from "@testing-library/react-native";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useFlowAnswersStore } from "~/features/measurement-flow/stores/use-flow-answers-store";
 import { useMeasurementFlowStore } from "~/features/measurement-flow/stores/use-measurement-flow-store";
-import type { AnalysisContent } from "~/shared/measurements/flow-node";
+import type { AnalysisContent, FlowNode } from "~/shared/measurements/flow-node";
 
 import { AnalysisNode } from "./analysis-node";
 
@@ -12,6 +12,7 @@ import { AnalysisNode } from "./analysis-node";
 // summaryProps captures the name the node hands to the summary card.
 const {
   summaryProps,
+  actionBarProps,
   useExperiments,
   useSession,
   useMeasurementUpload,
@@ -21,6 +22,7 @@ const {
   getTimeSyncState,
 } = vi.hoisted(() => ({
   summaryProps: vi.fn(),
+  actionBarProps: vi.fn(),
   useExperiments: vi.fn(),
   useSession: vi.fn(),
   useMeasurementUpload: vi.fn(),
@@ -60,7 +62,10 @@ vi.mock("./analysis-summary-card", () => ({
 }));
 vi.mock("./analysis-macro-result", () => ({ AnalysisMacroResult: () => null }));
 vi.mock("./analysis-action-bar", () => ({
-  AnalysisActionBar: () => null,
+  AnalysisActionBar: (props: { onUpload: () => void }) => {
+    actionBarProps(props);
+    return null;
+  },
   useScrollToTop: () => ({
     scrollViewRef: { current: null },
     hasScrolled: false,
@@ -92,6 +97,7 @@ beforeEach(() => {
     rememberAnswerSettings: {},
   });
   summaryProps.mockClear();
+  actionBarProps.mockClear();
   useExperiments.mockReturnValue({ experiments: [{ value: "exp-1", label: "From Query" }] });
   useSession.mockReturnValue({ session: { data: { user: { id: "user-1" } } } });
   useMeasurementUpload.mockReturnValue({ isUploading: false, uploadMeasurement: vi.fn() });
@@ -132,5 +138,65 @@ describe("AnalysisNode experiment name", () => {
     useMeasurementFlowStore.setState({ experimentId: "exp-missing", experimentLabel: undefined });
     render(<AnalysisNode content={CONTENT} />);
     expect(resolvedName()).toBe("Experiment");
+  });
+});
+
+describe("AnalysisNode upload with a command in the flow", () => {
+  const withMacro = {
+    params: {},
+    macroId: "macro-1",
+    macro: { id: "macro-1", name: "Chlorophyll", filename: "chloro.py" },
+  } as AnalysisContent;
+
+  // Command → Protocol → Macro: the command rides a "measurement" node with no
+  // protocolId. Regression (Vlad, on device): flowProtocolId picked the command
+  // node, so the upload threw "Missing protocol id" (swallowed by .catch) and no
+  // local measurement was created. It must now resolve the real protocol.
+  const commandProtocolMacroNodes = [
+    {
+      id: "cmd1",
+      type: "measurement",
+      name: "battery",
+      isStart: true,
+      content: { command: { format: "string", content: "battery" } },
+    },
+    {
+      id: "p1",
+      type: "measurement",
+      name: "Proto",
+      isStart: false,
+      content: { protocolId: "proto-1", protocol: { name: "Proto" } },
+    },
+    {
+      id: "m1",
+      type: "analysis",
+      name: "Macro",
+      isStart: false,
+      content: { macroId: "macro-1" },
+    },
+  ] as unknown as FlowNode[];
+
+  it("uploads the measurement even when a command node precedes the protocol", async () => {
+    const uploadMeasurement = vi.fn().mockResolvedValue(undefined);
+    useMeasurementUpload.mockReturnValue({ isUploading: false, uploadMeasurement });
+    useMeasurementFlowStore.setState({
+      experimentId: "exp-1",
+      experimentLabel: "Trial",
+      flowNodes: commandProtocolMacroNodes,
+      currentFlowStep: 2,
+      scanResult: { sample: [{ phi2: 0.8 }] },
+    });
+
+    render(<AnalysisNode content={withMacro} />);
+
+    const props = actionBarProps.mock.calls.at(-1)?.[0] as
+      | { onUpload: () => Promise<void> }
+      | undefined;
+    await act(async () => {
+      await props?.onUpload();
+    });
+
+    expect(uploadMeasurement).toHaveBeenCalledTimes(1);
+    expect(uploadMeasurement.mock.calls[0][0]).toMatchObject({ protocolId: "proto-1" });
   });
 });

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/command-node/command-node.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/command-node/command-node.tsx
@@ -8,13 +8,12 @@ import { useScanner } from "~/features/connection/hooks/use-scan-manager";
 import type { ScanResult } from "~/features/measurement-flow/domain/flow-transitions";
 import { useMeasurementFlowStore } from "~/features/measurement-flow/stores/use-measurement-flow-store";
 import { useTranslation } from "~/shared/i18n";
+import type { InlineCommandContent } from "~/shared/measurements/flow-node";
 import { createLogger } from "~/shared/observability/logger";
 import { Button } from "~/shared/ui/Button";
 import { useTheme } from "~/shared/ui/hooks/use-theme";
 
 import { resolveInlineCommand } from "@repo/api/utils/command-payload";
-
-import type { InlineCommandContent } from "~/shared/measurements/flow-node";
 
 const log = createLogger("command-node");
 

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/command-node/command-node.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/command-node/command-node.tsx
@@ -5,6 +5,7 @@ import { ScrollView, Text, View } from "react-native";
 import { toast } from "sonner-native";
 import { useConnectedDevice } from "~/features/connection/hooks/use-device-connection";
 import { useScanner } from "~/features/connection/hooks/use-scan-manager";
+import type { ScanResult } from "~/features/measurement-flow/domain/flow-transitions";
 import { useMeasurementFlowStore } from "~/features/measurement-flow/stores/use-measurement-flow-store";
 import { useTranslation } from "~/shared/i18n";
 import { createLogger } from "~/shared/observability/logger";
@@ -13,12 +14,14 @@ import { useTheme } from "~/shared/ui/hooks/use-theme";
 
 import { resolveInlineCommand } from "@repo/api/utils/command-payload";
 
-import type { InlineCommandContent } from "../../../types";
+import type { InlineCommandContent } from "~/shared/measurements/flow-node";
 
 const log = createLogger("command-node");
 
 interface CommandNodeProps {
   content: InlineCommandContent;
+  /** Flow node id (== cell id); keys the result so a downstream branch can read it. */
+  nodeId: string;
 }
 
 function formatResponse(result: unknown): string {
@@ -30,12 +33,12 @@ function formatResponse(result: unknown): string {
   }
 }
 
-export function CommandNode({ content }: CommandNodeProps) {
+export function CommandNode({ content, nodeId }: CommandNodeProps) {
   const { classes } = useTheme();
   const { t } = useTranslation("measurementFlow");
   const { executeCommand } = useScanner();
   const { data: device } = useConnectedDevice();
-  const { nextStep } = useMeasurementFlowStore();
+  const { nextStep, setScanResult } = useMeasurementFlowStore();
 
   const [isRunning, setIsRunning] = useState(false);
   const [response, setResponse] = useState<string>();
@@ -51,6 +54,9 @@ export function CommandNode({ content }: CommandNodeProps) {
     try {
       const result = await executeCommand(resolveInlineCommand(content));
       setResponse(formatResponse(result));
+      // Persist so a downstream branch can read this command's output and it
+      // uploads as a measurement, mirroring MeasurementNode.
+      setScanResult(result as ScanResult | undefined, nodeId);
     } catch (err) {
       log.error("command error", { err: (err as Error)?.message });
       setError((err as Error)?.message);
@@ -90,7 +96,11 @@ export function CommandNode({ content }: CommandNodeProps) {
 
       <View className="gap-3 px-4 py-3">
         <Button
-          title={isRunning ? t("measurementFlow:commandNode.running") : t("measurementFlow:commandNode.run")}
+          title={
+            isRunning
+              ? t("measurementFlow:commandNode.running")
+              : t("measurementFlow:commandNode.run")
+          }
           onPress={handleRun}
           disabled={isRunning}
           style={{ height: 44 }}

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/command-node/command-node.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/command-node/command-node.tsx
@@ -1,0 +1,109 @@
+import { clsx } from "clsx";
+import { Terminal } from "lucide-react-native";
+import React, { useState } from "react";
+import { ScrollView, Text, View } from "react-native";
+import { toast } from "sonner-native";
+import { useConnectedDevice } from "~/features/connection/hooks/use-device-connection";
+import { useScanner } from "~/features/connection/hooks/use-scan-manager";
+import { useMeasurementFlowStore } from "~/features/measurement-flow/stores/use-measurement-flow-store";
+import { useTranslation } from "~/shared/i18n";
+import { createLogger } from "~/shared/observability/logger";
+import { Button } from "~/shared/ui/Button";
+import { useTheme } from "~/shared/ui/hooks/use-theme";
+
+import { resolveInlineCommand } from "@repo/api/utils/command-payload";
+
+import type { InlineCommandContent } from "../../../types";
+
+const log = createLogger("command-node");
+
+interface CommandNodeProps {
+  content: InlineCommandContent;
+}
+
+function formatResponse(result: unknown): string {
+  if (typeof result === "string") return result;
+  try {
+    return JSON.stringify(result, null, 2);
+  } catch {
+    return String(result);
+  }
+}
+
+export function CommandNode({ content }: CommandNodeProps) {
+  const { classes } = useTheme();
+  const { t } = useTranslation("measurementFlow");
+  const { executeCommand } = useScanner();
+  const { data: device } = useConnectedDevice();
+  const { nextStep } = useMeasurementFlowStore();
+
+  const [isRunning, setIsRunning] = useState(false);
+  const [response, setResponse] = useState<string>();
+  const [error, setError] = useState<string>();
+
+  const handleRun = async () => {
+    if (!device) {
+      toast.error(t("measurementFlow:commandNode.toast.notConnected"));
+      return;
+    }
+    setError(undefined);
+    setIsRunning(true);
+    try {
+      const result = await executeCommand(resolveInlineCommand(content));
+      setResponse(formatResponse(result));
+    } catch (err) {
+      log.error("command error", { err: (err as Error)?.message });
+      setError((err as Error)?.message);
+      toast.error(t("measurementFlow:commandNode.toast.error"));
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  return (
+    <ScrollView style={{ flex: 1 }} contentContainerStyle={{ flexGrow: 1 }}>
+      <View className="flex-1 gap-4 p-4">
+        <View className="flex-row items-center gap-2">
+          <Terminal size={18} color="#119DA4" />
+          <Text className={clsx("text-base font-semibold", classes.text)}>
+            {t("measurementFlow:commandNode.heading")}
+          </Text>
+        </View>
+
+        <View className="bg-muted rounded-lg p-3">
+          <Text className={clsx("font-mono text-sm", classes.text)}>{content.content}</Text>
+        </View>
+
+        {error ? <Text className="text-sm text-red-500">{error}</Text> : null}
+
+        {response !== undefined ? (
+          <View className="gap-1">
+            <Text className={clsx("text-xs uppercase", classes.textMuted)}>
+              {t("measurementFlow:commandNode.responseLabel")}
+            </Text>
+            <View className="bg-muted rounded-lg p-3">
+              <Text className={clsx("font-mono text-sm", classes.text)}>{response}</Text>
+            </View>
+          </View>
+        ) : null}
+      </View>
+
+      <View className="gap-3 px-4 py-3">
+        <Button
+          title={isRunning ? t("measurementFlow:commandNode.running") : t("measurementFlow:commandNode.run")}
+          onPress={handleRun}
+          disabled={isRunning}
+          style={{ height: 44 }}
+        />
+        {response !== undefined ? (
+          <Button
+            title={t("measurementFlow:commandNode.continue")}
+            onPress={() => nextStep()}
+            variant="tertiary"
+            style={{ height: 44, borderColor: "transparent" }}
+          />
+        ) : null}
+      </View>
+    </ScrollView>
+  );
+}

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/measurement-node/measurement-node.test.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/measurement-node/measurement-node.test.tsx
@@ -110,7 +110,7 @@ beforeEach(() => {
 
 describe("MeasurementNode start-scan guards", () => {
   it("shows the protocol-unavailable toast (not scan error) when the node has no protocol", () => {
-    render(<MeasurementNode content={{ ...content, protocol: undefined }} />);
+    render(<MeasurementNode content={{ ...content, protocol: undefined }} nodeId="m1" />);
     fireEvent.press(screen.getByText(START_KEY));
 
     expect(toastError).toHaveBeenCalledWith(PROTOCOL_UNAVAILABLE_KEY);
@@ -118,7 +118,7 @@ describe("MeasurementNode start-scan guards", () => {
   });
 
   it("shows the no-protocol toast when the node has no protocolId", () => {
-    render(<MeasurementNode content={{ ...content, protocolId: "" }} />);
+    render(<MeasurementNode content={{ ...content, protocolId: "" }} nodeId="m1" />);
     fireEvent.press(screen.getByText(START_KEY));
 
     expect(toastError).toHaveBeenCalledWith("measurementFlow:measurementNode.toast.noProtocol");
@@ -128,7 +128,7 @@ describe("MeasurementNode start-scan guards", () => {
   it("blocks the scan and shows device-disconnected when the liveness probe finds no device", async () => {
     refetchConnectedDevice.mockResolvedValue({ data: null });
 
-    render(<MeasurementNode content={content} />);
+    render(<MeasurementNode content={content} nodeId="m1" />);
     fireEvent.press(screen.getByText(START_KEY));
 
     await waitFor(() => expect(toastError).toHaveBeenCalledWith(DEVICE_DISCONNECTED_KEY));
@@ -138,11 +138,11 @@ describe("MeasurementNode start-scan guards", () => {
   it("runs the scan and advances when the protocol and connection are available", async () => {
     executeScan.mockResolvedValue({ result: 42 });
 
-    render(<MeasurementNode content={content} />);
+    render(<MeasurementNode content={content} nodeId="m1" />);
     fireEvent.press(screen.getByText(START_KEY));
 
     await waitFor(() => expect(executeScan).toHaveBeenCalledWith(PROTOCOL));
-    expect(setScanResult).toHaveBeenCalledWith({ result: 42 });
+    expect(setScanResult).toHaveBeenCalledWith({ result: 42 }, "m1");
     expect(nextStep).toHaveBeenCalled();
     expect(toastError).not.toHaveBeenCalled();
   });
@@ -150,7 +150,7 @@ describe("MeasurementNode start-scan guards", () => {
   it("maps a transport failure to the device-disconnected toast", async () => {
     executeScan.mockRejectedValue(new Error("Failed to write to device"));
 
-    render(<MeasurementNode content={content} />);
+    render(<MeasurementNode content={content} nodeId="m1" />);
     fireEvent.press(screen.getByText(START_KEY));
 
     await waitFor(() => expect(toastError).toHaveBeenCalledWith(DEVICE_DISCONNECTED_KEY));
@@ -161,7 +161,7 @@ describe("MeasurementNode start-scan guards", () => {
   it("shows the generic scan-error toast when the scan itself fails", async () => {
     executeScan.mockRejectedValue(new Error("Invalid result"));
 
-    render(<MeasurementNode content={content} />);
+    render(<MeasurementNode content={content} nodeId="m1" />);
     fireEvent.press(screen.getByText(START_KEY));
 
     await waitFor(() => expect(toastError).toHaveBeenCalledWith(SCAN_ERROR_KEY));
@@ -171,7 +171,7 @@ describe("MeasurementNode start-scan guards", () => {
   it("stays silent when the measurement was cancelled", async () => {
     executeScan.mockRejectedValue(new Error("Measurement cancelled"));
 
-    render(<MeasurementNode content={content} />);
+    render(<MeasurementNode content={content} nodeId="m1" />);
     fireEvent.press(screen.getByText(START_KEY));
 
     await waitFor(() => expect(executeScan).toHaveBeenCalled());
@@ -182,7 +182,7 @@ describe("MeasurementNode start-scan guards", () => {
   it("hides the Start button entirely when no device is connected", () => {
     useConnectedDevice.mockReturnValue({ data: undefined, refetch: refetchConnectedDevice });
 
-    render(<MeasurementNode content={content} />);
+    render(<MeasurementNode content={content} nodeId="m1" />);
 
     expect(screen.queryByText(START_KEY)).toBeNull();
   });
@@ -195,7 +195,7 @@ describe("MeasurementNode start-scan guards", () => {
       }),
     );
 
-    render(<MeasurementNode content={content} />);
+    render(<MeasurementNode content={content} nodeId="m1" />);
     const button = screen.getByText(START_KEY);
     fireEvent.press(button);
     fireEvent.press(button);
@@ -210,7 +210,7 @@ describe("MeasurementNode in-scan controls", () => {
     scanState.isScanning = true;
     cancelCommand.mockResolvedValue(undefined);
 
-    render(<MeasurementNode content={content} />);
+    render(<MeasurementNode content={content} nodeId="m1" />);
     fireEvent.press(screen.getByText(CANCEL_KEY));
 
     await waitFor(() => expect(cancelCommand).toHaveBeenCalled());
@@ -221,11 +221,11 @@ describe("MeasurementNode in-scan controls", () => {
     scanState.isScanning = true;
     cancelCommand.mockResolvedValue(undefined);
 
-    const { rerender } = render(<MeasurementNode content={content} />);
+    const { rerender } = render(<MeasurementNode content={content} nodeId="m1" />);
     expect(cancelCommand).not.toHaveBeenCalled();
 
     useConnectedDevice.mockReturnValue({ data: undefined, refetch: refetchConnectedDevice });
-    rerender(<MeasurementNode content={content} />);
+    rerender(<MeasurementNode content={content} nodeId="m1" />);
 
     await waitFor(() => expect(cancelCommand).toHaveBeenCalled());
     expect(resetScan).toHaveBeenCalled();

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/measurement-node/measurement-node.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/measurement-node/measurement-node.tsx
@@ -17,9 +17,11 @@ import { ScanningState } from "./components/scanning-state";
 
 interface MeasurementNodeProps {
   content: MeasurementContent;
+  /** Flow node id (== cell id); keys the result so a downstream branch can read it. */
+  nodeId: string;
 }
 
-export function MeasurementNode({ content }: MeasurementNodeProps) {
+export function MeasurementNode({ content, nodeId }: MeasurementNodeProps) {
   const { classes, colors } = useTheme();
   const { t } = useTranslation("measurementFlow");
   const {
@@ -35,7 +37,7 @@ export function MeasurementNode({ content }: MeasurementNodeProps) {
     scanProgress,
     scanStartedAt,
     estimatedMs,
-  } = useMeasurementCapture(content);
+  } = useMeasurementCapture(content, nodeId);
 
   const renderState = () => {
     if (!device) {

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/evaluate-and-route.test.ts
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/evaluate-and-route.test.ts
@@ -24,6 +24,7 @@ interface MockFlowState {
   currentFlowStep: number;
   iterationCount: number;
   scanResult?: unknown;
+  producerCellId?: string;
   cells: WorkbookCell[];
   branchVisitCounts: Record<string, number>;
   setCurrentFlowStep: typeof mockSetCurrentFlowStep;
@@ -38,6 +39,7 @@ const flowState: MockFlowState = {
   currentFlowStep: 0,
   iterationCount: 0,
   scanResult: undefined,
+  producerCellId: undefined,
   cells: [],
   branchVisitCounts: {},
   setCurrentFlowStep: mockSetCurrentFlowStep,
@@ -125,6 +127,7 @@ beforeEach(() => {
   flowState.currentFlowStep = 0;
   flowState.iterationCount = 0;
   flowState.scanResult = undefined;
+  flowState.producerCellId = undefined;
   flowState.cells = [];
   flowState.branchVisitCounts = {};
 });
@@ -214,6 +217,7 @@ describe("evaluateAndRoute", () => {
 
   it("requires all conditions in a path (implicit AND), incl. measurement output", () => {
     mockGetAnswer.mockImplementation((_c, id) => (id === "q1" ? "yes" : undefined));
+    flowState.producerCellId = "p1";
     flowState.scanResult = { sample: [{ phi2: 0.8 }] };
     flowState.cells = [
       qCell("q1"),
@@ -242,6 +246,7 @@ describe("evaluateAndRoute", () => {
 
   it("does not match a path when one AND condition fails", () => {
     mockGetAnswer.mockImplementation((_c, id) => (id === "q1" ? "yes" : undefined));
+    flowState.producerCellId = "p1";
     flowState.scanResult = { sample: [{ phi2: 0.3 }] }; // fails the > 0.5 check
     flowState.cells = [
       qCell("q1"),

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/evaluate-and-route.test.ts
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/evaluate-and-route.test.ts
@@ -5,6 +5,7 @@ import type {
   BranchCell,
   BranchCondition,
   BranchPath,
+  CommandCell,
   ProtocolCell,
   QuestionCell,
   WorkbookCell,
@@ -92,6 +93,12 @@ const pCell = (id: string, protocolId: string): ProtocolCell => ({
   type: "protocol",
   isCollapsed: false,
   payload: { protocolId, version: 1 },
+});
+const cCell = (id: string): CommandCell => ({
+  id,
+  type: "command",
+  isCollapsed: false,
+  payload: { format: "string", content: "battery" },
 });
 const cond = (
   sourceCellId: string,
@@ -242,6 +249,30 @@ describe("evaluateAndRoute", () => {
 
     expect(mockSetLastMatchedPath).toHaveBeenCalledWith({ label: "PA", color: "#abcdef" });
     expect(mockSetCurrentFlowStep).toHaveBeenCalledWith(2);
+  });
+
+  it("resolves a command's scalar response so a Command→Branch takes the matching path", () => {
+    // Regression (Vlad, on device): mobile stored the raw command result, so the
+    // branch's `response` field was undefined and it fell to the default path
+    // while web (which wraps a scalar as { response }) matched. hydrateCells now
+    // mirrors web for command producers.
+    flowState.producerCellId = "cmd1";
+    flowState.scanResult = "OK";
+    flowState.cells = [
+      cCell("cmd1"),
+      branch(
+        "b1",
+        [path("pass", [cond("cmd1", "eq", "OK", "response")], "tgt"), path("pdef", [])],
+        "pdef",
+      ),
+    ];
+    flowState.flowNodes = [branchFlowNode("b1"), plainFlowNode("y"), plainFlowNode("tgt")];
+    flowState.currentFlowStep = 0;
+
+    evaluateAndRoute(branchFlowNode("b1"));
+
+    expect(mockSetLastMatchedPath).toHaveBeenCalledWith({ label: "PASS", color: "#abcdef" });
+    expect(mockSetCurrentFlowStep).toHaveBeenCalledWith(2); // "tgt" (pass), not the default fall-through
   });
 
   it("does not match a path when one AND condition fails", () => {

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/evaluate-and-route.ts
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/evaluate-and-route.ts
@@ -1,4 +1,3 @@
-import { flowProtocolId } from "~/features/measurement-flow/domain/flow-transitions";
 import { useFlowAnswersStore } from "~/features/measurement-flow/stores/use-flow-answers-store";
 import { useMeasurementFlowStore } from "~/features/measurement-flow/stores/use-measurement-flow-store";
 import { FlowNode } from "~/shared/measurements/flow-node";
@@ -50,7 +49,7 @@ export function evaluateAndRoute(node: FlowNode): void {
     iterationCount: flow.iterationCount,
     getAnswer,
     scanResult: flow.scanResult,
-    protocolId: flowProtocolId(flow.flowNodes),
+    producerCellId: flow.producerCellId,
   });
 
   const branchCell = hydrated.find((c): c is BranchCell => c.id === node.id && c.type === "branch");

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/hydrate-cells.test.ts
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/hydrate-cells.test.ts
@@ -59,10 +59,15 @@ describe("hydrateCells", () => {
     expect(resolveConditionValue(hydrated, "p1", "phi2")).toBe(0.8);
   });
 
-  it("attaches a command's result as an output cell keyed to the command cell", () => {
+  it("wraps a scalar command result under `response` (mirrors web) so a branch resolves it", () => {
+    const hydrated = hydrateCells([cCell("c1")], ctx({ scanResult: "87", producerCellId: "c1" }));
+    expect(resolveConditionValue(hydrated, "c1", "response")).toBe("87");
+  });
+
+  it("passes an object command result through so its fields resolve directly", () => {
     const hydrated = hydrateCells(
       [cCell("c1")],
-      ctx({ scanResult: { sample: [{ voltage: 3.9 }] }, producerCellId: "c1" }),
+      ctx({ scanResult: { voltage: 3.9 }, producerCellId: "c1" }),
     );
     expect(resolveConditionValue(hydrated, "c1", "voltage")).toBe(3.9);
   });

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/hydrate-cells.test.ts
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/hydrate-cells.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type {
+  CommandCell,
   OutputCell,
   ProtocolCell,
   QuestionCell,
@@ -25,6 +26,12 @@ const pCell = (id: string, protocolId: string): ProtocolCell => ({
   isCollapsed: false,
   payload: { protocolId, version: 1 },
 });
+const cCell = (id: string): CommandCell => ({
+  id,
+  type: "command",
+  isCollapsed: false,
+  payload: { format: "string", content: "battery" },
+});
 
 const ctx = (over: Partial<HydrationContext> = {}): HydrationContext => ({
   iterationCount: 0,
@@ -44,32 +51,40 @@ describe("hydrateCells", () => {
     expect(resolveConditionValue(hydrated, "q1", "answer")).toBeUndefined();
   });
 
-  it("attaches the latest measurement as an output cell keyed to its protocol", () => {
+  it("attaches the latest measurement as an output cell keyed to its producer", () => {
     const hydrated = hydrateCells(
       [pCell("p1", "proto-1")],
-      ctx({ scanResult: { sample: [{ phi2: 0.8 }] }, protocolId: "proto-1" }),
+      ctx({ scanResult: { sample: [{ phi2: 0.8 }] }, producerCellId: "p1" }),
     );
     expect(resolveConditionValue(hydrated, "p1", "phi2")).toBe(0.8);
+  });
+
+  it("attaches a command's result as an output cell keyed to the command cell", () => {
+    const hydrated = hydrateCells(
+      [cCell("c1")],
+      ctx({ scanResult: { sample: [{ voltage: 3.9 }] }, producerCellId: "c1" }),
+    );
+    expect(resolveConditionValue(hydrated, "c1", "voltage")).toBe(3.9);
   });
 
   it("wraps a non-array sample", () => {
     const hydrated = hydrateCells(
       [pCell("p1", "proto-1")],
-      ctx({ scanResult: { sample: { phi2: 0.5 } }, protocolId: "proto-1" }),
+      ctx({ scanResult: { sample: { phi2: 0.5 } }, producerCellId: "p1" }),
     );
     expect(resolveConditionValue(hydrated, "p1", "phi2")).toBe(0.5);
   });
 
   it("synthesizes no output when there is no scan result", () => {
-    const hydrated = hydrateCells([pCell("p1", "proto-1")], ctx({ protocolId: "proto-1" }));
+    const hydrated = hydrateCells([pCell("p1", "proto-1")], ctx({ producerCellId: "p1" }));
     expect(hydrated.some((c) => c.type === "output")).toBe(false);
     expect(resolveConditionValue(hydrated, "p1", "phi2")).toBeUndefined();
   });
 
-  it("synthesizes no output when no protocol cell matches the scanned protocol", () => {
+  it("synthesizes no output when no cell matches the producer id", () => {
     const hydrated = hydrateCells(
       [pCell("p1", "proto-1")],
-      ctx({ scanResult: { sample: [{ phi2: 0.8 }] }, protocolId: "proto-OTHER" }),
+      ctx({ scanResult: { sample: [{ phi2: 0.8 }] }, producerCellId: "p-OTHER" }),
     );
     expect(hydrated.some((c) => c.type === "output")).toBe(false);
   });
@@ -85,7 +100,7 @@ describe("hydrateCells", () => {
     const cells: WorkbookCell[] = [pCell("p1", "proto-1"), stale];
     const hydrated = hydrateCells(
       cells,
-      ctx({ scanResult: { sample: [{ phi2: 0.9 }] }, protocolId: "proto-1" }),
+      ctx({ scanResult: { sample: [{ phi2: 0.9 }] }, producerCellId: "p1" }),
     );
     expect(hydrated.filter((c) => c.type === "output")).toHaveLength(1);
     expect(resolveConditionValue(hydrated, "p1", "phi2")).toBe(0.9);

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/hydrate-cells.ts
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/hydrate-cells.ts
@@ -28,8 +28,18 @@ export function hydrateCells(cells: WorkbookCell[], ctx: HydrationContext): Work
   const producer = hydrated.find((c) => c.id === producerCellId);
   if (!producer) return hydrated;
 
-  const sample = (scanResult as { sample?: unknown }).sample;
-  const data = sample != null ? (Array.isArray(sample) ? sample : [sample]) : scanResult;
+  let data: unknown;
+  if (producer.type === "command") {
+    // Mirror web's toOutputData so a branch reads the same shape on both hosts:
+    // a plain object passes through; any scalar/array is wrapped as { response }.
+    data =
+      typeof scanResult === "object" && !Array.isArray(scanResult)
+        ? scanResult
+        : { response: scanResult };
+  } else {
+    const sample = (scanResult as { sample?: unknown }).sample;
+    data = sample != null ? (Array.isArray(sample) ? sample : [sample]) : scanResult;
+  }
 
   const outputCell: OutputCell = {
     id: `synthetic-output-${producer.id}`,

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/hydrate-cells.ts
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/hydrate-cells.ts
@@ -4,16 +4,16 @@ export interface HydrationContext {
   iterationCount: number;
   getAnswer: (cycle: number, cellId: string) => string | undefined;
   scanResult?: unknown;
-  /** Entity id of the protocol whose output `scanResult` holds (store.protocolId). */
-  protocolId?: string;
+  /** Cell id of the producer (protocol or command) whose output `scanResult` holds. */
+  producerCellId?: string;
 }
 
 // Snapshots cells with live values so the shared `evaluateBranch` can read them:
 // question `.answer` from the store, and the latest measurement as a synthetic
-// output cell. Mobile keeps one scanResult, so only the latest protocol's output
+// output cell. Mobile keeps one scanResult, so only the latest producer's output
 // resolves; others are undefined (false → default path).
 export function hydrateCells(cells: WorkbookCell[], ctx: HydrationContext): WorkbookCell[] {
-  const { iterationCount, getAnswer, scanResult, protocolId } = ctx;
+  const { iterationCount, getAnswer, scanResult, producerCellId } = ctx;
 
   const hydrated: WorkbookCell[] = cells.map((cell) =>
     cell.type === "question"
@@ -21,13 +21,11 @@ export function hydrateCells(cells: WorkbookCell[], ctx: HydrationContext): Work
       : { ...cell },
   );
 
-  if (scanResult == null || !protocolId) return hydrated;
+  if (scanResult == null || !producerCellId) return hydrated;
 
-  // The scan belongs to the protocol the measurement node ran (store.protocolId);
-  // find its cell so the synthetic output is keyed to the right producer.
-  const producer = hydrated.find(
-    (c) => c.type === "protocol" && c.payload.protocolId === protocolId,
-  );
+  // The scan belongs to the cell that produced it (store.producerCellId, a
+  // protocol or command); find it so the synthetic output is keyed to the producer.
+  const producer = hydrated.find((c) => c.id === producerCellId);
   if (!producer) return hydrated;
 
   const sample = (scanResult as { sample?: unknown }).sample;

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-states/active-state.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-states/active-state.tsx
@@ -4,6 +4,7 @@ import { FlowNode } from "~/shared/measurements/flow-node";
 
 import { AnalysisNode } from "../flow-nodes/analysis-node/analysis-node";
 import { BranchNode } from "../flow-nodes/branch-node/branch-node";
+import { CommandNode } from "../flow-nodes/command-node/command-node";
 import { InstructionNode } from "../flow-nodes/instruction-node";
 import { MeasurementNode } from "../flow-nodes/measurement-node/measurement-node";
 import { QuestionNode } from "../flow-nodes/question-node/question-node";
@@ -38,6 +39,11 @@ function renderNode(currentNode: FlowNode) {
         </ScrollableNode>
       );
     case "measurement":
+      // A measurement node carries either a protocol reference or an inline
+      // device command; the latter runs through the lightweight CommandNode.
+      if (currentNode.content?.command) {
+        return <CommandNode content={currentNode.content.command} />;
+      }
       return (
         <ScrollableNode>
           <MeasurementNode content={currentNode.content} />

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-states/active-state.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-states/active-state.tsx
@@ -42,11 +42,11 @@ function renderNode(currentNode: FlowNode) {
       // A measurement node carries either a protocol reference or an inline
       // device command; the latter runs through the lightweight CommandNode.
       if (currentNode.content?.command) {
-        return <CommandNode content={currentNode.content.command} />;
+        return <CommandNode content={currentNode.content.command} nodeId={currentNode.id} />;
       }
       return (
         <ScrollableNode>
-          <MeasurementNode content={currentNode.content} />
+          <MeasurementNode content={currentNode.content} nodeId={currentNode.id} />
         </ScrollableNode>
       );
     default:

--- a/apps/mobile/src/features/measurement-flow/stores/flow-store-persistence.test.ts
+++ b/apps/mobile/src/features/measurement-flow/stores/flow-store-persistence.test.ts
@@ -64,6 +64,7 @@ const MEASUREMENT_FIXTURE = `{
     "isFlowFinished": true,
     "isQuestionsSubmitPending": true,
     "scanResult": { "device_name": "MultispeQ v2.0", "spad": [41.2, 39.8] },
+    "producerCellId": "node-m1",
     "isFromOverview": true,
     "cells": [{ "id": "cell-b1", "type": "branch", "name": "N branch" }],
     "edges": [{ "id": "edge-1", "source": "node-q1", "target": "node-m1" }],
@@ -157,6 +158,7 @@ describe("measurement-flow-storage v1 wire format", () => {
       "isQuestionsSubmitPending",
       "iterationCount",
       "lastMatchedPath",
+      "producerCellId",
       "scanResult",
     ]);
   });

--- a/apps/mobile/src/features/measurement-flow/stores/use-measurement-flow-store.ts
+++ b/apps/mobile/src/features/measurement-flow/stores/use-measurement-flow-store.ts
@@ -45,7 +45,9 @@ interface MeasurementFlowStore extends FlowState {
   startNewIteration: () => void;
   retryCurrentIteration: () => void;
   finishFlow: () => void;
-  setScanResult: (result: ScanResult | undefined) => void;
+  // producerCellId records which cell (protocol or command) yielded the result;
+  // omitting it clears any stale attribution.
+  setScanResult: (result: ScanResult | undefined, producerCellId?: string) => void;
   setIterationAnchor: (anchor: { iteration: number; nodeId?: string }) => void;
   dismissQuestionsSubmit: () => void;
   navigateToQuestionFromOverview: (questionIndex: number) => void;
@@ -115,7 +117,7 @@ export const useMeasurementFlowStore = create<MeasurementFlowStore>()(
 
       finishFlow: () => set(finishFlowState),
 
-      setScanResult: (result) => set({ scanResult: result }),
+      setScanResult: (result, producerCellId) => set({ scanResult: result, producerCellId }),
       setIterationAnchor: (anchor) => set({ iterationAnchor: anchor }),
 
       dismissQuestionsSubmit: () => set(dismissQuestionsSubmitState),
@@ -147,6 +149,7 @@ export const useMeasurementFlowStore = create<MeasurementFlowStore>()(
         isFlowFinished: state.isFlowFinished,
         isQuestionsSubmitPending: state.isQuestionsSubmitPending,
         scanResult: state.scanResult,
+        producerCellId: state.producerCellId,
         isFromOverview: state.isFromOverview,
         cells: state.cells,
         edges: state.edges,

--- a/apps/mobile/src/features/measurement-flow/utils/estimate-flow-duration.test.ts
+++ b/apps/mobile/src/features/measurement-flow/utils/estimate-flow-duration.test.ts
@@ -10,14 +10,13 @@ const node = (type: FlowNode["type"]): FlowNode => ({
   isStart: false,
 });
 
-const commandNode = (): FlowNode =>
-  ({
-    id: "cmd",
-    type: "measurement",
-    name: "cmd",
-    content: { command: { format: "string", content: "battery" } },
-    isStart: false,
-  }) as FlowNode;
+const commandNode = (): FlowNode => ({
+  id: "cmd",
+  type: "measurement",
+  name: "cmd",
+  content: { command: { format: "string", content: "battery" } },
+  isStart: false,
+});
 
 describe("estimateFlowDuration", () => {
   it("returns 0 for an empty flow", () => {

--- a/apps/mobile/src/features/measurement-flow/utils/estimate-flow-duration.test.ts
+++ b/apps/mobile/src/features/measurement-flow/utils/estimate-flow-duration.test.ts
@@ -10,6 +10,15 @@ const node = (type: FlowNode["type"]): FlowNode => ({
   isStart: false,
 });
 
+const commandNode = (): FlowNode =>
+  ({
+    id: "cmd",
+    type: "measurement",
+    name: "cmd",
+    content: { command: { format: "string", content: "battery" } },
+    isStart: false,
+  }) as FlowNode;
+
 describe("estimateFlowDuration", () => {
   it("returns 0 for an empty flow", () => {
     expect(estimateFlowDuration([])).toBe(0);
@@ -34,5 +43,12 @@ describe("estimateFlowDuration", () => {
     const total = estimateFlowDuration([node("question"), node("question"), node("question")]);
     // 1.5 → rounded to 2 by Math.round
     expect(total).toBe(2);
+  });
+
+  it("treats an inline command as near-instant, not a 1.5 min scan", () => {
+    // protocol measurement (1.5) + command measurement (0) = 1.5 → 2
+    expect(estimateFlowDuration([node("measurement"), commandNode()])).toBe(2);
+    // a lone command still floors at 1 minute
+    expect(estimateFlowDuration([commandNode()])).toBe(1);
   });
 });

--- a/apps/mobile/src/features/measurement-flow/utils/estimate-flow-duration.ts
+++ b/apps/mobile/src/features/measurement-flow/utils/estimate-flow-duration.ts
@@ -2,7 +2,7 @@ import type { FlowNode } from "~/shared/measurements/flow-node";
 
 /**
  * Rough duration estimate for a measurement flow, in minutes. The numbers
- * below are heuristics — the API does not yet expose a real duration — and
+ * below are heuristics (the API does not yet expose a real duration) and
  * are intentionally conservative so users see something close to or slightly
  * above reality rather than under-estimating.
  */
@@ -16,6 +16,11 @@ const NODE_MINUTES: Record<FlowNode["type"], number> = {
 
 export function estimateFlowDuration(nodes: FlowNode[]): number {
   if (nodes.length === 0) return 0;
-  const sum = nodes.reduce((acc, n) => acc + (NODE_MINUTES[n.type] ?? 0), 0);
+  const sum = nodes.reduce((acc, n) => {
+    // An inline command rides the measurement node but runs in seconds, not the
+    // ~1.5 min a protocol scan takes.
+    if (n.type === "measurement" && n.content?.command) return acc;
+    return acc + (NODE_MINUTES[n.type] ?? 0);
+  }, 0);
   return Math.max(1, Math.round(sum));
 }

--- a/apps/mobile/src/shared/i18n/locales/en-US/measurement-flow.json
+++ b/apps/mobile/src/shared/i18n/locales/en-US/measurement-flow.json
@@ -123,6 +123,17 @@
       "noQuestionsAnswered": "No questions answered"
     }
   },
+  "commandNode": {
+    "heading": "Device command",
+    "responseLabel": "Response",
+    "run": "Run command",
+    "running": "Running…",
+    "continue": "Continue",
+    "toast": {
+      "notConnected": "Not connected to sensor",
+      "error": "Command failed"
+    }
+  },
   "measurementNode": {
     "errorState": {
       "title": "Measurement Failed",

--- a/apps/mobile/src/shared/i18n/locales/nl-NL/measurement-flow.json
+++ b/apps/mobile/src/shared/i18n/locales/nl-NL/measurement-flow.json
@@ -123,6 +123,17 @@
       "noQuestionsAnswered": "Geen vragen beantwoord"
     }
   },
+  "commandNode": {
+    "heading": "Apparaatopdracht",
+    "responseLabel": "Antwoord",
+    "run": "Opdracht uitvoeren",
+    "running": "Bezig…",
+    "continue": "Doorgaan",
+    "toast": {
+      "notConnected": "Geen verbinding met sensor",
+      "error": "Opdracht mislukt"
+    }
+  },
   "measurementNode": {
     "errorState": {
       "title": "Meting mislukt",

--- a/apps/mobile/src/shared/measurements/flow-node.ts
+++ b/apps/mobile/src/shared/measurements/flow-node.ts
@@ -60,17 +60,19 @@ export interface ResolvedMacro {
   code: string;
 }
 
-export interface MeasurementContent {
-  params: Record<string, any>;
-  protocolId: string;
-  protocol?: ResolvedProtocol;
-}
-
 // An inline device command (raw string / JSON / YAML) carried on a measurement
 // node when the workbook cell is an inline command rather than a protocol ref.
 export interface InlineCommandContent {
   format: "string" | "json" | "yaml";
   content: string;
+}
+
+export interface MeasurementContent {
+  params?: Record<string, any>;
+  // A measurement node carries EITHER a protocol reference OR an inline command.
+  protocolId?: string;
+  protocol?: ResolvedProtocol;
+  command?: InlineCommandContent;
 }
 
 export interface AnalysisContent {

--- a/apps/mobile/src/shared/measurements/flow-node.ts
+++ b/apps/mobile/src/shared/measurements/flow-node.ts
@@ -66,6 +66,13 @@ export interface MeasurementContent {
   protocol?: ResolvedProtocol;
 }
 
+// An inline device command (raw string / JSON / YAML) carried on a measurement
+// node when the workbook cell is an inline command rather than a protocol ref.
+export interface InlineCommandContent {
+  format: "string" | "json" | "yaml";
+  content: string;
+}
+
 export interface AnalysisContent {
   params: Record<string, any>;
   macroId: string;

--- a/apps/web/components/flow-editor/__tests__/flow-mapper.test.ts
+++ b/apps/web/components/flow-editor/__tests__/flow-mapper.test.ts
@@ -486,6 +486,20 @@ describe("FlowMapper inline command node", () => {
     });
   });
 
+  it("falls back to stepSpecification.command when data.command is absent", () => {
+    const flow = buildApiFlow({ nodes: [commandNode] });
+    const react = FlowMapper.toReactFlow(flow);
+    const data = react.nodes[0].data as FlowNodeDataWithSpec;
+    data.command = undefined;
+    (data as { stepSpecification?: unknown }).stepSpecification = {
+      command: { format: "string", content: "battery" },
+    };
+    const api = FlowMapper.toApiGraph(react.nodes, react.edges);
+    expect(api.nodes[0].content).toEqual({
+      command: { format: "string", content: "battery" },
+    });
+  });
+
   it("errors when a command node has empty content", () => {
     const flow = buildApiFlow({ nodes: [commandNode] });
     const react = FlowMapper.toReactFlow(flow);

--- a/apps/web/components/flow-editor/__tests__/flow-mapper.test.ts
+++ b/apps/web/components/flow-editor/__tests__/flow-mapper.test.ts
@@ -446,3 +446,70 @@ describe("FlowMapper.toApiGraph validation", () => {
     );
   });
 });
+
+describe("FlowMapper inline command node", () => {
+  const commandNode = {
+    id: "cmd-1",
+    type: "measurement" as const,
+    name: "battery",
+    content: { command: { format: "string" as const, content: "battery" } },
+    isStart: true,
+  };
+
+  it("maps a command-bearing measurement node to a COMMAND React Flow node", () => {
+    const flow = buildApiFlow({ nodes: [commandNode] });
+    const { nodes } = FlowMapper.toReactFlow(flow);
+    expect(nodes[0].type).toBe("COMMAND");
+    const data = nodes[0].data as FlowNodeDataWithSpec;
+    expect(data.command).toEqual({ format: "string", content: "battery" });
+  });
+
+  it("round-trips COMMAND back to a measurement node with command content", () => {
+    const flow = buildApiFlow({ nodes: [commandNode] });
+    const react = FlowMapper.toReactFlow(flow);
+    const api = FlowMapper.toApiGraph(react.nodes, react.edges);
+    expect(api.nodes[0].type).toBe("measurement");
+    expect(api.nodes[0].content).toEqual({
+      command: { format: "string", content: "battery" },
+    });
+    expect(zUpsertFlowBody.safeParse(api).success).toBe(true);
+  });
+
+  it("prefers the edited data.command over the original stepSpecification", () => {
+    const flow = buildApiFlow({ nodes: [commandNode] });
+    const react = FlowMapper.toReactFlow(flow);
+    const data = react.nodes[0].data as FlowNodeDataWithSpec;
+    data.command = { format: "json", content: '{"cmd":"battery"}' };
+    const api = FlowMapper.toApiGraph(react.nodes, react.edges);
+    expect(api.nodes[0].content).toEqual({
+      command: { format: "json", content: '{"cmd":"battery"}' },
+    });
+  });
+
+  it("errors when a command node has empty content", () => {
+    const flow = buildApiFlow({ nodes: [commandNode] });
+    const react = FlowMapper.toReactFlow(flow);
+    const data = react.nodes[0].data as FlowNodeDataWithSpec;
+    data.command = { format: "string", content: "" };
+    expect(() => FlowMapper.toApiGraph(react.nodes, react.edges)).toThrow(
+      "Command content is required",
+    );
+  });
+
+  it("keeps plain protocol measurement nodes on the MEASUREMENT type", () => {
+    const flow = buildApiFlow({
+      nodes: [
+        {
+          id: "m1",
+          type: "measurement" as const,
+          name: "M1",
+          content: { protocolId: "550e8400-e29b-41d4-a716-446655440000", params: {} },
+          isStart: true,
+        },
+      ],
+    });
+    const { nodes } = FlowMapper.toReactFlow(flow);
+    expect(nodes[0].type).toBe("MEASUREMENT");
+    expect((nodes[0].data as FlowNodeDataWithSpec).command).toBeUndefined();
+  });
+});

--- a/apps/web/components/flow-editor/flow-mapper.ts
+++ b/apps/web/components/flow-editor/flow-mapper.ts
@@ -9,6 +9,7 @@ import {
   zQuestionContent,
   zInstructionContent,
   zMeasurementContent,
+  zMeasurementCommandContent,
   zAnalysisContent,
   zBranchContent,
 } from "@repo/api/schemas/experiment.schema";
@@ -21,6 +22,7 @@ import { nodeTypeColorMap } from "../react-flow/node-config";
 type QuestionContent = z.infer<typeof zQuestionContent>;
 type InstructionContent = z.infer<typeof zInstructionContent>;
 type MeasurementContent = z.infer<typeof zMeasurementContent>;
+type MeasurementCommandContent = z.infer<typeof zMeasurementCommandContent>;
 type AnalysisContent = z.infer<typeof zAnalysisContent>;
 type BranchContent = z.infer<typeof zBranchContent>;
 type QuestionKind = z.infer<typeof zQuestionKind>;
@@ -37,6 +39,7 @@ type StepSpecification =
   | QuestionContent
   | InstructionContent
   | MeasurementContent
+  | MeasurementCommandContent
   | AnalysisContent
   | BranchContent;
 
@@ -50,6 +53,7 @@ export interface FlowNodeDataWithSpec extends FlowNodeDataBase {
   stepSpecification?: StepSpecification | QuestionUI; // UI format for questions, API format for others
   protocolId?: string; // measurement convenience field (when not yet set in stepSpecification)
   macroId?: string; // analysis convenience field (when not yet set in stepSpecification)
+  command?: MeasurementCommandContent["command"]; // command convenience field (COMMAND nodes)
 }
 
 export interface FlowEdgeData extends Record<string, unknown> {
@@ -65,6 +69,8 @@ const REACT_FLOW_TO_API_NODE_TYPE = {
   QUESTION: "question",
   INSTRUCTION: "instruction",
   MEASUREMENT: "measurement",
+  // Inline command rides the API measurement node type (zMeasurementCommandContent).
+  COMMAND: "measurement",
   ANALYSIS: "analysis",
   BRANCH: "branch",
 } as const;
@@ -120,7 +126,11 @@ export class FlowMapper {
         branch: "BRANCH",
       };
 
-      const nodeType = reactFlowTypeMapping[apiNode.type];
+      // A measurement node carrying an inline command renders as the COMMAND
+      // node type in the editor; the wire type stays "measurement".
+      const carriesCommand =
+        apiNode.type === "measurement" && isObject(apiNode.content) && "command" in apiNode.content;
+      const nodeType = carriesCommand ? "COMMAND" : reactFlowTypeMapping[apiNode.type];
 
       const config = nodeTypeColorMap[nodeType];
 
@@ -139,11 +149,16 @@ export class FlowMapper {
       };
 
       // For measurement nodes, also set protocolId directly on the node data
-      if (apiNode.type === "measurement" && isObject(apiNode.content)) {
+      if (apiNode.type === "measurement" && !carriesCommand && isObject(apiNode.content)) {
         const measurementContent = apiNode.content as MeasurementContent;
         if (measurementContent.protocolId) {
           nodeData.protocolId = measurementContent.protocolId;
         }
+      }
+
+      // For command nodes, set the inline command directly on the node data
+      if (carriesCommand) {
+        nodeData.command = (apiNode.content as MeasurementCommandContent).command;
       }
 
       // For analysis nodes, also set macroId directly on the node data
@@ -235,6 +250,18 @@ export class FlowMapper {
           }
           content = parsed.data;
         }
+      } else if (node.type === "COMMAND") {
+        // Inline command node: wire type is "measurement" with command content.
+        const command =
+          data.command ??
+          (isObject(data.stepSpecification)
+            ? (data.stepSpecification as Partial<MeasurementCommandContent>).command
+            : undefined);
+        const parsed = zMeasurementCommandContent.safeParse({ command });
+        if (!parsed.success) {
+          throw new Error(parsed.error.errors[0].message);
+        }
+        content = parsed.data;
       } else if (nodeType === "measurement") {
         const protocolId =
           data.protocolId ??

--- a/apps/web/components/react-flow/node-config.ts
+++ b/apps/web/components/react-flow/node-config.ts
@@ -1,12 +1,13 @@
 import { Position } from "@xyflow/react";
 import type { Edge } from "@xyflow/react";
-import { BookText, GitBranch, HelpCircle, Cpu, ChartColumn } from "lucide-react";
+import { BookText, GitBranch, HelpCircle, Cpu, ChartColumn, Terminal } from "lucide-react";
 import React from "react";
 
 export const ALL_NODE_TYPES = [
   "INSTRUCTION",
   "QUESTION",
   "MEASUREMENT",
+  "COMMAND",
   "ANALYSIS",
   "BRANCH",
 ] as const;
@@ -44,6 +45,16 @@ export const nodeTypeColorMap: Record<NodeType, NodeTypeConfig> = {
   MEASUREMENT: {
     accent: "#2D3142",
     icon: React.createElement(Cpu, { size: 16, strokeWidth: 2 }),
+    hasInput: true,
+    hasOutput: true,
+    defaultSourcePosition: Position.Right,
+    defaultTargetPosition: Position.Left,
+  },
+  // An inline device command; rides the API "measurement" node type so old
+  // clients degrade gracefully (see zMeasurementCommandContent).
+  COMMAND: {
+    accent: "#119DA4",
+    icon: React.createElement(Terminal, { size: 16, strokeWidth: 2 }),
     hasInput: true,
     hasOutput: true,
     defaultSourcePosition: Position.Right,

--- a/apps/web/components/react-flow/node-content.tsx
+++ b/apps/web/components/react-flow/node-content.tsx
@@ -11,6 +11,7 @@ const TYPE_LABELS: Record<NodeType, string> = {
   INSTRUCTION: "Instruction",
   QUESTION: "Question",
   MEASUREMENT: "Protocol",
+  COMMAND: "Command",
   ANALYSIS: "Macro",
   BRANCH: "Branch",
 };

--- a/apps/web/components/react-flow/node-utils.tsx
+++ b/apps/web/components/react-flow/node-utils.tsx
@@ -11,6 +11,7 @@ import { nodeTypeColorMap } from "./node-config";
 const DEFAULT_STEP_SPECIFICATIONS = {
   QUESTION: { kind: "open_ended", text: "" },
   MEASUREMENT: { protocolId: undefined },
+  COMMAND: { command: { format: "string", content: "" } },
   ANALYSIS: { macroId: undefined },
 } as const;
 

--- a/apps/web/components/shared/code-editor.tsx
+++ b/apps/web/components/shared/code-editor.tsx
@@ -4,6 +4,7 @@ import { javascript } from "@codemirror/lang-javascript";
 import { json } from "@codemirror/lang-json";
 import { markdown } from "@codemirror/lang-markdown";
 import { python } from "@codemirror/lang-python";
+import { yaml } from "@codemirror/lang-yaml";
 import { StreamLanguage, syntaxTree } from "@codemirror/language";
 import { r } from "@codemirror/legacy-modes/mode/r";
 import { forceLinting, lintGutter, linter } from "@codemirror/lint";
@@ -13,7 +14,7 @@ import { EditorView } from "@codemirror/view";
 import CodeMirror from "@uiw/react-codemirror";
 import { useCallback, useMemo } from "react";
 
-export type CodeLanguage = "json" | "javascript" | "python" | "r" | "markdown";
+export type CodeLanguage = "json" | "javascript" | "python" | "r" | "markdown" | "yaml";
 export type { Diagnostic };
 
 export type LintSource = (doc: string) => Diagnostic[];
@@ -30,6 +31,8 @@ const getLanguageExtension = (language: CodeLanguage) => {
       return StreamLanguage.define(r);
     case "markdown":
       return markdown();
+    case "yaml":
+      return yaml();
   }
 };
 

--- a/apps/web/components/shared/code-editor.tsx
+++ b/apps/web/components/shared/code-editor.tsx
@@ -14,7 +14,7 @@ import { EditorView } from "@codemirror/view";
 import CodeMirror from "@uiw/react-codemirror";
 import { useCallback, useMemo } from "react";
 
-export type CodeLanguage = "json" | "javascript" | "python" | "r" | "markdown" | "yaml";
+export type CodeLanguage = "json" | "javascript" | "python" | "r" | "markdown" | "yaml" | "text";
 export type { Diagnostic };
 
 export type LintSource = (doc: string) => Diagnostic[];
@@ -33,6 +33,9 @@ const getLanguageExtension = (language: CodeLanguage) => {
       return markdown();
     case "yaml":
       return yaml();
+    case "text":
+      // Plain text (e.g. a free-form device command); no language extension.
+      return [];
   }
 };
 

--- a/apps/web/components/shared/command-completions.test.ts
+++ b/apps/web/components/shared/command-completions.test.ts
@@ -1,13 +1,33 @@
-import { describe, it, expect } from "vitest";
+import type * as Autocomplete from "@codemirror/autocomplete";
+import { completionStatus, startCompletion } from "@codemirror/autocomplete";
+import type { EditorView } from "@codemirror/view";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { KNOWN_DEVICE_COMMANDS } from "@repo/api/schemas/device-command.schema";
 
 import {
   buildCommandTooltipDom,
   commandCompletionSource,
+  commandHoverSource,
   knownCommandAt,
+  openCompletionsOnFocus,
   wordAt,
 } from "./command-completions";
+
+vi.mock("@codemirror/autocomplete", async (importOriginal) => {
+  const actual = await importOriginal<typeof Autocomplete>();
+  return {
+    ...actual,
+    completionStatus: vi.fn((): "active" | "pending" | null => null),
+    startCompletion: vi.fn(),
+  };
+});
+
+// A CodeMirror view is heavy to stand up in jsdom; these callbacks only touch
+// the doc text / focus flags, so a structural stub is enough to exercise them.
+function fakeView(doc: string, hasFocus = true): EditorView {
+  return { hasFocus, state: { doc: { toString: () => doc } } } as unknown as EditorView;
+}
 
 interface FakeContext {
   matchBefore: (re: RegExp) => { from: number; to: number; text: string } | null;
@@ -95,5 +115,65 @@ describe("buildCommandTooltipDom", () => {
     const dom = buildCommandTooltipDom({ value: "memory", label: "Memory", group: "Device info" });
     expect(dom.textContent).toBe("memory · Device info");
     expect(dom.children).toHaveLength(1);
+  });
+});
+
+describe("commandHoverSource", () => {
+  it("anchors a tooltip to a known command and builds its description DOM", () => {
+    const tip = commandHoverSource(fakeView("battery"), 2);
+    expect(tip).not.toBeNull();
+    expect(tip?.pos).toBe(0);
+    expect(tip?.end).toBe(7);
+    expect(tip?.above).toBe(true);
+    const dom = tip?.create(fakeView("battery")).dom;
+    expect(dom?.textContent).toContain("battery · Connection");
+  });
+
+  it("returns null when the cursor is not over a known command", () => {
+    expect(commandHoverSource(fakeView("set_led_delay+1"), 2)).toBeNull();
+    expect(commandHoverSource(fakeView(""), 0)).toBeNull();
+  });
+});
+
+describe("openCompletionsOnFocus", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("never opens the completion list when read-only", () => {
+    const handler = openCompletionsOnFocus(true);
+    const view = fakeView("battery");
+    expect(handler(new FocusEvent("focus"), view)).toBe(false);
+    vi.runAllTimers();
+    expect(startCompletion).not.toHaveBeenCalled();
+  });
+
+  it("opens the completion list a tick after focus when idle and still focused", () => {
+    const handler = openCompletionsOnFocus(false);
+    const view = fakeView("battery");
+    expect(handler(new FocusEvent("focus"), view)).toBe(false);
+    // Deferred: not opened synchronously.
+    expect(startCompletion).not.toHaveBeenCalled();
+    vi.runAllTimers();
+    expect(startCompletion).toHaveBeenCalledWith(view);
+  });
+
+  it("does not reopen when a completion is already active", () => {
+    vi.mocked(completionStatus).mockReturnValueOnce("active");
+    const handler = openCompletionsOnFocus(false);
+    handler(new FocusEvent("focus"), fakeView("battery"));
+    vi.runAllTimers();
+    expect(startCompletion).not.toHaveBeenCalled();
+  });
+
+  it("does not open when focus was lost before the tick", () => {
+    const handler = openCompletionsOnFocus(false);
+    handler(new FocusEvent("focus"), fakeView("battery", false));
+    vi.runAllTimers();
+    expect(startCompletion).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/components/shared/command-completions.test.ts
+++ b/apps/web/components/shared/command-completions.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+
+import { KNOWN_DEVICE_COMMANDS } from "@repo/api/schemas/device-command.schema";
+
+import {
+  buildCommandTooltipDom,
+  commandCompletionSource,
+  knownCommandAt,
+  wordAt,
+} from "./command-completions";
+
+interface FakeContext {
+  matchBefore: (re: RegExp) => { from: number; to: number; text: string } | null;
+  explicit: boolean;
+}
+
+function context(
+  match: { from: number; to: number; text: string } | null,
+  explicit = false,
+): FakeContext {
+  return { matchBefore: () => match, explicit };
+}
+
+describe("wordAt", () => {
+  it("returns the contiguous non-whitespace word under the position", () => {
+    expect(wordAt("battery", 3)).toEqual({ from: 0, to: 7, text: "battery" });
+  });
+
+  it("finds the word when the cursor sits between multiple tokens", () => {
+    // "get flow"; cursor inside "flow"
+    expect(wordAt("get flow", 6)).toEqual({ from: 4, to: 8, text: "flow" });
+  });
+
+  it("returns null on whitespace / empty doc", () => {
+    expect(wordAt("", 0)).toBeNull();
+    expect(wordAt("a  b", 2)).toBeNull(); // flanked by spaces
+  });
+});
+
+describe("commandCompletionSource", () => {
+  it("returns all known commands as options when a word is being typed", () => {
+    const result = commandCompletionSource(context({ from: 0, to: 3, text: "bat" }) as never);
+    expect(result).not.toBeNull();
+    expect(result?.from).toBe(0);
+    expect(result?.options).toHaveLength(KNOWN_DEVICE_COMMANDS.length);
+    const battery = result?.options.find((o) => o.label === "battery");
+    expect(battery?.detail).toBe("Connection");
+    expect(battery?.info).toBe("Charge level in percent");
+  });
+
+  it("returns null on empty input unless explicitly requested", () => {
+    expect(commandCompletionSource(context({ from: 2, to: 2, text: "" }) as never)).toBeNull();
+  });
+
+  it("returns options on empty input when explicit (Ctrl-Space)", () => {
+    const result = commandCompletionSource(context({ from: 2, to: 2, text: "" }, true) as never);
+    expect(result?.options).toHaveLength(KNOWN_DEVICE_COMMANDS.length);
+  });
+
+  it("returns null when there is no match before the cursor", () => {
+    expect(commandCompletionSource(context(null) as never)).toBeNull();
+  });
+});
+
+describe("knownCommandAt", () => {
+  it("resolves a known command under the cursor", () => {
+    const hit = knownCommandAt("battery", 2);
+    expect(hit?.option.value).toBe("battery");
+    expect(hit?.from).toBe(0);
+    expect(hit?.to).toBe(7);
+  });
+
+  it("returns null for an unknown / custom command", () => {
+    expect(knownCommandAt("set_led_delay+1", 2)).toBeNull();
+  });
+
+  it("returns null when the cursor is not on a word", () => {
+    expect(knownCommandAt("", 0)).toBeNull();
+  });
+});
+
+describe("buildCommandTooltipDom", () => {
+  it("renders the command, group and description", () => {
+    const dom = buildCommandTooltipDom({
+      value: "battery",
+      label: "Battery",
+      group: "Connection",
+      description: "Charge level in percent",
+    });
+    expect(dom.textContent).toContain("battery · Connection");
+    expect(dom.textContent).toContain("Charge level in percent");
+  });
+
+  it("omits the description block when there is none", () => {
+    const dom = buildCommandTooltipDom({ value: "memory", label: "Memory", group: "Device info" });
+    expect(dom.textContent).toBe("memory · Device info");
+    expect(dom.children).toHaveLength(1);
+  });
+});

--- a/apps/web/components/shared/command-completions.ts
+++ b/apps/web/components/shared/command-completions.ts
@@ -2,12 +2,21 @@ import type { Completion, CompletionContext, CompletionResult } from "@codemirro
 import { autocompletion, completionStatus, startCompletion } from "@codemirror/autocomplete";
 import type { Extension } from "@codemirror/state";
 import { EditorState } from "@codemirror/state";
+import type { Tooltip } from "@codemirror/view";
 import { EditorView, hoverTooltip, placeholder as placeholderExt } from "@codemirror/view";
 
 import type { DeviceCommandOption } from "@repo/api/schemas/device-command.schema";
 import { KNOWN_DEVICE_COMMANDS } from "@repo/api/schemas/device-command.schema";
 
 const COMMANDS: readonly DeviceCommandOption[] = KNOWN_DEVICE_COMMANDS;
+
+// Built once: the completion source runs on nearly every keystroke.
+const COMPLETION_OPTIONS: Completion[] = COMMANDS.map((c) => ({
+  label: c.value,
+  detail: c.group,
+  info: c.description,
+  type: "keyword",
+}));
 
 /** Word under `pos` (a contiguous run of non-whitespace), or null. */
 export function wordAt(
@@ -29,14 +38,7 @@ export function commandCompletionSource(context: CompletionContext): CompletionR
   // Only auto-open once the user types, but allow explicit (Ctrl-Space) on empty.
   if (word.from === word.to && !context.explicit) return null;
 
-  const options: Completion[] = COMMANDS.map((c) => ({
-    label: c.value,
-    detail: c.group,
-    info: c.description,
-    type: "keyword",
-  }));
-
-  return { from: word.from, options, validFor: /^\S*$/ };
+  return { from: word.from, options: COMPLETION_OPTIONS, validFor: /^\S*$/ };
 }
 
 /** Known command under `pos`, or null when none / unknown. */
@@ -68,8 +70,8 @@ export function buildCommandTooltipDom(option: DeviceCommandOption): HTMLElement
   return dom;
 }
 
-/** Hover tooltip showing the description of a known command under the cursor. */
-const commandHover = hoverTooltip((view, pos) => {
+/** Hover-tooltip source: the description of a known command under the cursor. */
+export function commandHoverSource(view: EditorView, pos: number): Tooltip | null {
   const hit = knownCommandAt(view.state.doc.toString(), pos);
   if (!hit) return null;
   return {
@@ -78,7 +80,10 @@ const commandHover = hoverTooltip((view, pos) => {
     above: true,
     create: () => ({ dom: buildCommandTooltipDom(hit.option) }),
   };
-});
+}
+
+/** Hover tooltip showing the description of a known command under the cursor. */
+const commandHover = hoverTooltip(commandHoverSource);
 
 // Keep the command on a single line; strip any newline-introducing transaction.
 const singleLineFilter = EditorState.transactionFilter.of((tr) => (tr.newDoc.lines > 1 ? [] : tr));
@@ -110,6 +115,22 @@ interface CommandExtensionOptions {
 }
 
 /**
+ * Focus handler that opens the completion list once the editor is focused.
+ * Deferred past the focus/click tick so the view is actually focused; otherwise
+ * the list only appears on a second focus (tab away + back). Always returns
+ * false so the event keeps propagating.
+ */
+export function openCompletionsOnFocus(readOnly: boolean) {
+  return (_event: FocusEvent, view: EditorView): boolean => {
+    if (readOnly) return false;
+    setTimeout(() => {
+      if (view.hasFocus && completionStatus(view.state) === null) startCompletion(view);
+    }, 0);
+    return false;
+  };
+}
+
+/**
  * CodeMirror extensions that turn a plain editor into a known-command input:
  * autocomplete + hover hints sourced from {@link KNOWN_DEVICE_COMMANDS}. Suggestions
  * only; any string can still be typed. Fold these into an existing editor instead
@@ -129,18 +150,7 @@ export function buildCommandExtensions({
       activateOnTyping: true,
     }),
     commandHover,
-    // Open the completion list when the field is focused. Defer past the
-    // focus/click tick so the view is actually focused; otherwise the list
-    // only appears on a second focus (tab away + back).
-    EditorView.domEventHandlers({
-      focus: (_event, view) => {
-        if (readOnly) return false;
-        setTimeout(() => {
-          if (view.hasFocus && completionStatus(view.state) === null) startCompletion(view);
-        }, 0);
-        return false;
-      },
-    }),
+    EditorView.domEventHandlers({ focus: openCompletionsOnFocus(readOnly) }),
     ...(placeholder ? [placeholderExt(placeholder)] : []),
   ];
 }

--- a/apps/web/components/shared/command-completions.ts
+++ b/apps/web/components/shared/command-completions.ts
@@ -1,0 +1,146 @@
+import type { Completion, CompletionContext, CompletionResult } from "@codemirror/autocomplete";
+import { autocompletion, completionStatus, startCompletion } from "@codemirror/autocomplete";
+import type { Extension } from "@codemirror/state";
+import { EditorState } from "@codemirror/state";
+import { EditorView, hoverTooltip, placeholder as placeholderExt } from "@codemirror/view";
+
+import type { DeviceCommandOption } from "@repo/api/schemas/device-command.schema";
+import { KNOWN_DEVICE_COMMANDS } from "@repo/api/schemas/device-command.schema";
+
+const COMMANDS: readonly DeviceCommandOption[] = KNOWN_DEVICE_COMMANDS;
+
+/** Word under `pos` (a contiguous run of non-whitespace), or null. */
+export function wordAt(
+  doc: string,
+  pos: number,
+): { from: number; to: number; text: string } | null {
+  let from = pos;
+  let to = pos;
+  while (from > 0 && /\S/.test(doc[from - 1])) from--;
+  while (to < doc.length && /\S/.test(doc[to])) to++;
+  if (from === to) return null;
+  return { from, to, text: doc.slice(from, to) };
+}
+
+/** Completion source offering the known device commands with their descriptions. */
+export function commandCompletionSource(context: CompletionContext): CompletionResult | null {
+  const word = context.matchBefore(/\S*/);
+  if (!word) return null;
+  // Only auto-open once the user types, but allow explicit (Ctrl-Space) on empty.
+  if (word.from === word.to && !context.explicit) return null;
+
+  const options: Completion[] = COMMANDS.map((c) => ({
+    label: c.value,
+    detail: c.group,
+    info: c.description,
+    type: "keyword",
+  }));
+
+  return { from: word.from, options, validFor: /^\S*$/ };
+}
+
+/** Known command under `pos`, or null when none / unknown. */
+export function knownCommandAt(
+  doc: string,
+  pos: number,
+): { option: DeviceCommandOption; from: number; to: number } | null {
+  const word = wordAt(doc, pos);
+  if (!word) return null;
+  const option = COMMANDS.find((c) => c.value === word.text);
+  if (!option) return null;
+  return { option, from: word.from, to: word.to };
+}
+
+/** Build the hover-tooltip DOM (command · group + description) for a command. */
+export function buildCommandTooltipDom(option: DeviceCommandOption): HTMLElement {
+  const dom = document.createElement("div");
+  dom.className = "px-2 py-1 text-xs";
+  const title = document.createElement("div");
+  title.className = "font-mono font-medium";
+  title.textContent = `${option.value} · ${option.group}`;
+  dom.appendChild(title);
+  if (option.description) {
+    const desc = document.createElement("div");
+    desc.className = "text-muted-foreground mt-0.5";
+    desc.textContent = option.description;
+    dom.appendChild(desc);
+  }
+  return dom;
+}
+
+/** Hover tooltip showing the description of a known command under the cursor. */
+const commandHover = hoverTooltip((view, pos) => {
+  const hit = knownCommandAt(view.state.doc.toString(), pos);
+  if (!hit) return null;
+  return {
+    pos: hit.from,
+    end: hit.to,
+    above: true,
+    create: () => ({ dom: buildCommandTooltipDom(hit.option) }),
+  };
+});
+
+// Keep the command on a single line; strip any newline-introducing transaction.
+const singleLineFilter = EditorState.transactionFilter.of((tr) => (tr.newDoc.lines > 1 ? [] : tr));
+
+// Autocomplete popup: command grows so the group label is pushed to the right edge.
+const completionPopupTheme = EditorView.theme({
+  ".cm-tooltip-autocomplete": { minWidth: "340px" },
+  ".cm-tooltip-autocomplete > ul": { minWidth: "340px", maxHeight: "18rem" },
+  ".cm-tooltip-autocomplete > ul > li": {
+    display: "flex",
+    alignItems: "center",
+    padding: "3px 10px",
+  },
+  ".cm-completionLabel": { flex: "1 1 auto" },
+  ".cm-completionDetail": {
+    flex: "0 0 auto",
+    marginLeft: "auto",
+    paddingLeft: "1.5rem",
+    fontStyle: "italic",
+    opacity: "0.6",
+  },
+});
+
+interface CommandExtensionOptions {
+  /** Constrain the document to a single line (for the free-text `string` format). */
+  singleLine?: boolean;
+  placeholder?: string;
+  readOnly?: boolean;
+}
+
+/**
+ * CodeMirror extensions that turn a plain editor into a known-command input:
+ * autocomplete + hover hints sourced from {@link KNOWN_DEVICE_COMMANDS}. Suggestions
+ * only; any string can still be typed. Fold these into an existing editor instead
+ * of maintaining a separate command-editor component.
+ */
+export function buildCommandExtensions({
+  singleLine = false,
+  placeholder,
+  readOnly = false,
+}: CommandExtensionOptions = {}): Extension[] {
+  return [
+    ...(singleLine ? [singleLineFilter] : []),
+    completionPopupTheme,
+    autocompletion({
+      override: [commandCompletionSource],
+      icons: false,
+      activateOnTyping: true,
+    }),
+    commandHover,
+    // Open the completion list when the field is focused. Defer past the
+    // focus/click tick so the view is actually focused; otherwise the list
+    // only appears on a second focus (tab away + back).
+    EditorView.domEventHandlers({
+      focus: (_event, view) => {
+        if (readOnly) return false;
+        setTimeout(() => {
+          if (view.hasFocus && completionStatus(view.state) === null) startCompletion(view);
+        }, 0);
+        return false;
+      },
+    }),
+    ...(placeholder ? [placeholderExt(placeholder)] : []),
+  ];
+}

--- a/apps/web/components/side-panel-flow/__tests__/command-panel.test.tsx
+++ b/apps/web/components/side-panel-flow/__tests__/command-panel.test.tsx
@@ -30,6 +30,17 @@ describe("CommandPanel", () => {
     expect(screen.getByText(/.+/, { selector: "p.text-red-500" })).toBeInTheDocument();
   });
 
+  it("changes the command format via the selector, preserving content", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<CommandPanel command={{ format: "string", content: "battery" }} onChange={onChange} />);
+
+    await user.click(screen.getByRole("combobox", { name: "Command format" }));
+    await user.click(await screen.findByRole("option", { name: "JSON" }));
+
+    expect(onChange).toHaveBeenCalledWith({ format: "json", content: "battery" });
+  });
+
   it("hides the format selector when disabled", () => {
     render(
       <CommandPanel

--- a/apps/web/components/side-panel-flow/__tests__/command-panel.test.tsx
+++ b/apps/web/components/side-panel-flow/__tests__/command-panel.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, userEvent } from "@/test/test-utils";
+import { describe, it, expect, vi } from "vitest";
+
+import type { InlineCommandValue } from "../command-panel";
+import { CommandPanel } from "../command-panel";
+
+describe("CommandPanel", () => {
+  it("renders the command content in an editable field", () => {
+    render(<CommandPanel command={{ format: "string", content: "battery" }} onChange={vi.fn()} />);
+    expect(screen.getByRole("textbox")).toHaveValue("battery");
+  });
+
+  it("calls onChange with the edited content", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<CommandPanel command={{ format: "string", content: "" }} onChange={onChange} />);
+    await user.type(screen.getByRole("textbox"), "h");
+    expect(onChange).toHaveBeenCalled();
+    const updated = onChange.mock.lastCall?.[0] as InlineCommandValue;
+    expect(updated).toMatchObject({ format: "string", content: "h" });
+  });
+
+  it("defaults to an empty string command when no value is set yet", () => {
+    render(<CommandPanel onChange={vi.fn()} />);
+    expect(screen.getByRole("textbox")).toHaveValue("");
+  });
+
+  it("shows a validation error for malformed JSON content", () => {
+    render(<CommandPanel command={{ format: "json", content: "{not json" }} onChange={vi.fn()} />);
+    expect(screen.getByText(/.+/, { selector: "p.text-red-500" })).toBeInTheDocument();
+  });
+
+  it("hides the format selector when disabled", () => {
+    render(
+      <CommandPanel
+        command={{ format: "yaml", content: "cmd: battery" }}
+        onChange={vi.fn()}
+        disabled
+      />,
+    );
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.getByText("YAML")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/side-panel-flow/__tests__/side-panel-flow.test.tsx
+++ b/apps/web/components/side-panel-flow/__tests__/side-panel-flow.test.tsx
@@ -85,6 +85,30 @@ vi.mock("../measurement-panel", () => ({
   ),
 }));
 
+vi.mock("../command-panel", () => ({
+  CommandPanel: ({
+    command,
+    onChange,
+    disabled,
+  }: {
+    command?: { format: string; content: string };
+    onChange: (c: { format: string; content: string }) => void;
+    disabled?: boolean;
+  }) => (
+    <div>
+      <span>CommandPanel</span>
+      <div data-testid="cp-command">{JSON.stringify(command)}</div>
+      <button
+        type="button"
+        onClick={() => onChange({ format: "json", content: '{"cmd":"battery"}' })}
+        disabled={disabled}
+      >
+        Apply Command Change
+      </button>
+    </div>
+  ),
+}));
+
 vi.mock("../analysis-panel", () => ({
   AnalysisPanel: ({
     selectedMacroId,
@@ -370,6 +394,27 @@ describe("<ExperimentSidePanel />", () => {
     expect(props.onNodeDataChange).toHaveBeenCalledWith("na", {
       ...node.data,
       macroId: "macro-updated",
+    });
+  });
+
+  it("CommandPanel: passes the command and propagates onChange via onNodeDataChange", async () => {
+    const user = userEvent.setup();
+    const node = makeNode("nc", { command: { format: "string", content: "battery" } });
+
+    const { props } = renderPanel({
+      selectedNode: node,
+      nodeType: "COMMAND",
+    });
+
+    expect(screen.queryByText("CommandPanel")).toBeTruthy();
+    expect(screen.getByTestId("cp-command").textContent).toBe(
+      JSON.stringify({ format: "string", content: "battery" }),
+    );
+
+    await user.click(screen.getByRole("button", { name: /Apply Command Change/i }));
+    expect(props.onNodeDataChange).toHaveBeenCalledWith("nc", {
+      ...node.data,
+      command: { format: "json", content: '{"cmd":"battery"}' },
     });
   });
 

--- a/apps/web/components/side-panel-flow/command-panel.tsx
+++ b/apps/web/components/side-panel-flow/command-panel.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useMemo } from "react";
+
+import type { CommandFormat } from "@repo/api/schemas/experiment.schema";
+import { validateInlineCommand } from "@repo/api/utils/command-payload";
+import { useTranslation } from "@repo/i18n";
+import { Card, CardHeader, CardTitle, CardContent } from "@repo/ui/components/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui/components/select";
+
+import { buildCommandExtensions } from "../shared/command-completions";
+import { WorkbookCodeEditor } from "../workbook/workbook-code-editor";
+import type { EditorLanguage } from "../workbook/workbook-code-editor";
+
+const FORMAT_LABELS: Record<CommandFormat, string> = {
+  string: "String",
+  json: "JSON",
+  yaml: "YAML",
+};
+
+const FORMAT_LANGUAGE: Record<CommandFormat, EditorLanguage> = {
+  string: "text",
+  json: "json",
+  yaml: "yaml",
+};
+
+export interface InlineCommandValue {
+  format: CommandFormat;
+  content: string;
+}
+
+interface CommandPanelProps {
+  command?: InlineCommandValue;
+  onChange: (command: InlineCommandValue) => void;
+  disabled?: boolean;
+}
+
+export function CommandPanel({ command, onChange, disabled = false }: CommandPanelProps) {
+  const { t } = useTranslation("common");
+  const format = command?.format ?? "string";
+  const content = command?.content ?? "";
+
+  const validation = useMemo(() => validateInlineCommand({ format, content }), [format, content]);
+
+  // Known-command autocomplete + hover hints only apply to the free-text `string`
+  // format; json/yaml payloads are structured, not a single command word.
+  const commandExtensions = useMemo(
+    () =>
+      format === "string"
+        ? buildCommandExtensions({
+            singleLine: true,
+            placeholder: t("experiments.commandPanelPlaceholder"),
+            readOnly: disabled,
+          })
+        : undefined,
+    [format, disabled, t],
+  );
+
+  const commandBasicSetup = useMemo(
+    () =>
+      format === "string"
+        ? {
+            lineNumbers: false,
+            foldGutter: false,
+            highlightActiveLine: false,
+            highlightActiveLineGutter: false,
+          }
+        : undefined,
+    [format],
+  );
+
+  return (
+    <Card className="mb-6">
+      <CardHeader className="flex-row items-center justify-between space-y-0">
+        <CardTitle className="text-jii-dark-green">{t("experiments.commandPanelTitle")}</CardTitle>
+        {!disabled ? (
+          <Select
+            value={format}
+            onValueChange={(v) => onChange({ format: v as CommandFormat, content })}
+          >
+            <SelectTrigger className="h-7 w-[90px] text-xs" aria-label="Command format">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {(["string", "json", "yaml"] as const).map((f) => (
+                <SelectItem key={f} value={f} className="text-xs">
+                  {FORMAT_LABELS[f]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          <span className="text-xs uppercase text-[#68737B]">{FORMAT_LABELS[format]}</span>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <WorkbookCodeEditor
+          value={content}
+          onChange={disabled ? undefined : (v) => onChange({ format, content: v })}
+          language={FORMAT_LANGUAGE[format]}
+          minHeight={format === "string" ? "44px" : "120px"}
+          maxHeight="400px"
+          readOnly={disabled}
+          extraExtensions={commandExtensions}
+          basicSetup={commandBasicSetup}
+        />
+        {!validation.ok ? <p className="text-xs text-red-500">{validation.error}</p> : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/side-panel-flow/side-panel-flow.tsx
+++ b/apps/web/components/side-panel-flow/side-panel-flow.tsx
@@ -12,6 +12,8 @@ import {
 } from "@repo/ui/components/tooltip";
 
 import { AnalysisPanel } from "./analysis-panel";
+import type { InlineCommandValue } from "./command-panel";
+import { CommandPanel } from "./command-panel";
 import { EdgeSidePanel } from "./edge-panel";
 import { InstructionPanel } from "./instruction-panel";
 import { MeasurementPanel } from "./measurement-panel";
@@ -328,6 +330,21 @@ export function ExperimentSidePanel({
                   onNodeDataChange(selectedNode.id, {
                     ...selectedNode.data,
                     protocolId,
+                  });
+                }
+              }}
+              disabled={isDisabled}
+            />
+          )}
+          {/* CommandPanel for inline-command node */}
+          {displayNodeType === "COMMAND" && selectedNode && (
+            <CommandPanel
+              command={selectedNode.data.command as InlineCommandValue | undefined}
+              onChange={(command) => {
+                if (onNodeDataChange) {
+                  onNodeDataChange(selectedNode.id, {
+                    ...selectedNode.data,
+                    command,
                   });
                 }
               }}

--- a/apps/web/components/workbook/add-cell-button.tsx
+++ b/apps/web/components/workbook/add-cell-button.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { BookOpen, Code, FileText, GitBranch, HelpCircle, Microscope, Terminal } from "lucide-react";
+import {
+  BookOpen,
+  Code,
+  FileText,
+  GitBranch,
+  HelpCircle,
+  Microscope,
+  Terminal,
+} from "lucide-react";
 
 import type { WorkbookCell } from "@repo/api/schemas/workbook-cells.schema";
 import { Button } from "@repo/ui/components/button";

--- a/apps/web/components/workbook/add-cell-button.tsx
+++ b/apps/web/components/workbook/add-cell-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BookOpen, Code, FileText, GitBranch, HelpCircle, Microscope } from "lucide-react";
+import { BookOpen, Code, FileText, GitBranch, HelpCircle, Microscope, Terminal } from "lucide-react";
 
 import type { WorkbookCell } from "@repo/api/schemas/workbook-cells.schema";
 import { Button } from "@repo/ui/components/button";
@@ -38,6 +38,7 @@ const cellOptions: {
   { type: "markdown", label: "Markdown", icon: FileText, color: "#6F8596" },
   { type: "protocol", label: "Protocol", icon: Microscope, color: "#2D3142" },
   { type: "macro", label: "Macro", icon: Code, color: "#6C5CE7" },
+  { type: "command", label: "Command", icon: Terminal, color: "#119DA4" },
   { type: "question", label: "Question", icon: HelpCircle, color: "#C58AAE" },
   { type: "branch", label: "Branch", icon: GitBranch, color: "#F29D38" },
 ];

--- a/apps/web/components/workbook/cell-renderer.test.tsx
+++ b/apps/web/components/workbook/cell-renderer.test.tsx
@@ -5,6 +5,7 @@ import {
   createQuestionCell,
   createOutputCell,
   createBranchCell,
+  createCommandCell,
   createProtocol,
   createMacro,
 } from "@/test/factories";
@@ -57,6 +58,12 @@ describe("CellRenderer", () => {
     render(<CellRenderer cell={cell} onUpdate={noop} onDelete={noop} />);
 
     await waitFor(() => expect(screen.getByText("Chlorophyll Calc")).toBeInTheDocument());
+  });
+
+  it("renders command cell with its content", () => {
+    const cell = createCommandCell({ payload: { format: "string", content: "battery" } });
+    render(<CellRenderer cell={cell} onUpdate={noop} onDelete={noop} />);
+    expect(screen.getByTestId("code-editor")).toHaveTextContent("battery");
   });
 
   it("renders question cell with question text", () => {

--- a/apps/web/components/workbook/cell-renderer.tsx
+++ b/apps/web/components/workbook/cell-renderer.tsx
@@ -4,6 +4,7 @@ import type { WorkbookCell } from "@repo/api/schemas/workbook-cells.schema";
 import type { EntitySnapshots } from "@repo/api/schemas/workbook-version.schema";
 
 import { BranchCellComponent } from "./cells/branch-cell";
+import { CommandCellComponent } from "./cells/command-cell";
 import { MacroCellComponent } from "./cells/macro-cell";
 import { MarkdownCellComponent } from "./cells/markdown-cell";
 import { OutputCellComponent } from "./cells/output-cell";
@@ -62,6 +63,18 @@ export function CellRenderer({
           executionError={executionError}
           readOnly={readOnly}
           snapshot={entitySnapshots?.protocols[cell.payload.protocolId]}
+        />
+      );
+    case "command":
+      return (
+        <CommandCellComponent
+          cell={cell}
+          onUpdate={onUpdate}
+          onDelete={onDelete}
+          onRun={onRun}
+          executionStatus={executionStatus}
+          executionError={executionError}
+          readOnly={readOnly}
         />
       );
     case "macro":

--- a/apps/web/components/workbook/cells/branch-cell.test.tsx
+++ b/apps/web/components/workbook/cells/branch-cell.test.tsx
@@ -38,6 +38,13 @@ const protocolCell: WorkbookCell = {
   isCollapsed: false,
 };
 
+const commandCell: WorkbookCell = {
+  id: "cmd-1",
+  type: "command",
+  payload: { format: "string", content: "battery" },
+  isCollapsed: false,
+};
+
 function renderBranch(
   overrides: Partial<BranchCell> = {},
   props: Partial<React.ComponentProps<typeof BranchCellComponent>> = {},
@@ -109,6 +116,25 @@ describe("BranchCellComponent", () => {
 
     const updated = onUpdate.mock.calls[0][0] as BranchCell;
     expect(updated.paths[0].conditions).toHaveLength(2);
+  });
+
+  it("labels a command cell in the source-cell dropdown", async () => {
+    const user = userEvent.setup();
+    const cell = makeBranchCell();
+    render(
+      <BranchCellComponent
+        cell={cell}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+        allCells={[cell, commandCell]}
+      />,
+    );
+
+    // The condition row renders the source-cell select first.
+    const [sourceTrigger] = screen.getAllByRole("combobox");
+    await user.click(sourceTrigger);
+
+    expect(await screen.findByText("Command (battery)")).toBeInTheDocument();
   });
 
   it("renders the condition's IF / AND labels correctly for multiple conditions", () => {

--- a/apps/web/components/workbook/cells/branch-cell.tsx
+++ b/apps/web/components/workbook/cells/branch-cell.tsx
@@ -77,7 +77,10 @@ export function BranchCellComponent({
       (allCells ?? []).filter(
         (c) =>
           c.id !== cell.id &&
-          (c.type === "protocol" || c.type === "macro" || c.type === "question"),
+          (c.type === "protocol" ||
+            c.type === "command" ||
+            c.type === "macro" ||
+            c.type === "question"),
       ),
     [allCells, cell.id],
   );
@@ -120,6 +123,8 @@ export function BranchCellComponent({
       switch (c.type) {
         case "protocol":
           return `Protocol (${c.payload.name ?? c.payload.protocolId.slice(0, 8)})`;
+        case "command":
+          return `Command (${c.payload.name ?? c.payload.content.slice(0, 12)})`;
         case "macro":
           return `Macro (${c.payload.name ?? c.payload.macroId.slice(0, 8)})`;
         case "question":

--- a/apps/web/components/workbook/cells/branch-cell.tsx
+++ b/apps/web/components/workbook/cells/branch-cell.tsx
@@ -123,8 +123,10 @@ export function BranchCellComponent({
       switch (c.type) {
         case "protocol":
           return `Protocol (${c.payload.name ?? c.payload.protocolId.slice(0, 8)})`;
-        case "command":
-          return `Command (${c.payload.name ?? c.payload.content.slice(0, 12)})`;
+        case "command": {
+          const source = c.payload.name?.trim() ? c.payload.name : c.payload.content.slice(0, 12);
+          return `Command (${source.length > 0 ? source : "Empty"})`;
+        }
         case "macro":
           return `Macro (${c.payload.name ?? c.payload.macroId.slice(0, 8)})`;
         case "question":

--- a/apps/web/components/workbook/cells/command-cell.test.tsx
+++ b/apps/web/components/workbook/cells/command-cell.test.tsx
@@ -47,6 +47,40 @@ describe("CommandCellComponent", () => {
     expect(screen.getByText(/.+/, { selector: "p.text-red-500" })).toBeInTheDocument();
   });
 
+  it("toggles collapse through the cell wrapper", async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn();
+    render(<CommandCellComponent cell={inlineCell()} onUpdate={onUpdate} onDelete={vi.fn()} />);
+
+    const collapseBtn = document.querySelector("svg.lucide-chevron-down")?.closest("button");
+    if (!collapseBtn) throw new Error("collapse toggle not found");
+    await user.click(collapseBtn);
+
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "cmd-1", isCollapsed: true }),
+    );
+  });
+
+  it("copies the command content to the clipboard", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+
+    render(
+      <CommandCellComponent
+        cell={inlineCell({ content: "battery" })}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    const copyBtn = document.querySelector("svg.lucide-copy")?.closest("button");
+    if (!copyBtn) throw new Error("copy button not found");
+    await user.click(copyBtn);
+
+    expect(writeText).toHaveBeenCalledWith("battery");
+  });
+
   it("hides the format selector in read-only mode", () => {
     const { rerender } = render(
       <CommandCellComponent cell={inlineCell()} onUpdate={vi.fn()} onDelete={vi.fn()} />,

--- a/apps/web/components/workbook/cells/command-cell.test.tsx
+++ b/apps/web/components/workbook/cells/command-cell.test.tsx
@@ -11,7 +11,7 @@ function inlineCell(overrides: Partial<CommandCell["payload"]> = {}): CommandCel
     type: "command",
     isCollapsed: false,
     payload: { format: "string", content: "battery", ...overrides },
-  } as CommandCell;
+  };
 }
 
 describe("CommandCellComponent", () => {

--- a/apps/web/components/workbook/cells/command-cell.test.tsx
+++ b/apps/web/components/workbook/cells/command-cell.test.tsx
@@ -17,7 +17,7 @@ function inlineCell(overrides: Partial<CommandCell["payload"]> = {}): CommandCel
 describe("CommandCellComponent", () => {
   it("renders the command content in an editable field", () => {
     render(<CommandCellComponent cell={inlineCell()} onUpdate={vi.fn()} onDelete={vi.fn()} />);
-    expect(screen.getByLabelText("Device command")).toHaveValue("battery");
+    expect(screen.getByRole("textbox")).toHaveValue("battery");
   });
 
   it("calls onUpdate when the command text changes", async () => {
@@ -30,7 +30,7 @@ describe("CommandCellComponent", () => {
         onDelete={vi.fn()}
       />,
     );
-    await user.type(screen.getByLabelText("Device command"), "h");
+    await user.type(screen.getByRole("textbox"), "h");
     expect(onUpdate).toHaveBeenCalled();
     const updated = onUpdate.mock.lastCall?.[0] as CommandCell;
     expect(updated.payload).toMatchObject({ content: "h" });

--- a/apps/web/components/workbook/cells/command-cell.test.tsx
+++ b/apps/web/components/workbook/cells/command-cell.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, userEvent } from "@/test/test-utils";
+import { describe, it, expect, vi } from "vitest";
+
+import type { CommandCell } from "@repo/api/schemas/workbook-cells.schema";
+
+import { CommandCellComponent } from "./command-cell";
+
+function inlineCell(overrides: Partial<CommandCell["payload"]> = {}): CommandCell {
+  return {
+    id: "cmd-1",
+    type: "command",
+    isCollapsed: false,
+    payload: { format: "string", content: "battery", ...overrides },
+  } as CommandCell;
+}
+
+describe("CommandCellComponent", () => {
+  it("renders the command content in an editable field", () => {
+    render(<CommandCellComponent cell={inlineCell()} onUpdate={vi.fn()} onDelete={vi.fn()} />);
+    expect(screen.getByLabelText("Device command")).toHaveValue("battery");
+  });
+
+  it("calls onUpdate when the command text changes", async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn();
+    render(
+      <CommandCellComponent
+        cell={inlineCell({ content: "" })}
+        onUpdate={onUpdate}
+        onDelete={vi.fn()}
+      />,
+    );
+    await user.type(screen.getByLabelText("Device command"), "h");
+    expect(onUpdate).toHaveBeenCalled();
+    const updated = onUpdate.mock.lastCall?.[0] as CommandCell;
+    expect(updated.payload).toMatchObject({ content: "h" });
+  });
+
+  it("shows a validation error for malformed JSON content", () => {
+    render(
+      <CommandCellComponent
+        cell={inlineCell({ format: "json", content: "{not json" })}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/.+/, { selector: "p.text-red-500" })).toBeInTheDocument();
+  });
+
+  it("hides the format selector in read-only mode", () => {
+    const { rerender } = render(
+      <CommandCellComponent cell={inlineCell()} onUpdate={vi.fn()} onDelete={vi.fn()} />,
+    );
+    expect(screen.getByLabelText("Command format")).toBeInTheDocument();
+
+    rerender(
+      <CommandCellComponent cell={inlineCell()} onUpdate={vi.fn()} onDelete={vi.fn()} readOnly />,
+    );
+    expect(screen.queryByLabelText("Command format")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/workbook/cells/command-cell.tsx
+++ b/apps/web/components/workbook/cells/command-cell.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { Check, Copy, Terminal } from "lucide-react";
+import { useMemo } from "react";
+
+import type { CommandFormat } from "@repo/api/schemas/experiment.schema";
+import type { CommandCell as CommandCellType } from "@repo/api/schemas/workbook-cells.schema";
+import { validateInlineCommand } from "@repo/api/utils/command-payload";
+import { Button } from "@repo/ui/components/button";
+import { Input } from "@repo/ui/components/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repo/ui/components/select";
+
+import { CellWrapper } from "../cell-wrapper";
+import { WorkbookCodeEditor } from "../workbook-code-editor";
+
+const FORMAT_LABELS: Record<CommandFormat, string> = {
+  string: "String",
+  json: "JSON",
+  yaml: "YAML",
+};
+
+interface CommandCellProps {
+  cell: CommandCellType;
+  onUpdate: (cell: CommandCellType) => void;
+  onDelete: () => void;
+  onRun?: () => void;
+  executionStatus?: "idle" | "running" | "completed" | "error";
+  executionError?: string;
+  readOnly?: boolean;
+}
+
+export function CommandCellComponent({
+  cell,
+  onUpdate,
+  onDelete,
+  onRun,
+  executionStatus,
+  executionError,
+  readOnly,
+}: CommandCellProps) {
+  const { copy, copied } = useCopyToClipboard();
+  const { format, content } = cell.payload;
+
+  const validation = useMemo(() => validateInlineCommand({ format, content }), [format, content]);
+
+  const update = (patch: Partial<CommandCellType["payload"]>) =>
+    onUpdate({ ...cell, payload: { ...cell.payload, ...patch } });
+
+  const displayName = cell.payload.name ?? (content || "Command");
+
+  return (
+    <CellWrapper
+      icon={<Terminal className="h-3.5 w-3.5" />}
+      label={displayName}
+      accentColor="#119DA4"
+      isCollapsed={cell.isCollapsed}
+      onToggleCollapse={(collapsed) => onUpdate({ ...cell, isCollapsed: collapsed })}
+      onDelete={onDelete}
+      onRun={onRun}
+      executionStatus={executionStatus}
+      executionError={executionError}
+      readOnly={readOnly}
+      headerActions={
+        <div className="flex items-center gap-1">
+          {!readOnly ? (
+            <Select value={format} onValueChange={(v) => update({ format: v as CommandFormat })}>
+              <SelectTrigger className="h-7 w-[90px] text-xs" aria-label="Command format">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {(["string", "json", "yaml"] as const).map((f) => (
+                  <SelectItem key={f} value={f} className="text-xs">
+                    {FORMAT_LABELS[f]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <span className="text-xs uppercase text-[#68737B]">{FORMAT_LABELS[format]}</span>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-muted-foreground h-7 w-7 p-0"
+            onClick={() => void copy(content)}
+          >
+            {copied ? <Check className="h-3 w-3 text-emerald-500" /> : <Copy className="h-3 w-3" />}
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-2">
+        {format === "string" ? (
+          <Input
+            value={content}
+            onChange={(e) => update({ content: e.target.value })}
+            placeholder="Type a command, e.g. battery"
+            aria-label="Device command"
+            className="font-mono text-sm"
+            readOnly={readOnly}
+          />
+        ) : (
+          <WorkbookCodeEditor
+            value={content}
+            onChange={readOnly ? undefined : (v) => update({ content: v })}
+            language={format === "json" ? "json" : "yaml"}
+            minHeight={readOnly ? "80px" : "120px"}
+            maxHeight="400px"
+            readOnly={readOnly}
+          />
+        )}
+        {!validation.ok ? <p className="text-xs text-red-500">{validation.error}</p> : null}
+      </div>
+    </CellWrapper>
+  );
+}

--- a/apps/web/components/workbook/cells/command-cell.tsx
+++ b/apps/web/components/workbook/cells/command-cell.tsx
@@ -8,7 +8,6 @@ import type { CommandFormat } from "@repo/api/schemas/experiment.schema";
 import type { CommandCell as CommandCellType } from "@repo/api/schemas/workbook-cells.schema";
 import { validateInlineCommand } from "@repo/api/utils/command-payload";
 import { Button } from "@repo/ui/components/button";
-import { Input } from "@repo/ui/components/input";
 import {
   Select,
   SelectContent,
@@ -17,13 +16,21 @@ import {
   SelectValue,
 } from "@repo/ui/components/select";
 
+import { buildCommandExtensions } from "../../shared/command-completions";
 import { CellWrapper } from "../cell-wrapper";
 import { WorkbookCodeEditor } from "../workbook-code-editor";
+import type { EditorLanguage } from "../workbook-code-editor";
 
 const FORMAT_LABELS: Record<CommandFormat, string> = {
   string: "String",
   json: "JSON",
   yaml: "YAML",
+};
+
+const FORMAT_LANGUAGE: Record<CommandFormat, EditorLanguage> = {
+  string: "text",
+  json: "json",
+  yaml: "yaml",
 };
 
 interface CommandCellProps {
@@ -49,6 +56,34 @@ export function CommandCellComponent({
   const { format, content } = cell.payload;
 
   const validation = useMemo(() => validateInlineCommand({ format, content }), [format, content]);
+
+  // Known-command autocomplete + hover hints only apply to the free-text `string`
+  // format; json/yaml payloads are structured, not a single command word.
+  const commandExtensions = useMemo(
+    () =>
+      format === "string"
+        ? buildCommandExtensions({
+            singleLine: true,
+            placeholder: "Type a command, e.g. battery",
+            readOnly,
+          })
+        : undefined,
+    [format, readOnly],
+  );
+
+  // A single-line command reads as an input, not a code block; drop the gutter.
+  const commandBasicSetup = useMemo(
+    () =>
+      format === "string"
+        ? {
+            lineNumbers: false,
+            foldGutter: false,
+            highlightActiveLine: false,
+            highlightActiveLineGutter: false,
+          }
+        : undefined,
+    [format],
+  );
 
   const update = (patch: Partial<CommandCellType["payload"]>) =>
     onUpdate({ ...cell, payload: { ...cell.payload, ...patch } });
@@ -97,25 +132,16 @@ export function CommandCellComponent({
       }
     >
       <div className="space-y-2">
-        {format === "string" ? (
-          <Input
-            value={content}
-            onChange={(e) => update({ content: e.target.value })}
-            placeholder="Type a command, e.g. battery"
-            aria-label="Device command"
-            className="font-mono text-sm"
-            readOnly={readOnly}
-          />
-        ) : (
-          <WorkbookCodeEditor
-            value={content}
-            onChange={readOnly ? undefined : (v) => update({ content: v })}
-            language={format === "json" ? "json" : "yaml"}
-            minHeight={readOnly ? "80px" : "120px"}
-            maxHeight="400px"
-            readOnly={readOnly}
-          />
-        )}
+        <WorkbookCodeEditor
+          value={content}
+          onChange={readOnly ? undefined : (v) => update({ content: v })}
+          language={FORMAT_LANGUAGE[format]}
+          minHeight={format === "string" ? "44px" : readOnly ? "80px" : "120px"}
+          maxHeight="400px"
+          readOnly={readOnly}
+          extraExtensions={commandExtensions}
+          basicSetup={commandBasicSetup}
+        />
         {!validation.ok ? <p className="text-xs text-red-500">{validation.error}</p> : null}
       </div>
     </CellWrapper>

--- a/apps/web/components/workbook/cells/command-cell.tsx
+++ b/apps/web/components/workbook/cells/command-cell.tsx
@@ -7,6 +7,7 @@ import { useMemo } from "react";
 import type { CommandFormat } from "@repo/api/schemas/experiment.schema";
 import type { CommandCell as CommandCellType } from "@repo/api/schemas/workbook-cells.schema";
 import { validateInlineCommand } from "@repo/api/utils/command-payload";
+import { useTranslation } from "@repo/i18n";
 import { Button } from "@repo/ui/components/button";
 import {
   Select,
@@ -53,6 +54,8 @@ export function CommandCellComponent({
   readOnly,
 }: CommandCellProps) {
   const { copy, copied } = useCopyToClipboard();
+  const { t } = useTranslation("common");
+  const { t: tWorkbook } = useTranslation("workbook");
   const { format, content } = cell.payload;
 
   const validation = useMemo(() => validateInlineCommand({ format, content }), [format, content]);
@@ -64,11 +67,11 @@ export function CommandCellComponent({
       format === "string"
         ? buildCommandExtensions({
             singleLine: true,
-            placeholder: "Type a command, e.g. battery",
+            placeholder: t("experiments.commandPanelPlaceholder"),
             readOnly,
           })
         : undefined,
-    [format, readOnly],
+    [format, readOnly, t],
   );
 
   // A single-line command reads as an input, not a code block; drop the gutter.
@@ -88,7 +91,8 @@ export function CommandCellComponent({
   const update = (patch: Partial<CommandCellType["payload"]>) =>
     onUpdate({ ...cell, payload: { ...cell.payload, ...patch } });
 
-  const displayName = cell.payload.name ?? (content || "Command");
+  const nameOrContent = cell.payload.name?.trim() ? cell.payload.name : content;
+  const displayName = nameOrContent.length > 0 ? nameOrContent : tWorkbook("cells.command");
 
   return (
     <CellWrapper

--- a/apps/web/components/workbook/workbook-cell-summary.tsx
+++ b/apps/web/components/workbook/workbook-cell-summary.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Code, FileText, FlaskConical, GitBranch, HelpCircle } from "lucide-react";
+import { Code, FileText, FlaskConical, GitBranch, HelpCircle, Terminal } from "lucide-react";
 import type { ReactNode } from "react";
 
 import type { WorkbookCell } from "@repo/api/schemas/workbook-cells.schema";
@@ -9,6 +9,7 @@ import { cn } from "@repo/ui/lib/utils";
 
 const cellIcons: Record<string, ReactNode> = {
   protocol: <FlaskConical className="h-3 w-3" />,
+  command: <Terminal className="h-3 w-3" />,
   macro: <Code className="h-3 w-3" />,
   question: <HelpCircle className="h-3 w-3" />,
   branch: <GitBranch className="h-3 w-3" />,

--- a/apps/web/components/workbook/workbook-code-editor.tsx
+++ b/apps/web/components/workbook/workbook-code-editor.tsx
@@ -5,6 +5,7 @@ import type { Extension } from "@codemirror/state";
 import { oneDark } from "@codemirror/theme-one-dark";
 import { EditorView } from "@codemirror/view";
 import { useEffect, useMemo, useState } from "react";
+import type { ComponentProps } from "react";
 import { CodeEditor } from "~/components/shared/code-editor";
 import type { CodeLanguage, LintSource } from "~/components/shared/code-editor";
 
@@ -21,6 +22,8 @@ interface WorkbookCodeEditorProps {
   className?: string;
   lintSource?: LintSource;
   syntaxLinting?: boolean;
+  extraExtensions?: Extension[];
+  basicSetup?: ComponentProps<typeof CodeEditor>["basicSetup"];
 }
 
 const compactTheme = EditorView.theme({
@@ -38,6 +41,8 @@ export function WorkbookCodeEditor({
   className = "",
   lintSource,
   syntaxLinting = false,
+  extraExtensions: callerExtensions,
+  basicSetup,
 }: WorkbookCodeEditorProps) {
   const [isDark, setIsDark] = useState(false);
 
@@ -54,8 +59,9 @@ export function WorkbookCodeEditor({
   const extraExtensions = useMemo(() => {
     const exts: Extension[] = [compactTheme];
     if (isDark) exts.push(oneDark);
+    if (callerExtensions) exts.push(...callerExtensions);
     return exts;
-  }, [isDark]);
+  }, [isDark, callerExtensions]);
 
   return (
     <div
@@ -75,6 +81,7 @@ export function WorkbookCodeEditor({
         lintSource={lintSource}
         syntaxLinting={syntaxLinting}
         extraExtensions={extraExtensions}
+        basicSetup={basicSetup}
       />
     </div>
   );

--- a/apps/web/components/workbook/workbook-draft-editor.tsx
+++ b/apps/web/components/workbook/workbook-draft-editor.tsx
@@ -79,7 +79,7 @@ export function WorkbookDraftEditor({
     toKey: (c) => JSON.stringify(c),
     // Skip autosave while cells are transiently invalid (e.g. a half-typed or
     // just-added empty option) so the draft never persists a state the API
-    // would reject — edits resume saving once valid.
+    // would reject; edits resume saving once valid.
     isValid: (c) => zWorkbookCellArray.safeParse(c).success,
     save,
     delayMs: AUTO_SAVE_DELAY,
@@ -116,12 +116,12 @@ export function WorkbookDraftEditor({
   const isCreator = session?.user.id === createdBy;
 
   // Trigger the same `connect()` the toolbar uses when the user clicks Run on
-  // a Protocol cell with no device. Done before any await so the browser's
-  // Web Serial / Web Bluetooth picker still sees a live user gesture.
+  // a Protocol or Command cell with no device. Done before any await so the
+  // browser's Web Serial / Web Bluetooth picker still sees a live user gesture.
   const handleRunCell = useCallback(
     (cellId: string) => {
       const cell = cells.find((c) => c.id === cellId);
-      if (cell?.type === "protocol" && !isConnected) {
+      if ((cell?.type === "protocol" || cell?.type === "command") && !isConnected) {
         void connect();
         return;
       }

--- a/apps/web/components/workbook/workbook-editor.test.tsx
+++ b/apps/web/components/workbook/workbook-editor.test.tsx
@@ -68,6 +68,16 @@ describe("createDefaultCell", () => {
     expect(cell).toMatchObject({ type: "output", producedBy: "", isCollapsed: false });
   });
 
+  it("creates a command cell defaulting to an empty string payload", () => {
+    const cell = createDefaultCell("command");
+    expect(cell).toMatchObject({
+      type: "command",
+      payload: { format: "string", content: "" },
+      isCollapsed: false,
+    });
+    expect(cell.id).toBeDefined();
+  });
+
   it("creates a branch cell with one default path and condition", () => {
     const cell = createDefaultCell("branch");
     if (cell.type !== "branch") throw new Error("unexpected");

--- a/apps/web/components/workbook/workbook-editor.tsx
+++ b/apps/web/components/workbook/workbook-editor.tsx
@@ -84,6 +84,8 @@ export function createDefaultCell(
   switch (type) {
     case "markdown":
       return { ...base, type: "markdown", content: "" };
+    case "command":
+      return { ...base, type: "command", payload: { format: "string", content: "" } };
     case "protocol":
       throw new Error("Protocol cells must be created via the protocol picker");
     case "macro":
@@ -459,6 +461,7 @@ export function WorkbookEditor({
     for (const cell of cells) {
       if (
         cell.type === "protocol" ||
+        cell.type === "command" ||
         cell.type === "macro" ||
         cell.type === "question" ||
         cell.type === "branch"

--- a/apps/web/components/workbook/workbook-sidebar.test.tsx
+++ b/apps/web/components/workbook/workbook-sidebar.test.tsx
@@ -1,4 +1,9 @@
-import { createMarkdownCell, createProtocolCell, createQuestionCell } from "@/test/factories";
+import {
+  createCommandCell,
+  createMarkdownCell,
+  createProtocolCell,
+  createQuestionCell,
+} from "@/test/factories";
 import { render, screen, userEvent } from "@/test/test-utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
@@ -56,6 +61,24 @@ describe("WorkbookSidebar", () => {
     render(<WorkbookSidebar cells={[markdownCell]} onCellClick={onCellClick} />);
     await user.click(screen.getByText("Markdown"));
     expect(onCellClick).toHaveBeenCalledWith("md-1");
+  });
+
+  it("shows the command content as the command cell subtitle", () => {
+    const commandCell = createCommandCell({
+      id: "cmd-1",
+      payload: { format: "string", content: "battery" },
+    });
+    render(<WorkbookSidebar cells={[commandCell]} onCellClick={onCellClick} />);
+    expect(screen.getByText("battery")).toBeInTheDocument();
+  });
+
+  it("falls back to the command format when the command has no name or content", () => {
+    const commandCell = createCommandCell({
+      id: "cmd-2",
+      payload: { format: "yaml", content: "" },
+    });
+    render(<WorkbookSidebar cells={[commandCell]} onCellClick={onCellClick} />);
+    expect(screen.getByText("yaml")).toBeInTheDocument();
   });
 
   it("shows empty markdown subtitle as 'Empty'", () => {

--- a/apps/web/components/workbook/workbook-sidebar.tsx
+++ b/apps/web/components/workbook/workbook-sidebar.tsx
@@ -40,6 +40,7 @@ import { cn } from "@repo/ui/lib/utils";
 const cellColors: Record<string, string> = {
   question: "#C58AAE",
   protocol: "#2D3142",
+  command: "#119DA4",
   macro: "#6C5CE7",
   branch: "#F29D38",
   markdown: "#6F8596",
@@ -50,6 +51,7 @@ const cellColors: Record<string, string> = {
 const cellActiveBg: Record<string, string> = {
   question: "#F9F3F6",
   protocol: "#EAEBEE",
+  command: "#E7F6F6",
   macro: "#F1EFFD",
   branch: "#FBF3EA",
   markdown: "#F1F3F5",
@@ -58,6 +60,7 @@ const cellActiveBg: Record<string, string> = {
 const cellTypeLabels: Record<string, string> = {
   question: "Question",
   protocol: "Protocol",
+  command: "Command",
   macro: "Macro",
   branch: "Branch",
   markdown: "Markdown",
@@ -80,6 +83,8 @@ function getCellSubtitle(cell: WorkbookCell): string {
       return cell.question.text || "No question yet";
     case "protocol":
       return cell.payload.name ?? "JSON";
+    case "command":
+      return cell.payload.name ?? (cell.payload.content || cell.payload.format);
     case "macro":
       return cell.payload.name ?? capitalize(cell.payload.language);
     case "branch":
@@ -201,7 +206,7 @@ function SidebarRow({
         </div>
       </div>
 
-      {/* Drag handle (visual indicator only — the whole card drags) */}
+      {/* Drag handle (visual indicator only; the whole card drags) */}
       {draggable && (
         <div className="shrink-0">
           <GripVertical className="h-4 w-4" style={{ color: "#005E5E" }} />

--- a/apps/web/hooks/iot/useIotProtocolExecution/useIotProtocolExecution.test.ts
+++ b/apps/web/hooks/iot/useIotProtocolExecution/useIotProtocolExecution.test.ts
@@ -33,6 +33,42 @@ describe("useIotProtocolExecution", () => {
     });
   });
 
+  describe("executeCommand function", () => {
+    it("throws when not connected", async () => {
+      const { result } = renderHook(() => useIotProtocolExecution(null, false, "multispeq"));
+      await expect(result.current.executeCommand("battery")).rejects.toThrow(
+        "Not connected to device",
+      );
+    });
+
+    it("sends a raw string command with a short timeout and parses the response", async () => {
+      const mockExecute = vi.fn().mockResolvedValueOnce({ success: true, data: '{"battery": 87}' });
+      const mockDriver: Partial<IDeviceDriver> = { execute: mockExecute };
+
+      const { result } = renderHook(() =>
+        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "multispeq"),
+      );
+
+      const data = await result.current.executeCommand("battery");
+
+      expect(mockExecute).toHaveBeenCalledWith("battery", { timeoutMs: 10_000 });
+      expect(data).toEqual({ battery: 87 });
+    });
+
+    it("throws with the device error message on failure", async () => {
+      const mockExecute = vi
+        .fn()
+        .mockResolvedValueOnce({ success: false, error: { message: "Bad command" } });
+      const mockDriver: Partial<IDeviceDriver> = { execute: mockExecute };
+
+      const { result } = renderHook(() =>
+        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "multispeq"),
+      );
+
+      await expect(result.current.executeCommand("nope")).rejects.toThrow("Bad command");
+    });
+  });
+
   describe("multispeq execution", () => {
     it("sends protocol JSON directly as a single command", async () => {
       const mockExecute = vi

--- a/apps/web/hooks/iot/useIotProtocolExecution/useIotProtocolExecution.ts
+++ b/apps/web/hooks/iot/useIotProtocolExecution/useIotProtocolExecution.ts
@@ -25,6 +25,9 @@ function parseResponseData(data: unknown): unknown {
   }
 }
 
+// Console commands fail fast; protocols run the full measurement budget.
+const CONSOLE_COMMAND_TIMEOUT_MS = 10_000;
+
 // ── Hook ─────────────────────────────────────────────────────────────────────
 
 export function useIotProtocolExecution(
@@ -39,7 +42,7 @@ export function useIotProtocolExecution(
       }
 
       if (sensorFamily === "multispeq") {
-        // MultispeQ: send the protocol JSON array directly — device runs the measurement
+        // MultispeQ: send the protocol JSON array directly; device runs the measurement
         const result = await driver.execute(protocolCode);
         return parseResponseData(unwrap(result, "Protocol execution failed"));
       }
@@ -62,5 +65,18 @@ export function useIotProtocolExecution(
     [driver, isConnected, sensorFamily],
   );
 
-  return { executeProtocol };
+  // Inline command cell: a raw string (`hello`, `battery`) or a parsed JSON/YAML
+  // object/array, sent straight to the device with a short timeout.
+  const executeCommand = useCallback(
+    async (command: string | Record<string, unknown> | unknown[]) => {
+      if (!driver || !isConnected) {
+        throw new Error("Not connected to device");
+      }
+      const result = await driver.execute(command, { timeoutMs: CONSOLE_COMMAND_TIMEOUT_MS });
+      return parseResponseData(unwrap(result, "Command execution failed"));
+    },
+    [driver, isConnected],
+  );
+
+  return { executeProtocol, executeCommand };
 }

--- a/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.test.ts
+++ b/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.test.ts
@@ -270,6 +270,30 @@ describe("useWorkbookExecution", () => {
       expect(outputCell?.messages?.length).toBeGreaterThan(0);
       expect(mockExecuteCommand).not.toHaveBeenCalled();
     });
+
+    it("captures a device error when the command execution throws", async () => {
+      const cmd = createCommandCell({ payload: { format: "string", content: "battery" } });
+      mockIsConnected = true;
+      mockExecuteCommand.mockRejectedValue(new Error("Command timed out"));
+
+      const { result, onCellsChange } = renderExecution([cmd]);
+      await act(() => result.current.runCell(cmd.id));
+
+      const outputCell = findOutput(onCellsChange.mock.calls[0][0] as WorkbookCell[]);
+      expect(outputCell?.messages).toContain("Command timed out");
+    });
+  });
+
+  describe("runCell - non-executable cell", () => {
+    it("leaves the cells unchanged when dispatching a markdown cell", async () => {
+      const md = createMarkdownCell({ id: "md-1", content: "# Notes" });
+      const { result, onCellsChange } = renderExecution([md]);
+
+      await act(() => result.current.runCell(md.id));
+
+      const updated = onCellsChange.mock.calls[0][0] as WorkbookCell[];
+      expect(updated).toEqual([md]);
+    });
   });
 
   describe("runCell - macro", () => {

--- a/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.test.ts
+++ b/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.test.ts
@@ -1,5 +1,6 @@
 import {
   createBranchCell,
+  createCommandCell,
   createMacroCell,
   createMarkdownCell,
   createOutputCell,
@@ -21,6 +22,7 @@ import type { QuestionCell, WorkbookCell } from "@repo/api/schemas/workbook-cell
 import { useWorkbookExecution } from "./useWorkbookExecution";
 
 const mockExecuteProtocol = vi.fn();
+const mockExecuteCommand = vi.fn();
 const mockConnect = vi.fn();
 const mockDisconnect = vi.fn();
 
@@ -41,6 +43,7 @@ vi.mock("~/hooks/iot/useIotCommunication/useIotCommunication", () => ({
 vi.mock("~/hooks/iot/useIotProtocolExecution/useIotProtocolExecution", () => ({
   useIotProtocolExecution: () => ({
     executeProtocol: mockExecuteProtocol,
+    executeCommand: mockExecuteCommand,
   }),
 }));
 
@@ -71,6 +74,7 @@ describe("useWorkbookExecution", () => {
   beforeEach(() => {
     mockIsConnected = false;
     mockExecuteProtocol.mockReset();
+    mockExecuteCommand.mockReset();
     mockConnect.mockReset();
     mockDisconnect.mockReset();
     __resetProtocolCodeRegistry();
@@ -91,7 +95,7 @@ describe("useWorkbookExecution", () => {
     expect(updated).toHaveLength(2);
   });
 
-  describe("runCell — protocol", () => {
+  describe("runCell - protocol", () => {
     it("errors when protocol has no code", async () => {
       const proto = createProtocolCell();
       const protocol = createProtocol({
@@ -152,7 +156,7 @@ describe("useWorkbookExecution", () => {
 
     it("runs the live editor code directly, without re-fetching from the server", async () => {
       // Fixes the stale-protocol bug at the source: the device runs exactly the
-      // code currently in the editor, with no backend round-trip — so a debounced,
+      // code currently in the editor, with no backend round-trip, so a debounced,
       // not-yet-saved edit is never bypassed in favour of an older saved version.
       const proto = createProtocolCell();
       const liveCode = [{ _protocol_set_: [{ label: "live" }] }];
@@ -186,7 +190,7 @@ describe("useWorkbookExecution", () => {
       mockIsConnected = true;
       mockExecuteProtocol.mockResolvedValue({ measurement: 1 });
 
-      // No code source registered — e.g. the cell's editor is not mounted.
+      // No code source registered (e.g. the cell's editor is not mounted).
       const { result } = renderExecution([proto]);
 
       await act(() => result.current.runCell(proto.id));
@@ -214,7 +218,61 @@ describe("useWorkbookExecution", () => {
     });
   });
 
-  describe("runCell — macro", () => {
+  describe("runCell - inline command", () => {
+    it("sends a raw string command and wraps a scalar response", async () => {
+      const cmd = createCommandCell({ payload: { format: "string", content: "battery" } });
+      mockIsConnected = true;
+      mockExecuteCommand.mockResolvedValue("87%");
+
+      const { result, onCellsChange } = renderExecution([cmd]);
+      await act(() => result.current.runCell(cmd.id));
+
+      expect(mockExecuteCommand).toHaveBeenCalledWith("battery");
+      const outputCell = findOutput(onCellsChange.mock.calls[0][0] as WorkbookCell[]);
+      expect(outputCell?.data).toEqual({ response: "87%" });
+    });
+
+    it("parses a JSON command before sending and passes object responses through", async () => {
+      const cmd = createCommandCell({ payload: { format: "json", content: '[{"c":1}]' } });
+      mockIsConnected = true;
+      mockExecuteCommand.mockResolvedValue({ ok: true });
+
+      const { result, onCellsChange } = renderExecution([cmd]);
+      await act(() => result.current.runCell(cmd.id));
+
+      expect(mockExecuteCommand).toHaveBeenCalledWith([{ c: 1 }]);
+      const outputCell = findOutput(onCellsChange.mock.calls[0][0] as WorkbookCell[]);
+      expect(outputCell?.data).toEqual({ ok: true });
+    });
+
+    it("records an error when no device is connected", async () => {
+      const cmd = createCommandCell({ payload: { format: "string", content: "hello" } });
+      mockIsConnected = false;
+
+      const { result, onCellsChange } = renderExecution([cmd]);
+      await act(() => result.current.runCell(cmd.id));
+
+      const outputCell = findOutput(onCellsChange.mock.calls[0][0] as WorkbookCell[]);
+      expect(outputCell?.messages).toEqual(
+        expect.arrayContaining([expect.stringContaining("No device connected")]),
+      );
+      expect(mockExecuteCommand).not.toHaveBeenCalled();
+    });
+
+    it("records an error when inline content is invalid JSON", async () => {
+      const cmd = createCommandCell({ payload: { format: "json", content: "{not json" } });
+      mockIsConnected = true;
+
+      const { result, onCellsChange } = renderExecution([cmd]);
+      await act(() => result.current.runCell(cmd.id));
+
+      const outputCell = findOutput(onCellsChange.mock.calls[0][0] as WorkbookCell[]);
+      expect(outputCell?.messages?.length).toBeGreaterThan(0);
+      expect(mockExecuteCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("runCell - macro", () => {
     it("errors when no preceding output data", async () => {
       const macro = createMacroCell();
       const { result, onCellsChange } = renderExecution([macro]);
@@ -279,7 +337,7 @@ describe("useWorkbookExecution", () => {
     });
   });
 
-  describe("runCell — question", () => {
+  describe("runCell - question", () => {
     it("errors when question text is empty", async () => {
       const q = createQuestionCell({
         question: { kind: "open_ended", text: "", required: false },
@@ -341,7 +399,7 @@ describe("useWorkbookExecution", () => {
     });
   });
 
-  describe("runCell — branch", () => {
+  describe("runCell - branch", () => {
     it("evaluates branch and records matched path", async () => {
       const q = createQuestionCell({
         id: "q-1",

--- a/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.ts
+++ b/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.ts
@@ -9,12 +9,14 @@ import { tsr } from "~/lib/tsr";
 import type { SensorFamily } from "@repo/api/schemas/protocol.schema";
 import type {
   BranchCell,
+  CommandCell,
   MacroCell,
   OutputCell,
   ProtocolCell,
   QuestionCell,
   WorkbookCell,
 } from "@repo/api/schemas/workbook-cells.schema";
+import { resolveInlineCommand } from "@repo/api/utils/command-payload";
 import { evaluateBranch, validateBranchCell } from "@repo/api/utils/evaluate-branch";
 
 type CellExecutionStatus = "idle" | "running" | "completed" | "error";
@@ -136,13 +138,19 @@ export function useWorkbookExecution({
   const { isConnected, isConnecting, deviceInfo, driver, connect, disconnect } =
     useIotCommunication(sensorFamily, connectionType);
 
-  const { executeProtocol } = useIotProtocolExecution(driver, isConnected, sensorFamily);
+  const { executeProtocol, executeCommand } = useIotProtocolExecution(
+    driver,
+    isConnected,
+    sensorFamily,
+  );
   const executeMacroMutation = tsr.macros.executeMacro.useMutation();
 
   const isConnectedRef = useRef(isConnected);
   isConnectedRef.current = isConnected;
   const executeProtocolRef = useRef(executeProtocol);
   executeProtocolRef.current = executeProtocol;
+  const executeCommandRef = useRef(executeCommand);
+  executeCommandRef.current = executeCommand;
   const executeMacroMutationRef = useRef(executeMacroMutation);
   executeMacroMutationRef.current = executeMacroMutation;
 
@@ -200,6 +208,60 @@ export function useWorkbookExecution({
       } catch (err) {
         const executionTime = performance.now() - startTime;
         const message = err instanceof Error ? err.message : "Execution failed";
+        setCellState(cell.id, { status: "error", error: message });
+        return insertOutputAfterCell(
+          currentCells,
+          cell.id,
+          makeErrorOutputCell(cell.id, message, executionTime),
+        );
+      }
+    },
+    [setCellState],
+  );
+
+  // Normalises any non-object device response into the output cell's data shape.
+  const toOutputData = (data: unknown): Record<string, unknown> => {
+    if (data !== null && typeof data === "object" && !Array.isArray(data)) {
+      return data as Record<string, unknown>;
+    }
+    return { response: data };
+  };
+
+  const runCommandCell = useCallback(
+    async (cell: CommandCell, currentCells: WorkbookCell[]) => {
+      let command: string | Record<string, unknown> | unknown[];
+      try {
+        command = resolveInlineCommand(cell.payload);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Invalid command content";
+        setCellState(cell.id, { status: "error", error: message });
+        return insertOutputAfterCell(currentCells, cell.id, makeErrorOutputCell(cell.id, message));
+      }
+
+      if (!isConnectedRef.current) {
+        setCellState(cell.id, { status: "error", error: "No device connected" });
+        return insertOutputAfterCell(
+          currentCells,
+          cell.id,
+          makeErrorOutputCell(cell.id, "No device connected - connect a device to run this command"),
+        );
+      }
+
+      setCellState(cell.id, { status: "running" });
+      const startTime = performance.now();
+
+      try {
+        const data = await executeCommandRef.current(command);
+        const executionTime = performance.now() - startTime;
+        setCellState(cell.id, { status: "completed" });
+        return insertOutputAfterCell(
+          currentCells,
+          cell.id,
+          makeOutputCell(cell.id, toOutputData(data), executionTime, []),
+        );
+      } catch (err) {
+        const executionTime = performance.now() - startTime;
+        const message = err instanceof Error ? err.message : "Command execution failed";
         setCellState(cell.id, { status: "error", error: message });
         return insertOutputAfterCell(
           currentCells,
@@ -271,7 +333,7 @@ export function useWorkbookExecution({
         return insertOutputAfterCell(
           currentCells,
           cell.id,
-          makeErrorOutputCell(cell.id, "Question text is required — add a question before running"),
+          makeErrorOutputCell(cell.id, "Question text is required: add a question before running"),
         );
       }
 
@@ -359,6 +421,8 @@ export function useWorkbookExecution({
       switch (cell.type) {
         case "protocol":
           return runProtocolCell(cell, currentCells);
+        case "command":
+          return runCommandCell(cell, currentCells);
         case "macro":
           return runMacroCell(cell, cellIndex, currentCells);
         case "question":
@@ -369,7 +433,7 @@ export function useWorkbookExecution({
           return currentCells;
       }
     },
-    [runProtocolCell, runMacroCell, runQuestionCell, runBranchCell],
+    [runProtocolCell, runCommandCell, runMacroCell, runQuestionCell, runBranchCell],
   );
 
   // Returns the jump index into `currentCells`, or -1 if no jump.

--- a/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.ts
+++ b/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.ts
@@ -243,7 +243,10 @@ export function useWorkbookExecution({
         return insertOutputAfterCell(
           currentCells,
           cell.id,
-          makeErrorOutputCell(cell.id, "No device connected - connect a device to run this command"),
+          makeErrorOutputCell(
+            cell.id,
+            "No device connected - connect a device to run this command",
+          ),
         );
       }
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6.20.1",
     "@codemirror/lang-javascript": "^6.2.5",
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-markdown": "^6.5.0",
@@ -28,7 +29,7 @@
     "@codemirror/lint": "^6.9.5",
     "@codemirror/state": "^6.6.0",
     "@codemirror/theme-one-dark": "^6.1.3",
-    "@codemirror/view": "^6.41.1",
+    "@codemirror/view": "^6.43.0",
     "@dagrejs/dagre": "^3.0.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/lang-python": "^6.2.1",
+    "@codemirror/lang-yaml": "^6.1.2",
     "@codemirror/language": "^6.12.3",
     "@codemirror/legacy-modes": "^6.5.2",
     "@codemirror/lint": "^6.9.5",
@@ -65,6 +66,7 @@
     "react-resizable": "^3",
     "tailwind-merge": "^3.5.0",
     "uuid": "^14.0.0",
+    "yaml": "2.8.3",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/apps/web/test/factories.ts
+++ b/apps/web/test/factories.ts
@@ -36,6 +36,7 @@ import type { Protocol } from "@repo/api/schemas/protocol.schema";
 import type { Invitation, UserProfile } from "@repo/api/schemas/user.schema";
 import type {
   BranchCell,
+  CommandCell,
   MacroCell,
   MarkdownCell,
   OutputCell,
@@ -466,6 +467,26 @@ export function createProtocolCell(overrides: Partial<ProtocolCell> = {}): Proto
     payload: { protocolId: crypto.randomUUID(), version: 1 },
     isCollapsed: false,
     ...overrides,
+  };
+}
+
+export function createCommandCell(
+  overrides: Partial<Omit<CommandCell, "payload">> & {
+    payload?: Partial<{ format: "string" | "json" | "yaml"; content: string; name: string }>;
+  } = {},
+): CommandCell {
+  cellSeq++;
+  const { payload, ...rest } = overrides;
+  return {
+    id: `cell-cmd-${cellSeq}`,
+    type: "command",
+    isCollapsed: false,
+    ...rest,
+    payload: {
+      format: payload?.format ?? "string",
+      content: payload?.content ?? "battery",
+      ...(payload?.name !== undefined ? { name: payload.name } : {}),
+    },
   };
 }
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@ts-rest/core": "^3.52.1",
     "@ts-rest/open-api": "^3.52.1",
+    "yaml": "2.8.3",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/api/src/schemas/device-command.schema.ts
+++ b/packages/api/src/schemas/device-command.schema.ts
@@ -1,0 +1,94 @@
+/**
+ * Known MultispeQ console commands surfaced as autocomplete suggestions in the
+ * workbook command cell. These are the parameter-free diagnostic / status /
+ * calibration commands; parameterised commands (e.g. `set_colorcal1+…`) are
+ * intentionally excluded here and handled by dynamic command payload binding
+ * (OJD-1603).
+ *
+ * Mirrors the command strings in
+ * `@repo/iot` → `src/driver/multispeq/commands.ts` (MULTISPEQ_COMMANDS_V2).
+ * `@repo/api` is consumed by the backend, so it must not depend on `@repo/iot`;
+ * this curated list is kept in sync by hand.
+ *
+ * These are suggestions only; the command cell stays free-form, so any string
+ * the firmware understands can still be sent.
+ */
+export interface DeviceCommandOption {
+  value: string;
+  label: string;
+  group: string;
+  description?: string;
+}
+
+export const KNOWN_DEVICE_COMMANDS = [
+  // Connection / Status
+  {
+    value: "hello",
+    label: "Hello",
+    group: "Connection",
+    description: 'Responds "Instrument Ready"',
+  },
+  {
+    value: "battery",
+    label: "Battery",
+    group: "Connection",
+    description: "Charge level in percent",
+  },
+  { value: "usb", label: "USB", group: "Connection", description: "Check if connected via USB" },
+  {
+    value: "sleep",
+    label: "Sleep",
+    group: "Connection",
+    description: "Sleep (hold button 5s to wake)",
+  },
+  { value: "reset", label: "Reset", group: "Connection", description: "Reboot the instrument" },
+  { value: "reboot", label: "Reboot", group: "Connection", description: "Reboot the instrument" },
+
+  // Device info
+  {
+    value: "device_info",
+    label: "Device info",
+    group: "Device info",
+    description: "Name, version, id, battery, firmware, config",
+  },
+  {
+    value: "compiled",
+    label: "Compiled",
+    group: "Device info",
+    description: "Firmware compile date/time",
+  },
+  { value: "memory", label: "Memory", group: "Device info" },
+
+  // Sensors
+  {
+    value: "temp",
+    label: "Temperature",
+    group: "Sensors",
+    description: "Temperature + relative humidity (BME280)",
+  },
+
+  // Calibration / EEPROM
+  {
+    value: "print_all",
+    label: "Print all",
+    group: "Calibration",
+    description: "All EEPROM values",
+  },
+  {
+    value: "print_memory",
+    label: "Print memory",
+    group: "Calibration",
+    description: "Calibrations as JSON with checksum",
+  },
+  { value: "print_date", label: "Print date", group: "Calibration", description: "RTC date" },
+  { value: "print_magnetometer", label: "Print magnetometer", group: "Calibration" },
+  { value: "print_magnetometer_bias", label: "Print magnetometer bias", group: "Calibration" },
+
+  // Flow (v2)
+  { value: "get_flow", label: "Get flow", group: "Flow" },
+  { value: "flow_off", label: "Flow off", group: "Flow" },
+
+  // LED / Light
+  { value: "on_5v", label: "On 5V", group: "Light", description: "Turn on 5V for 30s" },
+  { value: "indicate_off", label: "Indicator off", group: "Light" },
+] as const satisfies readonly DeviceCommandOption[];

--- a/packages/api/src/schemas/experiment.schema.ts
+++ b/packages/api/src/schemas/experiment.schema.ts
@@ -360,6 +360,22 @@ export const zMeasurementContent = z.object({
   params: z.record(z.string(), z.unknown()).optional(),
 });
 
+// Inline command formats a command cell can carry. Defined here (rather than in
+// workbook-cells.schema) so workbook-cells can import it without an import cycle,
+// since workbook-cells already depends on this module.
+export const zCommandFormat = z.enum(["string", "json", "yaml"]);
+export type CommandFormat = z.infer<typeof zCommandFormat>;
+
+// A measurement node may instead carry an inline device command (raw string,
+// JSON, or YAML) from a command cell. Old apps' cells->flow drops this node
+// (unknown content shape), degrading gracefully; protocol nodes are unaffected.
+export const zMeasurementCommandContent = z.object({
+  command: z.object({
+    format: zCommandFormat,
+    content: z.string().min(1, "Command content is required"),
+  }),
+});
+
 export const zAnalysisContent = z.object({
   macroId: z.string().uuid("A valid macro must be selected for analysis nodes"),
   params: z.record(z.string(), z.unknown()).optional(),
@@ -387,6 +403,7 @@ export const zFlowNode = z.object({
     zQuestionContent,
     zInstructionContent,
     zMeasurementContent,
+    zMeasurementCommandContent,
     zAnalysisContent,
     zBranchContent,
   ]),
@@ -1595,7 +1612,7 @@ export type UploadFormFields = z.infer<typeof zUploadFormFields>;
 
 // --- Per-kind filename validation (validates + transforms to the safe upload-path) ---
 
-// Bare-basename filename schema for kinds where the file is "just the file" —
+// Bare-basename filename schema for kinds where the file is "just the file":
 // strip any leading path the client may have sent, enforce extension + length.
 function bareBasenameSchema(label: string, extensions: readonly string[]) {
   return z

--- a/packages/api/src/schemas/workbook-cells.schema.spec.ts
+++ b/packages/api/src/schemas/workbook-cells.schema.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 
 import {
   zProtocolCell,
+  zCommandCell,
   zMacroCell,
   zQuestionCell,
   zBranchCell,
@@ -69,6 +70,52 @@ describe("Workbook Cells Schema", () => {
         payload: { protocolId: uuidA, version: 0 },
       };
       expect(() => zProtocolCell.parse(cell)).toThrow();
+    });
+  });
+
+  describe("zCommandCell (inline)", () => {
+    it("accepts a raw string command", () => {
+      const cell = {
+        id: "c1",
+        type: "command",
+        payload: { format: "string", content: "battery" },
+      };
+      expect(zCommandCell.parse(cell)).toEqual({ ...cell, isCollapsed: false });
+    });
+
+    it("accepts json and yaml formats with an optional name", () => {
+      for (const format of ["json", "yaml"] as const) {
+        const cell = {
+          id: `c-${format}`,
+          type: "command",
+          payload: { format, content: "[]", name: "Custom" },
+        };
+        expect(zCommandCell.parse(cell)).toEqual({ ...cell, isCollapsed: false });
+      }
+    });
+
+    it("rejects empty content", () => {
+      const cell = { id: "c2", type: "command", payload: { format: "string", content: "" } };
+      expect(() => zCommandCell.parse(cell)).toThrow();
+    });
+
+    it("rejects an unknown format", () => {
+      const cell = { id: "c3", type: "command", payload: { format: "xml", content: "x" } };
+      expect(() => zCommandCell.parse(cell)).toThrow();
+    });
+
+    it("rejects payload with extra keys (strict)", () => {
+      const cell = {
+        id: "c4",
+        type: "command",
+        payload: { format: "string", content: "hello", extra: true },
+      };
+      expect(() => zCommandCell.parse(cell)).toThrow();
+    });
+
+    it("is accepted through the workbook cell union", () => {
+      const cell = { id: "c5", type: "command", payload: { format: "string", content: "hello" } };
+      expect(zWorkbookCell.parse(cell)).toMatchObject({ type: "command" });
     });
   });
 

--- a/packages/api/src/schemas/workbook-cells.schema.ts
+++ b/packages/api/src/schemas/workbook-cells.schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { sanitizeQuestionLabel, zQuestionContent } from "./experiment.schema";
+import { sanitizeQuestionLabel, zCommandFormat, zQuestionContent } from "./experiment.schema";
 import { zMacroLanguage } from "./macro.schema";
 
 const zBaseCell = z.object({
@@ -19,6 +19,23 @@ const zProtocolPayload = z
 export const zProtocolCell = zBaseCell.extend({
   type: z.literal("protocol"),
   payload: zProtocolPayload,
+});
+
+// An inline command cell sends a raw string (e.g. `hello`, `battery`), JSON, or
+// YAML straight to the instrument. Kept as a separate cell type (not folded into
+// the protocol cell) so old mobile apps, whose bundled cells->flow only knows
+// "protocol", keep rendering protocol cells and simply skip command cells.
+const zCommandPayload = z
+  .object({
+    format: zCommandFormat,
+    content: z.string().min(1, "Command content is required"),
+    name: z.string().optional(),
+  })
+  .strict();
+
+export const zCommandCell = zBaseCell.extend({
+  type: z.literal("command"),
+  payload: zCommandPayload,
 });
 
 // Macros are always persisted entities; the cell stores a ref. Versioning happens at the experiment/snapshot level.
@@ -87,6 +104,7 @@ export const zMarkdownCell = zBaseCell.extend({
 
 export const zWorkbookCell = z.union([
   zProtocolCell,
+  zCommandCell,
   zMacroCell,
   zQuestionCell,
   zBranchCell,
@@ -113,6 +131,7 @@ export const zWorkbookCellArray = z.array(zWorkbookCell).superRefine((cells, ctx
 });
 
 export type ProtocolCell = z.infer<typeof zProtocolCell>;
+export type CommandCell = z.infer<typeof zCommandCell>;
 export type MacroCell = z.infer<typeof zMacroCell>;
 export type QuestionCell = z.infer<typeof zQuestionCell>;
 export type BranchCell = z.infer<typeof zBranchCell>;
@@ -123,6 +142,7 @@ export type MarkdownCell = z.infer<typeof zMarkdownCell>;
 
 export type WorkbookCell =
   | ProtocolCell
+  | CommandCell
   | MacroCell
   | QuestionCell
   | BranchCell

--- a/packages/api/src/utils/cells-to-flow.spec.ts
+++ b/packages/api/src/utils/cells-to-flow.spec.ts
@@ -247,4 +247,20 @@ describe("cellsToFlowGraph", () => {
     const { nodes } = cellsToFlowGraph(cells);
     expect(nodes[0].name).toHaveLength(64);
   });
+
+  it("converts an inline command cell to a measurement node carrying the command", () => {
+    const cells: WorkbookCell[] = [
+      {
+        id: "c1",
+        type: "command",
+        isCollapsed: false,
+        payload: { format: "string", content: "battery" },
+      },
+    ];
+    const { nodes } = cellsToFlowGraph(cells);
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].type).toBe("measurement");
+    expect(nodes[0].name).toBe("battery");
+    expect(nodes[0].content).toEqual({ command: { format: "string", content: "battery" } });
+  });
 });

--- a/packages/api/src/utils/cells-to-flow.spec.ts
+++ b/packages/api/src/utils/cells-to-flow.spec.ts
@@ -263,4 +263,25 @@ describe("cellsToFlowGraph", () => {
     expect(nodes[0].name).toBe("battery");
     expect(nodes[0].content).toEqual({ command: { format: "string", content: "battery" } });
   });
+
+  it("derives a single-line node name from multi-line command content", () => {
+    const cells: WorkbookCell[] = [
+      {
+        id: "c1",
+        type: "command",
+        isCollapsed: false,
+        payload: { format: "yaml", content: "cmd: battery\nrepeat: 2" },
+      },
+    ];
+    // Newlines are collapsed to spaces so the flow-editor label stays on one line.
+    expect(cellsToFlowGraph(cells).nodes[0].name).toBe("cmd: battery repeat: 2");
+  });
+
+  it("falls back to a safe node name when a command has neither name nor content", () => {
+    const cells: WorkbookCell[] = [
+      { id: "c1", type: "command", isCollapsed: false, payload: { format: "string", content: "" } },
+    ];
+    // Never an empty string: zFlowNode.name requires a minimum length of 1.
+    expect(cellsToFlowGraph(cells).nodes[0].name).toBe("Command");
+  });
 });

--- a/packages/api/src/utils/cells-to-flow.ts
+++ b/packages/api/src/utils/cells-to-flow.ts
@@ -44,6 +44,17 @@ function cellToNode(cell: WorkbookCell, isStart: boolean): FlowNode | null {
         isStart,
       );
 
+    case "command":
+      // Inline command rides the existing measurement node so old apps drop it
+      // cleanly (unknown content) rather than choking on a new node type.
+      return makeNode(
+        cell.id,
+        "measurement",
+        (cell.payload.name ?? cell.payload.content).slice(0, 64),
+        { command: { format: cell.payload.format, content: cell.payload.content } } as Content,
+        isStart,
+      );
+
     case "macro":
       return makeNode(
         cell.id,

--- a/packages/api/src/utils/cells-to-flow.ts
+++ b/packages/api/src/utils/cells-to-flow.ts
@@ -51,7 +51,7 @@ function cellToNode(cell: WorkbookCell, isStart: boolean): FlowNode | null {
         cell.id,
         "measurement",
         (cell.payload.name ?? cell.payload.content).slice(0, 64),
-        { command: { format: cell.payload.format, content: cell.payload.content } } as Content,
+        { command: { format: cell.payload.format, content: cell.payload.content } },
         isStart,
       );
 

--- a/packages/api/src/utils/cells-to-flow.ts
+++ b/packages/api/src/utils/cells-to-flow.ts
@@ -44,16 +44,23 @@ function cellToNode(cell: WorkbookCell, isStart: boolean): FlowNode | null {
         isStart,
       );
 
-    case "command":
+    case "command": {
       // Inline command rides the existing measurement node so old apps drop it
       // cleanly (unknown content) rather than choking on a new node type.
+      const source = cell.payload.name?.trim() ? cell.payload.name : cell.payload.content;
+      const label = source
+        .replace(/[\r\n]+/g, " ")
+        .trim()
+        .slice(0, 64);
       return makeNode(
         cell.id,
         "measurement",
-        (cell.payload.name ?? cell.payload.content).slice(0, 64),
+        // Never empty: zFlowNode.name requires a min length of 1.
+        label.length > 0 ? label : "Command",
         { command: { format: cell.payload.format, content: cell.payload.content } },
         isStart,
       );
+    }
 
     case "macro":
       return makeNode(

--- a/packages/api/src/utils/command-payload.spec.ts
+++ b/packages/api/src/utils/command-payload.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+
+import { resolveInlineCommand, validateInlineCommand } from "./command-payload";
+
+describe("resolveInlineCommand", () => {
+  it("returns a raw string unchanged", () => {
+    expect(resolveInlineCommand({ format: "string", content: "battery" })).toBe("battery");
+  });
+
+  it("parses json content into an object/array", () => {
+    expect(resolveInlineCommand({ format: "json", content: '[{"c":1}]' })).toEqual([{ c: 1 }]);
+  });
+
+  it("parses yaml content into an object/array", () => {
+    expect(resolveInlineCommand({ format: "yaml", content: "- c: 1\n- c: 2" })).toEqual([
+      { c: 1 },
+      { c: 2 },
+    ]);
+  });
+
+  it("throws on malformed json", () => {
+    expect(() => resolveInlineCommand({ format: "json", content: "{not json" })).toThrow();
+  });
+});
+
+describe("validateInlineCommand", () => {
+  it("flags empty content", () => {
+    const result = validateInlineCommand({ format: "string", content: "   " });
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns the resolved value for valid yaml", () => {
+    const result = validateInlineCommand({ format: "yaml", content: "a: 1" });
+    expect(result).toEqual({ ok: true, value: { a: 1 } });
+  });
+
+  it("returns an error message for invalid json instead of throwing", () => {
+    const result = validateInlineCommand({ format: "json", content: "[" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(typeof result.error).toBe("string");
+  });
+});

--- a/packages/api/src/utils/command-payload.spec.ts
+++ b/packages/api/src/utils/command-payload.spec.ts
@@ -21,6 +21,12 @@ describe("resolveInlineCommand", () => {
   it("throws on malformed json", () => {
     expect(() => resolveInlineCommand({ format: "json", content: "{not json" })).toThrow();
   });
+
+  it("throws on an unknown format that bypasses the type checker", () => {
+    expect(() => resolveInlineCommand({ format: "xml" as never, content: "battery" })).toThrow(
+      /Unknown command format: xml/,
+    );
+  });
 });
 
 describe("validateInlineCommand", () => {

--- a/packages/api/src/utils/command-payload.ts
+++ b/packages/api/src/utils/command-payload.ts
@@ -27,9 +27,10 @@ export function resolveInlineCommand({ format, content }: InlineCommand): Resolv
 }
 
 /** Non-throwing variant for editor validation. */
-export function validateInlineCommand({ format, content }: InlineCommand):
-  | { ok: true; value: ResolvedCommand }
-  | { ok: false; error: string } {
+export function validateInlineCommand({
+  format,
+  content,
+}: InlineCommand): { ok: true; value: ResolvedCommand } | { ok: false; error: string } {
   if (content.trim().length === 0) {
     return { ok: false, error: "Command content is required" };
   }

--- a/packages/api/src/utils/command-payload.ts
+++ b/packages/api/src/utils/command-payload.ts
@@ -1,0 +1,41 @@
+import { parse as parseYaml } from "yaml";
+
+import type { CommandFormat } from "../schemas/experiment.schema";
+
+export interface InlineCommand {
+  format: CommandFormat;
+  content: string;
+}
+
+export type ResolvedCommand = string | Record<string, unknown> | unknown[];
+
+/**
+ * Resolve an inline command payload into what the device driver expects.
+ * `string` is sent raw (e.g. `hello`, `battery`); `json`/`yaml` parse into a
+ * protocol-shaped object/array. Throws on malformed JSON/YAML so callers can
+ * surface a useful error instead of sending garbage to the instrument.
+ */
+export function resolveInlineCommand({ format, content }: InlineCommand): ResolvedCommand {
+  switch (format) {
+    case "string":
+      return content;
+    case "json":
+      return JSON.parse(content) as ResolvedCommand;
+    case "yaml":
+      return parseYaml(content) as ResolvedCommand;
+  }
+}
+
+/** Non-throwing variant for editor validation. */
+export function validateInlineCommand({ format, content }: InlineCommand):
+  | { ok: true; value: ResolvedCommand }
+  | { ok: false; error: string } {
+  if (content.trim().length === 0) {
+    return { ok: false, error: "Command content is required" };
+  }
+  try {
+    return { ok: true, value: resolveInlineCommand({ format, content }) };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : "Invalid command content" };
+  }
+}

--- a/packages/api/src/utils/command-payload.ts
+++ b/packages/api/src/utils/command-payload.ts
@@ -23,6 +23,8 @@ export function resolveInlineCommand({ format, content }: InlineCommand): Resolv
       return JSON.parse(content) as ResolvedCommand;
     case "yaml":
       return parseYaml(content) as ResolvedCommand;
+    default:
+      throw new Error(`Unknown command format: ${String(format)}`);
   }
 }
 

--- a/packages/api/src/utils/flow-to-workbook-cells.spec.ts
+++ b/packages/api/src/utils/flow-to-workbook-cells.spec.ts
@@ -189,4 +189,23 @@ describe("flowNodesToWorkbookCells", () => {
     expect(cells).toHaveLength(1);
     expect((cells[0] as { content: string }).content).toBe("");
   });
+
+  it("converts an inline-command measurement node to a command cell", () => {
+    const nodes = [
+      makeNode({
+        id: "m2",
+        type: "measurement",
+        name: "battery",
+        isStart: true,
+        content: { command: { format: "string", content: "battery" } },
+      }),
+    ];
+    const cells = flowNodesToWorkbookCells(nodes, []);
+    expect(cells).toHaveLength(1);
+    expect(cells[0]).toMatchObject({
+      id: "m2",
+      type: "command",
+      payload: { format: "string", content: "battery" },
+    });
+  });
 });

--- a/packages/api/src/utils/flow-to-workbook-cells.ts
+++ b/packages/api/src/utils/flow-to-workbook-cells.ts
@@ -43,7 +43,22 @@ function nodeToCell(node: FlowNode): WorkbookCell | null {
   const content = node.content as Record<string, unknown>;
 
   switch (node.type) {
-    case "measurement":
+    case "measurement": {
+      // A measurement node carries either a protocol reference or an inline command.
+      const inline = content.command as { format?: string; content?: string } | undefined;
+      if (inline && typeof inline.content === "string") {
+        return {
+          id: node.id,
+          type: "command",
+          isCollapsed: false,
+          payload: {
+            format: (inline.format as "string" | "json" | "yaml" | undefined) ?? "string",
+            content: inline.content,
+            // Drop the auto-derived name so a round-trip doesn't fabricate one.
+            ...(node.name && node.name !== inline.content ? { name: node.name } : {}),
+          },
+        };
+      }
       return {
         id: node.id,
         type: "protocol",
@@ -54,6 +69,7 @@ function nodeToCell(node: FlowNode): WorkbookCell | null {
           name: node.name,
         },
       };
+    }
 
     case "analysis":
       return {

--- a/packages/i18n/locales/de-DE/common.json
+++ b/packages/i18n/locales/de-DE/common.json
@@ -127,6 +127,8 @@
     "needAdminAccessArchived": "Zugriff auf Einstellungen für archivierte Experimente verweigert",
     "needMemberAccess": "Sie müssen Mitglied sein, um auf die Experiment-Einstellungen zuzugreifen",
     "measurementPanelTitle": "Messprotokoll",
+    "commandPanelTitle": "Gerätebefehl",
+    "commandPanelPlaceholder": "Befehl eingeben, z. B. battery",
     "detailsTitle": "Details",
     "detailsDescription": "Geben Sie die grundlegenden Informationen zu Ihrem Experiment ein",
     "membersVisibilityTitle": "Mitglieder & Sichtbarkeit",

--- a/packages/i18n/locales/de-DE/experiments.json
+++ b/packages/i18n/locales/de-DE/experiments.json
@@ -73,7 +73,8 @@
       "INSTRUCTION": "Anleitung",
       "QUESTION": "Frage",
       "MEASUREMENT": "Messung",
-      "ANALYSIS": "Analyse"
+      "ANALYSIS": "Analyse",
+      "COMMAND": "Befehl"
     },
     "questionTooltip": {
       "title": "Datenspaltenname",

--- a/packages/i18n/locales/de-DE/workbook.json
+++ b/packages/i18n/locales/de-DE/workbook.json
@@ -91,6 +91,7 @@
     "timeseriesError": "Diese Ausgabe kann nicht mit dem Quellprotokoll dekodiert werden"
   },
   "cells": {
+    "command": "Befehl",
     "protocolReadOnly": "Schreibgeschützt. Zum Bearbeiten forken.",
     "macroReadOnly": "Schreibgeschützt. Zum Bearbeiten forken.",
     "fork": "Zum Bearbeiten forken",

--- a/packages/i18n/locales/de-DE/workbook.json
+++ b/packages/i18n/locales/de-DE/workbook.json
@@ -57,6 +57,8 @@
     "cellSummary": {
       "protocol_one": "{{count}} Protokoll",
       "protocol_other": "{{count}} Protokolle",
+      "command_one": "{{count}} Befehl",
+      "command_other": "{{count}} Befehle",
       "macro_one": "{{count}} Makro",
       "macro_other": "{{count}} Makros",
       "question_one": "{{count}} Frage",
@@ -73,7 +75,7 @@
     "expand": "Ausgabe ausklappen",
     "collapse": "Ausgabe einklappen",
     "clear": "Ausgabe löschen",
-    "empty": "Keine Messdaten verfügbar - führen Sie zuerst eine Protokollzelle aus",
+    "empty": "Keine Messdaten verfügbar - führen Sie zuerst eine Protokoll- oder Befehlszelle aus",
     "noData": "Keine Ausgabedaten",
     "tabTable": "Tabelle",
     "tabJson": "JSON",

--- a/packages/i18n/locales/en-US/common.json
+++ b/packages/i18n/locales/en-US/common.json
@@ -141,6 +141,8 @@
     "needMemberAccess": "You need to be a member to access experiment settings",
     "needAdminAccessArchived": "Settings access denied for archived experiments",
     "measurementPanelTitle": "Measurement Protocol",
+    "commandPanelTitle": "Device Command",
+    "commandPanelPlaceholder": "Type a command, e.g. battery",
     "detailsTitle": "Details",
     "detailsDescription": "Enter the basic information about your experiment",
     "membersVisibilityTitle": "Members & Visibility",

--- a/packages/i18n/locales/en-US/experiments.json
+++ b/packages/i18n/locales/en-US/experiments.json
@@ -98,7 +98,8 @@
       "INSTRUCTION": "Instruction",
       "QUESTION": "Question",
       "MEASUREMENT": "Measurement",
-      "ANALYSIS": "Analysis"
+      "ANALYSIS": "Analysis",
+      "COMMAND": "Command"
     },
     "questionTooltip": {
       "title": "Data Column Name",

--- a/packages/i18n/locales/en-US/workbook.json
+++ b/packages/i18n/locales/en-US/workbook.json
@@ -91,6 +91,7 @@
     "timeseriesError": "Cannot decode this output against the source protocol"
   },
   "cells": {
+    "command": "Command",
     "protocolReadOnly": "Read-only. Fork it to edit.",
     "macroReadOnly": "Read-only. Fork it to edit.",
     "fork": "Fork to edit",

--- a/packages/i18n/locales/en-US/workbook.json
+++ b/packages/i18n/locales/en-US/workbook.json
@@ -57,6 +57,8 @@
     "cellSummary": {
       "protocol_one": "{{count}} Protocol",
       "protocol_other": "{{count}} Protocols",
+      "command_one": "{{count}} Command",
+      "command_other": "{{count}} Commands",
       "macro_one": "{{count}} Macro",
       "macro_other": "{{count}} Macros",
       "question_one": "{{count}} Question",
@@ -73,7 +75,7 @@
     "expand": "Expand output",
     "collapse": "Collapse output",
     "clear": "Clear output",
-    "empty": "No measurement data available - run a protocol cell first",
+    "empty": "No measurement data available - run a protocol or command cell first",
     "noData": "No output data",
     "tabTable": "Table",
     "tabJson": "JSON",

--- a/packages/i18n/locales/nl-NL/common.json
+++ b/packages/i18n/locales/nl-NL/common.json
@@ -66,6 +66,8 @@
     "openJII": "openJII"
   },
   "experiments": {
+    "commandPanelTitle": "Apparaatopdracht",
+    "commandPanelPlaceholder": "Typ een opdracht, bijv. battery",
     "title": "Experimenten",
     "newExperiment": "Nieuw experiment",
     "overview": "Overzicht",

--- a/packages/i18n/locales/nl-NL/experiments.json
+++ b/packages/i18n/locales/nl-NL/experiments.json
@@ -71,7 +71,8 @@
       "INSTRUCTION": "Instructie",
       "QUESTION": "Vraag",
       "MEASUREMENT": "Meting",
-      "ANALYSIS": "Analyse"
+      "ANALYSIS": "Analyse",
+      "COMMAND": "Opdracht"
     },
     "questionTooltip": {
       "title": "Gegevenskolomnaam",

--- a/packages/i18n/locales/nl-NL/workbook.json
+++ b/packages/i18n/locales/nl-NL/workbook.json
@@ -91,6 +91,7 @@
     "timeseriesError": "Deze uitvoer kan niet worden gedecodeerd met het bronprotocol"
   },
   "cells": {
+    "command": "Opdracht",
     "protocolReadOnly": "Alleen-lezen. Fork het om te bewerken.",
     "macroReadOnly": "Alleen-lezen. Fork het om te bewerken.",
     "fork": "Forken om te bewerken",

--- a/packages/i18n/locales/nl-NL/workbook.json
+++ b/packages/i18n/locales/nl-NL/workbook.json
@@ -57,6 +57,8 @@
     "cellSummary": {
       "protocol_one": "{{count}} Protocol",
       "protocol_other": "{{count}} Protocollen",
+      "command_one": "{{count}} Opdracht",
+      "command_other": "{{count}} Opdrachten",
       "macro_one": "{{count}} Macro",
       "macro_other": "{{count}} Macro's",
       "question_one": "{{count}} Vraag",
@@ -73,7 +75,7 @@
     "expand": "Uitvoer uitvouwen",
     "collapse": "Uitvoer samenvouwen",
     "clear": "Uitvoer wissen",
-    "empty": "Geen meetgegevens beschikbaar - voer eerst een protocolcel uit",
+    "empty": "Geen meetgegevens beschikbaar - voer eerst een protocol- of opdrachtcel uit",
     "noData": "Geen uitvoergegevens",
     "tabTable": "Tabel",
     "tabJson": "JSON",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -691,6 +691,9 @@ importers:
       uuid:
         specifier: ^14.0.0
         version: 14.0.1
+      yaml:
+        specifier: 2.8.3
+        version: 2.8.3
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -793,12 +796,15 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@26.1.0)(msw@2.14.6(@types/node@26.1.0)(typescript@5.9.3))(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@26.1.0)(msw@2.14.6(@types/node@26.1.0)(typescript@5.9.3))(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3))
 
   apps/tools: {}
 
   apps/web:
     dependencies:
+      '@codemirror/autocomplete':
+        specifier: ^6.20.1
+        version: 6.20.3
       '@codemirror/lang-javascript':
         specifier: ^6.2.5
         version: 6.2.5
@@ -811,6 +817,9 @@ importers:
       '@codemirror/lang-python':
         specifier: ^6.2.1
         version: 6.2.1
+      '@codemirror/lang-yaml':
+        specifier: ^6.1.2
+        version: 6.1.3
       '@codemirror/language':
         specifier: ^6.12.3
         version: 6.12.4
@@ -827,7 +836,7 @@ importers:
         specifier: ^6.1.3
         version: 6.1.3
       '@codemirror/view':
-        specifier: ^6.41.1
+        specifier: ^6.43.0
         version: 6.43.6
       '@dagrejs/dagre':
         specifier: ^3.0.0
@@ -940,6 +949,9 @@ importers:
       uuid:
         specifier: ^14.0.0
         version: 14.0.1
+      yaml:
+        specifier: 2.8.3
+        version: 2.8.3
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -988,7 +1000,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.7.0(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3))
       '@vitest/coverage-v8':
         specifier: catalog:testing
         version: 4.1.4(vitest@4.1.4)
@@ -1015,7 +1027,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3))
 
   packages/analytics:
     dependencies:
@@ -1062,6 +1074,9 @@ importers:
       '@ts-rest/open-api':
         specifier: ^3.52.1
         version: 3.52.1(@ts-rest/core@3.52.1(@types/node@22.19.15)(zod@3.25.76))(zod@3.25.76)
+      yaml:
+        specifier: 2.8.3
+        version: 2.8.3
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -1092,7 +1107,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: catalog:testing
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3))
 
   packages/auth:
     dependencies:
@@ -2869,6 +2884,9 @@ packages:
 
   '@codemirror/lang-python@6.2.1':
     resolution: {integrity: sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==}
+
+  '@codemirror/lang-yaml@6.1.3':
+    resolution: {integrity: sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==}
 
   '@codemirror/language@6.12.4':
     resolution: {integrity: sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==}
@@ -5120,6 +5138,9 @@ packages:
 
   '@lezer/python@1.1.19':
     resolution: {integrity: sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ==}
+
+  '@lezer/yaml@1.0.4':
+    resolution: {integrity: sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==}
 
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -18048,6 +18069,11 @@ packages:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -19818,6 +19844,16 @@ snapshots:
       '@codemirror/state': 6.7.1
       '@lezer/common': 1.5.2
       '@lezer/python': 1.1.19
+
+  '@codemirror/lang-yaml@6.1.3':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/language': 6.12.4
+      '@codemirror/state': 6.7.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      '@lezer/yaml': 1.0.4
 
   '@codemirror/language@6.12.4':
     dependencies:
@@ -22210,7 +22246,7 @@ snapshots:
       string-env-interpolation: 1.0.1
       ts-log: 2.2.7
       tslib: 2.8.1
-      yaml: 2.9.0
+      yaml: 2.8.3
       yargs: 17.7.3
     transitivePeerDependencies:
       - '@fastify/websocket'
@@ -23297,6 +23333,12 @@ snapshots:
       '@lezer/highlight': 1.2.3
 
   '@lezer/python@1.1.19':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/yaml@1.0.4':
     dependencies:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
@@ -27190,7 +27232,7 @@ snapshots:
 
   '@vercel/stega@1.1.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@4.7.0(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -27198,7 +27240,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -27237,6 +27279,15 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/mocker@4.1.4(msw@2.14.6(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.14.6(@types/node@22.19.15)(typescript@5.9.3)
+      vite: 7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3)
+
   '@vitest/mocker@4.1.4(msw@2.14.6(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.4
@@ -27245,6 +27296,15 @@ snapshots:
     optionalDependencies:
       msw: 2.14.6(@types/node@22.19.15)(typescript@5.9.3)
       vite: 7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.4(msw@2.14.6(@types/node@26.1.0)(typescript@5.9.3))(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.14.6(@types/node@26.1.0)(typescript@5.9.3)
+      vite: 7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.4(msw@2.14.6(@types/node@26.1.0)(typescript@5.9.3))(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
@@ -33684,7 +33744,7 @@ snapshots:
       metro-cache: 0.83.7
       metro-core: 0.83.7
       metro-runtime: 0.83.7
-      yaml: 2.9.0
+      yaml: 2.8.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -38858,6 +38918,23 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rollup: 4.62.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.19.15
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.30.1
+      terser: 5.48.0
+      tsx: 4.23.0
+      yaml: 2.8.3
+
   vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.1
@@ -38875,6 +38952,23 @@ snapshots:
       tsx: 4.23.0
       yaml: 2.9.0
 
+  vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rollup: 4.62.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.1.0
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.30.1
+      terser: 5.48.0
+      tsx: 4.23.0
+      yaml: 2.8.3
+
   vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.1
@@ -38891,6 +38985,37 @@ snapshots:
       terser: 5.48.0
       tsx: 4.23.0
       yaml: 2.9.0
+
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(msw@2.14.6(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 22.19.15
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
+      '@vitest/ui': 4.1.4(vitest@4.1.4)
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
@@ -38917,6 +39042,37 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.15
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
+      '@vitest/ui': 4.1.4(vitest@4.1.4)
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@26.1.0)(msw@2.14.6(@types/node@26.1.0)(typescript@5.9.3))(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(msw@2.14.6(@types/node@26.1.0)(typescript@5.9.3))(vite@7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.6(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.1.0
       '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
       '@vitest/ui': 4.1.4(vitest@4.1.4)
       jsdom: 26.1.0
@@ -39378,7 +39534,10 @@ snapshots:
 
   yaml@1.10.3: {}
 
-  yaml@2.9.0: {}
+  yaml@2.8.3: {}
+
+  yaml@2.9.0:
+    optional: true
 
   yargs-parser@18.1.3:
     dependencies:


### PR DESCRIPTION
## Why

Long-term we are deprecating protocols as a separate concept: **a protocol is just a command**. Every past attempt to get there (#1659 enum cell, #1777 stacked reland, #1778 whole-product rename with DB migration) died from scope. This PR is the deliberate restart with the **smallest possible slice that gets a generic command into main and into real testing**.

The staged plan:

1. **This PR** — additive inline `command` cell (`string` | `json` | `yaml`), executable over serial and BLE exactly like a protocol, stored in the cell payload like a text/question block. No new table, no migration, old mobile apps skip it. Smallest reviewable unit.
2. **Validate** — command cells in real workbooks/flows on web + mobile against devices; confirm the free-form payload + `producerCellId` attribution model holds up.
3. **Kill protocols** — once validated, write the migration that removes protocols as a separate entity and migrates all existing protocols to commands (the #1778 work is the reference for scope: routes, DB rename, jsonb data-migration, carve-outs like the MQTT `{protocolId}` topic segment and `_protocol_set` firmware contract).

## What's included

- **@repo/api**: `zCommandCell` (`{format: string|json|yaml, content, name?}`), `command-payload` resolve/validate, `zMeasurementCommandContent` riding the existing `measurement` flow node (pre-command clients skip it instead of crashing), cells↔flow round-trip, known-command catalog (`device-command.schema.ts`).
- **Web**: command cell editor with format select, known-command autocomplete + hover hints (CodeMirror), execution via `useIotProtocolExecution.executeCommand`; graphical flow editor gets a `COMMAND` node (palette, flow-mapper round-trip, side-panel editor).
- **Mobile**: `CommandNode` runs inline commands through the scanner; scan attribution generalized from `protocolId` to `producerCellId` (persisted, wire-format pin updated) so downstream branch cells can read command output.
- **Backward compatible**: additive only — old mobile apps skip command cells; no schema/table changes.

## Provenance

Re-cut of the #1777 commits directly onto `main` (clean cherry-pick — the taxonomy stack dependency was unnecessary). Sander's known-command catalog from #1659 survives as autocomplete on a free-form editor instead of a closed enum. #1778's rename is intentionally excluded and becomes step 3.

## Verification (on this branch, based on `main`)

- `tsc` clean: @repo/api, web, mobile, backend
- @repo/api tests green (incl. schema, command-payload, cells↔flow round-trip)
- web: workbook components 263/263 + 17 new command completion/panel tests
- mobile: full suite green (wire-format pin updated for `producerCellId`)

Closes OJD-1556.