### PR TITLE
fix(iot): count averages/averages_delay in MultispeQ timeout estimate

### DIFF
--- a/packages/iot/src/driver/multispeq/multispeq-protocol-estimator.spec.ts
+++ b/packages/iot/src/driver/multispeq/multispeq-protocol-estimator.spec.ts
@@ -168,6 +168,64 @@ describe("estimateProtocolDurationMs", () => {
     expect(estimateProtocolDurationMs(protocol)).toBe(80);
   });
 
+  it("counts averages and averages_delay (the real keys, not just protocol_averages)", () => {
+    const protocol = [
+      {
+        v_arrays: [],
+        set_repeats: 1,
+        _protocol_set_: [
+          {
+            pulses: [10],
+            pulse_distance: [1000], // 10ms train
+            pre_illumination: [2, 800, 30_000], // 30s, re-run each average
+            averages: 10,
+            averages_delay: 5000, // ms, not seconds
+          },
+        ],
+      },
+    ];
+    // (10ms train + 30_000 pre-illum + 5_000 delay) × 10 averages
+    expect(estimateProtocolDurationMs(protocol)).toBe(350_100);
+  });
+
+  it("sizes a DIRK/ECS averaging protocol above its real ~8 min runtime (OJD-1643)", () => {
+    // Protocol with a 10-average DIRKecs block; each average re-runs a 30s
+    // pre-illumination, so the block alone is ~6 min. Before honoring the
+    // `averages` key the estimate was ~2.6 min and the run was cut off.
+    const protocol = [
+      {
+        share: 1,
+        set_repeats: 1,
+        _protocol_set_: [
+          { label: "Autogain", autogain: [[0, 1, 1, 10, 1000]], do_once: 1 },
+          {
+            label: "Fluorescence",
+            pre_illumination: [2, 800, 120_000],
+            pulses: [20, 400, 100, 100, 50, 50],
+            pulse_distance: [1000, 1000, 1000, 1000, 1000, 1000],
+            detectors: [[1], [1], [1], [1], [1], [1]],
+            averages: 1,
+            protocol_repeats: 1,
+          },
+          {
+            label: "DIRKecs",
+            pre_illumination: [2, 800, 30_000],
+            pulses: [300, 300, 300],
+            pulse_distance: [1000, 1000, 1000],
+            detectors: [[3], [3], [3]],
+            averages: 10,
+            averages_delay: 5000,
+            protocol_repeats: 1,
+          },
+        ],
+      },
+    ];
+    // autogain 3_000 + fluor (720+120_000) + dirk (900+30_000+5_000)×10
+    expect(estimateProtocolDurationMs(protocol)).toBe(482_720);
+    // Response budget must exceed the real ~8 min run (was ~5.3 min, timed out).
+    expect(resolveCommandTimeoutMs(protocol, 60_000)).toBeGreaterThan(8 * 60_000);
+  });
+
   it("adds pre-illumination duration to each block run", () => {
     const protocol = [
       {

--- a/packages/iot/src/driver/multispeq/multispeq-protocol-estimator.ts
+++ b/packages/iot/src/driver/multispeq/multispeq-protocol-estimator.ts
@@ -150,17 +150,33 @@ function preIlluminationMs(
 function estimateBlockMs(block: Json, vArrays: VArrays, vars: Record<string, number>): number {
   if (!isRecord(block)) return 0;
 
-  const repeats = Math.max(1, resolveField(block.protocol_repeats, vArrays, vars) ?? 1);
+  // `averages` repeats the whole block (pre_illumination included) per the
+  // PhotosynQ spec; missing it undercounted long DIRK/ECS blocks. `protocols` /
+  // `protocol_repeats` and `averages` / `protocol_averages` are aliases. OJD-1643.
+  const repeats = Math.max(
+    1,
+    resolveField(block.protocols, vArrays, vars) ??
+      resolveField(block.protocol_repeats, vArrays, vars) ??
+      1,
+  );
+  const averages = Math.max(
+    1,
+    resolveField(block.averages, vArrays, vars) ??
+      resolveField(block.protocol_averages, vArrays, vars) ??
+      1,
+  );
+  // protocols_delay is counted as seconds here (see OJD-1565); averages_delay is ms.
   const delayMs = (resolveField(block.protocols_delay, vArrays, vars) ?? 0) * 1_000;
+  const averagesDelayMs = resolveField(block.averages_delay, vArrays, vars) ?? 0;
   const preIllumMs = preIlluminationMs(block, vArrays, vars);
 
-  // A block with no pulse train still waits its pre_illumination and
+  // A block with no pulse train still waits its pre_illumination, averages and
   // protocols_delay. A standalone pre_illumination block (no pulses) is a
   // documented construct, so count it rather than treating it as 0.
   const hasPulses = Array.isArray(block.pulses) && block.pulses.length > 0;
   if (!hasPulses) {
     const setupMs = "autogain" in block ? SETUP_BLOCK_MS : 0;
-    return setupMs + (preIllumMs + delayMs) * repeats;
+    return setupMs + (preIllumMs + averagesDelayMs) * averages * repeats + delayMs * repeats;
   }
 
   const pulses = block.pulses as Json[];
@@ -175,9 +191,7 @@ function estimateBlockMs(block: Json, vArrays: VArrays, vars: Record<string, num
   }
   const pulseTrainMs = pulseTrainUs / 1000;
 
-  const averages = Math.max(1, resolveField(block.protocol_averages, vArrays, vars) ?? 1);
-
-  return (pulseTrainMs + preIllumMs) * repeats * averages + delayMs * repeats;
+  return (pulseTrainMs + preIllumMs + averagesDelayMs) * averages * repeats + delayMs * repeats;
 }
 
 function estimateSetMs(set: Json): number {


### PR DESCRIPTION
## Problem

Field teams hit `Measurement Failed - Command Timeout` on averaging protocols (mobile). The response-timeout estimator that sizes the driver read (`resolveCommandTimeoutMs`) undercounts any protocol that averages via the real MultispeQ key `averages`.

`estimateBlockMs` only multiplied a block by `protocol_averages` / `protocol_repeats` and only added `protocols_delay`. But per the [PhotosynQ command reference](https://help.photosynq.com/protocols/commands.html):

- `averages` repeats the **whole** subprotocol (pre_illumination included) and averages the passes into one data point.
- `averages_delay` is the inter-average delay, in **ms**.
- `protocol_averages` is **not in the spec at all**, so the estimator's averaging multiplier never fired for real protocols.

### Worked example (a real DIRK/ECS protocol)

`DIRKecs` block: `averages: 10` with a 30s `pre_illumination` re-run on every pass.

| | Estimate | Budget (estimate x2 + grace) | Real run |
|---|---|---|---|
| Before | ~2.6 min | ~5.3 min (cut off) | ~8 min |
| After | ~8.0 min | ~14.6 min (OK) | ~8 min |

That ~5.3 min budget is the "5 minute timeout" users reported.

## Fix

`estimateBlockMs` now honors `averages` / `averages_delay`, with `protocols`/`protocol_repeats` and `averages`/`protocol_averages` treated as aliases (so old and new protocol JSON both size correctly and it is forward/backward compatible).

## Verification

- All pre-existing estimator expectations unchanged, including `LIGHT_RESPONSE_CURVE` = 164_000.
- Two regression tests added: one for `averages`/`averages_delay`, one encoding the real DIRK/ECS protocol asserting the budget now exceeds the ~8 min runtime.

## Notes

- `protocols_delay` is left as-is (counted as seconds). The docs say ms; that mismatch only over-estimates (safe direction) and is tracked separately.
- Field workaround while a mobile build ships: add `"protocol_averages": N` next to any `"averages": N`. The device ignores the extra key; the app sizes the timeout correctly. This PR makes that unnecessary.

Refs OJD-1643.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Jan-IngenHousz-Institute/codesmith/open-jii/pr/1781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786613863&installation_id=146274774&pr_number=1781&repository=Jan-IngenHousz-Institute%2Fopen-jii&return_to=https%3A%2F%2Fgithub.com%2FJan-IngenHousz-Institute%2Fopen-jii%2Fpull%2F1781&signature=e331bac26a05ef64524db6cafdc0b5622128bc23bfe1acd8663fa4c9a54bd470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->