### PR TITLE
feat(iot): device lineage from broker identity to warehouse and UI

### DIFF
--- a/apps/backend/src/iot/application/use-cases/get-device-registry/get-device-registry.ts
+++ b/apps/backend/src/iot/application/use-cases/get-device-registry/get-device-registry.ts
@@ -1,0 +1,26 @@
+import { Injectable, Logger } from "@nestjs/common";
+
+import { Result } from "../../../../common/utils/fp-utils";
+import { IotDeviceDto } from "../../../core/models/iot-device.model";
+import { IotDeviceRepository } from "../../../core/repositories/iot-device.repository";
+
+export interface GetDeviceRegistryParams {
+  thingNames: string[];
+}
+
+@Injectable()
+export class GetDeviceRegistryUseCase {
+  private readonly logger = new Logger(GetDeviceRegistryUseCase.name);
+
+  constructor(private readonly deviceRepository: IotDeviceRepository) {}
+
+  async execute(params: GetDeviceRegistryParams): Promise<Result<IotDeviceDto[]>> {
+    this.logger.log({
+      msg: "Resolving device registry for lineage",
+      operation: "getDeviceRegistry",
+      thingNameCount: params.thingNames.length,
+    });
+
+    return await this.deviceRepository.findByThingNames(params.thingNames);
+  }
+}

--- a/apps/backend/src/iot/core/repositories/iot-device.repository.spec.ts
+++ b/apps/backend/src/iot/core/repositories/iot-device.repository.spec.ts
@@ -100,6 +100,28 @@ describe("IotDeviceRepository", () => {
     expect(result.value?.serialNumber).toBe(dto.serialNumber);
   });
 
+  it("resolves thing names to registry rows across owners", async () => {
+    const otherUser = await testApp.createTestUser({ name: "Other Owner" });
+    const mine = buildDto();
+    const theirs = buildDto();
+    await repository.create(mine, userId);
+    await repository.create(theirs, otherUser);
+
+    const result = await repository.findByThingNames([mine.thingName, theirs.thingName, "missing"]);
+
+    assertSuccess(result);
+    expect(result.value.map((d) => d.thingName).sort()).toEqual(
+      [mine.thingName, theirs.thingName].sort(),
+    );
+  });
+
+  it("returns an empty list without querying for an empty batch", async () => {
+    const result = await repository.findByThingNames([]);
+
+    assertSuccess(result);
+    expect(result.value).toEqual([]);
+  });
+
   it("deletes a device", async () => {
     const created = await repository.create(buildDto(), userId);
     assertSuccess(created);

--- a/apps/backend/src/iot/core/repositories/iot-device.repository.ts
+++ b/apps/backend/src/iot/core/repositories/iot-device.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject } from "@nestjs/common";
 
-import { and, desc, eq, iotDevices } from "@repo/database";
+import { and, desc, eq, inArray, iotDevices } from "@repo/database";
 import type { DatabaseInstance } from "@repo/database";
 
 import { Result, tryCatch } from "../../../common/utils/fp-utils";
@@ -56,6 +56,21 @@ export class IotDeviceRepository {
         .where(eq(iotDevices.serialNumber, serialNumber))
         .limit(1);
       return results.length === 0 ? null : results[0];
+    });
+  }
+
+  // Cross-owner lookup for the Databricks lineage webhook: the pipeline resolves
+  // broker-authenticated thing names to registry rows, so this is not owner-scoped.
+  async findByThingNames(thingNames: string[]): Promise<Result<IotDeviceDto[]>> {
+    return tryCatch(async () => {
+      if (thingNames.length === 0) {
+        return [];
+      }
+      const results = await this.database
+        .select()
+        .from(iotDevices)
+        .where(inArray(iotDevices.thingName, thingNames));
+      return results;
     });
   }
 

--- a/apps/backend/src/iot/iot.module.ts
+++ b/apps/backend/src/iot/iot.module.ts
@@ -6,6 +6,7 @@ import { AwsAdapter } from "../common/modules/aws/aws.adapter";
 import { AwsModule } from "../common/modules/aws/aws.module";
 import { ExperimentModule } from "../experiments/experiment.module";
 import { DeleteIotDeviceUseCase } from "./application/use-cases/delete-iot-device/delete-iot-device";
+import { GetDeviceRegistryUseCase } from "./application/use-cases/get-device-registry/get-device-registry";
 import { GetIotCredentialsUseCase } from "./application/use-cases/get-iot-credentials/get-iot-credentials";
 import { GetIotDeviceUseCase } from "./application/use-cases/get-iot-device/get-iot-device";
 import { GetIotUploadUrlUseCase } from "./application/use-cases/get-upload-url/get-upload-url";
@@ -17,13 +18,15 @@ import { RotateIotCredentialsUseCase } from "./application/use-cases/rotate-iot-
 import { ANALYTICS_PORT } from "./core/ports/analytics.port";
 import { AWS_PORT } from "./core/ports/aws.port";
 import { IotDeviceRepository } from "./core/repositories/iot-device.repository";
+import { DeviceRegistryWebhookController } from "./presentation/device-registry-webhook.controller";
 import { IotDeviceController } from "./presentation/iot-device.controller";
 import { IotController } from "./presentation/iot.controller";
 
 @Module({
   imports: [AwsModule, AnalyticsModule, ExperimentModule],
-  controllers: [IotController, IotDeviceController],
+  controllers: [IotController, IotDeviceController, DeviceRegistryWebhookController],
   providers: [
+    GetDeviceRegistryUseCase,
     GetIotCredentialsUseCase,
     GetIotUploadUrlUseCase,
     RegisterIotDeviceUseCase,

--- a/apps/backend/src/iot/presentation/device-registry-webhook.controller.spec.ts
+++ b/apps/backend/src/iot/presentation/device-registry-webhook.controller.spec.ts
@@ -1,0 +1,94 @@
+import * as crypto from "crypto";
+import { StatusCodes } from "http-status-codes";
+
+import { contract } from "@repo/api/contract";
+
+import { stableStringify } from "../../common/utils/stable-json";
+import { TestHarness } from "../../test/test-harness";
+
+describe("DeviceRegistryWebhookController", () => {
+  const testApp = TestHarness.App;
+
+  const apiKeyId = process.env.DATABRICKS_WEBHOOK_API_KEY_ID ?? "test-api-key-id";
+  const webhookSecret = process.env.DATABRICKS_WEBHOOK_SECRET ?? "test-webhook-secret";
+
+  const sign = (body: object) => {
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const message = `${timestamp}:${stableStringify(body)}`;
+    const signature = crypto.createHmac("sha256", webhookSecret).update(message).digest("hex");
+    return { timestamp, signature };
+  };
+
+  beforeAll(async () => {
+    await testApp.setup();
+  });
+
+  beforeEach(async () => {
+    await testApp.beforeEach();
+  });
+
+  afterEach(() => {
+    testApp.afterEach();
+  });
+
+  afterAll(async () => {
+    await testApp.teardown();
+  });
+
+  describe("handleGetDeviceRegistry", () => {
+    it("resolves thing names to their registry rows", async () => {
+      const userId = await testApp.createTestUser({ email: "owner@example.com", name: "Owner" });
+      const device = await testApp.createIotDevice({
+        createdBy: userId,
+        thingName: "ambyte_AA11",
+        serialNumber: "AA:11",
+        deviceType: "ambyte",
+        status: "active",
+      });
+
+      const body = { thingNames: ["ambyte_AA11", "ambyte_missing"] };
+      const { timestamp, signature } = sign(body);
+
+      const response = await testApp
+        .post(contract.iot.getDeviceRegistry.path)
+        .set("x-api-key-id", apiKeyId)
+        .set("x-databricks-signature", signature)
+        .set("x-databricks-timestamp", timestamp)
+        .send(body);
+
+      expect(response.status).toBe(StatusCodes.OK);
+      expect(response.body.success).toBe(true);
+      // Unknown thing names simply do not resolve (left-join yields nothing).
+      expect(response.body.devices).toEqual([
+        {
+          thingName: "ambyte_AA11",
+          id: device.id,
+          serialNumber: "AA:11",
+          deviceType: "ambyte",
+          status: "active",
+          createdBy: userId,
+        },
+      ]);
+    });
+
+    it("rejects an unsigned request", async () => {
+      await testApp
+        .post(contract.iot.getDeviceRegistry.path)
+        .send({ thingNames: ["ambyte_AA11"] })
+        .expect(StatusCodes.UNAUTHORIZED);
+    });
+
+    it("rejects an empty batch (min 1)", async () => {
+      const body = { thingNames: [] };
+      const { timestamp, signature } = sign(body);
+
+      await testApp
+        .post(contract.iot.getDeviceRegistry.path)
+        .set("x-api-key-id", apiKeyId)
+        .set("x-databricks-signature", signature)
+        .set("x-databricks-timestamp", timestamp)
+        .send(body)
+        .expect(StatusCodes.BAD_REQUEST);
+    });
+  });
+});

--- a/apps/backend/src/iot/presentation/device-registry-webhook.controller.spec.ts
+++ b/apps/backend/src/iot/presentation/device-registry-webhook.controller.spec.ts
@@ -2,9 +2,11 @@ import * as crypto from "crypto";
 import { StatusCodes } from "http-status-codes";
 
 import { contract } from "@repo/api/contract";
+import type { DeviceRegistryWebhookResponse } from "@repo/api/schemas/iot.schema";
 
 import { stableStringify } from "../../common/utils/stable-json";
 import { TestHarness } from "../../test/test-harness";
+import type { SuperTestResponse } from "../../test/test-harness";
 
 describe("DeviceRegistryWebhookController", () => {
   const testApp = TestHarness.App;
@@ -49,7 +51,7 @@ describe("DeviceRegistryWebhookController", () => {
       const body = { thingNames: ["ambyte_AA11", "ambyte_missing"] };
       const { timestamp, signature } = sign(body);
 
-      const response = await testApp
+      const response: SuperTestResponse<DeviceRegistryWebhookResponse> = await testApp
         .post(contract.iot.getDeviceRegistry.path)
         .set("x-api-key-id", apiKeyId)
         .set("x-databricks-signature", signature)

--- a/apps/backend/src/iot/presentation/device-registry-webhook.controller.spec.ts
+++ b/apps/backend/src/iot/presentation/device-registry-webhook.controller.spec.ts
@@ -4,9 +4,11 @@ import { StatusCodes } from "http-status-codes";
 import { contract } from "@repo/api/contract";
 import type { DeviceRegistryWebhookResponse } from "@repo/api/schemas/iot.schema";
 
+import { AppError, failure } from "../../common/utils/fp-utils";
 import { stableStringify } from "../../common/utils/stable-json";
 import { TestHarness } from "../../test/test-harness";
 import type { SuperTestResponse } from "../../test/test-harness";
+import { GetDeviceRegistryUseCase } from "../application/use-cases/get-device-registry/get-device-registry";
 
 describe("DeviceRegistryWebhookController", () => {
   const testApp = TestHarness.App;
@@ -30,6 +32,7 @@ describe("DeviceRegistryWebhookController", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     testApp.afterEach();
   });
 
@@ -71,6 +74,23 @@ describe("DeviceRegistryWebhookController", () => {
           createdBy: userId,
         },
       ]);
+    });
+
+    it("returns 500 when the registry lookup fails", async () => {
+      vi.spyOn(testApp.module.get(GetDeviceRegistryUseCase), "execute").mockResolvedValue(
+        failure(AppError.internal("db unavailable")),
+      );
+
+      const body = { thingNames: ["ambyte_AA11"] };
+      const { timestamp, signature } = sign(body);
+
+      await testApp
+        .post(contract.iot.getDeviceRegistry.path)
+        .set("x-api-key-id", apiKeyId)
+        .set("x-databricks-signature", signature)
+        .set("x-databricks-timestamp", timestamp)
+        .send(body)
+        .expect(StatusCodes.INTERNAL_SERVER_ERROR);
     });
 
     it("rejects an unsigned request", async () => {

--- a/apps/backend/src/iot/presentation/device-registry-webhook.controller.ts
+++ b/apps/backend/src/iot/presentation/device-registry-webhook.controller.ts
@@ -1,0 +1,56 @@
+import { Controller, Logger, UseGuards } from "@nestjs/common";
+import { AllowAnonymous } from "@thallesp/nestjs-better-auth";
+import { TsRestHandler, tsRestHandler } from "@ts-rest/nest";
+import { StatusCodes } from "http-status-codes";
+
+import { contract } from "@repo/api/contract";
+
+import { HmacGuard } from "../../common/guards/hmac.guard";
+import { handleFailure } from "../../common/utils/fp-utils";
+import { GetDeviceRegistryUseCase } from "../application/use-cases/get-device-registry/get-device-registry";
+
+@Controller()
+@AllowAnonymous()
+@UseGuards(HmacGuard)
+export class DeviceRegistryWebhookController {
+  private readonly logger = new Logger(DeviceRegistryWebhookController.name);
+
+  constructor(private readonly getDeviceRegistryUseCase: GetDeviceRegistryUseCase) {}
+
+  @TsRestHandler(contract.iot.getDeviceRegistry)
+  handleGetDeviceRegistry() {
+    return tsRestHandler(contract.iot.getDeviceRegistry, async ({ body }) => {
+      const result = await this.getDeviceRegistryUseCase.execute({
+        thingNames: body.thingNames,
+      });
+
+      if (result.isSuccess()) {
+        const devices = result.value.map((device) => ({
+          thingName: device.thingName,
+          id: device.id,
+          serialNumber: device.serialNumber,
+          deviceType: device.deviceType,
+          status: device.status,
+          createdBy: device.createdBy,
+        }));
+
+        this.logger.log({
+          msg: "Successfully resolved device registry",
+          operation: "getDeviceRegistry",
+          deviceCount: devices.length,
+          status: "success",
+        });
+
+        return {
+          status: StatusCodes.OK as const,
+          body: {
+            devices,
+            success: true,
+          },
+        };
+      }
+
+      return handleFailure(result, this.logger);
+    });
+  }
+}

--- a/apps/data/src/lib/enrich/enrich/backend_client.py
+++ b/apps/data/src/lib/enrich/enrich/backend_client.py
@@ -36,6 +36,7 @@ class BackendClient:
     
     WEBHOOK_USER_METADATA_PATH = "/api/v1/users/metadata"
     WEBHOOK_MACRO_BATCH_PATH = "/api/v1/macros/execute-batch"
+    WEBHOOK_IOT_REGISTRY_PATH = "/api/v1/iot/devices/registry"
     
     def __init__(self, base_url: str, api_key_id: str, webhook_secret: str, timeout: int = 30):
         """
@@ -212,6 +213,56 @@ class BackendClient:
             }
             
         return user_metadata
+
+    def get_device_registry(self, thing_names: List[str]) -> Dict[str, Dict[str, Any]]:
+        """
+        Resolve broker-authenticated client ids to their device registry rows.
+
+        For an X.509 device the MQTT client id equals its Thing name, so the
+        pipeline passes distinct client_id values here; Cognito/mobile client ids
+        match no registry row and are simply absent from the result.
+
+        Returns:
+            Dict mapping thing_name -> {id, serialNumber, deviceType, status, createdBy}
+        """
+        if not thing_names:
+            return {}
+        if not isinstance(thing_names, list):
+            raise BackendIntegrationError("thing_names must be a list")
+        if len(thing_names) > 500:
+            raise BackendIntegrationError(f"Too many thing names in batch: {len(thing_names)} (max 500)")
+
+        valid = [t for t in thing_names if t is not None and str(t).strip()]
+        if not valid:
+            return {}
+
+        payload = {"thingNames": valid}
+
+        try:
+            result = self._make_request(self.WEBHOOK_IOT_REGISTRY_PATH, payload)
+        except BackendIntegrationError:
+            raise
+        except Exception as e:
+            raise BackendIntegrationError(f"Unexpected error fetching device registry: {str(e)}")
+
+        registry: Dict[str, Dict[str, Any]] = {}
+        devices_list = result.get('devices', [])
+
+        if not isinstance(devices_list, list):
+            raise BackendIntegrationError(f"Invalid response format: expected 'devices' to be a list, got {type(devices_list)}")
+
+        for device in devices_list:
+            if not isinstance(device, dict) or 'thingName' not in device:
+                continue
+            registry[device['thingName']] = {
+                'id': device.get('id'),
+                'serialNumber': device.get('serialNumber'),
+                'deviceType': device.get('deviceType'),
+                'status': device.get('status'),
+                'createdBy': device.get('createdBy'),
+            }
+
+        return registry
 
 
     def execute_macro_batch(

--- a/apps/data/src/lib/enrich/enrich/device_metadata.py
+++ b/apps/data/src/lib/enrich/enrich/device_metadata.py
@@ -1,0 +1,81 @@
+"""
+Device Registry Enrichment
+
+Resolves the broker-authenticated client_id (== Thing name for X.509 devices) to
+the platform device registry (uuid, serial, owner, status) from the openJII
+backend API, mirroring user_metadata.add_user_column.
+"""
+
+from typing import Dict, Any, List
+import pandas as pd
+from pyspark.sql.types import StructType, StructField, StringType
+
+from .backend_client import BackendClient
+
+
+# device struct: STRUCT<id, serial_number, owner, status, device_type>
+device_schema = StructType([
+    StructField("id", StringType(), True),
+    StructField("serial_number", StringType(), True),
+    StructField("owner", StringType(), True),
+    StructField("status", StringType(), True),
+    StructField("device_type", StringType(), True),
+])
+
+
+def _fetch_device_registry(thing_names: List[str], backend_client: BackendClient) -> Dict[str, Dict[str, Any]]:
+    if not thing_names:
+        return {}
+    try:
+        return backend_client.get_device_registry(thing_names)
+    except Exception as e:
+        print(f"Error fetching device registry: {str(e)}")
+        return {}
+
+
+def add_device_registry(df, environment: str, dbutils):
+    """
+    Add a `device` struct resolved from the trusted client_id.
+
+    Mirrors add_user_column: fetches the registry once per Spark batch, keyed by
+    client_id (== Thing name for X.509 devices). Cognito/mobile client ids and
+    NULLs match no registry row and resolve to a NULL struct.
+
+    Args:
+        df: PySpark DataFrame with a 'client_id' column
+        environment: Environment name (dev, prod, etc.)
+        dbutils: Databricks utilities instance for accessing secrets
+
+    Returns:
+        DataFrame with an added `device` STRUCT<id, serial_number, owner, status, device_type>.
+    """
+    from .backend_client import BackendClient
+    from pyspark.sql import functions as F
+
+    # Get secrets on driver node to pass to workers
+    scope = f"node-webhook-secret-scope-{environment}"
+    base_url = dbutils.secrets.get(scope=scope, key="webhook_base_url")
+    api_key_id = dbutils.secrets.get(scope=scope, key="webhook_api_key_id")
+    webhook_secret = dbutils.secrets.get(scope=scope, key="webhook_secret")
+
+    @F.pandas_udf(device_schema)
+    def get_devices(client_ids: pd.Series) -> pd.DataFrame:
+        worker_client = BackendClient(base_url, api_key_id, webhook_secret)
+        unique = [c for c in client_ids.dropna().unique().tolist() if str(c).strip()]
+        registry = _fetch_device_registry(unique, worker_client)
+
+        def extract(cid):
+            if pd.isna(cid):
+                return pd.Series([None, None, None, None, None])
+            info = registry.get(cid, {})
+            return pd.Series([
+                info.get('id'),
+                info.get('serialNumber'),
+                info.get('createdBy'),
+                info.get('status'),
+                info.get('deviceType'),
+            ])
+
+        return client_ids.apply(extract)
+
+    return df.withColumn("device", get_devices(F.col("client_id")))

--- a/apps/data/src/pipelines/centrum_pipeline.py
+++ b/apps/data/src/pipelines/centrum_pipeline.py
@@ -595,6 +595,7 @@ def experiment_raw_data():
             "id",
             "experiment_id",
             "device_id",
+            "client_id",
             "device_name",
             "timestamp",
             "timezone",
@@ -709,6 +710,7 @@ def experiment_macro_data():
             "id",
             "experiment_id",
             "device_id",
+            "client_id",
             "device_name",
             "timestamp",
             "timezone",
@@ -726,6 +728,7 @@ def experiment_macro_data():
             "id",
             "experiment_id",
             "device_id",
+            "client_id",
             "device_name",
             "timestamp",
             "timezone",
@@ -801,6 +804,7 @@ def experiment_macro_data():
             F.col("macro_row_id").alias("id"),
             F.col("id").alias("raw_id"),
             "device_id",
+            "client_id",
             "device_name",
             "timestamp",
             "timezone",
@@ -1076,15 +1080,22 @@ def enriched_experiment_raw_data():
     """Enriched raw data with user profiles, annotations, and user metadata."""
     raw_data = dlt.read(EXPERIMENT_RAW_DATA_TABLE)
     contributors = dlt.read(EXPERIMENT_CONTRIBUTORS_TABLE)
+    devices = dlt.read(EXPERIMENT_DEVICES_TABLE)
     annotations_source = dlt.read(ANNOTATIONS_SOURCE_TABLE)
     metadata_source = dlt.read(METADATA_SOURCE_TABLE)
-    
+
     enriched = (
         raw_data
         .join(
             contributors,
             (raw_data.experiment_id == contributors.experiment_id) &
             (raw_data.user_id == contributors.user_id),
+            "left"
+        )
+        .join(
+            devices,
+            (raw_data.experiment_id == devices.experiment_id) &
+            (raw_data.client_id == devices.client_id),
             "left"
         )
         .select(
@@ -1100,6 +1111,7 @@ def enriched_experiment_raw_data():
             raw_data.questions_data,
             raw_data.annotations,
             contributors.user.alias("contributor"),
+            devices.device.alias("device"),
             raw_data.data,
             raw_data.processed_timestamp
         )
@@ -1145,15 +1157,22 @@ def enriched_experiment_macro_data():
     """Enriched macro data with user profiles, annotations, and user metadata."""
     macro_data = dlt.read(EXPERIMENT_MACRO_DATA_TABLE)
     contributors = dlt.read(EXPERIMENT_CONTRIBUTORS_TABLE)
+    devices = dlt.read(EXPERIMENT_DEVICES_TABLE)
     annotations_source = dlt.read(ANNOTATIONS_SOURCE_TABLE)
     metadata_source = dlt.read(METADATA_SOURCE_TABLE)
-    
+
     enriched = (
         macro_data
         .join(
             contributors,
             (macro_data.experiment_id == contributors.experiment_id) &
             (macro_data.user_id == contributors.user_id),
+            "left"
+        )
+        .join(
+            devices,
+            (macro_data.experiment_id == devices.experiment_id) &
+            (macro_data.client_id == devices.client_id),
             "left"
         )
         .select(
@@ -1167,6 +1186,7 @@ def enriched_experiment_macro_data():
             macro_data.timezone,
             macro_data.date,
             contributors.user.alias("contributor"),
+            devices.device.alias("device"),
             macro_data.macro_id,
             macro_data.macro_name,
             macro_data.macro_filename,

--- a/apps/data/src/pipelines/centrum_pipeline.py
+++ b/apps/data/src/pipelines/centrum_pipeline.py
@@ -11,6 +11,7 @@ import requests
 import pandas as pd
 from datetime import datetime
 from enrich.user_metadata import add_user_column
+from enrich.device_metadata import add_device_registry
 from enrich.annotations_metadata import add_annotation_column
 from enrich.custom_metadata import add_custom_metadata_column
 from enrich.macro_execution import make_execute_macro_udf
@@ -88,6 +89,7 @@ EXPERIMENT_RAW_DATA_TABLE = "experiment_raw_data"
 EXPERIMENT_DEVICE_DATA_TABLE = "experiment_device_data"
 EXPERIMENT_MACRO_DATA_TABLE = "experiment_macro_data"
 EXPERIMENT_CONTRIBUTORS_TABLE = "experiment_contributors"
+EXPERIMENT_DEVICES_TABLE = "experiment_devices"
 EXPERIMENT_TABLE_METADATA = "experiment_table_metadata"
 ENRICHED_RAW_DATA_VIEW = "enriched_experiment_raw_data"
 ENRICHED_MACRO_DATA_VIEW = "enriched_experiment_macro_data"
@@ -627,8 +629,9 @@ def experiment_device_data():
     Aggregate device stats per experiment from clean_data.
     """
     silver_df = dlt.read(SILVER_TABLE)
-    
-    return (
+    devices = dlt.read(EXPERIMENT_DEVICES_TABLE)
+
+    aggregated = (
         silver_df
         .filter("experiment_id IS NOT NULL")
         .groupBy("experiment_id", "device_id", "device_firmware")
@@ -650,17 +653,30 @@ def experiment_device_data():
                 )
             )
         )
+    )
+
+    # Attach the registry-resolved device struct via the trusted client_id
+    # (NULL for Cognito/unregistered rows — left join keeps every device row).
+    return (
+        aggregated
+        .join(
+            devices,
+            (aggregated.experiment_id == devices.experiment_id)
+            & (aggregated.client_id == devices.client_id),
+            "left"
+        )
         .select(
-            "id",
-            "experiment_id",
-            "device_id",
-            "client_id",
-            "device_firmware",
-            "device_name",
-            "device_version",
-            "device_battery",
-            "total_measurements",
-            "processed_timestamp"
+            aggregated.id,
+            aggregated.experiment_id,
+            aggregated.device_id,
+            aggregated.client_id,
+            aggregated.device_firmware,
+            aggregated.device_name,
+            aggregated.device_version,
+            aggregated.device_battery,
+            aggregated.total_measurements,
+            aggregated.processed_timestamp,
+            devices.device,
         )
     )
 
@@ -972,6 +988,39 @@ def experiment_contributors():
     unique_users = sensor_users.unionByName(upload_users).distinct()
 
     return add_user_column(unique_users, ENVIRONMENT, dbutils)
+
+# COMMAND ----------
+
+# DBTITLE 1,Gold Layer - Experiment Devices
+@dlt.table(
+    name=EXPERIMENT_DEVICES_TABLE,
+    comment="Gold layer: Registry-resolved devices per experiment (client_id -> device), full refresh each run.",
+    table_properties={
+        "quality": "gold",
+        "pipelines.autoOptimize.managed": "true",
+        "delta.autoOptimize.optimizeWrite": "true",
+        "delta.autoOptimize.autoCompact": "true",
+        "delta.enableRowTracking": "true",
+        "delta.enableChangeDataFeed": "true",
+    }
+)
+def experiment_devices():
+    """Devices observed per experiment, resolved against the registry via the
+    broker-authenticated client_id (== Thing name for X.509 devices). Cognito
+    rows have a non-Thing client_id and resolve to a NULL device struct.
+
+    Mirrors experiment_contributors: distinct keys from the data, enriched once
+    per run from the backend, then joined by the gold device dimension.
+    """
+    unique_devices = (
+        dlt.read(SILVER_TABLE)
+        .filter("experiment_id IS NOT NULL")
+        .filter("client_id IS NOT NULL")
+        .select("experiment_id", "client_id")
+        .distinct()
+    )
+
+    return add_device_registry(unique_devices, ENVIRONMENT, dbutils)
 
 # COMMAND ----------
 

--- a/apps/data/src/pipelines/centrum_pipeline.py
+++ b/apps/data/src/pipelines/centrum_pipeline.py
@@ -161,8 +161,12 @@ def raw_data():
             F.regexp_extract(F.col("partitionKey"), r"/experiment/([^/]+)/", 1),
             F.lit(None).cast(StringType())
         ))
+        # clientid() from the IoT rule is the broker-authenticated Thing name (X.509 devices);
+        # extracted top-level to avoid evolving the non-resettable bronze parsed_data struct.
+        .withColumn("client_id", F.get_json_object(F.col("data").cast("string"), "$.client_id"))
         .select(
             "experiment_id",
+            "client_id",
             "parsed_data",
             "ingestion_timestamp",
             "ingest_date",
@@ -317,6 +321,7 @@ def clean_data():
     bronze_clean = df.select(
         "id",
         "device_id",
+        "client_id",
         "device_name",
         "device_version",
         "device_battery",
@@ -348,6 +353,8 @@ def clean_data():
         .withColumn("hour", F.hour("timestamp"))
         .withColumn("ingest_latency_ms", F.lit(None).cast("long"))
         .withColumn("timezone", F.lit(None).cast("string"))
+        # Imported/transfer rows have no MQTT client identity.
+        .withColumn("client_id", F.lit(None).cast("string"))
         # Build macros array from macro columns (empty when no macro)
         # Apply legacy macro ID remapping inline
         .withColumn(
@@ -377,6 +384,7 @@ def clean_data():
         .select(
             "id",
             "device_id",
+            "client_id",
             "device_name",
             "device_version",
             "device_battery",
@@ -628,6 +636,7 @@ def experiment_device_data():
             F.max("device_name").alias("device_name"),
             F.max("device_version").alias("device_version"),
             F.max("device_battery").alias("device_battery"),
+            F.max("client_id").alias("client_id"),
             F.count("*").alias("total_measurements"),
             F.max("processed_timestamp").alias("processed_timestamp")
         )
@@ -645,6 +654,7 @@ def experiment_device_data():
             "id",
             "experiment_id",
             "device_id",
+            "client_id",
             "device_firmware",
             "device_name",
             "device_version",

--- a/apps/web/components/data-filters/filter-column-path.test.ts
+++ b/apps/web/components/data-filters/filter-column-path.test.ts
@@ -13,6 +13,12 @@ const contributorColumn: DataColumn = {
   type_text: WellKnownColumnTypes.CONTRIBUTOR,
 };
 
+const deviceColumn: DataColumn = {
+  name: "device",
+  type_name: "STRUCT",
+  type_text: WellKnownColumnTypes.DEVICE,
+};
+
 describe("filterColumnPathFor", () => {
   it("returns the bare column name for scalar columns", () => {
     expect(filterColumnPathFor(stringColumn)).toBe("label");
@@ -20,6 +26,10 @@ describe("filterColumnPathFor", () => {
 
   it("routes CONTRIBUTOR structs through their identity sub-field", () => {
     expect(filterColumnPathFor(contributorColumn)).toBe("owner.id");
+  });
+
+  it("routes DEVICE structs through their serial-number sub-field", () => {
+    expect(filterColumnPathFor(deviceColumn)).toBe("device.serial_number");
   });
 });
 

--- a/apps/web/components/data-filters/filter-column-path.ts
+++ b/apps/web/components/data-filters/filter-column-path.ts
@@ -6,6 +6,9 @@ export function filterColumnPathFor(column: DataColumn): string {
   if (column.type_text === WellKnownColumnTypes.CONTRIBUTOR) {
     return `${column.name}.id`;
   }
+  if (column.type_text === WellKnownColumnTypes.DEVICE) {
+    return `${column.name}.serial_number`;
+  }
   return column.name;
 }
 

--- a/apps/web/components/data-filters/use-distinct-options.test.ts
+++ b/apps/web/components/data-filters/use-distinct-options.test.ts
@@ -18,6 +18,11 @@ const contributorColumn: DataColumn = {
   type_name: "STRUCT",
   type_text: WellKnownColumnTypes.CONTRIBUTOR,
 };
+const deviceColumn: DataColumn = {
+  name: "device",
+  type_name: "STRUCT",
+  type_text: WellKnownColumnTypes.DEVICE,
+};
 
 describe("useDistinctOptions", () => {
   it("returns the fetched values and exposes truncated state", async () => {
@@ -44,6 +49,20 @@ describe("useDistinctOptions", () => {
     await waitFor(() => expect(result.current.values).toHaveLength(1));
     expect(result.current.isContributor).toBe(true);
     expect(result.current.contributorMap?.get("u-1")).toBe(struct);
+  });
+
+  it("flags DEVICE columns and does not build a contributor map", async () => {
+    const struct = JSON.stringify({ id: "d-1", serial_number: "AA:11" });
+    server.mount(contract.experiments.getDistinctColumnValues, {
+      body: { values: [struct], truncated: false },
+    });
+
+    const { result } = renderHook(() => useDistinctOptions(deviceColumn, "exp-1", "raw_data"));
+
+    await waitFor(() => expect(result.current.values).toHaveLength(1));
+    expect(result.current.isDevice).toBe(true);
+    expect(result.current.isContributor).toBe(false);
+    expect(result.current.contributorMap).toBeUndefined();
   });
 
   it("returns empty defaults while loading or when the request errors", async () => {
@@ -94,5 +113,19 @@ describe("chipValueForOption", () => {
 
   it("returns the raw value when contributor parsing fails", () => {
     expect(chipValueForOption("plain", true)).toBe("plain");
+  });
+
+  it("unwraps the serial number when the column is a DEVICE struct", () => {
+    const struct = JSON.stringify({ id: "d-1", serial_number: "AA:11", status: "active" });
+    expect(chipValueForOption(struct, false, true)).toBe("AA:11");
+  });
+
+  it("returns the raw value when device json is unparseable", () => {
+    expect(chipValueForOption("plain", false, true)).toBe("plain");
+  });
+
+  it("returns the raw value when the device struct has no serial number", () => {
+    const struct = JSON.stringify({ id: "d-1" });
+    expect(chipValueForOption(struct, false, true)).toBe(struct);
   });
 });

--- a/apps/web/components/data-filters/use-distinct-options.ts
+++ b/apps/web/components/data-filters/use-distinct-options.ts
@@ -12,8 +12,18 @@ export function useDistinctOptions(column: DataColumn, experimentId: string, tab
     column: column.name,
   });
   const isContributor = column.type_text === WellKnownColumnTypes.CONTRIBUTOR;
+  const isDevice = column.type_text === WellKnownColumnTypes.DEVICE;
   const contributorMap = useContributorIdMap(values, isContributor);
-  return { values, truncated, isLoading, isSuccess, error, isContributor, contributorMap };
+  return {
+    values,
+    truncated,
+    isLoading,
+    isSuccess,
+    error,
+    isContributor,
+    isDevice,
+    contributorMap,
+  };
 }
 
 export function useContributorIdMap(
@@ -49,10 +59,27 @@ function tryParseContributorId(json: string): string | null {
   }
 }
 
-export function chipValueForOption(raw: string | number, isContributor: boolean): string | number {
-  if (!isContributor) {
-    return raw;
+function tryParseDeviceSerial(json: string): string | null {
+  try {
+    const parsed = JSON.parse(json) as { serial_number?: unknown };
+    return typeof parsed.serial_number === "string" ? parsed.serial_number : null;
+  } catch {
+    return null;
   }
-  const id = tryParseContributorId(String(raw));
-  return id ?? raw;
+}
+
+export function chipValueForOption(
+  raw: string | number,
+  isContributor: boolean,
+  isDevice = false,
+): string | number {
+  if (isContributor) {
+    const id = tryParseContributorId(String(raw));
+    return id ?? raw;
+  }
+  if (isDevice) {
+    const serial = tryParseDeviceSerial(String(raw));
+    return serial ?? raw;
+  }
+  return raw;
 }

--- a/apps/web/components/data-filters/value-inputs/categorical-multi-input.tsx
+++ b/apps/web/components/data-filters/value-inputs/categorical-multi-input.tsx
@@ -37,7 +37,7 @@ export function CategoricalMultiInput({
 }: CategoricalMultiInputProps) {
   const { t } = useTranslation("common");
   const [open, setOpen] = useState(false);
-  const { values, isLoading, isSuccess, truncated, isContributor, contributorMap } =
+  const { values, isLoading, isSuccess, truncated, isContributor, isDevice, contributorMap } =
     useDistinctOptions(column, experimentId, tableName);
 
   const selected = useMemo<string[]>(
@@ -47,7 +47,7 @@ export function CategoricalMultiInput({
   const selectedSet = useMemo(() => new Set(selected), [selected]);
 
   const toggle = (raw: string | number) => {
-    const chipValue = chipValueForOption(raw, isContributor);
+    const chipValue = chipValueForOption(raw, isContributor, isDevice);
     const key = String(chipValue);
 
     if (selectedSet.has(key)) {
@@ -66,7 +66,8 @@ export function CategoricalMultiInput({
       ? t("dataFilters.pickValues")
       : t("dataFilters.selectedCount", { count: selected.length });
 
-  const getChipKey = (raw: string | number) => String(chipValueForOption(raw, isContributor));
+  const getChipKey = (raw: string | number) =>
+    String(chipValueForOption(raw, isContributor, isDevice));
 
   // DISTINCT keys on the whole contributor struct, so one person can return
   // several snapshots (name/avatar drift) that all collapse to the same id.
@@ -74,14 +75,14 @@ export function CategoricalMultiInput({
   const uniqueValues = useMemo(() => {
     const seen = new Set<string>();
     return values.filter((v) => {
-      const key = String(chipValueForOption(v, isContributor));
+      const key = String(chipValueForOption(v, isContributor, isDevice));
       if (seen.has(key)) {
         return false;
       }
       seen.add(key);
       return true;
     });
-  }, [values, isContributor]);
+  }, [values, isContributor, isDevice]);
 
   // Toggling anonymization re-pseudonymises contributor ids, so a selection
   // from the other mode no longer resolves and would show a raw id. Prune only
@@ -134,6 +135,7 @@ export function CategoricalMultiInput({
                     optionValue={String(v)}
                     isSelected={selectedSet.has(getChipKey(v))}
                     isContributor={isContributor}
+                    isDevice={isDevice}
                     onSelect={() => toggle(v)}
                   />
                 ))}

--- a/apps/web/components/data-filters/value-inputs/categorical-option.test.tsx
+++ b/apps/web/components/data-filters/value-inputs/categorical-option.test.tsx
@@ -20,6 +20,7 @@ describe("CategoricalOption", () => {
         optionValue="alpha"
         isSelected={false}
         isContributor={false}
+        isDevice={false}
         onSelect={vi.fn()}
       />,
     );
@@ -33,6 +34,7 @@ describe("CategoricalOption", () => {
         optionValue="alpha"
         isSelected={false}
         isContributor={false}
+        isDevice={false}
         onSelect={onSelect}
       />,
     );
@@ -47,9 +49,30 @@ describe("CategoricalOption", () => {
         optionValue={struct}
         isSelected={false}
         isContributor
+        isDevice={false}
         onSelect={vi.fn()}
       />,
     );
     expect(screen.getByText("Alice")).toBeInTheDocument();
+  });
+
+  it("renders the device serial number for DEVICE columns", () => {
+    const struct = JSON.stringify({
+      id: "d-1",
+      serial_number: "AA:11",
+      owner: "u-1",
+      status: "active",
+      device_type: "ambyte",
+    });
+    renderInCommand(
+      <CategoricalOption
+        optionValue={struct}
+        isSelected={false}
+        isContributor={false}
+        isDevice
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("AA:11")).toBeInTheDocument();
   });
 });

--- a/apps/web/components/data-filters/value-inputs/categorical-option.tsx
+++ b/apps/web/components/data-filters/value-inputs/categorical-option.tsx
@@ -6,11 +6,13 @@ import { CommandItem } from "@repo/ui/components/command";
 import { cn } from "@repo/ui/lib/utils";
 
 import { ContributorIdentity } from "../../contributor/contributor-identity";
+import { deviceDisplayName } from "../../experiment-visualizations/charts/data/device-cells";
 
 export interface CategoricalOptionProps {
   optionValue: string;
   isSelected: boolean;
   isContributor: boolean;
+  isDevice: boolean;
   onSelect: () => void;
 }
 
@@ -18,6 +20,7 @@ export function CategoricalOption({
   optionValue,
   isSelected,
   isContributor,
+  isDevice,
   onSelect,
 }: CategoricalOptionProps) {
   return (
@@ -25,6 +28,8 @@ export function CategoricalOption({
       <Check className={cn("mr-2 h-4 w-4 shrink-0", isSelected ? "opacity-100" : "opacity-0")} />
       {isContributor ? (
         <ContributorIdentity data={optionValue} size="compact" />
+      ) : isDevice ? (
+        <span className="truncate">{deviceDisplayName(optionValue)}</span>
       ) : (
         <span className="truncate">{optionValue}</span>
       )}

--- a/apps/web/components/data-filters/value-inputs/categorical-single-input.tsx
+++ b/apps/web/components/data-filters/value-inputs/categorical-single-input.tsx
@@ -37,11 +37,8 @@ export function CategoricalSingleInput({
 }: CategoricalSingleInputProps) {
   const { t } = useTranslation("common");
   const [open, setOpen] = useState(false);
-  const { values, isLoading, truncated, isContributor, contributorMap } = useDistinctOptions(
-    column,
-    experimentId,
-    tableName,
-  );
+  const { values, isLoading, truncated, isContributor, isDevice, contributorMap } =
+    useDistinctOptions(column, experimentId, tableName);
   const triggerId = useId();
 
   const display = useMemo(() => {
@@ -54,11 +51,12 @@ export function CategoricalSingleInput({
     isContributor && display && contributorMap ? contributorMap.get(display) : undefined;
 
   const handleSelect = (raw: string | number) => {
-    onChange(chipValueForOption(raw, isContributor));
+    onChange(chipValueForOption(raw, isContributor, isDevice));
     setOpen(false);
   };
 
-  const getChipKey = (raw: string | number) => String(chipValueForOption(raw, isContributor));
+  const getChipKey = (raw: string | number) =>
+    String(chipValueForOption(raw, isContributor, isDevice));
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -100,6 +98,7 @@ export function CategoricalSingleInput({
                   optionValue={String(v)}
                   isSelected={display === getChipKey(v)}
                   isContributor={isContributor}
+                  isDevice={isDevice}
                   onSelect={() => handleSelect(v)}
                 />
               ))}

--- a/apps/web/components/experiment-data/experiment-data-utils.test.tsx
+++ b/apps/web/components/experiment-data/experiment-data-utils.test.tsx
@@ -109,6 +109,13 @@ describe("formatValue", () => {
     expect(screen.getByText("John Doe")).toBeInTheDocument();
   });
 
+  it("renders device cell for DEVICE type", () => {
+    const deviceData = JSON.stringify({ id: "d-1", serial_number: "AA:11", status: "active" });
+    const result = formatValue(deviceData, WellKnownColumnTypes.DEVICE, "row-1", "col");
+    render(<div>{result}</div>);
+    expect(screen.getByText("AA:11")).toBeInTheDocument();
+  });
+
   it("renders map cell for MAP types", () => {
     const result = formatValue('{"a":"1","b":"2"}', "MAP<STRING,STRING>", "row-1", "col");
     render(<div>{result}</div>);

--- a/apps/web/components/experiment-data/experiment-data-utils.tsx
+++ b/apps/web/components/experiment-data/experiment-data-utils.tsx
@@ -3,6 +3,7 @@ import type { Row, HeaderGroup } from "@tanstack/react-table";
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import React from "react";
 import { ExperimentDataTableAnnotationsCell } from "~/components/experiment-data/table-cells/annotations/experiment-data-table-annotations-cell";
+import { deviceDisplayName } from "~/components/experiment-visualizations/charts/data/device-cells";
 import type {
   DataRow,
   TableMetadata,
@@ -105,6 +106,9 @@ export function formatValue(
     [ColumnPrimitiveType.STRING]: () => <ExperimentDataTableTextCell text={value as string} />,
     [WellKnownColumnTypes.CONTRIBUTOR]: () => (
       <ExperimentDataTableUserCell data={value as string} columnName={columnName ?? "User"} />
+    ),
+    [WellKnownColumnTypes.DEVICE]: () => (
+      <ExperimentDataTableTextCell text={deviceDisplayName(value)} />
     ),
     [WellKnownColumnTypes.ANNOTATIONS]: () => (
       <ExperimentDataTableAnnotationsCell

--- a/apps/web/components/experiment-visualizations/charts/data/device-cells.test.ts
+++ b/apps/web/components/experiment-visualizations/charts/data/device-cells.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { deviceDisplayName } from "./device-cells";
+
+describe("deviceDisplayName", () => {
+  it("returns the serial number from a device struct", () => {
+    const struct = JSON.stringify({ id: "d-1", serial_number: "AA:11", status: "active" });
+    expect(deviceDisplayName(struct)).toBe("AA:11");
+  });
+
+  it("trims and falls back to Unknown device when the serial is blank", () => {
+    expect(deviceDisplayName(JSON.stringify({ serial_number: "  " }))).toBe("Unknown device");
+    expect(deviceDisplayName(JSON.stringify({ id: "d-1" }))).toBe("Unknown device");
+  });
+
+  it("falls back to Unknown device for non-string or malformed values", () => {
+    expect(deviceDisplayName(null)).toBe("Unknown device");
+    expect(deviceDisplayName(42)).toBe("Unknown device");
+    expect(deviceDisplayName("not json")).toBe("Unknown device");
+  });
+});

--- a/apps/web/components/experiment-visualizations/charts/data/device-cells.ts
+++ b/apps/web/components/experiment-visualizations/charts/data/device-cells.ts
@@ -1,0 +1,18 @@
+// DEVICE columns come back as STRUCT<id, serial_number, owner, status, device_type>
+// JSON strings. Charts group and colour by the serial number, so both the data hook
+// and the colour-map picker flatten each cell through this one converter to stay aligned.
+
+const UNKNOWN_DEVICE = "Unknown device";
+
+export function deviceDisplayName(value: unknown): string {
+  if (typeof value !== "string") {
+    return UNKNOWN_DEVICE;
+  }
+  try {
+    const parsed = JSON.parse(value) as { serial_number?: unknown };
+    const serial = typeof parsed.serial_number === "string" ? parsed.serial_number.trim() : "";
+    return serial.length > 0 ? serial : UNKNOWN_DEVICE;
+  } catch {
+    return UNKNOWN_DEVICE;
+  }
+}

--- a/apps/web/components/experiment-visualizations/workspace/shelves/color/categorical-color-map.tsx
+++ b/apps/web/components/experiment-visualizations/workspace/shelves/color/categorical-color-map.tsx
@@ -22,6 +22,7 @@ import {
 import { toBucketKey } from "../../../charts/data/cell-coercion";
 import { contributorDisplayName } from "../../../charts/data/contributor-cells";
 import { dataSourcesByRole, firstDataSourceByRole } from "../../../charts/data/data-sources";
+import { deviceDisplayName } from "../../../charts/data/device-cells";
 
 /** Cap the override list so a high-cardinality column doesn't make the
  *  shelf scrollable into oblivion. The user picks colors for the top N
@@ -66,8 +67,9 @@ export function CategoricalColorMap({ form, columns }: CategoricalColorMapProps)
   // CONTRIBUTOR distinct values arrive as STRUCT JSON; the renderer flattens
   // them to the contributor name, so the picker must key/label by name too or
   // the overrides never match what the chart looks up.
-  const isContributor =
-    columns.find((c) => c.name === colorColumn)?.type_text === WellKnownColumnTypes.CONTRIBUTOR;
+  const colorColumnType = columns.find((c) => c.name === colorColumn)?.type_text;
+  const isContributor = colorColumnType === WellKnownColumnTypes.CONTRIBUTOR;
+  const isDevice = colorColumnType === WellKnownColumnTypes.DEVICE;
 
   // Mirror the renderer's seriesKey for `getCategoryColor` lookups.
   const seriesKeys = useMemo(() => {
@@ -93,14 +95,18 @@ export function CategoricalColorMap({ form, columns }: CategoricalColorMapProps)
     const seen = new Set<string>();
     const out: Category[] = [];
     for (const value of rawValues) {
-      const key = isContributor ? contributorDisplayName(value) : toBucketKey(value);
+      const key = isContributor
+        ? contributorDisplayName(value)
+        : isDevice
+          ? deviceDisplayName(value)
+          : toBucketKey(value);
       if (seen.has(key)) continue;
       seen.add(key);
       out.push({ key, label: key === "" ? t("workspace.shelves.colorMap.nullLabel") : key });
     }
     out.sort((a, b) => a.label.localeCompare(b.label));
     return out;
-  }, [rawValues, isContributor, t]);
+  }, [rawValues, isContributor, isDevice, t]);
 
   // Read the live colorMap at commit time, not the render-time snapshot:
   // debounced swatch commits from different rows can land close together and

--- a/apps/web/components/experiment-visualizations/workspace/visualization-workspace.tsx
+++ b/apps/web/components/experiment-visualizations/workspace/visualization-workspace.tsx
@@ -79,7 +79,9 @@ export function VisualizationWorkspace({
     () =>
       (tableMetadata?.rawColumns ?? []).filter(
         (col) =>
-          isPlottableColumn(col.type_text) || col.type_text === WellKnownColumnTypes.CONTRIBUTOR,
+          isPlottableColumn(col.type_text) ||
+          col.type_text === WellKnownColumnTypes.CONTRIBUTOR ||
+          col.type_text === WellKnownColumnTypes.DEVICE,
       ),
     [tableMetadata],
   );

--- a/apps/web/hooks/experiment/useExperimentVisualizationData/useExperimentVisualizationData.ts
+++ b/apps/web/hooks/experiment/useExperimentVisualizationData/useExperimentVisualizationData.ts
@@ -87,7 +87,7 @@ function isWindowOnlyAggregation(aggregation: DataAggregation): boolean {
 }
 
 // Flatten CONTRIBUTOR/DEVICE structs to their display field so the chart layer sees plain strings.
-function flattenContributorCells<
+function flattenStructCells<
   T extends {
     columns: { name: string; type_text: string }[];
     rows: Record<string, unknown>[];
@@ -252,7 +252,7 @@ export const useExperimentVisualizationData = (
         rows: remappedRows,
       };
     })();
-    return flattenContributorCells(afterAlias);
+    return flattenStructCells(afterAlias);
   }, [tableData, aggregation, aggregationActive]);
 
   return {

--- a/apps/web/hooks/experiment/useExperimentVisualizationData/useExperimentVisualizationData.ts
+++ b/apps/web/hooks/experiment/useExperimentVisualizationData/useExperimentVisualizationData.ts
@@ -1,4 +1,5 @@
 import { contributorDisplayName } from "@/components/experiment-visualizations/charts/data/contributor-cells";
+import { deviceDisplayName } from "@/components/experiment-visualizations/charts/data/device-cells";
 import { shouldRetryQuery } from "@/util/query-retry";
 import { useMemo } from "react";
 import { tsr } from "~/lib/tsr";
@@ -85,23 +86,28 @@ function isWindowOnlyAggregation(aggregation: DataAggregation): boolean {
   return fns.every((f) => WINDOW_FUNCTIONS.has(f.function));
 }
 
-// Flatten CONTRIBUTOR structs to their `name` so the chart layer sees plain strings.
+// Flatten CONTRIBUTOR/DEVICE structs to their display field so the chart layer sees plain strings.
 function flattenContributorCells<
   T extends {
     columns: { name: string; type_text: string }[];
     rows: Record<string, unknown>[];
   },
 >(table: T): T {
-  const contributorColumns = table.columns.filter(
-    (c) => c.type_text === WellKnownColumnTypes.CONTRIBUTOR,
+  const structColumns = table.columns.filter(
+    (c) =>
+      c.type_text === WellKnownColumnTypes.CONTRIBUTOR ||
+      c.type_text === WellKnownColumnTypes.DEVICE,
   );
-  if (contributorColumns.length === 0) {
+  if (structColumns.length === 0) {
     return table;
   }
   const rows = table.rows.map((row) => {
     const out: Record<string, unknown> = { ...row };
-    for (const col of contributorColumns) {
-      out[col.name] = contributorDisplayName(row[col.name]);
+    for (const col of structColumns) {
+      out[col.name] =
+        col.type_text === WellKnownColumnTypes.DEVICE
+          ? deviceDisplayName(row[col.name])
+          : contributorDisplayName(row[col.name]);
     }
     return out;
   });

--- a/infrastructure/modules/iot-core/main.tf
+++ b/infrastructure/modules/iot-core/main.tf
@@ -306,9 +306,9 @@ resource "aws_iam_policy" "databricks_large_iot_read" {
 resource "aws_iot_topic_rule" "iot_rules" {
   for_each = local.ingest_channels
 
-  name        = local.iot_rule_names[each.key]
-  enabled     = true
-  sql         = "SELECT topic() as topic, * FROM '${local.iot_topic_filters[each.key]}'"
+  name    = local.iot_rule_names[each.key]
+  enabled = true
+  sql         = "SELECT topic() as topic, clientid() as client_id, * FROM '${local.iot_topic_filters[each.key]}'"
   sql_version = "2016-03-23"
 
   kinesis {

--- a/packages/api/src/contracts/iot.contract.ts
+++ b/packages/api/src/contracts/iot.contract.ts
@@ -12,7 +12,10 @@ import {
   zRegisterIotDeviceBody,
   zRegisterIotDeviceResponse,
   zIssueIotCredentialsResponse,
+  zDeviceRegistryWebhookPayload,
+  zDeviceRegistryWebhookResponse,
 } from "../schemas/iot.schema";
+import { zWebhookAuthHeader, zWebhookErrorResponse } from "../schemas/user.schema";
 
 const c = initContract();
 
@@ -43,6 +46,22 @@ export const iotContract = c.router({
     description:
       "Returns a pre-signed S3 PutObject URL for uploading IoT payloads larger than 128 KB. " +
       "The URL is valid for 15 minutes. Upload the JSON payload directly to the returned URL using HTTP PUT.",
+  },
+
+  // --- Device registry webhook (Databricks lineage) ---
+  getDeviceRegistry: {
+    method: "POST",
+    path: "/api/v1/iot/devices/registry",
+    body: zDeviceRegistryWebhookPayload,
+    headers: zWebhookAuthHeader,
+    responses: {
+      200: zDeviceRegistryWebhookResponse,
+      400: zWebhookErrorResponse,
+      401: zWebhookErrorResponse,
+    },
+    summary: "Resolve thing names to registry rows for Databricks pipelines",
+    description:
+      "Resolves thing names to their registered device rows (id, serial, type, status, owner) so the lineage pipeline can join measurements to the registry.",
   },
 
   // --- IotDevice registry ---

--- a/packages/api/src/schemas/experiment.schema.ts
+++ b/packages/api/src/schemas/experiment.schema.ts
@@ -1443,12 +1443,18 @@ export const zAnnotationsColumnType = z.literal(
 
 export const zContributorColumnType = z.literal("STRUCT<id: STRING, name: STRING, avatar: STRING>");
 
+export const zDeviceColumnType = z.literal(
+  "STRUCT<id: STRING, serial_number: STRING, owner: STRING, status: STRING, device_type: STRING>",
+);
+
 export type AnnotationsColumnType = z.infer<typeof zAnnotationsColumnType>;
 export type ContributorColumnType = z.infer<typeof zContributorColumnType>;
+export type DeviceColumnType = z.infer<typeof zDeviceColumnType>;
 
 export const WellKnownColumnTypes = {
   ANNOTATIONS: zAnnotationsColumnType.value,
   CONTRIBUTOR: zContributorColumnType.value,
+  DEVICE: zDeviceColumnType.value,
 } as const;
 
 export const zColumnInfo = z.object({

--- a/packages/api/src/schemas/iot.schema.ts
+++ b/packages/api/src/schemas/iot.schema.ts
@@ -72,6 +72,7 @@ export const zDeviceRegistryWebhookResponse = z.object({
 });
 
 export type DeviceRegistryEntry = z.infer<typeof zDeviceRegistryEntry>;
+export type DeviceRegistryWebhookResponse = z.infer<typeof zDeviceRegistryWebhookResponse>;
 
 export const zIotDevicePathParam = z.object({
   deviceId: z.string().uuid().describe("ID of the device"),

--- a/packages/api/src/schemas/iot.schema.ts
+++ b/packages/api/src/schemas/iot.schema.ts
@@ -52,6 +52,27 @@ export const zRegisterIotDeviceBody = z.object({
 
 export const zRegisterIotDeviceResponse = zIotDevice;
 
+// --- Device registry webhook (Databricks lineage: thing_name -> registry) ---
+export const zDeviceRegistryWebhookPayload = z.object({
+  thingNames: z.array(z.string()).min(1).max(500),
+});
+
+export const zDeviceRegistryEntry = z.object({
+  thingName: z.string(),
+  id: z.string().uuid(),
+  serialNumber: z.string(),
+  deviceType: zDeviceType,
+  status: zIotDeviceStatus,
+  createdBy: z.string().uuid(),
+});
+
+export const zDeviceRegistryWebhookResponse = z.object({
+  devices: z.array(zDeviceRegistryEntry),
+  success: z.boolean(),
+});
+
+export type DeviceRegistryEntry = z.infer<typeof zDeviceRegistryEntry>;
+
 export const zIotDevicePathParam = z.object({
   deviceId: z.string().uuid().describe("ID of the device"),
 });

--- a/packages/api/src/utils/column-type-utils.spec.ts
+++ b/packages/api/src/utils/column-type-utils.spec.ts
@@ -209,8 +209,9 @@ describe("column-type-utils", () => {
   });
 
   describe("isWellKnownSortableType", () => {
-    it("should return true only for CONTRIBUTOR type", () => {
+    it("should return true for CONTRIBUTOR and DEVICE types", () => {
       expect(isWellKnownSortableType(WellKnownColumnTypes.CONTRIBUTOR)).toBe(true);
+      expect(isWellKnownSortableType(WellKnownColumnTypes.DEVICE)).toBe(true);
     });
 
     it("should return false for non-sortable well-known types", () => {
@@ -227,6 +228,10 @@ describe("column-type-utils", () => {
   describe("getWellKnownSortField", () => {
     it("should return 'name' for CONTRIBUTOR type", () => {
       expect(getWellKnownSortField(WellKnownColumnTypes.CONTRIBUTOR)).toBe("name");
+    });
+
+    it("should return 'serial_number' for DEVICE type", () => {
+      expect(getWellKnownSortField(WellKnownColumnTypes.DEVICE)).toBe("serial_number");
     });
 
     it("should return undefined for non-sortable well-known types", () => {

--- a/packages/api/src/utils/column-type-utils.ts
+++ b/packages/api/src/utils/column-type-utils.ts
@@ -153,11 +153,11 @@ export function isWellKnownType(type?: string): boolean {
 
 /**
  * Check if a well-known type is sortable
- * Only CONTRIBUTOR type is sortable (ANNOTATIONS and QUESTIONS are arrays)
+ * CONTRIBUTOR and DEVICE structs are sortable (ANNOTATIONS and QUESTIONS are arrays)
  */
 export function isWellKnownSortableType(type?: string): boolean {
   if (!type) return false;
-  return type === WellKnownColumnTypes.CONTRIBUTOR;
+  return type === WellKnownColumnTypes.CONTRIBUTOR || type === WellKnownColumnTypes.DEVICE;
 }
 
 /**
@@ -171,6 +171,8 @@ export function getWellKnownSortField(type?: string): string | undefined {
   switch (type) {
     case WellKnownColumnTypes.CONTRIBUTOR:
       return "name";
+    case WellKnownColumnTypes.DEVICE:
+      return "serial_number";
     default:
       return undefined;
   }


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Measurements could not be traced back to the device that produced them. Device columns in the warehouse were self-reported payload fields, and the platform device registry (added earlier) was disconnected from the data pipeline. This wires the two together end to end, so every row carries the registry identity of the device that sent it, and that identity becomes a first-class dimension in tables, charts, and filters.

The identity comes from the broker, not the payload. The IoT topic rule now selects `clientid() as client_id` alongside the topic, which for X.509 devices is the authenticated Thing name and therefore cannot be forged by a device sending misleading JSON. That value is extracted at the top level in bronze rather than being folded into the existing `parsed_data` struct, which is not resettable, and then carried through silver into the gold tables. Rows that arrive via import or project transfer have no MQTT identity and carry a NULL `client_id`.

To resolve those names to registry rows, the backend exposes an HMAC-signed webhook at `/api/v1/iot/devices/registry` that takes a batch of thing names (1-500) and returns `{id, serialNumber, deviceType, status, createdBy}` for each match. The lookup is deliberately not owner-scoped: the pipeline authenticates as a trusted caller and resolves devices across owners, which is why it lives behind the shared HMAC guard rather than the user-facing device routes.

On the pipeline side this mirrors the existing contributor enrichment. A new gold `experiment_devices` table takes the distinct `(experiment_id, client_id)` pairs, enriches them once per run through the webhook, and produces a `device` struct. That struct is then left-joined into `experiment_device_data` and into the enriched raw and macro views, so unregistered or Cognito-authenticated client ids resolve to NULL rather than dropping rows.

Surfacing this in the app introduces a `DEVICE` well-known column type for the struct, alongside the existing `CONTRIBUTOR` one. Device columns are sortable and filterable by serial number, selectable as a plot or color dimension, and rendered through a single converter that flattens the struct to its serial so the data hook, the color-map picker, and the filter chips all key on the same value and stay in sync.

## OJD-1602

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Jan-IngenHousz-Institute/codesmith/open-jii/pr/1783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786632301&installation_id=146274774&pr_number=1783&repository=Jan-IngenHousz-Institute%2Fopen-jii&return_to=https%3A%2F%2Fgithub.com%2FJan-IngenHousz-Institute%2Fopen-jii%2Fpull%2F1783&signature=92f62cc0096bf610e141f39fd0155bc48c3f2792bfe476a3057465cc39cb6048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->