### PR TITLE
feat: device identification handshake, global device context, Ambit/MiniPAR drivers, per-device dispatch

### DIFF
--- a/apps/backend/src/macros/application/use-cases/execute-macro-batch/execute-macro-batch.spec.ts
+++ b/apps/backend/src/macros/application/use-cases/execute-macro-batch/execute-macro-batch.spec.ts
@@ -8,9 +8,14 @@ import {
   AppError,
 } from "../../../../common/utils/fp-utils";
 import { TestHarness } from "../../../../test/test-harness";
+import type { LambdaExecutionPayload } from "../../../core/models/macro-execution.model";
 import type { CreateMacroDto } from "../../../core/models/macro.model";
 import type { LambdaPort } from "../../../core/ports/lambda.port";
 import { LAMBDA_PORT } from "../../../core/ports/lambda.port";
+import {
+  macroSnapshotKey,
+  MacroSnapshotRepository,
+} from "../../../core/repositories/macro-snapshot.repository";
 import { MacroRepository } from "../../../core/repositories/macro.repository";
 import { ExecuteMacroBatchUseCase } from "./execute-macro-batch";
 
@@ -19,6 +24,7 @@ describe("ExecuteMacroBatchUseCase", () => {
   let testUserId: string;
   let useCase: ExecuteMacroBatchUseCase;
   let macroRepository: MacroRepository;
+  let macroSnapshotRepository: MacroSnapshotRepository;
   let lambdaPort: LambdaPort;
 
   beforeAll(async () => {
@@ -30,6 +36,7 @@ describe("ExecuteMacroBatchUseCase", () => {
     testUserId = await testApp.createTestUser({});
     useCase = testApp.module.get(ExecuteMacroBatchUseCase);
     macroRepository = testApp.module.get(MacroRepository);
+    macroSnapshotRepository = testApp.module.get(MacroSnapshotRepository);
     lambdaPort = testApp.module.get(LAMBDA_PORT);
   });
 
@@ -157,6 +164,93 @@ describe("ExecuteMacroBatchUseCase", () => {
       });
 
       expect(invokeSpy).toHaveBeenCalledWith("test-fn", expect.objectContaining({ timeout: 30 }));
+    });
+
+    it("passes each item's workbook context to the sandbox", async () => {
+      const macro = await createTestMacro();
+      const invokeSpy = vi.spyOn(lambdaPort, "invokeLambda").mockResolvedValue(
+        success({
+          statusCode: 200,
+          payload: {
+            status: "success",
+            results: [{ id: "item-1", success: true, output: {} }],
+          },
+        }),
+      );
+      vi.spyOn(lambdaPort, "getFunctionNameForLanguage").mockReturnValue("test-fn");
+
+      const context = { baseline: { value: 3 } };
+      await useCase.execute({
+        items: [{ id: "item-1", macro_id: macro.id, data: {}, context }],
+      });
+
+      expect(invokeSpy).toHaveBeenCalledWith(
+        "test-fn",
+        expect.objectContaining({
+          items: [{ id: "item-1", data: {}, context }],
+        }),
+      );
+    });
+
+    it("uses the published snapshot and separates versions of the same macro", async () => {
+      const macroId = faker.string.uuid();
+      const version1 = faker.string.uuid();
+      const version2 = faker.string.uuid();
+      vi.spyOn(macroSnapshotRepository, "findScriptsByVersionIds").mockResolvedValue(
+        success(
+          new Map([
+            [
+              macroSnapshotKey(version1, macroId),
+              { id: macroId, name: "Pinned v1", language: "python", code: "code-v1" },
+            ],
+            [
+              macroSnapshotKey(version2, macroId),
+              { id: macroId, name: "Pinned v2", language: "javascript", code: "code-v2" },
+            ],
+          ]),
+        ),
+      );
+      const liveSpy = vi.spyOn(macroRepository, "findScriptsByIds");
+      const invokeSpy = vi
+        .spyOn(lambdaPort, "invokeLambda")
+        .mockImplementation((_name, payload) => {
+          const items = (payload as LambdaExecutionPayload).items;
+          return Promise.resolve(
+            success({
+              statusCode: 200,
+              payload: {
+                status: "success",
+                results: items.map((item) => ({
+                  id: item.id,
+                  success: true,
+                  output: {},
+                })),
+              },
+            }),
+          );
+        });
+      vi.spyOn(lambdaPort, "getFunctionNameForLanguage").mockImplementation(
+        (language) => `sandbox-${language}`,
+      );
+
+      const result = await useCase.execute({
+        items: [
+          { id: "item-1", macro_id: macroId, workbook_version_id: version1, data: {} },
+          { id: "item-2", macro_id: macroId, workbook_version_id: version2, data: {} },
+        ],
+      });
+
+      assertSuccess(result);
+      expect(liveSpy).toHaveBeenCalledWith([]);
+      expect(invokeSpy).toHaveBeenCalledTimes(2);
+      expect(invokeSpy).toHaveBeenCalledWith(
+        "sandbox-python",
+        expect.objectContaining({ script: "code-v1" }),
+      );
+      expect(invokeSpy).toHaveBeenCalledWith(
+        "sandbox-javascript",
+        expect.objectContaining({ script: "code-v2" }),
+      );
     });
   });
 

--- a/apps/backend/src/macros/application/use-cases/execute-macro-batch/execute-macro-batch.ts
+++ b/apps/backend/src/macros/application/use-cases/execute-macro-batch/execute-macro-batch.ts
@@ -13,6 +13,10 @@ import type { LambdaExecutionPayload } from "../../../core/models/macro-executio
 import { LambdaExecutionResponseSchema } from "../../../core/models/macro-execution.model";
 import type { MacroScript } from "../../../core/models/macro.model";
 import { LAMBDA_PORT, LambdaPort } from "../../../core/ports/lambda.port";
+import {
+  macroSnapshotKey,
+  MacroSnapshotRepository,
+} from "../../../core/repositories/macro-snapshot.repository";
 import { MacroRepository } from "../../../core/repositories/macro.repository";
 
 @Injectable()
@@ -21,6 +25,7 @@ export class ExecuteMacroBatchUseCase {
 
   constructor(
     private readonly macroRepository: MacroRepository,
+    private readonly macroSnapshotRepository: MacroSnapshotRepository,
     @Inject(LAMBDA_PORT) private readonly lambdaPort: LambdaPort,
   ) {}
 
@@ -34,31 +39,65 @@ export class ExecuteMacroBatchUseCase {
       timeout: request.timeout,
     });
 
-    // 1. Collect unique macro IDs and fetch scripts (cached in repository)
-    const uniqueMacroIds = [...new Set(request.items.map((item) => item.macro_id))];
+    // 1. Resolve published snapshot scripts for workbook measurements. Legacy
+    // callers without a workbook version continue to use the live macro row.
+    const liveMacroIds = [
+      ...new Set(
+        request.items.filter((item) => !item.workbook_version_id).map((item) => item.macro_id),
+      ),
+    ];
+    const workbookVersionIds = [
+      ...new Set(
+        request.items.flatMap((item) =>
+          item.workbook_version_id ? [item.workbook_version_id] : [],
+        ),
+      ),
+    ];
 
-    const macrosResult = await this.macroRepository.findScriptsByIds(uniqueMacroIds);
-    if (macrosResult.isFailure()) {
+    const [macrosResult, snapshotsResult] = await Promise.all([
+      this.macroRepository.findScriptsByIds(liveMacroIds),
+      this.macroSnapshotRepository.findScriptsByVersionIds(workbookVersionIds),
+    ]);
+    if (macrosResult.isFailure() || snapshotsResult.isFailure()) {
       return failure(
         AppError.internal("Failed to fetch macro scripts", ErrorCodes.MACRO_EXECUTION_FAILED),
       );
     }
 
     const macroMap = macrosResult.value;
+    const snapshotMap = snapshotsResult.value;
 
-    // 2. Group items by macro_id
-    const groups = new Map<string, typeof request.items>();
+    // 2. Group by macro + version. The same macro UUID can legitimately have
+    // different code in two published workbook versions in one Spark batch.
+    const groups = new Map<
+      string,
+      {
+        macroId: string;
+        workbookVersionId?: string;
+        items: typeof request.items;
+      }
+    >();
     for (const item of request.items) {
-      const group = groups.get(item.macro_id) ?? [];
-      group.push(item);
-      groups.set(item.macro_id, group);
+      const key = item.workbook_version_id
+        ? macroSnapshotKey(item.workbook_version_id, item.macro_id)
+        : `live:${item.macro_id}`;
+      const group = groups.get(key) ?? {
+        macroId: item.macro_id,
+        workbookVersionId: item.workbook_version_id,
+        items: [],
+      };
+      group.items.push(item);
+      groups.set(key, group);
     }
 
-    // 3. Fan out Lambda invocations in parallel (one per macro_id)
+    // 3. Fan out Lambda invocations in parallel (one per macro snapshot)
     const groupResults = await Promise.all(
-      [...groups.entries()].map(([macroId, items]) =>
-        this.processGroup(macroId, items, macroMap.get(macroId), request.timeout ?? 30),
-      ),
+      [...groups.values()].map(({ macroId, workbookVersionId, items }) => {
+        const macro = workbookVersionId
+          ? snapshotMap.get(macroSnapshotKey(workbookVersionId, macroId))
+          : macroMap.get(macroId);
+        return this.processGroup(macroId, items, macro, request.timeout ?? 30, workbookVersionId);
+      }),
     );
 
     // 4. Merge results
@@ -96,16 +135,20 @@ export class ExecuteMacroBatchUseCase {
     items: MacroBatchExecutionRequestBody["items"],
     macro: MacroScript | undefined,
     timeout: number,
+    workbookVersionId?: string,
   ): Promise<{ results: MacroBatchExecutionResultItem[]; error?: string }> {
     if (!macro) {
+      const notFound = workbookVersionId
+        ? `Macro snapshot not found: ${macroId} in workbook version ${workbookVersionId}`
+        : `Macro not found: ${macroId}`;
       return {
         results: items.map((item) => ({
           id: item.id,
           macro_id: macroId,
           success: false,
-          error: `Macro not found: ${macroId}`,
+          error: notFound,
         })),
-        error: `Macro not found: ${macroId}`,
+        error: notFound,
       };
     }
 
@@ -113,7 +156,11 @@ export class ExecuteMacroBatchUseCase {
 
     const payload: LambdaExecutionPayload = {
       script: macro.code,
-      items: items.map((item) => ({ id: item.id, data: item.data })),
+      items: items.map((item) => ({
+        id: item.id,
+        data: item.data,
+        context: item.context,
+      })),
       timeout,
     };
 

--- a/apps/backend/src/macros/application/use-cases/execute-macro/execute-macro.ts
+++ b/apps/backend/src/macros/application/use-cases/execute-macro/execute-macro.ts
@@ -52,7 +52,7 @@ export class ExecuteMacroUseCase {
 
     const payload: LambdaExecutionPayload = {
       script: macro.code,
-      items: [{ id: itemId, data: request.data }],
+      items: [{ id: itemId, data: request.data, context: request.context }],
       timeout: request.timeout ?? 30,
     };
 

--- a/apps/backend/src/macros/core/models/macro-execution.model.ts
+++ b/apps/backend/src/macros/core/models/macro-execution.model.ts
@@ -11,6 +11,9 @@ import { z } from "zod";
 export interface LambdaExecutionItem {
   id: string;
   data: Record<string, unknown> | unknown[];
+  // Upstream cell outputs keyed by canonical name; injected into the sandbox as
+  // read-only `ctx`. Absent for legacy/batch callers that send only `data`.
+  context?: Record<string, unknown>;
 }
 
 export interface LambdaExecutionPayload {

--- a/apps/backend/src/macros/core/repositories/macro-snapshot.repository.spec.ts
+++ b/apps/backend/src/macros/core/repositories/macro-snapshot.repository.spec.ts
@@ -1,0 +1,93 @@
+import { faker } from "@faker-js/faker";
+
+import { assertSuccess } from "../../../common/utils/fp-utils";
+import { TestHarness } from "../../../test/test-harness";
+import { WorkbookVersionRepository } from "../../../workbooks/core/repositories/workbook-version.repository";
+import { macroSnapshotKey, MacroSnapshotRepository } from "./macro-snapshot.repository";
+
+describe("MacroSnapshotRepository", () => {
+  const testApp = TestHarness.App;
+  let repository: MacroSnapshotRepository;
+  let workbookVersionRepository: WorkbookVersionRepository;
+  let userId: string;
+
+  beforeAll(async () => {
+    await testApp.setup();
+  });
+
+  beforeEach(async () => {
+    await testApp.beforeEach();
+    userId = await testApp.createTestUser({});
+    repository = testApp.module.get(MacroSnapshotRepository);
+    workbookVersionRepository = testApp.module.get(WorkbookVersionRepository);
+  });
+
+  afterEach(() => testApp.afterEach());
+  afterAll(async () => testApp.teardown());
+
+  it("returns an empty map without querying versions", async () => {
+    const result = await repository.findScriptsByVersionIds([]);
+    assertSuccess(result);
+    expect(result.value.size).toBe(0);
+  });
+
+  it("resolves code and language from the immutable workbook snapshot", async () => {
+    const macroId = faker.string.uuid();
+    const workbook = await testApp.createWorkbook({ name: "Snapshot workbook", createdBy: userId });
+    const versionResult = await workbookVersionRepository.create({
+      workbookId: workbook.id,
+      version: 1,
+      cells: [
+        {
+          id: "macro-cell",
+          type: "macro",
+          isCollapsed: false,
+          payload: { macroId, language: "python", name: "Pinned analysis" },
+        },
+      ],
+      metadata: {},
+      entitySnapshots: {
+        protocols: {},
+        macros: { [macroId]: { code: "cGlubmVkLWNvZGU=" } },
+      },
+      createdBy: userId,
+    });
+    assertSuccess(versionResult);
+
+    const result = await repository.findScriptsByVersionIds([versionResult.value.id]);
+
+    assertSuccess(result);
+    expect(result.value.get(macroSnapshotKey(versionResult.value.id, macroId))).toEqual({
+      id: macroId,
+      name: "Pinned analysis",
+      language: "python",
+      code: "cGlubmVkLWNvZGU=",
+    });
+  });
+
+  it("does not invent a script when a referenced snapshot is missing", async () => {
+    const macroId = faker.string.uuid();
+    const workbook = await testApp.createWorkbook({ name: "Old workbook", createdBy: userId });
+    const versionResult = await workbookVersionRepository.create({
+      workbookId: workbook.id,
+      version: 1,
+      cells: [
+        {
+          id: "macro-cell",
+          type: "macro",
+          isCollapsed: false,
+          payload: { macroId, language: "javascript" },
+        },
+      ],
+      metadata: {},
+      entitySnapshots: { protocols: {}, macros: {} },
+      createdBy: userId,
+    });
+    assertSuccess(versionResult);
+
+    const result = await repository.findScriptsByVersionIds([versionResult.value.id]);
+
+    assertSuccess(result);
+    expect(result.value.size).toBe(0);
+  });
+});

--- a/apps/backend/src/macros/core/repositories/macro-snapshot.repository.ts
+++ b/apps/backend/src/macros/core/repositories/macro-snapshot.repository.ts
@@ -1,0 +1,87 @@
+import { Inject, Injectable } from "@nestjs/common";
+
+import type { WorkbookCell } from "@repo/api/domains/workbook/workbook-cells.schema";
+import type { EntitySnapshots } from "@repo/api/domains/workbook/workbook-version.schema";
+import { inArray, workbookVersions } from "@repo/database";
+import type { DatabaseInstance } from "@repo/database";
+
+import type { Result } from "../../../common/utils/fp-utils";
+import { success, tryCatch } from "../../../common/utils/fp-utils";
+import type { MacroScript } from "../models/macro.model";
+import { CACHE_PORT, CachePort } from "../ports/cache.port";
+
+type MacroSnapshotBundle = Record<string, MacroScript>;
+const cacheKey = (versionId: string) => `workbook-version:${versionId}`;
+
+export function macroSnapshotKey(workbookVersionId: string, macroId: string): string {
+  return `${workbookVersionId}:${macroId}`;
+}
+
+/**
+ * Resolves executable macro scripts from immutable published workbook versions.
+ * This keeps delayed/offline measurement uploads deterministic even when the
+ * live macro row has been edited since the workbook was published.
+ */
+@Injectable()
+export class MacroSnapshotRepository {
+  constructor(
+    @Inject("DATABASE")
+    private readonly database: DatabaseInstance,
+    @Inject(CACHE_PORT) private readonly cachePort: CachePort,
+  ) {}
+
+  async findScriptsByVersionIds(versionIds: string[]): Promise<Result<Map<string, MacroScript>>> {
+    if (versionIds.length === 0) return success(new Map());
+
+    return tryCatch(async () => {
+      const bundles = await this.cachePort.tryCacheMany<MacroSnapshotBundle>(
+        versionIds.map(cacheKey),
+        async (missedKeys) => {
+          const missedIds = missedKeys.map((key) => key.slice("workbook-version:".length));
+          const rows = await this.database
+            .select({
+              id: workbookVersions.id,
+              cells: workbookVersions.cells,
+              entitySnapshots: workbookVersions.entitySnapshots,
+            })
+            .from(workbookVersions)
+            .where(inArray(workbookVersions.id, missedIds));
+
+          return new Map(rows.map((row) => [cacheKey(row.id), this.buildSnapshotBundle(row)]));
+        },
+      );
+
+      const scripts = new Map<string, MacroScript>();
+      for (const versionId of versionIds) {
+        const bundle = bundles.get(cacheKey(versionId));
+        if (!bundle) continue;
+        for (const [macroId, script] of Object.entries(bundle)) {
+          scripts.set(macroSnapshotKey(versionId, macroId), script);
+        }
+      }
+      return scripts;
+    });
+  }
+
+  private buildSnapshotBundle(row: {
+    cells: unknown;
+    entitySnapshots: unknown;
+  }): MacroSnapshotBundle {
+    const bundle: MacroSnapshotBundle = {};
+    const cells = row.cells as WorkbookCell[];
+    const snapshots = row.entitySnapshots as Partial<EntitySnapshots>;
+    for (const cell of cells) {
+      if (cell.type !== "macro") continue;
+      const macroId = cell.payload.macroId;
+      const snapshot = snapshots.macros?.[macroId];
+      if (!snapshot?.code) continue;
+      bundle[macroId] = {
+        id: macroId,
+        name: cell.payload.name ?? macroId,
+        language: cell.payload.language,
+        code: snapshot.code,
+      };
+    }
+    return bundle;
+  }
+}

--- a/apps/backend/src/macros/macro.module.ts
+++ b/apps/backend/src/macros/macro.module.ts
@@ -24,6 +24,7 @@ import { CACHE_PORT } from "./core/ports/cache.port";
 import { LAMBDA_PORT } from "./core/ports/lambda.port";
 // Repositories
 import { MacroProtocolRepository } from "./core/repositories/macro-protocol.repository";
+import { MacroSnapshotRepository } from "./core/repositories/macro-snapshot.repository";
 import { MacroRepository } from "./core/repositories/macro.repository";
 import { MacroWebhookController } from "./presentation/macro-webhook.controller";
 // Controllers
@@ -49,6 +50,7 @@ import { MacroController } from "./presentation/macro.controller";
 
     // Repositories
     MacroRepository,
+    MacroSnapshotRepository,
     MacroProtocolRepository,
 
     // Macro use cases

--- a/apps/data/src/lib/enrich/enrich/backend_client.py
+++ b/apps/data/src/lib/enrich/enrich/backend_client.py
@@ -9,7 +9,6 @@ import hashlib
 import hmac
 import json
 import time
-from operator import itemgetter
 from typing import Any
 from urllib.parse import urljoin
 
@@ -271,11 +270,13 @@ class BackendClient:
         """
         Execute macros via the backend batch endpoint.
 
-        The backend groups items by macro_id, fetches scripts from the DB,
-        fans out Lambda invocations (one per macro_id), and returns results.
+        The backend groups items by macro_id + workbook_version_id, resolves
+        published snapshots (or the live macro for legacy items), fans out
+        Lambda invocations, and returns results.
 
         Args:
-            items: List of dicts with keys: id (str), macro_id (str uuid), data (dict).
+            items: Dicts with id, macro_id, data, and optional
+                workbook_version_id/context.
             timeout: Per-Lambda timeout in seconds (1-60).
             max_batch_size: Max items per HTTP request (default 500, API limit 5000).
 
@@ -289,11 +290,15 @@ class BackendClient:
         if not items:
             return {"results": []}
 
-        # Sort by macro_id so each HTTP chunk is homogeneous: the backend's
-        # internal groupBy(macro_id) then produces fewer Lambda invocations
-        # per request, and any chunk-level failure is scoped to items sharing
-        # a macro_id rather than a random mix.
-        sorted_items = sorted(items, key=itemgetter("macro_id"))
+        # Keep each HTTP chunk as homogeneous as possible. A macro UUID may
+        # point at different immutable code across workbook versions.
+        sorted_items = sorted(
+            items,
+            key=lambda item: (
+                item.get("macro_id") or "",
+                item.get("workbook_version_id") or "",
+            ),
+        )
 
         all_results: list[dict[str, Any]] = []
         all_errors: list[str] = []

--- a/apps/data/src/lib/enrich/enrich/macro_execution.py
+++ b/apps/data/src/lib/enrich/enrich/macro_execution.py
@@ -5,8 +5,8 @@ Provides a pandas UDF that calls the backend's /api/v1/macros/execute-batch
 endpoint instead of running macros locally on Spark workers.
 
 The backend:
-  1. Groups items by macro_id
-  2. Fetches macro scripts from the database
+  1. Groups items by macro_id + workbook_version_id
+  2. Resolves immutable workbook snapshots (or live macros for legacy rows)
   3. Invokes the appropriate Lambda function (Python / JS / R)
   4. Returns results with output or error per item
 
@@ -15,6 +15,7 @@ ran unsandboxed code on Databricks workers.
 """
 
 import json
+from typing import Any
 
 import pandas as pd
 from pyspark.sql import functions as F
@@ -35,6 +36,16 @@ def _is_scalar_na(value) -> bool:
     """``True`` iff ``value`` is a scalar NA. Wraps the pandas check so pyright
     sees a bool instead of the ndarray-or-bool union ``pd.isna`` declares."""
     return bool(pd.api.types.is_scalar(value) and pd.isna(value))
+
+
+def _add_workbook_metadata(item: dict[str, Any], row) -> None:
+    """Attach optional deterministic workbook execution fields to an API item."""
+    workbook_version_id = row.get("workbook_version_id")
+    macro_context = row.get("macro_context")
+    if not _is_scalar_na(workbook_version_id):
+        item["workbook_version_id"] = str(workbook_version_id)
+    if not _is_scalar_na(macro_context):
+        item["context"] = macro_context
 
 
 # Schema returned by the pandas UDF
@@ -60,6 +71,8 @@ def make_execute_macro_udf(
       - id: row identifier (string)
       - macro_id: UUID of the macro to execute (string)
       - data: measurement data (VARIANT, string, or native object)
+      - workbook_version_id: immutable workbook snapshot UUID (optional)
+      - macro_context: upstream workbook namespace as JSON (optional)
 
     Returns a struct<result: string, error: string> where result is JSON.
 
@@ -94,7 +107,7 @@ def make_execute_macro_udf(
         errors: list[str | None] = [None] * len(pdf)
 
         # Build items list for the backend
-        items = []
+        items: list[dict[str, Any]] = []
         idx_map = []  # maps backend item index -> original DataFrame index
 
         for pos, (_, row) in enumerate(pdf.iterrows()):
@@ -113,13 +126,13 @@ def make_execute_macro_udf(
             elif not isinstance(data, str):
                 data = json.dumps(data)
 
-            items.append(
-                {
-                    "id": str(row_id),
-                    "macro_id": str(macro_id),
-                    "data": data,
-                }
-            )
+            item: dict[str, Any] = {
+                "id": str(row_id),
+                "macro_id": str(macro_id),
+                "data": data,
+            }
+            _add_workbook_metadata(item, row)
+            items.append(item)
             idx_map.append(pos)
 
         if not items:

--- a/apps/data/src/pipelines/centrum/bronze/raw_data.py
+++ b/apps/data/src/pipelines/centrum/bronze/raw_data.py
@@ -58,9 +58,22 @@ def raw_data():
         # clientid() from the IoT rule is the broker-authenticated Thing name (X.509 devices);
         # extracted top-level to avoid evolving the non-resettable bronze parsed_data struct.
         .withColumn("client_id", F.get_json_object(F.col("data").cast("string"), "$.client_id"))
+        # Workbook execution metadata is also extracted top-level. Adding fields
+        # to parsed_data would evolve the nested struct of this non-resettable
+        # bronze table. macro_context stays JSON because its keys are dynamic.
+        .withColumn(
+            "workbook_version_id",
+            F.get_json_object(F.col("data").cast("string"), "$.workbook_version_id"),
+        )
+        .withColumn(
+            "macro_context",
+            F.get_json_object(F.col("data").cast("string"), "$.macro_context"),
+        )
         .select(
             "experiment_id",
             "client_id",
+            "workbook_version_id",
+            "macro_context",
             "parsed_data",
             "ingestion_timestamp",
             "ingest_date",

--- a/apps/data/src/pipelines/centrum/gold/experiment_macro_data.py
+++ b/apps/data/src/pipelines/centrum/gold/experiment_macro_data.py
@@ -56,6 +56,8 @@ def experiment_macro_data():
             "questions_data",
             "annotations",
             "skip_macro_processing",
+            "workbook_version_id",
+            "macro_context",
             F.explode("macros").alias("macro")
         )
         .select(
@@ -74,6 +76,8 @@ def experiment_macro_data():
             "questions_data",
             "annotations",
             "skip_macro_processing",
+            "workbook_version_id",
+            "macro_context",
             F.col("macro.id").alias("macro_id"),
             F.col("macro.name").alias("macro_name"),
             F.col("macro.filename").alias("macro_filename")
@@ -93,7 +97,13 @@ def experiment_macro_data():
                 & F.col("macro_id").rlike(MACRO_ID_UUID_PATTERN)
                 & ~F.coalesce(F.col("skip_macro_processing"), F.lit(False)),
                 sandbox_macro_udf(
-                    F.struct("id", "macro_id", F.col("data"))
+                    F.struct(
+                        "id",
+                        "macro_id",
+                        F.col("data"),
+                        "workbook_version_id",
+                        "macro_context",
+                    )
                 ),
             )
         )
@@ -146,6 +156,7 @@ def experiment_macro_data():
             "macro_id",
             "macro_name",
             "macro_filename",
+            "workbook_version_id",
             "macro_output",
             "macro_error",
             "processed_timestamp",

--- a/apps/data/src/pipelines/centrum/gold/experiment_raw_data.py
+++ b/apps/data/src/pipelines/centrum/gold/experiment_raw_data.py
@@ -151,6 +151,8 @@ def experiment_raw_data():
             "user_id",
             "protocol_id",
             "workbook_run_id",
+            "workbook_version_id",
+            "macro_context",
             "data",
             "output_data",
             "date",

--- a/apps/data/src/pipelines/centrum/silver/clean_data.py
+++ b/apps/data/src/pipelines/centrum/silver/clean_data.py
@@ -60,6 +60,8 @@ def clean_data():
         # Null on single-device uploads; rows of one multi-device workbook
         # run share it and can be joined back on it.
         .withColumn("workbook_run_id", F.col("parsed_data.workbook_run_id"))
+        .withColumn("workbook_version_id", F.col("workbook_version_id"))
+        .withColumn("macro_context", F.col("macro_context"))
         # NOTE: timestamp === normalized UTC timestamp. timezone is the IANA name (e.g. "Europe/Amsterdam").
         # Together they are the source of truth: all local-time representations are derived from these two.
         .withColumn("timezone", F.col("parsed_data.timezone"))
@@ -188,6 +190,8 @@ def clean_data():
         "experiment_id",
         "protocol_id",
         "workbook_run_id",
+        "workbook_version_id",
+        "macro_context",
         "timestamp",
         "date",
         "hour",
@@ -236,6 +240,8 @@ def clean_data():
         # Imported/legacy data has no topic and no workbook-run concept.
         .withColumn("protocol_id", F.lit(None).cast("string"))
         .withColumn("workbook_run_id", F.lit(None).cast("string"))
+        .withColumn("workbook_version_id", F.lit(None).cast("string"))
+        .withColumn("macro_context", F.lit(None).cast("string"))
         # Mark imported data to skip macro processing
         .withColumn("skip_macro_processing", F.lit(True))
         .select(
@@ -256,6 +262,8 @@ def clean_data():
             "experiment_id",
             "protocol_id",
             "workbook_run_id",
+            "workbook_version_id",
+            "macro_context",
             "timestamp",
             "date",
             "hour",

--- a/apps/data/tests/lib/test_backend_client.py
+++ b/apps/data/tests/lib/test_backend_client.py
@@ -169,3 +169,25 @@ def test_execute_macro_batch_chunk_failure_synthesizes_per_item_errors(client: B
 
 def test_execute_macro_batch_empty_short_circuits(client: BackendClient) -> None:
     assert client.execute_macro_batch([]) == {"results": []}
+
+
+@responses.activate
+def test_execute_macro_batch_sorts_same_macro_by_workbook_version(client: BackendClient) -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE_URL}/api/v1/macros/execute-batch",
+        json={"success": True, "results": []},
+        status=200,
+    )
+    client.execute_macro_batch(
+        [
+            {"id": "v2", "macro_id": "macro", "workbook_version_id": "version-2", "data": {}},
+            {"id": "live", "macro_id": "macro", "data": {}},
+            {"id": "v1", "macro_id": "macro", "workbook_version_id": "version-1", "data": {}},
+        ]
+    )
+
+    body = responses.calls[0].request.body
+    assert body is not None
+    sent = json.loads(body)["items"]
+    assert [item["id"] for item in sent] == ["live", "v1", "v2"]

--- a/apps/data/tests/lib/test_macro_execution.py
+++ b/apps/data/tests/lib/test_macro_execution.py
@@ -1,0 +1,29 @@
+import pandas as pd
+from enrich.macro_execution import _add_workbook_metadata
+
+
+def test_add_workbook_metadata_carries_snapshot_and_context() -> None:
+    item: dict = {"id": "row-1", "macro_id": "macro-1", "data": "{}"}
+
+    _add_workbook_metadata(
+        item,
+        {
+            "workbook_version_id": "version-1",
+            "macro_context": '{"baseline":{"value":3}}',
+        },
+    )
+
+    assert item["workbook_version_id"] == "version-1"
+    assert item["context"] == '{"baseline":{"value":3}}'
+
+
+def test_add_workbook_metadata_omits_null_legacy_fields() -> None:
+    item: dict = {"id": "row-1", "macro_id": "macro-1", "data": "{}"}
+
+    _add_workbook_metadata(
+        item,
+        {"workbook_version_id": None, "macro_context": pd.NA},
+    )
+
+    assert "workbook_version_id" not in item
+    assert "context" not in item

--- a/apps/macro-sandbox/lib/wrappers/wrapper.R
+++ b/apps/macro-sandbox/lib/wrappers/wrapper.R
@@ -189,6 +189,10 @@ for (item in batch_items) {
     measurement <- measurement[[1]]
   }
   run_env$json <- measurement
+  # Upstream cell outputs keyed by canonical name, read-only via a locked binding.
+  # R copy-on-modify means nested reads are inherently isolated per item.
+  run_env$ctx <- if (is.null(item$context)) list() else item$context
+  lockBinding("ctx", run_env)
   # Use an environment (reference semantics) so output$key <- val works in-place.
   run_env$output <- new.env(parent = emptyenv())
   

--- a/apps/macro-sandbox/lib/wrappers/wrapper.js
+++ b/apps/macro-sandbox/lib/wrappers/wrapper.js
@@ -77,11 +77,28 @@ function cloneData(data) {
   return data;
 }
 
+// Deep-clone and recursively freeze, so `ctx` is read-only to macro code and a
+// mutation can never leak into the next item through the shared compiled context.
+function deepFreezeClone(value) {
+  if (Array.isArray(value)) {
+    return Object.freeze(value.map(deepFreezeClone));
+  }
+  if (value !== null && typeof value === "object") {
+    const obj = Object.create(null);
+    for (const key of Object.keys(value)) {
+      obj[key] = deepFreezeClone(value[key]);
+    }
+    return Object.freeze(obj);
+  }
+  return value;
+}
+
 // 4. CREATE CONTEXT ONCE
 // Minimal sandbox: no Date, performance, setTimeout, process, require, eval
 const sandbox = {
   json: null,
   input_data: null,
+  ctx: Object.create(null),
   output: Object.create(null),
   console: { log: () => {} },
   Date: undefined,
@@ -153,6 +170,7 @@ for (const item of batchItems) {
   const measurement = unwrapMeasurement(item.data);
   sandbox.json = cloneData(measurement);
   sandbox.input_data = cloneData(measurement);
+  sandbox.ctx = item.context ? deepFreezeClone(item.context) : Object.create(null);
   sandbox.output = Object.create(null);
 
   try {

--- a/apps/macro-sandbox/lib/wrappers/wrapper.py
+++ b/apps/macro-sandbox/lib/wrappers/wrapper.py
@@ -260,12 +260,23 @@ class SafeInstance:
     def __repr__(self):
         return repr(object.__getattribute__(self, '_obj'))
 
+def _freeze(value):
+    """Make ctx read-only to macro code: dicts become MappingProxyType and lists
+    become tuples, recursively, so a macro cannot mutate shared upstream state."""
+    if isinstance(value, dict):
+        return types.MappingProxyType({k: _freeze(v) for k, v in value.items()})
+    if isinstance(value, list):
+        return tuple(_freeze(v) for v in value)
+    return value
+
+
 results = []
 
 # 4. EXECUTION LOOP
 for item in batch_items:
     row_data = item.get("data")
     row_id = item.get("id")
+    row_context = item.get("context") or {}
 
     # Macros expect `json` to be the single measurement object. Unwrap a
     # non-empty list down to its first element, matching the legacy
@@ -290,6 +301,7 @@ for item in batch_items:
             "NameError": NameError,
         },
         "json": row_data,
+        "ctx": _freeze(row_context),
         "output": {},
         "ArrayNth": SafeCallable(ArrayNth),
         "ArrayRange": SafeCallable(ArrayRange),

--- a/apps/mobile/src/features/connection/hooks/use-multi-scanner.test.tsx
+++ b/apps/mobile/src/features/connection/hooks/use-multi-scanner.test.tsx
@@ -30,9 +30,11 @@ function entry(device: Device, patch: Partial<DeviceExecutorEntry> = {}): Device
     executor: {
       execute: vi.fn(),
       cancel: vi.fn().mockResolvedValue(undefined),
+      getIdentity: vi.fn().mockResolvedValue({ family: "multispeq", raw: {} }),
       onProgress: vi.fn(() => () => undefined),
       destroy: vi.fn().mockResolvedValue(undefined),
     },
+    identity: undefined,
     isExecuting: false,
     isCancelled: false,
     error: undefined,
@@ -107,6 +109,51 @@ describe("useMultiScanner", () => {
     ]);
     expect(client.getQueryData(connectionKeys.battery(DEVICE_A.id))).toBe(81);
     expect(client.getQueryData(connectionKeys.battery(DEVICE_B.id))).toBeUndefined();
+  });
+
+  it("runs each assignment's own command; devices without one sit the round out", async () => {
+    setEntries([entry(DEVICE_A), entry(DEVICE_B)]);
+    const executeCommandOn = vi.fn().mockResolvedValue({ ok: 1 });
+    useScannerCommandExecutorStore.setState({ executeCommandOn });
+
+    const { result } = renderHook(() => useMultiScanner(), { wrapper });
+
+    const commandA = [{ _protocol_set_: [{ v: "a" }] }];
+    let round: Round | undefined;
+    await act(async () => {
+      round = await result.current.executeScanAssignments([
+        { device: DEVICE_A, command: commandA, protocolId: "proto-a", protocolName: "A" },
+      ]);
+    });
+
+    expect(executeCommandOn).toHaveBeenCalledTimes(1);
+    expect(executeCommandOn).toHaveBeenCalledWith(DEVICE_A.id, commandA);
+    expect(round?.successes.map((s) => s.device.id)).toEqual([DEVICE_A.id]);
+    expect(round?.failures).toEqual([]);
+  });
+
+  it("merges pre-resolved failures into the round without touching the devices", async () => {
+    setEntries([entry(DEVICE_A), entry(DEVICE_B)]);
+    const executeCommandOn = vi.fn().mockResolvedValue({ device_battery: 55 });
+    useScannerCommandExecutorStore.setState({ executeCommandOn });
+
+    const { result } = renderHook(() => useMultiScanner(), { wrapper });
+
+    let round: Round | undefined;
+    await act(async () => {
+      round = await result.current.executeScanAssignments(
+        [{ device: DEVICE_A, command: "battery" }],
+        [{ device: DEVICE_B, error: new Error("Protocol code is unavailable") }],
+      );
+    });
+
+    expect(executeCommandOn).toHaveBeenCalledTimes(1);
+    expect(round?.successes.map((s) => s.device.id)).toEqual([DEVICE_A.id]);
+    expect(round?.failures).toEqual([
+      { device: DEVICE_B, error: new Error("Protocol code is unavailable") },
+    ]);
+    // Battery patching applies to assignment rounds too.
+    expect(client.getQueryData(connectionKeys.battery(DEVICE_A.id))).toBe(55);
   });
 
   it("returns an empty round without devices", async () => {

--- a/apps/mobile/src/features/connection/hooks/use-multi-scanner.ts
+++ b/apps/mobile/src/features/connection/hooks/use-multi-scanner.ts
@@ -23,12 +23,22 @@ export interface MultiScanRound {
   failures: DeviceScanFailure[];
 }
 
+/** One device's payload for a scan round; devices without one sit the round out. */
+export interface ScanAssignment {
+  device: Device;
+  command: string | object;
+  /** Provenance of the payload (dispatch rounds), threaded to the upload. */
+  protocolId?: string;
+  protocolName?: string;
+}
+
 /**
- * Multi-scan (see CONTEXT.md): run one protocol on the given devices in
- * parallel. Per-device outcomes; one failing sensor doesn't block the
- * others. The round always resolves; failures are data, not exceptions, so
- * the caller keeps successes accumulated across retry rounds and decides
- * between continue-with-successful and retry-failed.
+ * Multi-scan (see CONTEXT.md): run each assignment's command on its device in
+ * parallel (the broadcast form assigns one protocol to every device).
+ * Per-device outcomes; one failing sensor doesn't block the others. The round
+ * always resolves; failures are data, not exceptions, so the caller keeps
+ * successes accumulated across retry rounds and decides between
+ * continue-with-successful and retry-failed.
  */
 export function useMultiScanner() {
   const executors = useScannerCommandExecutorStore((s) => s.executors);
@@ -37,22 +47,22 @@ export function useMultiScanner() {
   const mutation = useMutation({
     networkMode: "always",
     mutationFn: async ({
-      protocol,
-      devices,
+      assignments,
+      prefailed = [],
     }: {
-      protocol: { code: Record<string, unknown>[] };
-      devices: Device[];
+      assignments: ScanAssignment[];
+      /** Entries that failed before reaching the device (e.g. unresolvable payload). */
+      prefailed?: DeviceScanFailure[];
     }): Promise<MultiScanRound> => {
-      const protocolCode = protocol.code;
-      if (!protocolCode || devices.length === 0) {
-        return { successes: [], failures: [] };
+      if (assignments.length === 0) {
+        return { successes: [], failures: [...prefailed] };
       }
 
       const { executeCommandOn } = useScannerCommandExecutorStore.getState();
       const settled = await Promise.allSettled(
-        devices.map((device) => executeCommandOn(device.id, protocolCode)),
+        assignments.map(({ device, command }) => executeCommandOn(device.id, command)),
       );
-      const outcomes = devices.map((device, i): DeviceCommandOutcome => {
+      const outcomes = assignments.map(({ device }, i): DeviceCommandOutcome => {
         const result = settled[i];
         return result.status === "fulfilled"
           ? { device, status: "fulfilled", result: result.value }
@@ -65,6 +75,7 @@ export function useMultiScanner() {
       });
 
       const round = partitionScanOutcomes(outcomes);
+      round.failures.push(...prefailed);
 
       // Scan replies embed the battery level; patch each device's battery
       // cache so consumers stay fresh without re-firing the battery command.
@@ -97,7 +108,15 @@ export function useMultiScanner() {
 
   return {
     executeScanAll: (protocol: { code: Record<string, unknown>[] }, devices: Device[]) =>
-      mutation.mutateAsync({ protocol, devices }),
+      mutation.mutateAsync({
+        assignments: protocol.code
+          ? devices.map((device) => ({ device, command: protocol.code }))
+          : [],
+      }),
+    // Dispatch rounds: each device runs its own payload; pre-resolved
+    // failures ride along so one bad target doesn't sink the round.
+    executeScanAssignments: (assignments: ScanAssignment[], prefailed?: DeviceScanFailure[]) =>
+      mutation.mutateAsync({ assignments, prefailed }),
     deviceStates,
     isScanning: mutation.isPending,
     lastRound: mutation.data,

--- a/apps/mobile/src/features/connection/services/multispeq-communication/driver-command-executor.ts
+++ b/apps/mobile/src/features/connection/services/multispeq-communication/driver-command-executor.ts
@@ -3,7 +3,7 @@ import { createLogger } from "~/shared/observability/logger";
 import type { Trace } from "~/shared/observability/trace";
 import { startTrace } from "~/shared/observability/trace";
 
-import type { ITransportAdapter, Logger as IotLogger } from "@repo/iot";
+import type { DeviceIdentity, ITransportAdapter, Logger as IotLogger } from "@repo/iot";
 import { MultispeqDriver } from "@repo/iot";
 
 const log = createLogger("multispeq");
@@ -49,6 +49,12 @@ export interface IMultispeqCommandExecutor {
   execute(command: string | object, options?: ExecuteOptions): Promise<string | object>;
   /** Abort the in-flight command (sends `-1+` and rejects it as cancelled). */
   cancel(): Promise<void>;
+  /**
+   * Structured device identity (name, id, firmware, battery) via the driver's
+   * identification handshake. Bypasses progress/trace plumbing like a
+   * background command; safe to fire right after connect.
+   */
+  getIdentity(): Promise<DeviceIdentity>;
   /**
    * Subscribe to live progress of the in-flight command. Returns an
    * unsubscribe function. Emissions are throttled so a chatty transfer can't
@@ -262,6 +268,10 @@ class DriverCommandExecutor implements IMultispeqCommandExecutor {
 
   cancel(): Promise<void> {
     return this.initPromise.then(() => this.driver.cancel());
+  }
+
+  getIdentity(): Promise<DeviceIdentity> {
+    return this.initPromise.then(() => this.driver.getDeviceIdentity());
   }
 
   destroy(): Promise<void> {

--- a/apps/mobile/src/features/connection/services/multispeq-communication/mock-device/create-mock-command-executor.ts
+++ b/apps/mobile/src/features/connection/services/multispeq-communication/mock-device/create-mock-command-executor.ts
@@ -34,6 +34,16 @@ export function createMockCommandExecutor(deviceId: string): IMultispeqCommandEx
       cancelled = true;
       return Promise.resolve();
     },
+    getIdentity() {
+      return Promise.resolve({
+        family: "multispeq" as const,
+        name: `Mock MultispeQ ${deviceId}`,
+        deviceId: `mock-${deviceId}`,
+        firmwareVersion: "2.311-mock",
+        batteryPercent: 80 + parseInt(deviceId, 10),
+        raw: {},
+      });
+    },
     onProgress() {
       return () => undefined;
     },

--- a/apps/mobile/src/features/connection/stores/use-scanner-command-executor-store.test.ts
+++ b/apps/mobile/src/features/connection/stores/use-scanner-command-executor-store.test.ts
@@ -52,6 +52,9 @@ function createControllableExecutor(): ControllableExecutor {
       calls[calls.length - 1]?.reject(new Error("Command cancelled"));
       return Promise.resolve();
     },
+    getIdentity() {
+      return Promise.resolve({ family: "multispeq" as const, name: "MultispeQ", raw: {} });
+    },
     onProgress(listener) {
       progressListener = listener;
       return () => {

--- a/apps/mobile/src/features/connection/stores/use-scanner-command-executor-store.ts
+++ b/apps/mobile/src/features/connection/stores/use-scanner-command-executor-store.ts
@@ -8,6 +8,7 @@ import { createMultispeqCommandExecutor } from "~/features/connection/services/s
 import { createLogger } from "~/shared/observability/logger";
 import type { Device } from "~/shared/types/device";
 
+import type { DeviceIdentity } from "@repo/iot";
 import { estimateProtocolDurationMs } from "@repo/iot";
 
 const log = createLogger("scanner-executor");
@@ -15,6 +16,12 @@ const log = createLogger("scanner-executor");
 export interface DeviceExecutorEntry {
   device: Device;
   executor: IMultispeqCommandExecutor;
+  /**
+   * Identification-handshake result, patched in asynchronously after connect.
+   * Undefined while the handshake is in flight or when it failed; consumers
+   * must treat it as best-effort.
+   */
+  identity: DeviceIdentity | undefined;
   isExecuting: boolean;
   isCancelled: boolean;
   error: Error | undefined;
@@ -84,6 +91,7 @@ function freshEntry(device: Device, executor: IMultispeqCommandExecutor): Device
   return {
     device,
     executor,
+    identity: undefined,
     isExecuting: false,
     isCancelled: false,
     error: undefined,
@@ -133,6 +141,16 @@ export const useScannerCommandExecutorStore = create<ScannerCommandExecutorStore
       .destroy()
       .catch((e) => log.warn("executor destroy failed", { err: (e as Error)?.message }));
 
+  // Best-effort, fire-and-patch: connect never blocks on identification, and a
+  // failed handshake just leaves `identity` undefined ($device branches then
+  // fall to their default path).
+  const captureIdentity = (deviceId: string, executor: IMultispeqCommandExecutor) => {
+    executor
+      .getIdentity()
+      .then((identity) => patchEntry(deviceId, { identity }))
+      .catch((e) => log.warn("identity handshake failed", { err: (e as Error)?.message }));
+  };
+
   return {
     executors: new Map(),
     isInitializing: false,
@@ -166,6 +184,7 @@ export const useScannerCommandExecutorStore = create<ScannerCommandExecutorStore
         const next = new Map(get().executors);
         next.set(device.id, freshEntry(device, executor));
         setEntries(next);
+        captureIdentity(device.id, executor);
       } catch (error) {
         set({ error: toError(error) });
       }
@@ -296,15 +315,18 @@ export const useScannerCommandExecutorStore = create<ScannerCommandExecutorStore
         }
 
         const next = new Map<string, DeviceExecutorEntry>();
+        let added: { deviceId: string; executor: IMultispeqCommandExecutor } | undefined;
         if (device) {
           const executor = await createMultispeqCommandExecutor(device);
           if (executor) {
             next.set(device.id, freshEntry(device, executor));
+            added = { deviceId: device.id, executor };
           }
         }
 
         setEntries(next);
         set({ isInitializing: false, error: undefined });
+        if (added) captureIdentity(added.deviceId, added.executor);
       } catch (error) {
         set({
           error: toError(error),

--- a/apps/mobile/src/features/measurement-flow/components/measurement-result/measurement-result.tsx
+++ b/apps/mobile/src/features/measurement-flow/components/measurement-result/measurement-result.tsx
@@ -1,8 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import { clsx } from "clsx";
 import { ChevronRight, MessageCircleMore } from "lucide-react-native";
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { View, Text, TouchableOpacity, ActivityIndicator } from "react-native";
+import type { MacroOutput } from "~/features/measurement-flow/utils/process-scan/process-scan";
 import { applyMacro } from "~/features/measurement-flow/utils/process-scan/process-scan";
 import { useTranslation } from "~/shared/i18n";
 import { TabBar } from "~/shared/ui/TabBar";
@@ -17,6 +18,10 @@ type TabKey = "result" | "raw";
 interface MeasurementResultProps {
   rawMeasurement: any;
   macro: any;
+  /** Upstream cell outputs the macro reads as `ctx.<name>` (flow context only). */
+  ctx?: Record<string, unknown>;
+  /** Called with the macro outputs once computed, so a flow can persist them. */
+  onProcessed?: (outputs: MacroOutput[]) => void;
   /** When set, shows a Comment row that calls this on press */
   onCommentPress?: () => void;
 }
@@ -24,6 +29,8 @@ interface MeasurementResultProps {
 export function MeasurementResult({
   rawMeasurement,
   macro,
+  ctx,
+  onProcessed,
   onCommentPress,
 }: MeasurementResultProps) {
   const { classes, colors } = useTheme();
@@ -46,9 +53,17 @@ export function MeasurementResult({
     // applyMacro is a pure local computation; "always" keeps it from being
     // paused by the onlineManager while offline.
     networkMode: "always",
-    queryKey: ["measurement-result", rawMeasurement, macro],
-    queryFn: () => applyMacro(rawMeasurement, macro),
+    // ctx enters the key as a stable serialization so a changed upstream
+    // output recomputes, while an identical rebuild does not.
+    queryKey: ["measurement-result", rawMeasurement, macro, ctx ? JSON.stringify(ctx) : undefined],
+    queryFn: () => applyMacro(rawMeasurement, macro, ctx ?? {}),
   });
+
+  // Surface the computed outputs so a flow can persist them (cellOutputs) for
+  // downstream branches/macros. No-op outside a flow (onProcessed unset).
+  useEffect(() => {
+    if (processedMeasurement && onProcessed) onProcessed(processedMeasurement);
+  }, [processedMeasurement, onProcessed]);
 
   const messageGroups: MacroMessageGroup[] =
     processedMeasurement

--- a/apps/mobile/src/features/measurement-flow/components/python-macro-provider.tsx
+++ b/apps/mobile/src/features/measurement-flow/components/python-macro-provider.tsx
@@ -18,17 +18,20 @@ export function PythonMacroProvider({ children }: { children: React.ReactNode })
   const requestIdRef = useRef(0);
   const webViewRef = useRef<WebView>(null);
 
-  const runPythonMacro = useCallback(async (code: string, json: object): Promise<MacroOutput> => {
-    const requestId = `py-${++requestIdRef.current}`;
-    return new Promise<MacroOutput>((resolve, reject) => {
-      pendingRef.current.set(requestId, { resolve, reject });
-      const payload = { requestId, code, json };
-      const msg = JSON.stringify(payload);
-      webViewRef.current?.injectJavaScript(
-        `window.postMessage(${JSON.stringify(msg)}, '*'); true;`,
-      );
-    });
-  }, []);
+  const runPythonMacro = useCallback(
+    async (code: string, json: object, ctx: Record<string, unknown> = {}): Promise<MacroOutput> => {
+      const requestId = `py-${++requestIdRef.current}`;
+      return new Promise<MacroOutput>((resolve, reject) => {
+        pendingRef.current.set(requestId, { resolve, reject });
+        const payload = { requestId, code, json, ctx };
+        const msg = JSON.stringify(payload);
+        webViewRef.current?.injectJavaScript(
+          `window.postMessage(${JSON.stringify(msg)}, '*'); true;`,
+        );
+      });
+    },
+    [],
+  );
 
   useEffect(() => {
     registerPythonMacroRunner(runPythonMacro);

--- a/apps/mobile/src/features/measurement-flow/domain/flow-transitions.test.ts
+++ b/apps/mobile/src/features/measurement-flow/domain/flow-transitions.test.ts
@@ -88,7 +88,42 @@ describe("edge transitions", () => {
       branchVisitCounts: {},
       lastMatchedPath: undefined,
       branchReturnStack: [],
+      devicePlan: undefined,
+      consumedNodeIds: [],
     });
+  });
+
+  it("nextStep skips consumed dispatch targets exactly once", () => {
+    const state = inFlow({
+      flowNodes: [makeMeasurement("m1"), makeMeasurement("m2"), makeQuestion("q1")],
+      currentFlowStep: 0,
+      consumedNodeIds: ["m2"],
+    });
+    expect(nextStepState(state)).toEqual({ currentFlowStep: 2, consumedNodeIds: [] });
+  });
+
+  it("nextStep wraps the iteration when only consumed targets remain", () => {
+    const state = inFlow({
+      flowNodes: [makeQuestion("q1"), makeMeasurement("m1"), makeMeasurement("m2")],
+      currentFlowStep: 1,
+      iterationCount: 1,
+      consumedNodeIds: ["m2"],
+    });
+    expect(nextStepState(state)).toMatchObject({
+      currentFlowStep: 0,
+      iterationCount: 2,
+      consumedNodeIds: [],
+      devicePlan: undefined,
+    });
+  });
+
+  it("nextStep leaves unrelated consumed ids for a later skip", () => {
+    const state = inFlow({
+      flowNodes: [makeMeasurement("m1"), makeQuestion("q1"), makeMeasurement("m2")],
+      currentFlowStep: 0,
+      consumedNodeIds: ["m2"],
+    });
+    expect(nextStepState(state)).toEqual({ currentFlowStep: 1 });
   });
 
   it("previousStep from step 0 abandons the flow but leaves isFromOverview untouched", () => {

--- a/apps/mobile/src/features/measurement-flow/domain/flow-transitions.ts
+++ b/apps/mobile/src/features/measurement-flow/domain/flow-transitions.ts
@@ -11,6 +11,15 @@ export type ScanResult = Record<string, unknown>;
 export interface ScanResultEntry {
   device?: { id: string; name: string };
   result: ScanResult;
+  /** Dispatch rounds: the protocol this device actually ran (per-device upload). */
+  protocolId?: string;
+  protocolName?: string;
+}
+
+/** One device's routing from a device-scoped (dispatcher) branch. */
+export interface DevicePlanEntry {
+  deviceId: string;
+  targetCellId: string;
 }
 
 /** The branch path the flow last routed through, surfaced inline in the hero. */
@@ -45,6 +54,9 @@ export interface FlowState {
   // Cell id of the producer (protocol or command) that yielded scanResult;
   // keys the synthetic output cell in hydrateCells for branch evaluation.
   producerCellId?: string;
+  // Macro/analysis outputs keyed by cell id so downstream branches and macros
+  // can read them on-device (the web runtime stores these as output cells).
+  cellOutputs: Record<string, unknown>;
   isFromOverview: boolean;
   // Workbook-derived data for on-device branch evaluation; empty for legacy
   // flow-only experiments. Persisted so a resumed branching flow keeps routing.
@@ -53,6 +65,11 @@ export interface FlowState {
   lastMatchedPath?: MatchedPath;
   branchVisitCounts: Record<string, number>;
   branchReturnStack: BranchReturn[];
+  // Transient dispatch routing from a device-scoped branch (NOT persisted:
+  // excluded from partialize; a resumed flow re-broadcasts like before).
+  devicePlan?: DevicePlanEntry[];
+  // Dispatch targets already executed this round; nextStep skips each once.
+  consumedNodeIds: string[];
 }
 
 export const initialFlowState: FlowState = {
@@ -67,12 +84,15 @@ export const initialFlowState: FlowState = {
   scanResult: undefined,
   scanResults: undefined,
   producerCellId: undefined,
+  cellOutputs: {},
   isFromOverview: false,
   cells: [],
   edges: [],
   lastMatchedPath: undefined,
   branchVisitCounts: {},
   branchReturnStack: [],
+  devicePlan: undefined,
+  consumedNodeIds: [],
 };
 
 // Iteration-scoped branch routing, cleared on every new iteration, retry,
@@ -81,6 +101,8 @@ const clearedBranchIteration: Partial<FlowState> = {
   branchVisitCounts: {},
   lastMatchedPath: undefined,
   branchReturnStack: [],
+  devicePlan: undefined,
+  consumedNodeIds: [],
 };
 
 // One readable interpretation of the mode flags. Precedence mirrors the
@@ -118,7 +140,16 @@ export function nextStepState(state: FlowState): Partial<FlowState> {
     return { currentFlowStep: firstMeasurementStep(state.flowNodes), isFromOverview: false };
   }
   if (state.experimentId && state.flowNodes.length > 0) {
-    const nextFlowStep = state.currentFlowStep + 1;
+    // Skip dispatch targets the last device round already executed, each once.
+    let nextFlowStep = state.currentFlowStep + 1;
+    const skippedIds: string[] = [];
+    while (
+      nextFlowStep < state.flowNodes.length &&
+      state.consumedNodeIds.includes(state.flowNodes[nextFlowStep].id)
+    ) {
+      skippedIds.push(state.flowNodes[nextFlowStep].id);
+      nextFlowStep += 1;
+    }
     if (nextFlowStep >= state.flowNodes.length) {
       if (isQuestionsOnlyFlow(state.flowNodes)) {
         return { isQuestionsSubmitPending: true, currentFlowStep: state.flowNodes.length };
@@ -128,6 +159,12 @@ export function nextStepState(state: FlowState): Partial<FlowState> {
         currentFlowStep: 0,
         iterationCount: state.iterationCount + 1,
         ...clearedBranchIteration,
+      };
+    }
+    if (skippedIds.length > 0) {
+      return {
+        currentFlowStep: nextFlowStep,
+        consumedNodeIds: state.consumedNodeIds.filter((id) => !skippedIds.includes(id)),
       };
     }
     return { currentFlowStep: nextFlowStep };
@@ -170,6 +207,7 @@ export function previousStepState(state: FlowState): Partial<FlowState> {
       scanResult: undefined,
       scanResults: undefined,
       producerCellId: undefined,
+      cellOutputs: {},
       cells: [],
       edges: [],
       ...clearedBranchIteration,
@@ -190,6 +228,7 @@ export function startNewIterationState(state: FlowState): Partial<FlowState> {
     scanResult: undefined,
     scanResults: undefined,
     producerCellId: undefined,
+    cellOutputs: {},
     isFromOverview: false,
     ...clearedBranchIteration,
   };
@@ -202,6 +241,7 @@ export function retryIterationState(): Partial<FlowState> {
     scanResult: undefined,
     scanResults: undefined,
     producerCellId: undefined,
+    cellOutputs: {},
     isFromOverview: false,
     ...clearedBranchIteration,
   };
@@ -224,6 +264,7 @@ export function dismissQuestionsSubmitState(state: FlowState): Partial<FlowState
     scanResult: undefined,
     scanResults: undefined,
     producerCellId: undefined,
+    cellOutputs: {},
     ...clearedBranchIteration,
   };
 }

--- a/apps/mobile/src/features/measurement-flow/domain/flow-transitions.ts
+++ b/apps/mobile/src/features/measurement-flow/domain/flow-transitions.ts
@@ -40,6 +40,9 @@ export interface BranchReturn {
 export interface FlowState {
   experimentId?: string;
   experimentLabel?: string;
+  // Immutable workbook version whose protocol/macro snapshots this run uses.
+  // Uploaded with measurements so cloud macro execution resolves the same code.
+  workbookVersionId?: string;
   currentStep: number;
   flowNodes: FlowNode[];
   currentFlowStep: number;
@@ -75,6 +78,7 @@ export interface FlowState {
 export const initialFlowState: FlowState = {
   experimentId: undefined,
   experimentLabel: undefined,
+  workbookVersionId: undefined,
   currentStep: 0,
   flowNodes: [],
   currentFlowStep: 0,
@@ -198,6 +202,7 @@ export function previousStepState(state: FlowState): Partial<FlowState> {
     return {
       experimentId: undefined,
       experimentLabel: undefined,
+      workbookVersionId: undefined,
       currentStep: 0,
       flowNodes: [],
       currentFlowStep: 0,

--- a/apps/mobile/src/features/measurement-flow/hooks/__tests__/use-load-experiment-flow.test.ts
+++ b/apps/mobile/src/features/measurement-flow/hooks/__tests__/use-load-experiment-flow.test.ts
@@ -81,8 +81,9 @@ describe("useLoadExperimentFlow", () => {
     const { result } = renderHook(() => useLoadExperimentFlow("e1"));
 
     await waitFor(() => expect(setFlowGraph).toHaveBeenCalled());
-    const [nodesArg, edgesArg, cellsArg] = setFlowGraph.mock.calls[0] as [
+    const [nodesArg, edgesArg, cellsArg, versionIdArg] = setFlowGraph.mock.calls[0] as [
       FlowNode[],
+      unknown,
       unknown,
       unknown,
     ];
@@ -92,6 +93,7 @@ describe("useLoadExperimentFlow", () => {
     expect(measurement?.content?.protocol).toBeDefined();
     expect(edgesArg).toEqual(cellsToFlowGraph(cells).edges);
     expect(cellsArg).toBe(cells);
+    expect(versionIdArg).toBe("v1");
     expect(setFlowNodes).not.toHaveBeenCalled();
     expect(result.current.isReady).toBe(true);
   });

--- a/apps/mobile/src/features/measurement-flow/hooks/use-load-experiment-flow.ts
+++ b/apps/mobile/src/features/measurement-flow/hooks/use-load-experiment-flow.ts
@@ -49,8 +49,13 @@ export function useLoadExperimentFlow(experimentId: string | undefined): {
     const cells = body?.cells;
     if (!cells) return;
     const { nodes, edges } = cellsToFlowGraph(cells);
-    setFlowGraph(hydrateFlowNodes(nodes, cells, body?.entitySnapshots), edges, cells);
-  }, [versionData, setFlowGraph]);
+    setFlowGraph(
+      hydrateFlowNodes(nodes, cells, body?.entitySnapshots),
+      edges,
+      cells,
+      workbookVersionId,
+    );
+  }, [versionData, workbookVersionId, setFlowGraph]);
 
   // The list resolved but the experiment has no workbook: every experiment is
   // workbook-backed, so surface an error rather than hang.

--- a/apps/mobile/src/features/measurement-flow/hooks/use-measurement-capture.test.tsx
+++ b/apps/mobile/src/features/measurement-flow/hooks/use-measurement-capture.test.tsx
@@ -1,0 +1,278 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MeasurementContent } from "~/shared/measurements/flow-node";
+import type { Device } from "~/shared/types/device";
+
+import { useMeasurementCapture } from "./use-measurement-capture";
+
+const mocks = vi.hoisted(() => {
+  const flowState = {
+    nextStep: vi.fn(),
+    setScanResults: vi.fn(),
+    navigateToQuestionFromOverview: vi.fn(),
+    devicePlan: undefined as { deviceId: string; targetCellId: string }[] | undefined,
+    completeDevicePlan: vi.fn(),
+    flowNodes: [] as {
+      id: string;
+      name: string;
+      type: string;
+      content: unknown;
+      isStart: boolean;
+    }[],
+  };
+  const useMeasurementFlowStore = vi.fn(() => flowState);
+  Object.assign(useMeasurementFlowStore, { getState: () => flowState });
+
+  return {
+    devices: [] as Device[],
+    refetchConnectedDevices: vi.fn(),
+    executeScanAll: vi.fn(),
+    executeScanAssignments: vi.fn(),
+    resetScan: vi.fn(),
+    cancelAll: vi.fn(),
+    openDeviceSheet: vi.fn(),
+    playSound: vi.fn(),
+    logWarn: vi.fn(),
+    logError: vi.fn(),
+    toastError: vi.fn(),
+    resolveInlineCommand: vi.fn(),
+    flowState,
+    useMeasurementFlowStore,
+    isScanning: false,
+  };
+});
+
+vi.mock("~/features/connection/hooks/use-device-connection", () => ({
+  useConnectedDevices: () => ({
+    data: mocks.devices,
+    refetch: mocks.refetchConnectedDevices,
+  }),
+}));
+vi.mock("~/features/connection/hooks/use-multi-scanner", () => ({
+  useMultiScanner: () => ({
+    executeScanAll: mocks.executeScanAll,
+    executeScanAssignments: mocks.executeScanAssignments,
+    isScanning: mocks.isScanning,
+    deviceStates: [],
+    lastRound: null,
+    reset: mocks.resetScan,
+    cancelAll: mocks.cancelAll,
+  }),
+}));
+vi.mock("~/features/connection/stores/use-device-sheet-store", () => ({
+  useDeviceSheetStore: (selector: (state: { open: () => void }) => unknown) =>
+    selector({ open: mocks.openDeviceSheet }),
+}));
+vi.mock("~/features/connection/stores/use-scanner-command-executor-store", () => ({
+  useScannerCommandExecutorStore: (
+    selector: (state: { progress: number; scanStartedAt: number; estimatedMs: number }) => unknown,
+  ) => selector({ progress: 0, scanStartedAt: 0, estimatedMs: 0 }),
+}));
+vi.mock("~/features/measurement-flow/stores/use-measurement-flow-store", () => ({
+  useMeasurementFlowStore: mocks.useMeasurementFlowStore,
+}));
+vi.mock("~/features/measurement-flow/utils/play-sound", () => ({
+  playSound: mocks.playSound,
+}));
+vi.mock("~/features/connection/utils/classify-scan-error", () => ({
+  classifyScanError: () => "unknown",
+}));
+vi.mock("~/shared/i18n", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("~/shared/observability/logger", () => ({
+  createLogger: () => ({ warn: mocks.logWarn, error: mocks.logError }),
+}));
+vi.mock("sonner-native", () => ({ toast: { error: mocks.toastError } }));
+vi.mock("@repo/api/transforms/command-payload", () => ({
+  resolveInlineCommand: mocks.resolveInlineCommand,
+}));
+
+const DEVICE_A: Device = { id: "usb-a", type: "usb", name: "Device A" };
+const DEVICE_B: Device = { id: "usb-b", type: "usb", name: "Device B" };
+const DEVICE_C: Device = { id: "usb-c", type: "usb", name: "Device C" };
+const DEVICE_D: Device = { id: "usb-d", type: "usb", name: "Device D" };
+const DEVICE_E: Device = { id: "usb-e", type: "usb", name: "Device E" };
+
+const CONTENT: MeasurementContent = {
+  protocolId: "shared-protocol",
+  protocol: { code: [{ set: [] }], name: "Shared protocol" },
+};
+
+describe("useMeasurementCapture", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.devices = [DEVICE_A, DEVICE_B];
+    mocks.isScanning = false;
+    mocks.refetchConnectedDevices.mockResolvedValue({ data: [DEVICE_A, DEVICE_B] });
+    mocks.cancelAll.mockResolvedValue(undefined);
+    mocks.playSound.mockResolvedValue(undefined);
+    mocks.resolveInlineCommand.mockImplementation((command: { content: string }) => {
+      if (command.content === "bad") throw new Error("invalid inline command");
+      return `resolved:${command.content}`;
+    });
+    Object.assign(mocks.flowState, {
+      devicePlan: undefined,
+      flowNodes: [],
+    });
+  });
+
+  it("records a successful broadcast round in connection order and advances", async () => {
+    mocks.executeScanAll.mockResolvedValue({
+      successes: [
+        { device: DEVICE_B, result: { value: 2 } },
+        { device: DEVICE_A, result: { value: 1 } },
+      ],
+      failures: [],
+    });
+    const { result } = renderHook(() => useMeasurementCapture(CONTENT, "measurement-cell"));
+
+    await act(async () => result.current.startScan());
+
+    expect(mocks.executeScanAll).toHaveBeenCalledWith(CONTENT.protocol, [DEVICE_A, DEVICE_B]);
+    expect(mocks.flowState.setScanResults).toHaveBeenCalledWith(
+      [
+        { device: { id: "usb-a", name: "Device A" }, result: { value: 1 } },
+        { device: { id: "usb-b", name: "Device B" }, result: { value: 2 } },
+      ],
+      "measurement-cell",
+    );
+    expect(mocks.resetScan).toHaveBeenCalledOnce();
+    expect(mocks.playSound).toHaveBeenCalledOnce();
+    expect(mocks.flowState.nextStep).toHaveBeenCalledOnce();
+  });
+
+  it("resolves each dispatch target independently and preserves payload provenance", async () => {
+    mocks.devices = [DEVICE_A, DEVICE_B, DEVICE_C, DEVICE_D, DEVICE_E];
+    mocks.refetchConnectedDevices.mockResolvedValue({ data: mocks.devices });
+    mocks.flowState.devicePlan = mocks.devices.map((device, index) => ({
+      deviceId: device.id,
+      targetCellId: `target-${index + 1}`,
+    }));
+    mocks.flowState.flowNodes = [
+      {
+        id: "target-1",
+        name: "Protocol target",
+        type: "measurement",
+        content: {
+          protocolId: "proto-a",
+          protocol: { code: [{ set: [{ label: "a" }] }], name: "Protocol A" },
+        },
+        isStart: false,
+      },
+      {
+        id: "target-2",
+        name: "Command target",
+        type: "measurement",
+        content: { command: { format: "string", content: "status" } },
+        isStart: false,
+      },
+      // target-3 is deliberately absent from the hydrated flow.
+      {
+        id: "target-4",
+        name: "Bad command",
+        type: "measurement",
+        content: { command: { format: "string", content: "bad" } },
+        isStart: false,
+      },
+      {
+        id: "target-5",
+        name: "Missing protocol",
+        type: "measurement",
+        content: { protocolId: "proto-missing" },
+        isStart: false,
+      },
+    ];
+    mocks.executeScanAssignments.mockImplementation((assignments, prefailed) =>
+      Promise.resolve({
+        successes: assignments.map(({ device }: { device: Device }, index: number) => ({
+          device,
+          result: { value: index + 1 },
+        })),
+        failures: prefailed,
+      }),
+    );
+    const { result } = renderHook(() => useMeasurementCapture({}, "target-1"));
+
+    await act(async () => result.current.startScan());
+
+    const [assignments, prefailed] = mocks.executeScanAssignments.mock.calls[0];
+    expect(assignments).toEqual([
+      {
+        device: DEVICE_A,
+        command: [{ set: [{ label: "a" }] }],
+        protocolId: "proto-a",
+        protocolName: "Protocol A",
+      },
+      { device: DEVICE_B, command: "resolved:status", protocolName: "Command target" },
+    ]);
+    expect(
+      prefailed.map(({ device, error }: { device: Device; error: Error }) => [
+        device.id,
+        error.message,
+      ]),
+    ).toEqual([
+      ["usb-c", "Dispatch target is not part of this flow"],
+      ["usb-d", "invalid inline command"],
+      ["usb-e", "Protocol code is unavailable for this dispatch target"],
+    ]);
+
+    act(() => result.current.completeWithSuccesses());
+
+    expect(mocks.flowState.setScanResults).toHaveBeenCalledWith(
+      [
+        {
+          device: { id: "usb-a", name: "Device A" },
+          result: { value: 1 },
+          protocolId: "proto-a",
+          protocolName: "Protocol A",
+        },
+        {
+          device: { id: "usb-b", name: "Device B" },
+          result: { value: 2 },
+          protocolId: undefined,
+          protocolName: "Command target",
+        },
+      ],
+      "target-1",
+    );
+    expect(mocks.flowState.completeDevicePlan).toHaveBeenCalledOnce();
+  });
+
+  it("blocks immediately when no device is connected", async () => {
+    mocks.devices = [];
+    const { result } = renderHook(() => useMeasurementCapture(CONTENT));
+
+    await act(async () => result.current.startScan());
+
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "measurementFlow:measurementNode.toast.notConnected",
+    );
+    expect(mocks.refetchConnectedDevices).not.toHaveBeenCalled();
+  });
+
+  it("turns an unexpected scan rejection into the coherent scan error", async () => {
+    mocks.executeScanAll.mockRejectedValue(new Error("executor exploded"));
+    const { result } = renderHook(() => useMeasurementCapture(CONTENT));
+
+    await act(async () => result.current.startScan());
+
+    expect(mocks.logError).toHaveBeenCalledWith("scan error", { err: "executor exploded" });
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "measurementFlow:measurementNode.toast.scanError",
+    );
+  });
+
+  it("cancels before resetting when all devices disconnect during a scan", async () => {
+    mocks.devices = [];
+    mocks.isScanning = true;
+
+    renderHook(() => useMeasurementCapture(CONTENT));
+
+    await waitFor(() => expect(mocks.cancelAll).toHaveBeenCalledOnce());
+    expect(mocks.cancelAll.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.resetScan.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/apps/mobile/src/features/measurement-flow/hooks/use-measurement-capture.ts
+++ b/apps/mobile/src/features/measurement-flow/hooks/use-measurement-capture.ts
@@ -2,18 +2,54 @@ import { useEffect, useRef } from "react";
 import { toast } from "sonner-native";
 import { useConnectedDevices } from "~/features/connection/hooks/use-device-connection";
 import { useMultiScanner } from "~/features/connection/hooks/use-multi-scanner";
-import type { DeviceScanResult } from "~/features/connection/services/scan-manager/utils/partition-scan-outcomes";
+import type { MultiScanRound, ScanAssignment } from "~/features/connection/hooks/use-multi-scanner";
+import type {
+  DeviceScanFailure,
+  DeviceScanResult,
+} from "~/features/connection/services/scan-manager/utils/partition-scan-outcomes";
 import { useDeviceSheetStore } from "~/features/connection/stores/use-device-sheet-store";
 import { useScannerCommandExecutorStore } from "~/features/connection/stores/use-scanner-command-executor-store";
 import { classifyScanError } from "~/features/connection/utils/classify-scan-error";
-import type { ScanResult } from "~/features/measurement-flow/domain/flow-transitions";
+import type {
+  DevicePlanEntry,
+  ScanResult,
+} from "~/features/measurement-flow/domain/flow-transitions";
 import { useMeasurementFlowStore } from "~/features/measurement-flow/stores/use-measurement-flow-store";
 import { playSound } from "~/features/measurement-flow/utils/play-sound";
 import { useTranslation } from "~/shared/i18n";
-import type { MeasurementContent } from "~/shared/measurements/flow-node";
+import type { FlowNode, MeasurementContent } from "~/shared/measurements/flow-node";
 import { createLogger } from "~/shared/observability/logger";
+import type { Device } from "~/shared/types/device";
+
+import { resolveInlineCommand } from "@repo/api/transforms/command-payload";
 
 const log = createLogger("measurement-capture");
+
+interface ResolvedTarget {
+  command: string | object;
+  protocolId?: string;
+  protocolName?: string;
+}
+
+// Resolves a dispatch target's payload from its hydrated flow node (protocol
+// snapshot code or inline command), the same mechanism the current node uses.
+// Errors fail only that device's round entry, never the whole round.
+function resolveTargetPayload(node: FlowNode | undefined): ResolvedTarget | Error {
+  const content = node?.content as MeasurementContent | undefined;
+  if (!node || !content) return new Error("Dispatch target is not part of this flow");
+  if (content.command) {
+    try {
+      return { command: resolveInlineCommand(content.command), protocolName: node.name };
+    } catch (err) {
+      return err instanceof Error ? err : new Error(String(err));
+    }
+  }
+  const code = content.protocol?.code;
+  if (!content.protocolId || !code || code.length === 0) {
+    return new Error("Protocol code is unavailable for this dispatch target");
+  }
+  return { command: code, protocolId: content.protocolId, protocolName: content.protocol?.name };
+}
 
 // View-model for MeasurementNode: owns the multi-scan lifecycle so the
 // component is a pure render switch over the returned state. nodeId (== cell
@@ -24,6 +60,7 @@ export function useMeasurementCapture(content: MeasurementContent, nodeId?: stri
   const protocol = content.protocol;
   const {
     executeScanAll,
+    executeScanAssignments,
     isScanning,
     deviceStates,
     lastRound,
@@ -31,7 +68,17 @@ export function useMeasurementCapture(content: MeasurementContent, nodeId?: stri
     cancelAll,
   } = useMultiScanner();
   const { data: devices = [], refetch: refetchConnectedDevices } = useConnectedDevices();
-  const { nextStep, setScanResults, navigateToQuestionFromOverview } = useMeasurementFlowStore();
+  const {
+    nextStep,
+    setScanResults,
+    navigateToQuestionFromOverview,
+    devicePlan,
+    completeDevicePlan,
+  } = useMeasurementFlowStore();
+  // The dispatch plan applies only while THIS node is one of its targets;
+  // otherwise it is stale routing state and the node broadcasts as before.
+  const activePlan =
+    nodeId && devicePlan?.some((p) => p.targetCellId === nodeId) ? devicePlan : undefined;
   const openDeviceSheet = useDeviceSheetStore((s) => s.open);
   // Primary's live progress (legacy mirrors); the round shares one protocol so
   // the estimate applies to every device.
@@ -43,6 +90,12 @@ export function useMeasurementCapture(content: MeasurementContent, nodeId?: stri
   // that already returned a result is not re-scanned when the user retries
   // the failed ones.
   const successesRef = useRef<DeviceScanResult[]>([]);
+
+  // Per-device payload provenance of the dispatch round (deviceId keyed),
+  // stamped onto each result so its upload carries its own protocolId.
+  const assignmentMetaRef = useRef<Record<string, { protocolId?: string; protocolName?: string }>>(
+    {},
+  );
 
   // Keep stable refs so the disconnect-cleanup effect below doesn't need to
   // list these as dependencies (avoids any memoisation concerns).
@@ -85,9 +138,14 @@ export function useMeasurementCapture(content: MeasurementContent, nodeId?: stri
       ordered.map(({ device, result }) => ({
         device: { id: device.id, name: device.name },
         result: result as ScanResult,
+        ...assignmentMetaRef.current[device.id],
       })),
       nodeId,
     );
+    assignmentMetaRef.current = {};
+    // The round covered every dispatch target; consumedNodeIds keeps skipping
+    // the other targets once while the plan itself is done.
+    if (activePlan) completeDevicePlan();
     // Single-node flows wrap nextStep() straight back to this same mounted
     // node; clear the finished round first so it renders Ready again instead
     // of a stale scanning screen with a dead Cancel button.
@@ -98,6 +156,29 @@ export function useMeasurementCapture(content: MeasurementContent, nodeId?: stri
     nextStep();
   };
 
+  // Build per-device assignments from the plan; a device whose target payload
+  // cannot be resolved fails its own entry, the rest of the round still runs.
+  const runDispatchRound = (plan: DevicePlanEntry[], pendingDevices: Device[]) => {
+    const { flowNodes } = useMeasurementFlowStore.getState();
+    const assignments: ScanAssignment[] = [];
+    const prefailed: DeviceScanFailure[] = [];
+    for (const device of pendingDevices) {
+      const target = plan.find((p) => p.deviceId === device.id);
+      const node = flowNodes.find((n) => n.id === target?.targetCellId);
+      const resolved = resolveTargetPayload(node);
+      if (resolved instanceof Error) {
+        prefailed.push({ device, error: resolved });
+      } else {
+        assignments.push({ device, ...resolved });
+        assignmentMetaRef.current[device.id] = {
+          protocolId: resolved.protocolId,
+          protocolName: resolved.protocolName,
+        };
+      }
+    }
+    return executeScanAssignments(assignments, prefailed);
+  };
+
   const startScan = async () => {
     if (isScanning || isStartingRef.current) return;
     isStartingRef.current = true;
@@ -106,13 +187,17 @@ export function useMeasurementCapture(content: MeasurementContent, nodeId?: stri
         toast.error(t("measurementFlow:measurementNode.toast.notConnected"));
         return;
       }
-      if (!content.protocolId) {
-        toast.error(t("measurementFlow:measurementNode.toast.noProtocol"));
-        return;
-      }
-      if (!protocol) {
-        toast.error(t("measurementFlow:measurementNode.toast.protocolUnavailable"));
-        return;
+      // A dispatch round resolves each device's payload from ITS target cell,
+      // so the current node's own protocol guards only apply to broadcast.
+      if (!activePlan) {
+        if (!content.protocolId) {
+          toast.error(t("measurementFlow:measurementNode.toast.noProtocol"));
+          return;
+        }
+        if (!protocol) {
+          toast.error(t("measurementFlow:measurementNode.toast.protocolUnavailable"));
+          return;
+        }
       }
 
       // The cached device list is polled (~3s) and lags a real drop; probe the
@@ -124,9 +209,12 @@ export function useMeasurementCapture(content: MeasurementContent, nodeId?: stri
         return;
       }
 
-      // Only scan devices that haven't succeeded in a previous round.
+      // Only scan devices that haven't succeeded in a previous round; a
+      // dispatch round additionally covers only the devices in the plan.
       const pendingDevices = liveDevices.filter(
-        (d) => !successesRef.current.some((s) => s.device.id === d.id),
+        (d) =>
+          !successesRef.current.some((s) => s.device.id === d.id) &&
+          (!activePlan || activePlan.some((p) => p.deviceId === d.id)),
       );
       if (pendingDevices.length === 0) {
         completeWithSuccesses();
@@ -134,7 +222,14 @@ export function useMeasurementCapture(content: MeasurementContent, nodeId?: stri
       }
 
       try {
-        const round = await executeScanAll(protocol, pendingDevices);
+        let round: MultiScanRound;
+        if (activePlan) {
+          round = await runDispatchRound(activePlan, pendingDevices);
+        } else if (protocol) {
+          round = await executeScanAll(protocol, pendingDevices);
+        } else {
+          return; // unreachable: guarded above
+        }
         successesRef.current = [
           ...successesRef.current.filter(
             (s) => !round.successes.some((r) => r.device.id === s.device.id),
@@ -175,6 +270,7 @@ export function useMeasurementCapture(content: MeasurementContent, nodeId?: stri
 
   const cancelScan = () => {
     successesRef.current = [];
+    assignmentMetaRef.current = {};
     // Await the cancel before resetting so the commands settle as
     // "Measurement cancelled", not a raw error the scan catch would misread.
     void (async () => {

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-macro-result.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-macro-result.tsx
@@ -2,6 +2,7 @@ import { clsx } from "clsx";
 import React from "react";
 import { View, Text } from "react-native";
 import { MeasurementResult } from "~/features/measurement-flow/components/measurement-result/measurement-result";
+import type { MacroOutput } from "~/features/measurement-flow/utils/process-scan/process-scan";
 import { useTranslation } from "~/shared/i18n";
 import type { ResolvedMacro } from "~/shared/measurements/flow-node";
 import { useTheme } from "~/shared/ui/hooks/use-theme";
@@ -11,6 +12,10 @@ interface AnalysisMacroResultProps {
   isLoading: boolean;
   macroId: string;
   scanResult: object | undefined;
+  /** Upstream cell outputs the macro reads as `ctx.<name>`. */
+  ctx?: Record<string, unknown>;
+  /** Called with the macro outputs once computed, so the flow can persist them. */
+  onProcessed?: (outputs: MacroOutput[]) => void;
   onCommentPress: () => void;
 }
 
@@ -19,6 +24,8 @@ export function AnalysisMacroResult({
   isLoading,
   macroId,
   scanResult,
+  ctx,
+  onProcessed,
   onCommentPress,
 }: AnalysisMacroResultProps) {
   const { classes } = useTheme();
@@ -61,6 +68,12 @@ export function AnalysisMacroResult({
   }
 
   return (
-    <MeasurementResult rawMeasurement={scanResult} macro={macro} onCommentPress={onCommentPress} />
+    <MeasurementResult
+      rawMeasurement={scanResult}
+      macro={macro}
+      ctx={ctx}
+      onProcessed={onProcessed}
+      onCommentPress={onCommentPress}
+    />
   );
 }

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
@@ -68,7 +68,10 @@ vi.mock("./analysis-summary-card", () => ({
   },
 }));
 vi.mock("./analysis-macro-result", () => ({
-  AnalysisMacroResult: (props: { ctx?: Record<string, unknown> }) => {
+  AnalysisMacroResult: (props: {
+    ctx?: Record<string, unknown>;
+    onProcessed?: (outputs: Record<string, unknown>[]) => void;
+  }) => {
     macroResultProps(props);
     return null;
   },
@@ -155,6 +158,25 @@ describe("AnalysisNode experiment name", () => {
     useMeasurementFlowStore.setState({ experimentId: "exp-missing", experimentLabel: undefined });
     render(<AnalysisNode content={CONTENT} nodeId="m1" />);
     expect(resolvedName()).toBe("Experiment");
+  });
+});
+
+describe("AnalysisNode macro output", () => {
+  it("persists the primary output once and ignores empty or identical callbacks", () => {
+    useMeasurementFlowStore.setState({ cellOutputs: {} });
+    render(<AnalysisNode content={CONTENT} nodeId="m1" />);
+    const onProcessed = macroResultProps.mock.calls.at(-1)?.[0]?.onProcessed as
+      | ((outputs: Record<string, unknown>[]) => void)
+      | undefined;
+
+    act(() => onProcessed?.([]));
+    expect(useMeasurementFlowStore.getState().cellOutputs.m1).toBeUndefined();
+
+    act(() => onProcessed?.([{ chlorophyll: 42 }]));
+    expect(useMeasurementFlowStore.getState().cellOutputs.m1).toEqual({ chlorophyll: 42 });
+
+    act(() => onProcessed?.([{ chlorophyll: 42 }]));
+    expect(useMeasurementFlowStore.getState().cellOutputs.m1).toEqual({ chlorophyll: 42 });
   });
 });
 

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
@@ -12,6 +12,7 @@ import { AnalysisNode } from "./analysis-node";
 // summaryProps captures the name the node hands to the summary card.
 const {
   summaryProps,
+  macroResultProps,
   actionBarProps,
   useExperiments,
   useSession,
@@ -22,6 +23,7 @@ const {
   getTimeSyncState,
 } = vi.hoisted(() => ({
   summaryProps: vi.fn(),
+  macroResultProps: vi.fn(),
   actionBarProps: vi.fn(),
   useExperiments: vi.fn(),
   useSession: vi.fn(),
@@ -65,7 +67,12 @@ vi.mock("./analysis-summary-card", () => ({
     return null;
   },
 }));
-vi.mock("./analysis-macro-result", () => ({ AnalysisMacroResult: () => null }));
+vi.mock("./analysis-macro-result", () => ({
+  AnalysisMacroResult: (props: { ctx?: Record<string, unknown> }) => {
+    macroResultProps(props);
+    return null;
+  },
+}));
 vi.mock("./analysis-action-bar", () => ({
   AnalysisActionBar: (props: { onUpload: () => void }) => {
     actionBarProps(props);
@@ -102,6 +109,7 @@ beforeEach(() => {
     rememberAnswerSettings: {},
   });
   summaryProps.mockClear();
+  macroResultProps.mockClear();
   actionBarProps.mockClear();
   useExperiments.mockReturnValue({ experiments: [{ value: "exp-1", label: "From Query" }] });
   useSession.mockReturnValue({ session: { data: { user: { id: "user-1" } } } });
@@ -191,6 +199,7 @@ describe("AnalysisNode upload with a command in the flow", () => {
     useMeasurementFlowStore.setState({
       experimentId: "exp-1",
       experimentLabel: "Trial",
+      workbookVersionId: "version-1",
       flowNodes: commandProtocolMacroNodes,
       currentFlowStep: 2,
       scanResult: { sample: [{ phi2: 0.8 }] },
@@ -208,6 +217,7 @@ describe("AnalysisNode upload with a command in the flow", () => {
     expect(uploadMeasurements).toHaveBeenCalledTimes(1);
     expect(uploadMeasurements.mock.calls[0][0]).toMatchObject({
       protocolId: "proto-1",
+      workbookVersionId: "version-1",
       results: [{ rawMeasurement: { sample: [{ phi2: 0.8 }] } }],
     });
   });
@@ -218,12 +228,28 @@ describe("AnalysisNode upload with a command in the flow", () => {
     useMeasurementFlowStore.setState({
       experimentId: "exp-1",
       experimentLabel: "Trial",
+      workbookVersionId: "version-1",
       flowNodes: commandProtocolMacroNodes,
       currentFlowStep: 2,
       scanResult: { sample: [{ phi2: 0.8 }] },
       scanResults: [
         { device: { id: "1", name: "MultispeQ #1" }, result: { sample: [{ phi2: 0.8 }] } },
         { device: { id: "2", name: "MultispeQ #2" }, result: { sample: [{ phi2: 0.7 }] } },
+      ],
+      producerCellId: "p1",
+      cells: [
+        {
+          id: "p1",
+          type: "protocol",
+          isCollapsed: false,
+          payload: { protocolId: "proto-1", version: 1, name: "Measurement" },
+        },
+        {
+          id: "m1",
+          type: "macro",
+          isCollapsed: false,
+          payload: { macroId: "macro-1", language: "python", name: "Analysis" },
+        },
       ],
     });
 
@@ -233,6 +259,9 @@ describe("AnalysisNode upload with a command in the flow", () => {
     expect(screen.getAllByText(/measurementFlow:analysis.workbookRun.deviceHeading/)).toHaveLength(
       2,
     );
+    const contexts = macroResultProps.mock.calls.map(([props]) => props.ctx);
+    expect(contexts[0]).toMatchObject({ measurement: { phi2: 0.8 } });
+    expect(contexts[1]).toMatchObject({ measurement: { phi2: 0.7 } });
 
     const props = actionBarProps.mock.calls.at(-1)?.[0] as
       | { onUpload: () => Promise<void> }
@@ -243,9 +272,18 @@ describe("AnalysisNode upload with a command in the flow", () => {
 
     expect(uploadMeasurements).toHaveBeenCalledTimes(1);
     expect(uploadMeasurements.mock.calls[0][0]).toMatchObject({
+      workbookVersionId: "version-1",
       results: [
-        { rawMeasurement: { sample: [{ phi2: 0.8 }] }, device: { id: "1" } },
-        { rawMeasurement: { sample: [{ phi2: 0.7 }] }, device: { id: "2" } },
+        {
+          rawMeasurement: { sample: [{ phi2: 0.8 }] },
+          device: { id: "1" },
+          macroContext: { measurement: { phi2: 0.8 } },
+        },
+        {
+          rawMeasurement: { sample: [{ phi2: 0.7 }] },
+          device: { id: "2" },
+          macroContext: { measurement: { phi2: 0.7 } },
+        },
       ],
     });
   });

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
@@ -47,6 +47,11 @@ vi.mock("~/shared/time/time-sync", () => ({
   getSyncedLocalISO: () => getSyncedLocalISO(),
   getTimeSyncState: () => getTimeSyncState(),
 }));
+// $device ctx reads the connected-device registry; empty here (no device).
+vi.mock("~/features/connection/stores/use-scanner-command-executor-store", () => ({
+  useScannerCommandExecutorStore: (selector: (s: { executors: Map<string, unknown> }) => unknown) =>
+    selector({ executors: new Map() }),
+}));
 vi.mock("~/shared/i18n", () => ({
   useTranslation: () => ({
     t: (key: string) =>
@@ -117,7 +122,7 @@ describe("AnalysisNode experiment name", () => {
       experimentId: "exp-1",
       experimentLabel: "Greenhouse Trial B",
     });
-    render(<AnalysisNode content={CONTENT} />);
+    render(<AnalysisNode content={CONTENT} nodeId="m1" />);
     expect(resolvedName()).toBe("Greenhouse Trial B");
   });
 
@@ -127,20 +132,20 @@ describe("AnalysisNode experiment name", () => {
       experimentId: "exp-1",
       experimentLabel: "Wheat Trial 2026",
     });
-    render(<AnalysisNode content={CONTENT} />);
+    render(<AnalysisNode content={CONTENT} nodeId="m1" />);
     expect(resolvedName()).toBe("Wheat Trial 2026");
   });
 
   it("uses the live query label when no persisted label is present", () => {
     useMeasurementFlowStore.setState({ experimentId: "exp-1", experimentLabel: undefined });
-    render(<AnalysisNode content={CONTENT} />);
+    render(<AnalysisNode content={CONTENT} nodeId="m1" />);
     expect(resolvedName()).toBe("From Query");
   });
 
   it("falls back to the default when neither label nor query resolves", () => {
     useExperiments.mockReturnValue({ experiments: [] });
     useMeasurementFlowStore.setState({ experimentId: "exp-missing", experimentLabel: undefined });
-    render(<AnalysisNode content={CONTENT} />);
+    render(<AnalysisNode content={CONTENT} nodeId="m1" />);
     expect(resolvedName()).toBe("Experiment");
   });
 });
@@ -191,7 +196,7 @@ describe("AnalysisNode upload with a command in the flow", () => {
       scanResult: { sample: [{ phi2: 0.8 }] },
     });
 
-    render(<AnalysisNode content={withMacro} />);
+    render(<AnalysisNode content={withMacro} nodeId="m1" />);
 
     const props = actionBarProps.mock.calls.at(-1)?.[0] as
       | { onUpload: () => Promise<void> }
@@ -222,7 +227,7 @@ describe("AnalysisNode upload with a command in the flow", () => {
       ],
     });
 
-    render(<AnalysisNode content={withMacro} />);
+    render(<AnalysisNode content={withMacro} nodeId="m1" />);
 
     // Per-device headings only show for multi rounds.
     expect(screen.getAllByText(/measurementFlow:analysis.workbookRun.deviceHeading/)).toHaveLength(
@@ -241,6 +246,48 @@ describe("AnalysisNode upload with a command in the flow", () => {
       results: [
         { rawMeasurement: { sample: [{ phi2: 0.8 }] }, device: { id: "1" } },
         { rawMeasurement: { sample: [{ phi2: 0.7 }] }, device: { id: "2" } },
+      ],
+    });
+  });
+
+  it("threads each dispatch result's own protocolId/protocolName to the upload", async () => {
+    const uploadMeasurements = vi.fn().mockResolvedValue(undefined);
+    useMeasurementUpload.mockReturnValue({ isUploading: false, uploadMeasurements });
+    useMeasurementFlowStore.setState({
+      experimentId: "exp-1",
+      experimentLabel: "Trial",
+      flowNodes: commandProtocolMacroNodes,
+      currentFlowStep: 2,
+      scanResult: { sample: [{ phi2: 0.8 }] },
+      scanResults: [
+        {
+          device: { id: "1", name: "MultispeQ #1" },
+          result: { sample: [{ phi2: 0.8 }] },
+          protocolId: "proto-1",
+          protocolName: "Proto",
+        },
+        {
+          device: { id: "2", name: "Ambit #1" },
+          result: { sample: [{ spad: 40 }] },
+          protocolId: "proto-2",
+          protocolName: "SPAD",
+        },
+      ],
+    });
+
+    render(<AnalysisNode content={withMacro} nodeId="m1" />);
+
+    const props = actionBarProps.mock.calls.at(-1)?.[0] as
+      | { onUpload: () => Promise<void> }
+      | undefined;
+    await act(async () => {
+      await props?.onUpload();
+    });
+
+    expect(uploadMeasurements.mock.calls[0][0]).toMatchObject({
+      results: [
+        { device: { id: "1" }, protocolId: "proto-1", protocolName: "Proto" },
+        { device: { id: "2" }, protocolId: "proto-2", protocolName: "SPAD" },
       ],
     });
   });

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.tsx
@@ -1,13 +1,15 @@
 import { clsx } from "clsx";
 import { CircleCheckBig } from "lucide-react-native";
-import React, { useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { View, Text, ScrollView } from "react-native";
 import { useSession } from "~/features/auth/hooks/use-session";
+import { useScannerCommandExecutorStore } from "~/features/connection/stores/use-scanner-command-executor-store";
 import { useExperiments } from "~/features/experiments/hooks/use-experiments";
 import { resolveExperimentName } from "~/features/measurement-flow/domain/experiment-name";
 import { flowProtocolId } from "~/features/measurement-flow/domain/flow-transitions";
 import { useFlowAnswersStore } from "~/features/measurement-flow/stores/use-flow-answers-store";
 import { useMeasurementFlowStore } from "~/features/measurement-flow/stores/use-measurement-flow-store";
+import type { MacroOutput } from "~/features/measurement-flow/utils/process-scan/process-scan";
 import { useMeasurementUpload } from "~/features/recent-measurements/hooks/use-measurement-upload";
 import { useMeasurements } from "~/features/recent-measurements/hooks/use-measurements";
 import type { StoredMeasurement } from "~/shared/db/measurements-storage";
@@ -20,6 +22,10 @@ import { useTheme } from "~/shared/ui/hooks/use-theme";
 import { CommentModal } from "~/shared/ui/measurement/comment-modal";
 import { MeasurementQuestionsModal } from "~/shared/ui/measurement/measurement-questions-modal";
 
+import { buildCellNamespace } from "@repo/api/transforms/build-cell-namespace";
+import { DEVICE_CONTEXT_KEY, toDeviceContext } from "@repo/api/transforms/device-context";
+
+import { hydrateCells } from "../utils/hydrate-cells";
 import { AnalysisActionBar, useScrollToTop } from "./analysis-action-bar";
 import { AnalysisMacroResult } from "./analysis-macro-result";
 import { AnalysisSummaryCard } from "./analysis-summary-card";
@@ -28,9 +34,11 @@ const log = createLogger("analysis-node");
 
 interface AnalysisNodeProps {
   content: AnalysisContent;
+  /** Flow node id == workbook cell id of this macro cell. */
+  nodeId: string;
 }
 
-export function AnalysisNode({ content }: AnalysisNodeProps) {
+export function AnalysisNode({ content, nodeId }: AnalysisNodeProps) {
   const { classes } = useTheme();
   const { t } = useTranslation("measurementFlow");
   // Resolved once at flow-load (hydrateFlowNodes): cell metadata + derived filename.
@@ -44,10 +52,15 @@ export function AnalysisNode({ content }: AnalysisNodeProps) {
     experimentLabel,
     iterationCount,
     flowNodes,
+    cells,
+    producerCellId,
+    cellOutputs,
+    setCellOutput,
   } = useMeasurementFlowStore();
   const protocolId = flowProtocolId(flowNodes);
   const { experiments } = useExperiments();
   const { session } = useSession();
+  const executors = useScannerCommandExecutorStore((s) => s.executors);
 
   // Name of the active measurement's protocol, read off its hydrated flow node.
   const activeProtocolName = flowNodes.find(
@@ -69,7 +82,7 @@ export function AnalysisNode({ content }: AnalysisNodeProps) {
   );
   const isMultiDevice = results.length > 1;
 
-  const { getCycleAnswers } = useFlowAnswersStore();
+  const { getCycleAnswers, getAnswer } = useFlowAnswersStore();
   const [measurementComment, setMeasurementComment] = useState("");
   const [commentModalVisible, setCommentModalVisible] = useState(false);
   const [questionsModalVisible, setQuestionsModalVisible] = useState(false);
@@ -79,6 +92,54 @@ export function AnalysisNode({ content }: AnalysisNodeProps) {
 
   const cycleAnswers = getCycleAnswers(iterationCount);
   const questions = convertCycleAnswersToArray(cycleAnswers, flowNodes);
+
+  // Upstream outputs this macro reads as `ctx.<name>`: question answers, the
+  // live scan and prior macro outputs. beforeIndex stops at this cell, so the
+  // macro never reads its own (or a later cell's) output.
+  const baseCtx = useMemo(() => {
+    const hydrated = hydrateCells(cells, {
+      iterationCount,
+      getAnswer,
+      scanResult,
+      producerCellId,
+      cellOutputs,
+    });
+    const selfIndex = hydrated.findIndex((c) => c.id === nodeId);
+    return buildCellNamespace(hydrated, selfIndex >= 0 ? selfIndex : undefined).ctx;
+  }, [cells, iterationCount, getAnswer, scanResult, producerCellId, cellOutputs, nodeId]);
+
+  // One ctx per rendered result: baseCtx plus that device's `$device` identity
+  // from the scanner store (handshake identity when it landed, else a
+  // multispeq fallback built from the device record).
+  const macroCtxs = useMemo<Record<string, unknown>[]>(() => {
+    const entries = Array.from(executors.values());
+    return results.map(({ device }, index) => {
+      const entry = device ? executors.get(device.id) : entries[index];
+      const identity =
+        entry?.identity ??
+        (device
+          ? { family: "multispeq", name: device.name, deviceId: device.id }
+          : entry
+            ? { family: "multispeq", name: entry.device.name, deviceId: entry.device.id }
+            : undefined);
+      if (!identity) return baseCtx;
+      return { ...baseCtx, [DEVICE_CONTEXT_KEY]: toDeviceContext(identity, index) };
+    });
+  }, [executors, results, baseCtx]);
+
+  // Persist the Primary device's macro output so downstream branches/macros can
+  // read it. Compare-before-set: the store write rebuilds ctx and re-runs this
+  // callback, so an identical output must not write (and loop) again.
+  const handleProcessed = useCallback(
+    (outputs: MacroOutput[]) => {
+      const first = outputs[0];
+      if (first === undefined) return;
+      const existing = useMeasurementFlowStore.getState().cellOutputs[nodeId];
+      if (existing !== undefined && JSON.stringify(existing) === JSON.stringify(first)) return;
+      setCellOutput(nodeId, first);
+    },
+    [nodeId, setCellOutput],
+  );
 
   // Capture the display timestamp once so it stays stable across re-renders.
   // The upload handler captures its own fresh timestamp independently.
@@ -131,7 +192,14 @@ export function AnalysisNode({ content }: AnalysisNodeProps) {
     const timezone = getTimeSyncState().timezone;
 
     await uploadMeasurements({
-      results: results.map(({ device, result }) => ({ rawMeasurement: result, device })),
+      // Dispatch rounds stamped a per-device protocolId/protocolName on each
+      // result; the upload publishes those on their own protocol topic.
+      results: results.map(({ device, result, protocolId: resultProtocolId, protocolName }) => ({
+        rawMeasurement: result,
+        device,
+        protocolId: resultProtocolId,
+        protocolName,
+      })),
       timestamp,
       timezone,
       experimentName,
@@ -195,6 +263,8 @@ export function AnalysisNode({ content }: AnalysisNodeProps) {
                 isLoading={false}
                 macroId={content.macroId}
                 scanResult={result}
+                ctx={macroCtxs[index]}
+                onProcessed={index === 0 ? handleProcessed : undefined}
                 onCommentPress={() => setCommentModalVisible(true)}
               />
             </View>
@@ -205,6 +275,8 @@ export function AnalysisNode({ content }: AnalysisNodeProps) {
             isLoading={false}
             macroId={content.macroId}
             scanResult={scanResult}
+            ctx={macroCtxs[0]}
+            onProcessed={handleProcessed}
             onCommentPress={() => setCommentModalVisible(true)}
           />
         )}

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.tsx
@@ -23,7 +23,7 @@ import { CommentModal } from "~/shared/ui/measurement/comment-modal";
 import { MeasurementQuestionsModal } from "~/shared/ui/measurement/measurement-questions-modal";
 
 import { buildCellNamespace } from "@repo/api/transforms/build-cell-namespace";
-import { DEVICE_CONTEXT_KEY, toDeviceContext } from "@repo/api/transforms/device-context";
+import { toDeviceContext } from "@repo/api/transforms/device-context";
 
 import { hydrateCells } from "../utils/hydrate-cells";
 import { AnalysisActionBar, useScrollToTop } from "./analysis-action-bar";
@@ -55,6 +55,7 @@ export function AnalysisNode({ content, nodeId }: AnalysisNodeProps) {
     cells,
     producerCellId,
     cellOutputs,
+    workbookVersionId,
     setCellOutput,
   } = useMeasurementFlowStore();
   const protocolId = flowProtocolId(flowNodes);
@@ -96,21 +97,20 @@ export function AnalysisNode({ content, nodeId }: AnalysisNodeProps) {
   // Upstream outputs this macro reads as `ctx.<name>`: question answers, the
   // live scan and prior macro outputs. beforeIndex stops at this cell, so the
   // macro never reads its own (or a later cell's) output.
-  const baseCtx = useMemo(() => {
+  const hydratedCells = useMemo(() => {
     const hydrated = hydrateCells(cells, {
       iterationCount,
       getAnswer,
       scanResult,
+      scanResults,
       producerCellId,
       cellOutputs,
     });
-    const selfIndex = hydrated.findIndex((c) => c.id === nodeId);
-    return buildCellNamespace(hydrated, selfIndex >= 0 ? selfIndex : undefined).ctx;
-  }, [cells, iterationCount, getAnswer, scanResult, producerCellId, cellOutputs, nodeId]);
+    return hydrated;
+  }, [cells, iterationCount, getAnswer, scanResult, scanResults, producerCellId, cellOutputs]);
 
-  // One ctx per rendered result: baseCtx plus that device's `$device` identity
-  // from the scanner store (handshake identity when it landed, else a
-  // multispeq fallback built from the device record).
+  // One device-scoped ctx per rendered result, including that device's
+  // upstream measurement and `$device` identity.
   const macroCtxs = useMemo<Record<string, unknown>[]>(() => {
     const entries = Array.from(executors.values());
     return results.map(({ device }, index) => {
@@ -122,10 +122,13 @@ export function AnalysisNode({ content, nodeId }: AnalysisNodeProps) {
           : entry
             ? { family: "multispeq", name: entry.device.name, deviceId: entry.device.id }
             : undefined);
-      if (!identity) return baseCtx;
-      return { ...baseCtx, [DEVICE_CONTEXT_KEY]: toDeviceContext(identity, index) };
+      const selfIndex = hydratedCells.findIndex((c) => c.id === nodeId);
+      return buildCellNamespace(hydratedCells, selfIndex >= 0 ? selfIndex : undefined, {
+        deviceId: device?.id,
+        device: identity ? toDeviceContext(identity, index) : undefined,
+      }).ctx;
     });
-  }, [executors, results, baseCtx]);
+  }, [executors, results, hydratedCells, nodeId]);
 
   // Persist the Primary device's macro output so downstream branches/macros can
   // read it. Compare-before-set: the store write rebuilds ctx and re-runs this
@@ -194,12 +197,15 @@ export function AnalysisNode({ content, nodeId }: AnalysisNodeProps) {
     await uploadMeasurements({
       // Dispatch rounds stamped a per-device protocolId/protocolName on each
       // result; the upload publishes those on their own protocol topic.
-      results: results.map(({ device, result, protocolId: resultProtocolId, protocolName }) => ({
-        rawMeasurement: result,
-        device,
-        protocolId: resultProtocolId,
-        protocolName,
-      })),
+      results: results.map(
+        ({ device, result, protocolId: resultProtocolId, protocolName }, index) => ({
+          rawMeasurement: result,
+          device,
+          protocolId: resultProtocolId,
+          protocolName,
+          macroContext: macroCtxs[index],
+        }),
+      ),
       timestamp,
       timezone,
       experimentName,
@@ -211,6 +217,7 @@ export function AnalysisNode({ content, nodeId }: AnalysisNodeProps) {
         name: macro.name,
         filename: macro.filename,
       },
+      workbookVersionId,
       questions,
       commentText: measurementComment.trim() || undefined,
       protocolName: activeProtocolName ?? protocolId,

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/evaluate-and-route.test.ts
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/evaluate-and-route.test.ts
@@ -18,6 +18,7 @@ const mockNextStep = vi.fn();
 const mockSetLastMatchedPath = vi.fn();
 const mockIncrementBranchVisit = vi.fn();
 const mockRecordBranchJump = vi.fn();
+const mockSetDevicePlan = vi.fn();
 const mockGetAnswer = vi.fn((_c: number, _id: string): string | undefined => undefined);
 
 interface MockFlowState {
@@ -33,6 +34,7 @@ interface MockFlowState {
   setLastMatchedPath: typeof mockSetLastMatchedPath;
   incrementBranchVisit: typeof mockIncrementBranchVisit;
   recordBranchJump: typeof mockRecordBranchJump;
+  setDevicePlan: typeof mockSetDevicePlan;
 }
 
 const flowState: MockFlowState = {
@@ -48,6 +50,7 @@ const flowState: MockFlowState = {
   setLastMatchedPath: mockSetLastMatchedPath,
   incrementBranchVisit: mockIncrementBranchVisit,
   recordBranchJump: mockRecordBranchJump,
+  setDevicePlan: mockSetDevicePlan,
 };
 
 vi.mock("~/features/measurement-flow/stores/use-measurement-flow-store", () => ({
@@ -56,6 +59,19 @@ vi.mock("~/features/measurement-flow/stores/use-measurement-flow-store", () => (
 vi.mock("~/features/measurement-flow/stores/use-flow-answers-store", () => ({
   useFlowAnswersStore: { getState: () => ({ getAnswer: mockGetAnswer }) },
 }));
+
+// Primary-device registry backing the $device branch source.
+const scannerState: { executors: Map<string, unknown> } = { executors: new Map() };
+vi.mock("~/features/connection/stores/use-scanner-command-executor-store", () => ({
+  useScannerCommandExecutorStore: { getState: () => scannerState },
+}));
+
+function connectDevice(id: string, name: string, identity?: Record<string, unknown>) {
+  scannerState.executors.set(id, {
+    device: { type: "usb", name, id },
+    identity,
+  });
+}
 
 const branchFlowNode = (id: string): FlowNode => ({
   id,
@@ -130,6 +146,7 @@ const branch = (id: string, paths: BranchPath[], defaultPathId?: string): Branch
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetAnswer.mockReturnValue(undefined);
+  scannerState.executors = new Map();
   flowState.flowNodes = [];
   flowState.currentFlowStep = 0;
   flowState.iterationCount = 0;
@@ -381,5 +398,164 @@ describe("evaluateAndRoute", () => {
     expect(mockSetLastMatchedPath).not.toHaveBeenCalled();
     expect(mockSetCurrentFlowStep).not.toHaveBeenCalled();
     expect(mockNextStep).not.toHaveBeenCalled();
+  });
+});
+
+describe("$device branch = dispatcher", () => {
+  // Family-split fixture: multispeq devices go to protocol "pm", ambit
+  // devices to protocol "pa"; both targets ride measurement flow nodes.
+  const familyBranch = () =>
+    branch(
+      "b1",
+      [
+        path("pms", [cond("$device", "eq", "multispeq", "family")], "pm"),
+        path("pam", [cond("$device", "eq", "ambit", "family")], "pa"),
+      ],
+      undefined,
+    );
+  const familyFixture = () => {
+    flowState.cells = [familyBranch(), pCell("pm", "proto-m"), pCell("pa", "proto-a")];
+    flowState.flowNodes = [
+      branchFlowNode("b1"),
+      measurementFlowNode("pm", "proto-m"),
+      measurementFlowNode("pa", "proto-a"),
+      plainFlowNode("after"),
+    ];
+    flowState.currentFlowStep = 0;
+  };
+
+  it("builds a per-device plan and routes to the earliest target, consuming the rest", () => {
+    connectDevice("usb-1", "MultispeQ A", { family: "multispeq", deviceId: "aa", raw: {} });
+    connectDevice("usb-2", "Ambit B", { family: "ambit", deviceId: "bb", raw: {} });
+    familyFixture();
+
+    evaluateAndRoute(branchFlowNode("b1"));
+
+    expect(mockSetDevicePlan).toHaveBeenCalledWith(
+      [
+        { deviceId: "usb-1", targetCellId: "pm" },
+        { deviceId: "usb-2", targetCellId: "pa" },
+      ],
+      ["pa"],
+    );
+    // A dispatcher matches several paths at once: no single ACTIVE chip.
+    expect(mockSetLastMatchedPath).toHaveBeenCalledWith(undefined);
+    expect(mockRecordBranchJump).toHaveBeenCalledWith(1);
+    expect(mockSetCurrentFlowStep).toHaveBeenCalledWith(1); // earliest target "pm"
+  });
+
+  it("groups devices on the same path onto one target with nothing consumed", () => {
+    connectDevice("usb-1", "MultispeQ A", { family: "multispeq", deviceId: "aa", raw: {} });
+    connectDevice("usb-2", "MultispeQ B", { family: "multispeq", deviceId: "bb", raw: {} });
+    familyFixture();
+
+    evaluateAndRoute(branchFlowNode("b1"));
+
+    expect(mockSetDevicePlan).toHaveBeenCalledWith(
+      [
+        { deviceId: "usb-1", targetCellId: "pm" },
+        { deviceId: "usb-2", targetCellId: "pm" },
+      ],
+      [],
+    );
+    expect(mockSetCurrentFlowStep).toHaveBeenCalledWith(1);
+  });
+
+  it("skips a device matching no path; the rest still dispatch", () => {
+    connectDevice("usb-1", "Ambit A", { family: "ambit", deviceId: "aa", raw: {} });
+    connectDevice("usb-2", "Mystery", { family: "ambyte", deviceId: "bb", raw: {} });
+    familyFixture();
+
+    evaluateAndRoute(branchFlowNode("b1"));
+
+    expect(mockSetDevicePlan).toHaveBeenCalledWith([{ deviceId: "usb-1", targetCellId: "pa" }], []);
+    expect(mockSetCurrentFlowStep).toHaveBeenCalledWith(2); // "pa" is the only target
+  });
+
+  it("falls back to family multispeq while the identity handshake is pending", () => {
+    connectDevice("usb-1", "MultispeQ A", undefined);
+    familyFixture();
+
+    evaluateAndRoute(branchFlowNode("b1"));
+
+    expect(mockSetDevicePlan).toHaveBeenCalledWith([{ deviceId: "usb-1", targetCellId: "pm" }], []);
+    expect(mockSetCurrentFlowStep).toHaveBeenCalledWith(1);
+  });
+
+  it("clears the plan and falls through sequentially when no device matches", () => {
+    connectDevice("usb-1", "Mystery", { family: "ambyte", deviceId: "aa", raw: {} });
+    familyFixture();
+
+    evaluateAndRoute(branchFlowNode("b1"));
+
+    expect(mockSetDevicePlan).toHaveBeenCalledWith(undefined, []);
+    expect(mockRecordBranchJump).toHaveBeenCalledWith(1);
+    expect(mockSetCurrentFlowStep).toHaveBeenCalledWith(1); // sequential, not a dispatch jump
+  });
+
+  it("clears the plan and falls through when no device is connected", () => {
+    familyFixture();
+
+    evaluateAndRoute(branchFlowNode("b1"));
+
+    expect(mockSetDevicePlan).toHaveBeenCalledWith(undefined, []);
+    expect(mockSetLastMatchedPath).toHaveBeenCalledWith(undefined);
+    expect(mockSetCurrentFlowStep).toHaveBeenCalledWith(1);
+  });
+
+  it("skips a device whose matched path targets a non-measurement cell", () => {
+    connectDevice("usb-1", "MultispeQ A", { family: "multispeq", deviceId: "aa", raw: {} });
+    flowState.cells = [
+      qCell("q1"),
+      branch("b1", [path("pms", [cond("$device", "eq", "multispeq", "family")], "q1")], undefined),
+    ];
+    flowState.flowNodes = [plainFlowNode("q1"), branchFlowNode("b1"), plainFlowNode("after")];
+    flowState.currentFlowStep = 1;
+
+    evaluateAndRoute(branchFlowNode("b1"));
+
+    expect(mockSetDevicePlan).toHaveBeenCalledWith(undefined, []);
+    expect(mockSetCurrentFlowStep).toHaveBeenCalledWith(2);
+  });
+
+  it("dispatches command-cell targets too", () => {
+    connectDevice("usb-1", "MultispeQ A", { family: "multispeq", deviceId: "aa", raw: {} });
+    flowState.cells = [
+      branch(
+        "b1",
+        [path("pms", [cond("$device", "eq", "multispeq", "family")], "cmd1")],
+        undefined,
+      ),
+      cCell("cmd1"),
+    ];
+    flowState.flowNodes = [
+      branchFlowNode("b1"),
+      measurementFlowNode("cmd1", ""),
+      plainFlowNode("after"),
+    ];
+    flowState.currentFlowStep = 0;
+
+    evaluateAndRoute(branchFlowNode("b1"));
+
+    expect(mockSetDevicePlan).toHaveBeenCalledWith(
+      [{ deviceId: "usb-1", targetCellId: "cmd1" }],
+      [],
+    );
+    expect(mockSetCurrentFlowStep).toHaveBeenCalledWith(1);
+  });
+
+  it("leaves non-device branches untouched (no plan writes)", () => {
+    mockGetAnswer.mockImplementation((_c, id) => (id === "q1" ? "yes" : undefined));
+    flowState.cells = [
+      qCell("q1"),
+      branch("b1", [path("pa", [cond("q1", "eq", "yes")], "tgt"), path("pdef", [])], "pdef"),
+    ];
+    flowState.flowNodes = [branchFlowNode("b1"), plainFlowNode("y"), plainFlowNode("tgt")];
+    flowState.currentFlowStep = 0;
+
+    evaluateAndRoute(branchFlowNode("b1"));
+
+    expect(mockSetDevicePlan).not.toHaveBeenCalled();
+    expect(mockSetCurrentFlowStep).toHaveBeenCalledWith(2);
   });
 });

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/evaluate-and-route.ts
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/evaluate-and-route.ts
@@ -1,11 +1,41 @@
+import { useScannerCommandExecutorStore } from "~/features/connection/stores/use-scanner-command-executor-store";
+import type { DeviceExecutorEntry } from "~/features/connection/stores/use-scanner-command-executor-store";
+import type { DevicePlanEntry } from "~/features/measurement-flow/domain/flow-transitions";
 import { useFlowAnswersStore } from "~/features/measurement-flow/stores/use-flow-answers-store";
 import { useMeasurementFlowStore } from "~/features/measurement-flow/stores/use-measurement-flow-store";
 import { FlowNode } from "~/shared/measurements/flow-node";
+import { createLogger } from "~/shared/observability/logger";
 
 import type { BranchCell, WorkbookCell } from "@repo/api/domains/workbook/workbook-cells.schema";
-import { evaluateBranch } from "@repo/api/transforms/evaluate-branch";
+import { toDeviceContext } from "@repo/api/transforms/device-context";
+import type { BranchRuntimeContext } from "@repo/api/transforms/evaluate-branch";
+import { evaluateBranch, isDeviceScopedBranch } from "@repo/api/transforms/evaluate-branch";
 
 import { hydrateCells } from "./hydrate-cells";
+
+const log = createLogger("evaluate-and-route");
+
+// Identity is best-effort; while the handshake is pending (or failed) the
+// family falls back to multispeq, the only family mobile connects today.
+function entryIdentity(entry: DeviceExecutorEntry) {
+  return (
+    entry.identity ?? {
+      family: "multispeq",
+      name: entry.device.name,
+      deviceId: entry.device.id,
+    }
+  );
+}
+
+/** `$device` conditions of a non-dispatch branch read the primary device. */
+function primaryDeviceRuntime(): BranchRuntimeContext | undefined {
+  const primary: DeviceExecutorEntry | undefined = useScannerCommandExecutorStore
+    .getState()
+    .executors.values()
+    .next().value;
+  if (!primary) return undefined;
+  return { device: toDeviceContext(entryIdentity(primary), 0) };
+}
 
 // Caps branch goto-loops; mirrors web's useWorkbookExecution MAX_VISITS_PER_CELL.
 export const MAX_BRANCH_VISITS = 100;
@@ -24,6 +54,67 @@ function advanceSequential(): void {
   }
   recordBranchJump(nextIndex);
   setCurrentFlowStep(nextIndex);
+}
+
+type FlowStore = ReturnType<typeof useMeasurementFlowStore.getState>;
+
+/**
+ * Device-scoped branch = dispatcher (mirrors web's runDeviceDispatchBranch):
+ * every connected device evaluates the branch with ITS identity and the plan
+ * maps each device to its matched protocol/command cell. The flow routes to
+ * the EARLIEST target in flow order; the measurement round there executes
+ * every device's own payload, so the other targets are consumed (skipped
+ * once). Devices matching no measurement are skipped, never an error.
+ */
+function dispatchDeviceBranch(
+  flow: FlowStore,
+  branchCell: BranchCell,
+  hydrated: WorkbookCell[],
+): void {
+  const entries = Array.from(useScannerCommandExecutorStore.getState().executors.values());
+
+  const plan: DevicePlanEntry[] = [];
+  const skipped: string[] = [];
+  entries.forEach((entry, index) => {
+    const matched = evaluateBranch(branchCell, hydrated, {
+      device: toDeviceContext(entryIdentity(entry), index),
+    });
+    const target = matched?.gotoCellId
+      ? hydrated.find((c) => c.id === matched.gotoCellId)
+      : undefined;
+    const isMeasurementTarget =
+      !!target && (target.type === "protocol" || target.type === "command");
+    if (isMeasurementTarget && flow.flowNodes.some((n) => n.id === target.id)) {
+      plan.push({ deviceId: entry.device.id, targetCellId: target.id });
+    } else {
+      skipped.push(entry.device.name);
+    }
+  });
+
+  // A dispatcher matches several paths at once: no single ACTIVE path chip.
+  flow.setLastMatchedPath(undefined);
+
+  if (skipped.length > 0) {
+    log.info("dispatch: devices without a matched measurement sit out this round", {
+      devices: skipped.join(", "),
+    });
+  }
+
+  if (plan.length === 0) {
+    flow.setDevicePlan(undefined, []);
+    advanceSequential();
+    return;
+  }
+
+  const targetIds = new Set(plan.map((p) => p.targetCellId));
+  const firstIdx = flow.flowNodes.findIndex((n) => targetIds.has(n.id));
+  const consumed = flow.flowNodes
+    .filter((n, i) => targetIds.has(n.id) && i !== firstIdx)
+    .map((n) => n.id);
+  flow.setDevicePlan(plan, consumed);
+  // Same Back semantics as a plain matched jump: only forward records a return.
+  if (firstIdx > flow.currentFlowStep) flow.recordBranchJump(firstIdx);
+  flow.setCurrentFlowStep(firstIdx);
 }
 
 // Evaluates a branch via the reused `evaluateBranch` (first match wins, else
@@ -50,6 +141,7 @@ export function evaluateAndRoute(node: FlowNode): void {
     getAnswer,
     scanResult: flow.scanResult,
     producerCellId: flow.producerCellId,
+    cellOutputs: flow.cellOutputs,
   });
 
   const branchCell = hydrated.find((c): c is BranchCell => c.id === node.id && c.type === "branch");
@@ -61,7 +153,12 @@ export function evaluateAndRoute(node: FlowNode): void {
     return;
   }
 
-  const matched = evaluateBranch(branchCell, hydrated);
+  if (isDeviceScopedBranch(branchCell)) {
+    dispatchDeviceBranch(flow, branchCell, hydrated);
+    return;
+  }
+
+  const matched = evaluateBranch(branchCell, hydrated, primaryDeviceRuntime());
   flow.setLastMatchedPath(matched ? { label: matched.label, color: matched.color } : undefined);
 
   if (matched?.gotoCellId) {

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/evaluate-and-route.ts
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/evaluate-and-route.ts
@@ -34,7 +34,7 @@ function primaryDeviceRuntime(): BranchRuntimeContext | undefined {
     .executors.values()
     .next().value;
   if (!primary) return undefined;
-  return { device: toDeviceContext(entryIdentity(primary), 0) };
+  return { device: toDeviceContext(entryIdentity(primary), 0), deviceId: primary.device.id };
 }
 
 // Caps branch goto-loops; mirrors web's useWorkbookExecution MAX_VISITS_PER_CELL.
@@ -78,6 +78,7 @@ function dispatchDeviceBranch(
   entries.forEach((entry, index) => {
     const matched = evaluateBranch(branchCell, hydrated, {
       device: toDeviceContext(entryIdentity(entry), index),
+      deviceId: entry.device.id,
     });
     const target = matched?.gotoCellId
       ? hydrated.find((c) => c.id === matched.gotoCellId)
@@ -140,6 +141,7 @@ export function evaluateAndRoute(node: FlowNode): void {
     iterationCount: flow.iterationCount,
     getAnswer,
     scanResult: flow.scanResult,
+    scanResults: flow.scanResults,
     producerCellId: flow.producerCellId,
     cellOutputs: flow.cellOutputs,
   });

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/hydrate-cells.test.ts
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/hydrate-cells.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type {
   CommandCell,
+  MacroCell,
   OutputCell,
   ProtocolCell,
   QuestionCell,
@@ -31,6 +32,12 @@ const cCell = (id: string): CommandCell => ({
   type: "command",
   isCollapsed: false,
   payload: { format: "string", content: "battery" },
+});
+const mCell = (id: string): MacroCell => ({
+  id,
+  type: "macro",
+  isCollapsed: false,
+  payload: { macroId: "00000000-0000-0000-0000-000000000001", language: "javascript" },
 });
 
 const ctx = (over: Partial<HydrationContext> = {}): HydrationContext => ({
@@ -115,5 +122,36 @@ describe("hydrateCells", () => {
     const cells = [qCell("q1")];
     hydrateCells(cells, ctx({ getAnswer: () => "x" }));
     expect(cells[0].answer).toBeUndefined();
+  });
+
+  it("synthesizes output cells from cellOutputs (macro results)", () => {
+    const hydrated = hydrateCells([mCell("m1")], ctx({ cellOutputs: { m1: { fvfm: 0.72 } } }));
+    expect(resolveConditionValue(hydrated, "m1", "fvfm")).toBe(0.72);
+  });
+
+  it("synthesizes both a macro output and the latest scan", () => {
+    const hydrated = hydrateCells(
+      [pCell("p1", "proto-1"), mCell("m1")],
+      ctx({
+        scanResult: { sample: [{ phi2: 0.8 }] },
+        producerCellId: "p1",
+        cellOutputs: { m1: { fvfm: 0.72 } },
+      }),
+    );
+    expect(resolveConditionValue(hydrated, "p1", "phi2")).toBe(0.8);
+    expect(resolveConditionValue(hydrated, "m1", "fvfm")).toBe(0.72);
+  });
+
+  it("prefers the live scan over a stored cellOutputs entry for the same producer", () => {
+    const hydrated = hydrateCells(
+      [pCell("p1", "proto-1")],
+      ctx({
+        scanResult: { sample: [{ phi2: 0.9 }] },
+        producerCellId: "p1",
+        cellOutputs: { p1: { phi2: 0.1 } },
+      }),
+    );
+    expect(hydrated.filter((c) => c.type === "output")).toHaveLength(1);
+    expect(resolveConditionValue(hydrated, "p1", "phi2")).toBe(0.9);
   });
 });

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/hydrate-cells.test.ts
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/hydrate-cells.test.ts
@@ -66,6 +66,23 @@ describe("hydrateCells", () => {
     expect(resolveConditionValue(hydrated, "p1", "phi2")).toBe(0.8);
   });
 
+  it("hydrates and scopes every device's live measurement", () => {
+    const hydrated = hydrateCells(
+      [pCell("p1", "proto-1")],
+      ctx({
+        scanResult: { sample: [{ phi2: 0.8 }] },
+        scanResults: [
+          { device: { id: "usb-a", name: "A" }, result: { sample: [{ phi2: 0.8 }] } },
+          { device: { id: "usb-b", name: "B" }, result: { sample: [{ phi2: 0.6 }] } },
+        ],
+        producerCellId: "p1",
+      }),
+    );
+
+    expect(resolveConditionValue(hydrated, "p1", "phi2", { deviceId: "usb-a" })).toBe(0.8);
+    expect(resolveConditionValue(hydrated, "p1", "phi2", { deviceId: "usb-b" })).toBe(0.6);
+  });
+
   it("wraps a scalar command result under `response` (mirrors web) so a branch resolves it", () => {
     const hydrated = hydrateCells([cCell("c1")], ctx({ scanResult: "87", producerCellId: "c1" }));
     expect(resolveConditionValue(hydrated, "c1", "response")).toBe("87");

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/hydrate-cells.ts
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/hydrate-cells.ts
@@ -4,6 +4,8 @@ export interface HydrationContext {
   iterationCount: number;
   getAnswer: (cycle: number, cellId: string) => string | undefined;
   scanResult?: unknown;
+  /** Per-device form of the live result, used to scope ctx/branches by connection id. */
+  scanResults?: { device?: { id: string; name: string }; result: unknown }[];
   /** Cell id of the producer (protocol or command) whose output `scanResult` holds. */
   producerCellId?: string;
   /** Macro/analysis outputs keyed by cell id (store.cellOutputs). */
@@ -15,7 +17,7 @@ export interface HydrationContext {
 // measurement, and macro outputs, each as a synthetic output cell keyed to
 // its producer.
 export function hydrateCells(cells: WorkbookCell[], ctx: HydrationContext): WorkbookCell[] {
-  const { iterationCount, getAnswer, scanResult, producerCellId, cellOutputs } = ctx;
+  const { iterationCount, getAnswer, scanResult, scanResults, producerCellId, cellOutputs } = ctx;
 
   const hydrated: WorkbookCell[] = cells.map((cell) =>
     cell.type === "question"
@@ -28,27 +30,40 @@ export function hydrateCells(cells: WorkbookCell[], ctx: HydrationContext): Work
 
   // The scan belongs to the cell that produced it (store.producerCellId, a
   // protocol or command); find it so the synthetic output is keyed to the producer.
-  if (scanResult != null && producerCellId) {
+  const liveResults = scanResults ?? (scanResult != null ? [{ result: scanResult }] : []);
+  if (liveResults.length > 0 && producerCellId) {
     const producer = hydrated.find((c) => c.id === producerCellId);
     if (producer) {
-      let data: unknown;
-      if (producer.type === "command") {
-        // Mirror web's toOutputData so a branch reads the same shape on both hosts:
-        // a plain object passes through; any scalar/array is wrapped as { response }.
-        data =
-          typeof scanResult === "object" && !Array.isArray(scanResult)
-            ? scanResult
-            : { response: scanResult };
-      } else {
-        const sample = (scanResult as { sample?: unknown }).sample;
-        data = sample != null ? (Array.isArray(sample) ? sample : [sample]) : scanResult;
-      }
+      const normalize = (result: unknown): unknown => {
+        if (producer.type === "command") {
+          // Mirror web's toOutputData so a branch reads the same shape on both hosts:
+          // a plain object passes through; any scalar/array is wrapped as { response }.
+          return typeof result === "object" && !Array.isArray(result)
+            ? result
+            : { response: result };
+        }
+        const sample = (result as { sample?: unknown }).sample;
+        return sample != null ? (Array.isArray(sample) ? sample : [sample]) : result;
+      };
+      const data = normalize(liveResults[0].result);
+      const deviceResults = liveResults.flatMap((entry) =>
+        entry.device
+          ? [
+              {
+                deviceId: entry.device.id,
+                deviceLabel: entry.device.name,
+                data: normalize(entry.result),
+              },
+            ]
+          : [],
+      );
       synthetic.push({
         id: `synthetic-output-${producer.id}`,
         type: "output",
         isCollapsed: false,
         producedBy: producer.id,
         data,
+        deviceResults: deviceResults.length > 0 ? deviceResults : undefined,
       });
       producedIds.add(producer.id);
     }

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/hydrate-cells.ts
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/hydrate-cells.ts
@@ -6,14 +6,16 @@ export interface HydrationContext {
   scanResult?: unknown;
   /** Cell id of the producer (protocol or command) whose output `scanResult` holds. */
   producerCellId?: string;
+  /** Macro/analysis outputs keyed by cell id (store.cellOutputs). */
+  cellOutputs?: Record<string, unknown>;
 }
 
-// Snapshots cells with live values so the shared `evaluateBranch` can read them:
-// question `.answer` from the store, and the latest measurement as a synthetic
-// output cell. Mobile keeps one scanResult, so only the latest producer's output
-// resolves; others are undefined (false → default path).
+// Snapshots cells with live values so the shared `evaluateBranch` and macro
+// `ctx` can read them: question `.answer` from the store, the latest
+// measurement, and macro outputs, each as a synthetic output cell keyed to
+// its producer.
 export function hydrateCells(cells: WorkbookCell[], ctx: HydrationContext): WorkbookCell[] {
-  const { iterationCount, getAnswer, scanResult, producerCellId } = ctx;
+  const { iterationCount, getAnswer, scanResult, producerCellId, cellOutputs } = ctx;
 
   const hydrated: WorkbookCell[] = cells.map((cell) =>
     cell.type === "question"
@@ -21,37 +23,56 @@ export function hydrateCells(cells: WorkbookCell[], ctx: HydrationContext): Work
       : { ...cell },
   );
 
-  if (scanResult == null || !producerCellId) return hydrated;
+  const synthetic: OutputCell[] = [];
+  const producedIds = new Set<string>();
 
   // The scan belongs to the cell that produced it (store.producerCellId, a
   // protocol or command); find it so the synthetic output is keyed to the producer.
-  const producer = hydrated.find((c) => c.id === producerCellId);
-  if (!producer) return hydrated;
-
-  let data: unknown;
-  if (producer.type === "command") {
-    // Mirror web's toOutputData so a branch reads the same shape on both hosts:
-    // a plain object passes through; any scalar/array is wrapped as { response }.
-    data =
-      typeof scanResult === "object" && !Array.isArray(scanResult)
-        ? scanResult
-        : { response: scanResult };
-  } else {
-    const sample = (scanResult as { sample?: unknown }).sample;
-    data = sample != null ? (Array.isArray(sample) ? sample : [sample]) : scanResult;
+  if (scanResult != null && producerCellId) {
+    const producer = hydrated.find((c) => c.id === producerCellId);
+    if (producer) {
+      let data: unknown;
+      if (producer.type === "command") {
+        // Mirror web's toOutputData so a branch reads the same shape on both hosts:
+        // a plain object passes through; any scalar/array is wrapped as { response }.
+        data =
+          typeof scanResult === "object" && !Array.isArray(scanResult)
+            ? scanResult
+            : { response: scanResult };
+      } else {
+        const sample = (scanResult as { sample?: unknown }).sample;
+        data = sample != null ? (Array.isArray(sample) ? sample : [sample]) : scanResult;
+      }
+      synthetic.push({
+        id: `synthetic-output-${producer.id}`,
+        type: "output",
+        isCollapsed: false,
+        producedBy: producer.id,
+        data,
+      });
+      producedIds.add(producer.id);
+    }
   }
 
-  const outputCell: OutputCell = {
-    id: `synthetic-output-${producer.id}`,
-    type: "output",
-    isCollapsed: false,
-    producedBy: producer.id,
-    data,
-  };
+  // Macro/analysis outputs are stored raw (object), matching the web runtime.
+  // The live scan wins over a stale stored output for the same producer.
+  for (const [cellId, data] of Object.entries(cellOutputs ?? {})) {
+    if (producedIds.has(cellId)) continue;
+    synthetic.push({
+      id: `synthetic-output-${cellId}`,
+      type: "output",
+      isCollapsed: false,
+      producedBy: cellId,
+      data,
+    });
+    producedIds.add(cellId);
+  }
 
-  // Drop any stale output for this producer, then append the live one.
+  if (synthetic.length === 0) return hydrated;
+
+  // Drop any stale output for these producers, then append the live ones.
   return [
-    ...hydrated.filter((c) => !(c.type === "output" && c.producedBy === producer.id)),
-    outputCell,
+    ...hydrated.filter((c) => !(c.type === "output" && producedIds.has(c.producedBy))),
+    ...synthetic,
   ];
 }

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-states/active-state.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-states/active-state.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { View, ScrollView } from "react-native";
+import { useMeasurementFlowStore } from "~/features/measurement-flow/stores/use-measurement-flow-store";
 import { FlowNode } from "~/shared/measurements/flow-node";
 
 import { AnalysisNode } from "../flow-nodes/analysis-node/analysis-node";
@@ -24,12 +25,12 @@ const ScrollableNode = ({ children }: { children: React.ReactNode }) => (
   </ScrollView>
 );
 
-function renderNode(currentNode: FlowNode) {
+function renderNode(currentNode: FlowNode, isDispatchTarget: boolean) {
   switch (currentNode.type) {
     case "question":
       return <QuestionNode node={currentNode} />;
     case "analysis":
-      return <AnalysisNode content={currentNode.content} />;
+      return <AnalysisNode content={currentNode.content} nodeId={currentNode.id} />;
     case "branch":
       return <BranchNode node={currentNode} />;
     case "instruction":
@@ -40,8 +41,10 @@ function renderNode(currentNode: FlowNode) {
       );
     case "measurement":
       // A measurement node carries either a protocol reference or an inline
-      // device command; the latter runs through the lightweight CommandNode.
-      if (currentNode.content?.command) {
+      // device command; the latter runs through the lightweight CommandNode,
+      // except as a dispatch target, where the multi-device MeasurementNode
+      // runs each device's own payload.
+      if (currentNode.content?.command && !isDispatchTarget) {
         return <CommandNode content={currentNode.content.command} nodeId={currentNode.id} />;
       }
       return (
@@ -55,6 +58,9 @@ function renderNode(currentNode: FlowNode) {
 }
 
 export function ActiveState({ currentNode }: ActiveStateProps) {
+  const isDispatchTarget = useMeasurementFlowStore(
+    (s) => s.devicePlan?.some((p) => p.targetCellId === currentNode.id) ?? false,
+  );
   // Each node controls its own navigation/actions; no shared footer here.
-  return <View className="flex-1">{renderNode(currentNode)}</View>;
+  return <View className="flex-1">{renderNode(currentNode, isDispatchTarget)}</View>;
 }

--- a/apps/mobile/src/features/measurement-flow/services/python/python-macro-sandbox.ts
+++ b/apps/mobile/src/features/measurement-flow/services/python/python-macro-sandbox.ts
@@ -1,7 +1,7 @@
 /**
  * Inline HTML for a hidden WebView that runs Python macros via Pyodide.
- * Listens for postMessage({ requestId, code, json }), wraps code in a function
- * that receives json, runs it, and posts back { requestId, result } or { requestId, error }.
+ * Listens for postMessage({ requestId, code, json, ctx }), wraps code in a function
+ * that receives json and ctx, runs it, and posts back { requestId, result } or { requestId, error }.
  */
 export const pythonMacroSandboxHtml = `
 <!DOCTYPE html>
@@ -24,16 +24,18 @@ export const pythonMacroSandboxHtml = `
     return s.split('\\n').map(function(line) { return '    ' + line; }).join('\\n');
   }
 
-  async function runMacro(requestId, code, json) {
+  async function runMacro(requestId, code, json, ctx) {
     try {
       var resultHolder = {};
       pyodide.globals.set('__result_holder__', resultHolder);
       var jsonB64 = btoa(unescape(encodeURIComponent(JSON.stringify(json))));
+      var ctxB64 = btoa(unescape(encodeURIComponent(JSON.stringify(ctx || {}))));
       var wrapped =
         'import base64, json\\n' +
         '__json_input__ = json.loads(base64.b64decode("' + jsonB64 + '").decode("utf-8"))\\n' +
-        'def __macro__(json):\\n' + indent(code) + '\\n\\n' +
-        '__result__ = __macro__(__json_input__)\\n' +
+        '__ctx_input__ = json.loads(base64.b64decode("' + ctxB64 + '").decode("utf-8"))\\n' +
+        'def __macro__(json, ctx):\\n' + indent(code) + '\\n\\n' +
+        '__result__ = __macro__(__json_input__, __ctx_input__)\\n' +
         '__result_holder__.result = json.dumps(__result__)\\n';
       await pyodide.runPythonAsync(wrapped);
       var raw = resultHolder.result;
@@ -54,7 +56,7 @@ export const pythonMacroSandboxHtml = `
       var payload = typeof data === 'string' ? JSON.parse(data) : data;
       if (!payload || payload.requestId === undefined || payload.code === undefined) return;
       if (pyodideReady) {
-        runMacro(payload.requestId, payload.code, payload.json || {});
+        runMacro(payload.requestId, payload.code, payload.json || {}, payload.ctx || {});
       } else {
         pending.push(payload);
       }
@@ -67,7 +69,7 @@ export const pythonMacroSandboxHtml = `
     window.pyodide = pyodide;
     pyodideReady = true;
     send({ type: 'ready' });
-    pending.forEach(function(p) { runMacro(p.requestId, p.code, p.json || {}); });
+    pending.forEach(function(p) { runMacro(p.requestId, p.code, p.json || {}, p.ctx || {}); });
     pending.length = 0;
   }).catch(function(err) {
     send({ type: 'error', message: err.message || String(err) });

--- a/apps/mobile/src/features/measurement-flow/stores/flow-store-persistence.test.ts
+++ b/apps/mobile/src/features/measurement-flow/stores/flow-store-persistence.test.ts
@@ -71,6 +71,7 @@ const MEASUREMENT_FIXTURE = `{
       }
     ],
     "producerCellId": "node-m1",
+    "cellOutputs": { "node-a1": { "spad_avg": 40.5 } },
     "isFromOverview": true,
     "cells": [{ "id": "cell-b1", "type": "branch", "name": "N branch" }],
     "edges": [{ "id": "edge-1", "source": "node-q1", "target": "node-m1" }],
@@ -152,6 +153,7 @@ describe("measurement-flow-storage v1 wire format", () => {
     expect(Object.keys(persisted).sort()).toEqual([
       "branchReturnStack",
       "branchVisitCounts",
+      "cellOutputs",
       "cells",
       "currentFlowStep",
       "currentStep",

--- a/apps/mobile/src/features/measurement-flow/stores/flow-store-persistence.test.ts
+++ b/apps/mobile/src/features/measurement-flow/stores/flow-store-persistence.test.ts
@@ -23,6 +23,7 @@ const MEASUREMENT_FIXTURE = `{
   "state": {
     "experimentId": "exp-42",
     "experimentLabel": "Greenhouse Trial B",
+    "workbookVersionId": "version-17",
     "protocolId": "proto-7",
     "currentStep": 1,
     "flowNodes": [
@@ -169,6 +170,7 @@ describe("measurement-flow-storage v1 wire format", () => {
       "producerCellId",
       "scanResult",
       "scanResults",
+      "workbookVersionId",
     ]);
   });
 });

--- a/apps/mobile/src/features/measurement-flow/stores/use-measurement-flow-store.test.ts
+++ b/apps/mobile/src/features/measurement-flow/stores/use-measurement-flow-store.test.ts
@@ -39,6 +39,8 @@ function resetStore() {
     lastMatchedPath: undefined,
     branchVisitCounts: {},
     branchReturnStack: [],
+    devicePlan: undefined,
+    consumedNodeIds: [],
   });
 }
 
@@ -515,6 +517,60 @@ describe("useMeasurementFlowStore", () => {
       expect(state.lastMatchedPath).toBeUndefined();
       expect(state.branchReturnStack).toEqual([]);
     });
+  });
+
+  describe("device dispatch plan", () => {
+    const plan = [
+      { deviceId: "usb-1", targetCellId: "m1" },
+      { deviceId: "usb-2", targetCellId: "m2" },
+    ];
+
+    it("setDevicePlan stores the plan with its consumed targets", () => {
+      useMeasurementFlowStore.getState().setDevicePlan(plan, ["m2"]);
+      const state = useMeasurementFlowStore.getState();
+      expect(state.devicePlan).toEqual(plan);
+      expect(state.consumedNodeIds).toEqual(["m2"]);
+    });
+
+    it("setDevicePlan(undefined) deactivates dispatch entirely", () => {
+      useMeasurementFlowStore.getState().setDevicePlan(plan, ["m2"]);
+      useMeasurementFlowStore.getState().setDevicePlan(undefined, []);
+      const state = useMeasurementFlowStore.getState();
+      expect(state.devicePlan).toBeUndefined();
+      expect(state.consumedNodeIds).toEqual([]);
+    });
+
+    it("completeDevicePlan drops the plan but keeps consumed ids for skip-once", () => {
+      useMeasurementFlowStore.getState().setDevicePlan(plan, ["m2"]);
+      useMeasurementFlowStore.getState().completeDevicePlan();
+      const state = useMeasurementFlowStore.getState();
+      expect(state.devicePlan).toBeUndefined();
+      expect(state.consumedNodeIds).toEqual(["m2"]);
+    });
+
+    it("nextStep skips a consumed target once, then removes it", () => {
+      useMeasurementFlowStore.setState({
+        experimentId: "exp-1",
+        flowNodes: [makeMeasurement("m1"), makeMeasurement("m2"), makeQuestion("q1")],
+        currentFlowStep: 0,
+        consumedNodeIds: ["m2"],
+      });
+      useMeasurementFlowStore.getState().nextStep();
+      const state = useMeasurementFlowStore.getState();
+      expect(state.currentFlowStep).toBe(2);
+      expect(state.consumedNodeIds).toEqual([]);
+    });
+
+    it.each(["startNewIteration", "retryCurrentIteration", "resetFlow"] as const)(
+      "%s clears the plan and consumed targets",
+      (action) => {
+        useMeasurementFlowStore.getState().setDevicePlan(plan, ["m2"]);
+        useMeasurementFlowStore.getState()[action]();
+        const state = useMeasurementFlowStore.getState();
+        expect(state.devicePlan).toBeUndefined();
+        expect(state.consumedNodeIds).toEqual([]);
+      },
+    );
   });
 
   describe("branch back navigation", () => {

--- a/apps/mobile/src/features/measurement-flow/stores/use-measurement-flow-store.test.ts
+++ b/apps/mobile/src/features/measurement-flow/stores/use-measurement-flow-store.test.ts
@@ -435,12 +435,13 @@ describe("useMeasurementFlowStore", () => {
         },
       ] as never;
 
-      useMeasurementFlowStore.getState().setFlowGraph(nodes, edges, cells);
+      useMeasurementFlowStore.getState().setFlowGraph(nodes, edges, cells, "version-1");
 
       const state = useMeasurementFlowStore.getState();
       expect(state.flowNodes).toEqual(nodes);
       expect(state.edges).toEqual(edges);
       expect(state.cells).toEqual(cells);
+      expect(state.workbookVersionId).toBe("version-1");
       expect(state.currentFlowStep).toBe(0);
       expect(state.branchVisitCounts).toEqual({});
       expect(state.lastMatchedPath).toBeUndefined();

--- a/apps/mobile/src/features/measurement-flow/stores/use-measurement-flow-store.ts
+++ b/apps/mobile/src/features/measurement-flow/stores/use-measurement-flow-store.ts
@@ -39,7 +39,12 @@ interface MeasurementFlowStore extends FlowState {
   reset: () => void;
 
   setFlowNodes: (nodes: FlowNode[]) => void;
-  setFlowGraph: (nodes: FlowNode[], edges: FlowEdge[], cells: WorkbookCell[]) => void;
+  setFlowGraph: (
+    nodes: FlowNode[],
+    edges: FlowEdge[],
+    cells: WorkbookCell[],
+    workbookVersionId?: string,
+  ) => void;
   setLastMatchedPath: (path: MatchedPath | undefined) => void;
   incrementBranchVisit: (nodeId: string) => void;
   recordBranchJump: (landing: number) => void;
@@ -100,11 +105,12 @@ export const useMeasurementFlowStore = create<MeasurementFlowStore>()(
           branchReturnStack: [],
         }),
 
-      setFlowGraph: (nodes, edges, cells) =>
+      setFlowGraph: (nodes, edges, cells, workbookVersionId) =>
         set({
           flowNodes: nodes,
           edges,
           cells,
+          workbookVersionId,
           currentFlowStep: 0,
           branchVisitCounts: {},
           lastMatchedPath: undefined,
@@ -172,6 +178,7 @@ export const useMeasurementFlowStore = create<MeasurementFlowStore>()(
       partialize: (state) => ({
         experimentId: state.experimentId,
         experimentLabel: state.experimentLabel,
+        workbookVersionId: state.workbookVersionId,
         currentStep: state.currentStep,
         flowNodes: state.flowNodes,
         currentFlowStep: state.currentFlowStep,

--- a/apps/mobile/src/features/measurement-flow/stores/use-measurement-flow-store.ts
+++ b/apps/mobile/src/features/measurement-flow/stores/use-measurement-flow-store.ts
@@ -2,6 +2,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import type {
+  DevicePlanEntry,
   FlowState,
   MatchedPath,
   ScanResult,
@@ -52,6 +53,15 @@ interface MeasurementFlowStore extends FlowState {
   // Multi-scan: per-device results in connect order; scanResult mirrors the
   // Primary device's result for branch evaluation and legacy consumers.
   setScanResults: (results: ScanResultEntry[], producerCellId?: string) => void;
+  // Persists a macro/analysis output under its cell id for downstream reads.
+  setCellOutput: (cellId: string, data: unknown) => void;
+  // Dispatcher branch routing: the per-device plan plus the target node ids
+  // the round covers beyond the routed-to node (skipped once by nextStep).
+  // Passing plan=undefined deactivates dispatch entirely.
+  setDevicePlan: (plan: DevicePlanEntry[] | undefined, consumedNodeIds: string[]) => void;
+  // Round done: drop the plan but keep consumedNodeIds so advancing still
+  // skips the other targets once.
+  completeDevicePlan: () => void;
   setIterationAnchor: (anchor: { iteration: number; nodeId?: string }) => void;
   dismissQuestionsSubmit: () => void;
   navigateToQuestionFromOverview: (questionIndex: number) => void;
@@ -130,6 +140,14 @@ export const useMeasurementFlowStore = create<MeasurementFlowStore>()(
 
       setScanResults: (results, producerCellId) =>
         set({ scanResults: results, scanResult: results[0]?.result, producerCellId }),
+
+      setCellOutput: (cellId, data) =>
+        set((state) => ({ cellOutputs: { ...state.cellOutputs, [cellId]: data } })),
+
+      setDevicePlan: (plan, consumedNodeIds) => set({ devicePlan: plan, consumedNodeIds }),
+
+      completeDevicePlan: () => set({ devicePlan: undefined }),
+
       setIterationAnchor: (anchor) => set({ iterationAnchor: anchor }),
 
       dismissQuestionsSubmit: () => set(dismissQuestionsSubmitState),
@@ -163,6 +181,7 @@ export const useMeasurementFlowStore = create<MeasurementFlowStore>()(
         scanResult: state.scanResult,
         scanResults: state.scanResults,
         producerCellId: state.producerCellId,
+        cellOutputs: state.cellOutputs,
         isFromOverview: state.isFromOverview,
         cells: state.cells,
         edges: state.edges,

--- a/apps/mobile/src/features/measurement-flow/utils/process-scan/process-scan.test.ts
+++ b/apps/mobile/src/features/measurement-flow/utils/process-scan/process-scan.test.ts
@@ -34,7 +34,7 @@ vi.mock("expo-file-system", () => ({
 
 const encode = (code: string) => Buffer.from(code, "utf8").toString("base64");
 
-describe("applyMacro — input isolation (OJD-1463)", () => {
+describe("applyMacro: input isolation (OJD-1463)", () => {
   describe("JavaScript macros", () => {
     it("does not mutate top-level scalar properties on the original sample", async () => {
       const sample = { meta: "original", phi2: 0.5 };
@@ -144,7 +144,7 @@ describe("applyMacro — input isolation (OJD-1463)", () => {
       });
 
       await applyMacro(result, {
-        code: encode("# python body irrelevant — runner is mocked"),
+        code: encode("# python body irrelevant; runner is mocked"),
         language: "python",
       });
 
@@ -172,5 +172,54 @@ describe("applyMacro — input isolation (OJD-1463)", () => {
       expect(sample1.data_raw).toEqual([1, 2, 3]);
       expect(sample2.data_raw).toEqual([4, 5, 6]);
     });
+  });
+});
+
+describe("applyMacro: ctx namespace", () => {
+  it("exposes upstream ctx to a JS macro", async () => {
+    const result = { sample: { phi2: 0.5 } };
+    const code = encode(`return { sum: ctx.baseline.value + ctx.stress.value };`);
+    const [out] = await applyMacro(
+      result,
+      { code, language: "javascript" },
+      { baseline: { value: 10 }, stress: { value: 4 } },
+    );
+    expect(out).toEqual({ sum: 14 });
+  });
+
+  it("defaults ctx to an empty object", async () => {
+    const result = { sample: { phi2: 0.5 } };
+    const code = encode(`return { empty: Object.keys(ctx).length === 0 };`);
+    const [out] = await applyMacro(result, { code, language: "javascript" });
+    expect(out).toEqual({ empty: true });
+  });
+
+  it("freezes ctx so a JS macro cannot mutate upstream state", async () => {
+    const result = { sample: { phi2: 0.5 } };
+    const code = encode(`
+      try { ctx.baseline.value = 999; } catch (e) {}
+      return { v: ctx.baseline.value };
+    `);
+    const [out] = await applyMacro(
+      result,
+      { code, language: "javascript" },
+      { baseline: { value: 10 } },
+    );
+    expect(out).toEqual({ v: 10 });
+  });
+
+  it("passes ctx through to the Python runner", async () => {
+    let receivedCtx: unknown = null;
+    registerPythonMacroRunner((_code, _json, ctx) => {
+      receivedCtx = ctx;
+      return Promise.resolve({ ok: true });
+    });
+    await applyMacro(
+      { sample: { phi2: 0.5 } },
+      { code: encode("# irrelevant"), language: "python" },
+      { baseline: { value: 7 } },
+    );
+    registerPythonMacroRunner(null);
+    expect(receivedCtx).toEqual({ baseline: { value: 7 } });
   });
 });

--- a/apps/mobile/src/features/measurement-flow/utils/process-scan/process-scan.ts
+++ b/apps/mobile/src/features/measurement-flow/utils/process-scan/process-scan.ts
@@ -27,20 +27,28 @@ async function loadMathLib() {
 
 const mathLibSourcePromise = loadMathLib();
 
-async function executeMacro(code: string, json: object): Promise<MacroOutput> {
-  // console.log("[macro] (JS) input:", JSON.stringify(json));
+// Deep-freeze so macro code reads `ctx` as read-only, matching the Lambda sandbox.
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object") {
+    for (const key of Object.keys(value)) {
+      deepFreeze((value as Record<string, unknown>)[key]);
+    }
+    Object.freeze(value);
+  }
+  return value;
+}
+
+async function executeMacro(code: string, json: object, ctx: object): Promise<MacroOutput> {
   const mathLibSource = await mathLibSourcePromise;
-  // Wrap the macro code in an IIFE to isolate its scope from mathLibSource variables
-  // This prevents variable name conflicts while still allowing access to mathLib functions
-  // The IIFE returns the output, which we capture and return
+  // Wrap the macro in an IIFE that receives `json` (nearest input) and `ctx`
+  // (upstream outputs by name), isolating its scope from mathLib internals.
   const macroSource =
-    mathLibSource + "\n\n\n" + "return (function(json) {\n" + code + "\n})(json);";
+    mathLibSource + "\n\n\n" + "return (function(json, ctx) {\n" + code + "\n})(json, ctx);";
 
   try {
     // eslint-disable-next-line @typescript-eslint/no-implied-eval
-    const fn = new Function("json", macroSource);
-    const output = fn(structuredClone(json));
-    // console.log("[macro] (JS) output:", JSON.stringify(output));
+    const fn = new Function("json", "ctx", macroSource);
+    const output = fn(structuredClone(json), deepFreeze(structuredClone(ctx)));
     return output;
   } catch (err) {
     log.error("(JS) error", { err: (err as Error)?.message });
@@ -56,6 +64,7 @@ export interface MacroInput {
 export async function applyMacro(
   result: object,
   macro: MacroInput | string,
+  ctx: Record<string, unknown> = {},
 ): Promise<MacroOutput[]> {
   if (!("sample" in result)) {
     throw new Error("Result does not contain sample data");
@@ -85,7 +94,7 @@ export async function applyMacro(
     for (let i = 0; i < samples.length; i++) {
       const sample = samples[i];
       try {
-        const out = await runPython(code, structuredClone(sample));
+        const out = await runPython(code, structuredClone(sample), ctx);
         log.debug("(Python) sample ok", { i });
         outputs.push(out);
       } catch (err) {
@@ -99,7 +108,7 @@ export async function applyMacro(
   const outputs: MacroOutput[] = [];
   for (let i = 0; i < samples.length; i++) {
     try {
-      const out = await executeMacro(code, samples[i]);
+      const out = await executeMacro(code, samples[i], ctx);
       outputs.push(out);
     } catch (err) {
       log.error("(JS) sample failed", { i, err: (err as Error)?.message });

--- a/apps/mobile/src/features/measurement-flow/utils/process-scan/python-macro-runner.ts
+++ b/apps/mobile/src/features/measurement-flow/utils/process-scan/python-macro-runner.ts
@@ -1,6 +1,10 @@
 import type { MacroOutput } from "./process-scan";
 
-export type RunPythonMacroFn = (code: string, json: object) => Promise<MacroOutput>;
+export type RunPythonMacroFn = (
+  code: string,
+  json: object,
+  ctx?: Record<string, unknown>,
+) => Promise<MacroOutput>;
 
 let runner: RunPythonMacroFn | null = null;
 

--- a/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.test.tsx
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.test.tsx
@@ -49,7 +49,11 @@ const SHARED = {
 type SavedCall = [
   {
     topic: string;
-    measurementResult: { workbook_run_id?: string };
+    measurementResult: {
+      workbook_run_id?: string;
+      workbook_version_id?: string;
+      macro_context?: string;
+    };
     metadata: { protocolName: string };
   },
   string,
@@ -74,12 +78,14 @@ describe("useMeasurementUpload", () => {
     await act(async () => {
       await result.current.uploadMeasurements({
         ...SHARED,
+        workbookVersionId: "version-1",
         results: [
           {
             rawMeasurement: { a: 1 },
             device: { id: "d1", name: "A" },
             protocolId: "proto-a",
             protocolName: "Proto A",
+            macroContext: { measurement: { a: 1 } },
           },
           {
             rawMeasurement: { b: 2 },
@@ -104,6 +110,10 @@ describe("useMeasurementUpload", () => {
     const runIds = calls.map(([m]) => m.measurementResult.workbook_run_id);
     expect(runIds[0]).toBeTruthy();
     expect(new Set(runIds).size).toBe(1);
+    expect(calls[0][0].measurementResult).toMatchObject({
+      workbook_version_id: "version-1",
+      macro_context: JSON.stringify({ measurement: { a: 1 } }),
+    });
 
     expect(enqueueMany).toHaveBeenCalledWith(["saved-1", "saved-2", "saved-3"]);
   });

--- a/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.test.tsx
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useMeasurementUpload } from "./use-measurement-upload";
+
+const { saveMeasurement, enqueueMany } = vi.hoisted(() => ({
+  saveMeasurement: vi.fn(),
+  enqueueMany: vi.fn(),
+}));
+
+vi.mock("~/features/recent-measurements/hooks/use-measurements", () => ({
+  useMeasurements: () => ({ saveMeasurement }),
+}));
+vi.mock("~/shared/composition/upload", () => ({
+  getOutbox: () => ({ enqueueMany }),
+}));
+// Keeps the environment store out; the template shape is all that matters.
+vi.mock("~/shared/measurements/measurement-topic", () => ({
+  getMultispeqMqttTopic: ({
+    experimentId,
+    protocolId,
+  }: {
+    experimentId: string;
+    protocolId: string;
+  }) => `topic/${experimentId}/${protocolId}`,
+}));
+vi.mock("~/features/recent-measurements/services/export-measurements", () => ({
+  exportSingleMeasurementToFile: vi.fn(),
+}));
+vi.mock("~/shared/ui/AlertDialog", () => ({ showAlert: vi.fn() }));
+vi.mock("sonner-native", () => ({ toast: { error: vi.fn() } }));
+vi.mock("~/shared/i18n", () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+
+const SHARED = {
+  timestamp: "2026-04-20T10:00:00.000Z",
+  timezone: "Europe/Amsterdam",
+  experimentName: "Trial",
+  experimentId: "exp-1",
+  protocolId: "proto-shared",
+  protocolName: "Shared",
+  userId: "user-1",
+  macro: null,
+  questions: [],
+};
+
+type SavedCall = [
+  {
+    topic: string;
+    measurementResult: { workbook_run_id?: string };
+    metadata: { protocolName: string };
+  },
+  string,
+];
+
+describe("useMeasurementUpload", () => {
+  let client: QueryClient;
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    client = new QueryClient();
+    vi.clearAllMocks();
+    let n = 0;
+    saveMeasurement.mockImplementation(() => Promise.resolve(`saved-${++n}`));
+  });
+
+  it("publishes each result on ITS protocol topic while sharing one workbook_run_id", async () => {
+    const { result } = renderHook(() => useMeasurementUpload(), { wrapper });
+
+    await act(async () => {
+      await result.current.uploadMeasurements({
+        ...SHARED,
+        results: [
+          {
+            rawMeasurement: { a: 1 },
+            device: { id: "d1", name: "A" },
+            protocolId: "proto-a",
+            protocolName: "Proto A",
+          },
+          {
+            rawMeasurement: { b: 2 },
+            device: { id: "d2", name: "B" },
+            protocolId: "proto-b",
+            protocolName: "Proto B",
+          },
+          // No per-result protocol: falls back to the batch-level one.
+          { rawMeasurement: { c: 3 }, device: { id: "d3", name: "C" } },
+        ],
+      });
+    });
+
+    const calls = saveMeasurement.mock.calls as SavedCall[];
+    expect(calls.map(([m]) => m.topic)).toEqual([
+      "topic/exp-1/proto-a",
+      "topic/exp-1/proto-b",
+      "topic/exp-1/proto-shared",
+    ]);
+    expect(calls.map(([m]) => m.metadata.protocolName)).toEqual(["Proto A", "Proto B", "Shared"]);
+
+    const runIds = calls.map(([m]) => m.measurementResult.workbook_run_id);
+    expect(runIds[0]).toBeTruthy();
+    expect(new Set(runIds).size).toBe(1);
+
+    expect(enqueueMany).toHaveBeenCalledWith(["saved-1", "saved-2", "saved-3"]);
+  });
+
+  it("omits workbook_run_id for a single-device round", async () => {
+    const { result } = renderHook(() => useMeasurementUpload(), { wrapper });
+
+    await act(async () => {
+      await result.current.uploadMeasurements({
+        ...SHARED,
+        results: [{ rawMeasurement: { a: 1 }, device: { id: "d1", name: "A" } }],
+      });
+    });
+
+    const [measurement] = saveMeasurement.mock.calls[0] as SavedCall;
+    expect(measurement.topic).toBe("topic/exp-1/proto-shared");
+    expect(measurement.measurementResult).not.toHaveProperty("workbook_run_id");
+  });
+});

--- a/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.ts
@@ -78,7 +78,14 @@ export function useMeasurementUpload() {
       questions,
       commentText,
     }: SharedUploadArgs & {
-      results: { rawMeasurement: any; device?: { id: string; name: string } }[];
+      results: {
+        rawMeasurement: any;
+        device?: { id: string; name: string };
+        // Dispatch rounds: the protocol this device actually ran; overrides
+        // the batch-level protocolId/protocolName for this result only.
+        protocolId?: string;
+        protocolName?: string;
+      }[];
     }) => {
       // Reject malformed input instead of resolving as a no-op. `typeof
       // null === "object"` would otherwise slip a null through to
@@ -95,16 +102,21 @@ export function useMeasurementUpload() {
         throw new Error("No measurements to upload");
       }
 
-      const topic = getMultispeqMqttTopic({ experimentId, protocolId });
       // Measurements taken together ARE one run: every multi-device round is
       // stamped with one shared workbook_run_id. Each row is still its own
-      // MQTT message in the ordinary envelope (see CONTEXT.md: Workbook run).
+      // MQTT message in the ordinary envelope (see CONTEXT.md: Workbook run),
+      // published on ITS protocol's topic when the round was heterogeneous.
       const workbookRunId = results.length > 1 ? uuidv4() : undefined;
 
       const savedIds: string[] = [];
       let lastStorageError: unknown;
 
-      for (const { rawMeasurement, device } of results) {
+      for (const result of results) {
+        const { rawMeasurement, device } = result;
+        const topic = getMultispeqMqttTopic({
+          experimentId,
+          protocolId: result.protocolId ?? protocolId,
+        });
         const measurementData = buildUploadPayload({
           rawMeasurement,
           userId,
@@ -120,7 +132,11 @@ export function useMeasurementUpload() {
         const measurement = {
           topic,
           measurementResult: measurementData,
-          metadata: { experimentName, protocolName, timestamp: measurementData.timestamp },
+          metadata: {
+            experimentName,
+            protocolName: result.protocolName ?? protocolName,
+            timestamp: measurementData.timestamp,
+          },
         };
 
         try {

--- a/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.ts
@@ -55,6 +55,7 @@ interface SharedUploadArgs {
   macro: { id: string; name: string; filename: string } | null;
   questions: AnswerData[];
   commentText?: string;
+  workbookVersionId?: string;
 }
 
 export function useMeasurementUpload() {
@@ -77,6 +78,7 @@ export function useMeasurementUpload() {
       macro,
       questions,
       commentText,
+      workbookVersionId,
     }: SharedUploadArgs & {
       results: {
         rawMeasurement: any;
@@ -85,6 +87,7 @@ export function useMeasurementUpload() {
         // the batch-level protocolId/protocolName for this result only.
         protocolId?: string;
         protocolName?: string;
+        macroContext?: Record<string, unknown>;
       }[];
     }) => {
       // Reject malformed input instead of resolving as a no-op. `typeof
@@ -112,7 +115,7 @@ export function useMeasurementUpload() {
       let lastStorageError: unknown;
 
       for (const result of results) {
-        const { rawMeasurement, device } = result;
+        const { rawMeasurement, device, macroContext } = result;
         const topic = getMultispeqMqttTopic({
           experimentId,
           protocolId: result.protocolId ?? protocolId,
@@ -126,6 +129,8 @@ export function useMeasurementUpload() {
           questions,
           commentText,
           workbookRunId,
+          workbookVersionId,
+          macroContext,
           fallbackDeviceId: device?.id,
         });
 

--- a/apps/mobile/src/features/recent-measurements/services/build-upload-payload.test.ts
+++ b/apps/mobile/src/features/recent-measurements/services/build-upload-payload.test.ts
@@ -98,6 +98,21 @@ describe("buildUploadPayload payload construction", () => {
     expect("_sample_encoding" in payload).toBe(false);
   });
 
+  it("serializes workbook version and device-scoped macro context", () => {
+    const macroContext = { measurement: { phi2: 0.8 }, $device: { id: "device-1" } };
+    const payload = buildUploadPayload({
+      ...baseArgs,
+      rawMeasurement: { sample: [{ phi2: 0.8 }] },
+      workbookVersionId: "version-1",
+      macroContext,
+    });
+
+    expect(payload).toMatchObject({
+      workbook_version_id: "version-1",
+      macro_context: JSON.stringify(macroContext),
+    });
+  });
+
   it("null sample survives untouched: no injection, no compression, no marker", () => {
     const payload = buildUploadPayload({ ...baseArgs, rawMeasurement: { sample: null } });
 

--- a/apps/mobile/src/features/recent-measurements/services/build-upload-payload.ts
+++ b/apps/mobile/src/features/recent-measurements/services/build-upload-payload.ts
@@ -18,6 +18,10 @@ export interface BuildUploadPayloadArgs {
   commentText?: string;
   /** One uuid per multi-device round (see CONTEXT.md: Workbook run). */
   workbookRunId?: string;
+  /** Immutable workbook version that owns the macro snapshot. */
+  workbookVersionId?: string;
+  /** Device-scoped upstream workbook values consumed by the macro as `ctx`. */
+  macroContext?: Record<string, unknown>;
   fallbackDeviceId?: string;
 }
 
@@ -32,6 +36,8 @@ export function buildUploadPayload({
   questions,
   commentText,
   workbookRunId,
+  workbookVersionId,
+  macroContext,
   fallbackDeviceId,
 }: BuildUploadPayloadArgs) {
   const macroFilenames = macro?.filename ? [macro.filename] : [];
@@ -60,6 +66,8 @@ export function buildUploadPayload({
       ? { device_id: fallbackDeviceId }
       : {}),
     ...(workbookRunId ? { workbook_run_id: workbookRunId } : {}),
+    ...(workbookVersionId ? { workbook_version_id: workbookVersionId } : {}),
+    ...(macroContext ? { macro_context: JSON.stringify(macroContext) } : {}),
   };
 
   // Compress the (large) sample field to reduce MQTT payload size.

--- a/apps/web/components/workbook/cells/branch-cell.tsx
+++ b/apps/web/components/workbook/cells/branch-cell.tsx
@@ -9,6 +9,7 @@ import type {
   BranchPath,
   WorkbookCell,
 } from "@repo/api/domains/workbook/workbook-cells.schema";
+import { DEVICE_CONTEXT_FIELDS, DEVICE_CONTEXT_KEY } from "@repo/api/transforms/device-context";
 import { Button } from "@repo/ui/components/button";
 import {
   Collapsible,
@@ -92,6 +93,9 @@ export function BranchCellComponent({
 
   const getFieldsForSource = useCallback(
     (sourceCellId: string): string[] => {
+      // The connected device exposes a fixed field list from its identity.
+      if (sourceCellId === DEVICE_CONTEXT_KEY) return [...DEVICE_CONTEXT_FIELDS];
+
       if (!allCells) return [];
 
       // Questions only expose a single implicit "answer" field.
@@ -192,7 +196,12 @@ export function BranchCellComponent({
                   const updated = { ...c, [field]: value };
                   if (field === "sourceCellId") {
                     const src = (allCells ?? []).find((ac) => ac.id === value);
-                    if (src?.type === "question") {
+                    if (value === DEVICE_CONTEXT_KEY) {
+                      // Keep a still-valid device field on reselect; default to family.
+                      if (!(DEVICE_CONTEXT_FIELDS as readonly string[]).includes(c.field)) {
+                        updated.field = "family";
+                      }
+                    } else if (src?.type === "question") {
                       updated.field = "answer";
                     } else if (c.field === "answer") {
                       updated.field = "";
@@ -263,6 +272,9 @@ export function BranchCellComponent({
             <SelectValue placeholder="source..." />
           </SelectTrigger>
           <SelectContent>
+            <SelectItem value={DEVICE_CONTEXT_KEY} className="text-xs font-medium">
+              Connected device
+            </SelectItem>
             {sourceCells.map((sc) => (
               <SelectItem key={sc.id} value={sc.id} className="text-xs">
                 {getCellLabel(sc)}

--- a/apps/web/components/workbook/workbook-header.tsx
+++ b/apps/web/components/workbook/workbook-header.tsx
@@ -3,7 +3,11 @@
 import { AutosaveIndicator } from "@/components/shared/autosave/autosave-indicator";
 import { orpcClient } from "@/lib/orpc";
 import { decodeBase64 } from "@/util/base64";
-import { SENSOR_FAMILY_OPTIONS } from "@/util/sensor-family";
+import {
+  SENSOR_FAMILY_OPTIONS,
+  getSensorFamilyBadgeColor,
+  getSensorFamilyLabel,
+} from "@/util/sensor-family";
 import { ChevronDown, Circle, GitBranch, Play, Square, Trash2, Usb } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useIotBrowserSupport } from "~/hooks/iot/useIotBrowserSupport";
@@ -40,7 +44,7 @@ interface WorkbookHeaderProps {
   cells: WorkbookCell[];
   isConnected: boolean;
   isConnecting: boolean;
-  connectedDevices: { id: string; label: string }[];
+  connectedDevices: { id: string; label: string; family?: SensorFamily }[];
   sensorFamily: SensorFamily;
   onSensorFamilyChange?: (family: SensorFamily) => void;
   connectionType: WorkbookConnectionType;
@@ -346,7 +350,16 @@ export function WorkbookHeader({
                   className="flex items-center justify-between gap-4"
                   onSelect={() => onDisconnectDevice?.(device.id)}
                 >
-                  <span>{device.label}</span>
+                  <span className="flex items-center gap-1.5">
+                    <span>{device.label}</span>
+                    {device.family && (
+                      <span
+                        className={`rounded px-1 py-0.5 text-[10px] font-medium text-white ${getSensorFamilyBadgeColor(device.family)}`}
+                      >
+                        {getSensorFamilyLabel(device.family)}
+                      </span>
+                    )}
+                  </span>
                   <span className="text-[11px] text-[#68737B]">Disconnect</span>
                 </DropdownMenuItem>
               ))}

--- a/apps/web/hooks/iot/device-type-mapping.test.ts
+++ b/apps/web/hooks/iot/device-type-mapping.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { sensorFamilyToDeviceType } from "./device-type-mapping";
+
+describe("sensorFamilyToDeviceType", () => {
+  it.each([
+    ["multispeq", "multispeq"],
+    ["ambit", "ambit"],
+    ["minipar", "minipar"],
+    ["ambyte", "generic"],
+    ["generic", "generic"],
+  ] as const)("maps %s to %s", (family, expected) => {
+    expect(sensorFamilyToDeviceType(family)).toBe(expected);
+  });
+});

--- a/apps/web/hooks/iot/device-type-mapping.ts
+++ b/apps/web/hooks/iot/device-type-mapping.ts
@@ -12,7 +12,12 @@ export function sensorFamilyToDeviceType(sensorFamily: SensorFamily): DeviceType
   switch (sensorFamily) {
     case "multispeq":
       return "multispeq";
-    default:
+    case "ambit":
+      return "ambit";
+    case "minipar":
+      return "minipar";
+    case "ambyte":
+    case "generic":
       return "generic";
   }
 }

--- a/apps/web/hooks/iot/useIotCommunication/useIotCommunication.test.ts
+++ b/apps/web/hooks/iot/useIotCommunication/useIotCommunication.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, waitFor } from "@/test/test-utils";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
-import { useIotCommunication } from "./useIotCommunication";
+import { createDriver, useIotCommunication } from "./useIotCommunication";
 
 // Mock the IoT package
 vi.mock("@repo/iot", () => ({
@@ -27,6 +27,12 @@ vi.mock("@repo/iot", () => ({
       }),
       destroy: vi.fn().mockResolvedValue(undefined),
     };
+  }),
+  AmbitDriver: vi.fn(function () {
+    return { family: "ambit" };
+  }),
+  MiniParDriver: vi.fn(function () {
+    return { family: "minipar" };
   }),
   GENERIC_BLE_UUIDS: {
     SERVICE: "generic-service",
@@ -76,6 +82,13 @@ vi.mock("@repo/iot/transport/web", () => ({
 describe("useIotCommunication", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe("createDriver", () => {
+    it("constructs the dedicated Ambit and MiniPAR drivers", () => {
+      expect(createDriver("ambit")).toMatchObject({ family: "ambit" });
+      expect(createDriver("minipar")).toMatchObject({ family: "minipar" });
+    });
   });
 
   describe("initial state", () => {

--- a/apps/web/hooks/iot/useIotCommunication/useIotCommunication.ts
+++ b/apps/web/hooks/iot/useIotCommunication/useIotCommunication.ts
@@ -5,9 +5,11 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { SensorFamily } from "@repo/api/domains/protocol/protocol.schema";
 import type { IDeviceDriver, ITransportAdapter } from "@repo/iot";
 import {
+  AmbitDriver,
   GenericDeviceDriver,
   GENERIC_BLE_UUIDS,
   GENERIC_SERIAL_DEFAULTS,
+  MiniParDriver,
   MultispeqDriver,
   MULTISPEQ_SERIAL_DEFAULTS,
   isTransportSupported,
@@ -56,7 +58,16 @@ export async function createAdapter(
 }
 
 export function createDriver(sensorFamily: SensorFamily): IDeviceDriver {
-  return sensorFamily === "multispeq" ? new MultispeqDriver() : new GenericDeviceDriver();
+  switch (sensorFamily) {
+    case "multispeq":
+      return new MultispeqDriver();
+    case "ambit":
+      return new AmbitDriver();
+    case "minipar":
+      return new MiniParDriver();
+    default:
+      return new GenericDeviceDriver();
+  }
 }
 
 // ── Hook ─────────────────────────────────────────────────────────────────────

--- a/apps/web/hooks/iot/useIotConnections/useIotConnections.test.ts
+++ b/apps/web/hooks/iot/useIotConnections/useIotConnections.test.ts
@@ -1,18 +1,30 @@
 import { renderHook, act } from "@/test/test-utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+import type { DeviceIdentity } from "@repo/iot";
+
 import { useIotConnections } from "./useIotConnections";
 
 const mockCreateAdapter = vi.fn();
-const mockCreateDriver = vi.fn();
+const mockIdentifyDevice = vi.fn();
+const mockToast = vi.fn();
 
 vi.mock("../useIotCommunication/useIotCommunication", () => ({
   createAdapter: (...args: unknown[]) => mockCreateAdapter(...args) as unknown,
-  createDriver: (...args: unknown[]) => mockCreateDriver(...args) as unknown,
+}));
+
+vi.mock("@repo/iot", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  identifyDevice: (...args: unknown[]) => mockIdentifyDevice(...args) as unknown,
+}));
+
+vi.mock("@repo/ui/hooks/use-toast", () => ({
+  toast: (...args: unknown[]) => mockToast(...args) as unknown,
 }));
 
 interface FakeAdapter {
   onStatusChanged: ReturnType<typeof vi.fn>;
+  onDataReceived: ReturnType<typeof vi.fn>;
   disconnect: ReturnType<typeof vi.fn>;
   emitStatus: (connected: boolean) => void;
 }
@@ -23,28 +35,43 @@ function makeAdapter(): FakeAdapter {
     onStatusChanged: vi.fn((cb: (connected: boolean) => void) => {
       statusCb = cb;
     }),
+    onDataReceived: vi.fn(),
     disconnect: vi.fn().mockResolvedValue(undefined),
     emitStatus: (connected: boolean) => statusCb?.(connected),
   };
 }
 
-function makeDriver() {
+function makeConnector() {
   return {
     initialize: vi.fn().mockResolvedValue(undefined),
     destroy: vi.fn().mockResolvedValue(undefined),
   };
 }
 
+/** Queue an identifyDevice resolution: family + optional name + a fresh connector. */
+function identifyAs(family: DeviceIdentity["family"], name?: string) {
+  const connector = makeConnector();
+  mockIdentifyDevice.mockResolvedValueOnce({
+    family,
+    info: { family, name, raw: {} },
+    connector,
+  });
+  return connector;
+}
+
 describe("useIotConnections", () => {
   beforeEach(() => {
     mockCreateAdapter.mockReset();
-    mockCreateDriver.mockReset();
+    mockIdentifyDevice.mockReset();
+    mockToast.mockReset();
+    window.history.replaceState({}, "", "/");
   });
 
   it("accumulates devices with numbered labels in connect order", async () => {
     const adapters = [makeAdapter(), makeAdapter()];
     mockCreateAdapter.mockResolvedValueOnce(adapters[0]).mockResolvedValueOnce(adapters[1]);
-    mockCreateDriver.mockImplementation(() => makeDriver());
+    identifyAs("multispeq");
+    identifyAs("multispeq");
 
     const { result } = renderHook(() => useIotConnections("multispeq"));
 
@@ -53,11 +80,41 @@ describe("useIotConnections", () => {
 
     expect(mockCreateAdapter).toHaveBeenCalledWith("multispeq", "serial");
     expect(result.current.connections.map((c) => c.label)).toEqual(["Device #1", "Device #2"]);
+    expect(result.current.connections.map((c) => c.family)).toEqual(["multispeq", "multispeq"]);
     expect(result.current.error).toBeNull();
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it("labels a device by its identified name and stores the identity", async () => {
+    mockCreateAdapter.mockResolvedValue(makeAdapter());
+    identifyAs("multispeq", "MultispeQ");
+
+    const { result } = renderHook(() => useIotConnections("multispeq"));
+    await act(() => result.current.connect("serial"));
+
+    expect(result.current.connections[0].label).toBe("MultispeQ");
+    expect(result.current.connections[0].identity).toEqual({
+      family: "multispeq",
+      name: "MultispeQ",
+      raw: {},
+    });
+  });
+
+  it("lets the identified family outrank the toolbar family, with a toast", async () => {
+    mockCreateAdapter.mockResolvedValue(makeAdapter());
+    identifyAs("ambit", "NEW Name Here");
+
+    const { result } = renderHook(() => useIotConnections("multispeq"));
+    await act(() => result.current.connect("serial"));
+
+    expect(result.current.connections[0].family).toBe("ambit");
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Different device identified" }),
+    );
   });
 
   it("connects mock devices without a browser adapter", async () => {
-    mockCreateDriver.mockImplementation(() => makeDriver());
+    identifyAs("multispeq", "Mock MultispeQ 1");
 
     const { result } = renderHook(() => useIotConnections("multispeq"));
     await act(() => result.current.connect("mock"));
@@ -69,9 +126,7 @@ describe("useIotConnections", () => {
   it("records the error and releases the adapter when connect fails", async () => {
     const adapter = makeAdapter();
     mockCreateAdapter.mockResolvedValue(adapter);
-    const driver = makeDriver();
-    driver.initialize.mockRejectedValue(new Error("port is busy"));
-    mockCreateDriver.mockReturnValue(driver);
+    mockIdentifyDevice.mockRejectedValue(new Error("port is busy"));
 
     const { result } = renderHook(() => useIotConnections("multispeq"));
     await act(() => result.current.connect("serial"));
@@ -82,8 +137,8 @@ describe("useIotConnections", () => {
   });
 
   it("disconnectDevice removes exactly that device and destroys its driver", async () => {
-    const drivers = [makeDriver(), makeDriver()];
-    mockCreateDriver.mockReturnValueOnce(drivers[0]).mockReturnValueOnce(drivers[1]);
+    const connectors = [identifyAs("multispeq", "Mock MultispeQ 1")];
+    connectors.push(identifyAs("multispeq", "Mock MultispeQ 2"));
 
     const { result } = renderHook(() => useIotConnections("multispeq"));
     await act(() => result.current.connect("mock"));
@@ -93,8 +148,8 @@ describe("useIotConnections", () => {
     await act(() => result.current.disconnectDevice(first.id));
 
     expect(result.current.connections.map((c) => c.label)).toEqual(["Mock MultispeQ 2"]);
-    expect(drivers[0].destroy).toHaveBeenCalled();
-    expect(drivers[1].destroy).not.toHaveBeenCalled();
+    expect(connectors[0].destroy).toHaveBeenCalled();
+    expect(connectors[1].destroy).not.toHaveBeenCalled();
 
     // Unknown ids are a no-op.
     await act(() => result.current.disconnectDevice("nope"));
@@ -102,8 +157,7 @@ describe("useIotConnections", () => {
   });
 
   it("disconnectAll empties the registry and destroys every driver", async () => {
-    const drivers = [makeDriver(), makeDriver()];
-    mockCreateDriver.mockReturnValueOnce(drivers[0]).mockReturnValueOnce(drivers[1]);
+    const connectors = [identifyAs("multispeq"), identifyAs("multispeq")];
 
     const { result } = renderHook(() => useIotConnections("multispeq"));
     await act(() => result.current.connect("mock"));
@@ -112,14 +166,15 @@ describe("useIotConnections", () => {
     await act(() => result.current.disconnectAll());
 
     expect(result.current.connections).toHaveLength(0);
-    expect(drivers[0].destroy).toHaveBeenCalled();
-    expect(drivers[1].destroy).toHaveBeenCalled();
+    expect(connectors[0].destroy).toHaveBeenCalled();
+    expect(connectors[1].destroy).toHaveBeenCalled();
   });
 
   it("drops only the reporting device when its transport disconnects", async () => {
     const adapters = [makeAdapter(), makeAdapter()];
     mockCreateAdapter.mockResolvedValueOnce(adapters[0]).mockResolvedValueOnce(adapters[1]);
-    mockCreateDriver.mockImplementation(() => makeDriver());
+    identifyAs("multispeq");
+    identifyAs("multispeq");
 
     const { result } = renderHook(() => useIotConnections("multispeq"));
     await act(() => result.current.connect("serial"));
@@ -131,13 +186,14 @@ describe("useIotConnections", () => {
   });
 
   it("keeps numbering unique after disconnects", async () => {
-    mockCreateDriver.mockImplementation(() => makeDriver());
+    identifyAs("multispeq");
+    identifyAs("multispeq");
 
     const { result } = renderHook(() => useIotConnections("multispeq"));
     await act(() => result.current.connect("mock"));
     await act(() => result.current.disconnectAll());
     await act(() => result.current.connect("mock"));
 
-    expect(result.current.connections.map((c) => c.label)).toEqual(["Mock MultispeQ 2"]);
+    expect(result.current.connections.map((c) => c.label)).toEqual(["Device #2"]);
   });
 });

--- a/apps/web/hooks/iot/useIotConnections/useIotConnections.ts
+++ b/apps/web/hooks/iot/useIotConnections/useIotConnections.ts
@@ -1,30 +1,38 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { MockTransportAdapter } from "~/lib/iot/mock-devices";
+import { MockTransportAdapter, parseMockFamilies } from "~/lib/iot/mock-devices";
 
 import type { SensorFamily } from "@repo/api/domains/protocol/protocol.schema";
-import type { IDeviceDriver, ITransportAdapter } from "@repo/iot";
+import type { DeviceIdentity, IDeviceDriver, ITransportAdapter } from "@repo/iot";
+import { identifyDevice } from "@repo/iot";
+import { toast } from "@repo/ui/hooks/use-toast";
 
-import { createAdapter, createDriver } from "../useIotCommunication/useIotCommunication";
+import { createAdapter } from "../useIotCommunication/useIotCommunication";
 
 export type WorkbookConnectionType = "bluetooth" | "serial" | "mock";
 
 export interface IotDeviceConnection {
   /** Stable per-connection id (uuid); devices carry no usable web identifier. */
   id: string;
-  /** "Device #N" by connect order; mock devices name themselves. */
+  /** Device-reported name when the handshake resolved one, else "Device #N". */
   label: string;
-  /** Family captured at connect time; a later family switch must not retarget live drivers. */
+  /**
+   * Family resolved by the post-connect identification handshake. The
+   * handshake outranks the toolbar selection: what answered the probe is
+   * what we are talking to.
+   */
   family: SensorFamily;
+  /** Structured identity from the handshake (name, id, firmware, battery). */
+  identity: DeviceIdentity;
   driver: IDeviceDriver;
 }
 
 /**
- * Device registry for the workbook host: N same-family devices connected at
- * once (a USB hub of sensors), each with its own driver. Connect order is
- * insertion order; the first entry is the primary device. Mirrors the mobile
- * scanner registry semantics.
+ * Device registry for the workbook host: N devices connected at once (a USB
+ * hub of sensors), each identified by a post-connect handshake and driving
+ * its own connector. Connect order is insertion order; the first entry is
+ * the primary device. Mirrors the mobile scanner registry semantics.
  */
 export function useIotConnections(sensorFamily: SensorFamily) {
   const [connections, setConnections] = useState<IotDeviceConnection[]>([]);
@@ -60,23 +68,36 @@ export function useIotConnections(sensorFamily: SensorFamily) {
       let adapter: ITransportAdapter | undefined;
       try {
         const index = connectCounterRef.current + 1;
-        adapter =
-          connectionType === "mock"
-            ? new MockTransportAdapter(index)
-            : await createAdapter(sensorFamily, connectionType);
+        if (connectionType === "mock") {
+          // Successive connect clicks cycle through the ?mockDevices= families.
+          const families = parseMockFamilies();
+          adapter = new MockTransportAdapter(index, families[(index - 1) % families.length]);
+        } else {
+          adapter = await createAdapter(sensorFamily, connectionType);
+        }
 
-        const driver = createDriver(sensorFamily);
-        await driver.initialize(adapter);
+        // Identification handshake: probe who actually answered, and let that
+        // outrank the toolbar family.
+        const { family, info, connector } = await identifyDevice(adapter, {
+          probeTimeoutMs: 2000,
+        });
 
         // The user disconnected everything while this connect was in flight;
         // honor that instead of resurrecting a connection.
         if (generation !== generationRef.current) {
-          await driver.destroy();
+          await connector.destroy();
           return;
         }
 
+        if (family !== sensorFamily) {
+          toast({
+            title: "Different device identified",
+            description: `Connected as ${sensorFamily}, but the device identifies as ${family}. Using ${family}.`,
+          });
+        }
+
         const id = crypto.randomUUID();
-        const label = connectionType === "mock" ? `Mock MultispeQ ${index}` : `Device #${index}`;
+        const label = info.name ?? `Device #${index}`;
 
         // Unplug/power-off: drop exactly this device; the others keep running.
         adapter.onStatusChanged((connected) => {
@@ -84,7 +105,10 @@ export function useIotConnections(sensorFamily: SensorFamily) {
         });
 
         connectCounterRef.current = index;
-        setConnections((prev) => [...prev, { id, label, family: sensorFamily, driver }]);
+        setConnections((prev) => [
+          ...prev,
+          { id, label, family, identity: info, driver: connector },
+        ]);
       } catch (err) {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         await adapter?.disconnect().catch(() => {});

--- a/apps/web/hooks/iot/useIotProtocolExecution/useIotProtocolExecution.ts
+++ b/apps/web/hooks/iot/useIotProtocolExecution/useIotProtocolExecution.ts
@@ -37,13 +37,21 @@ export async function executeProtocolWithDriver(
   sensorFamily: SensorFamily,
   protocolCode: Record<string, unknown>[],
 ): Promise<unknown> {
-  if (sensorFamily === "multispeq") {
-    // MultispeQ: send the protocol JSON array directly; device runs the measurement
+  if (sensorFamily === "multispeq" || sensorFamily === "minipar") {
+    // MultispeQ + MiniPAR: send the protocol JSON array directly; the device
+    // runs the measurement and replies one envelope.
     const result = await driver.execute(protocolCode);
     return parseResponseData(unwrap(result, "Protocol execution failed"));
   }
 
-  // Generic / Ambyte: load config → run → retrieve data
+  if (sensorFamily === "ambit") {
+    // Ambit measures via its Ambyte gateway; a direct session is command/response.
+    throw new Error(
+      "Ambit devices do not run protocol cells over a direct connection. Use a command cell instead.",
+    );
+  }
+
+  // Generic: load config → run → retrieve data
   unwrap(
     await driver.execute({ command: "SET_CONFIG", params: { protocol: protocolCode } }),
     "Failed to load protocol on device",

--- a/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.test.ts
+++ b/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.test.ts
@@ -29,7 +29,16 @@ const mockConnect = vi.fn();
 const mockDisconnect = vi.fn();
 
 // One entry per connected device; single-entry = legacy single-device runs.
-let mockConnections: { id: string; label: string; driver: unknown }[] = [];
+function mockConnection(id: string, label: string) {
+  return {
+    id,
+    label,
+    family: "multispeq" as const,
+    identity: { family: "multispeq" as const, name: label, raw: {} },
+    driver: {},
+  };
+}
+let mockConnections: ReturnType<typeof mockConnection>[] = [];
 
 vi.mock("~/hooks/iot/useIotConnections/useIotConnections", () => ({
   useIotConnections: () => ({
@@ -50,7 +59,7 @@ vi.mock("~/hooks/iot/useIotProtocolExecution/useIotProtocolExecution", () => ({
 }));
 
 function setMockConnected(connected: boolean) {
-  mockConnections = connected ? [{ id: "dev-1", label: "Device #1", driver: {} }] : [];
+  mockConnections = connected ? [mockConnection("dev-1", "Device #1")] : [];
 }
 
 function renderExecution(
@@ -168,10 +177,10 @@ describe("useWorkbookExecution", () => {
       });
       server.mount(contract.protocols.getProtocol, { body: protocol });
       mockConnections = [
-        { id: "dev-1", label: "Mock MultispeQ 1", driver: {} },
-        { id: "dev-2", label: "Mock MultispeQ 2", driver: {} },
-        { id: "dev-3", label: "Mock MultispeQ 3", driver: {} },
-        { id: "dev-4", label: "Mock MultispeQ 4", driver: {} },
+        mockConnection("dev-1", "Mock MultispeQ 1"),
+        mockConnection("dev-2", "Mock MultispeQ 2"),
+        mockConnection("dev-3", "Mock MultispeQ 3"),
+        mockConnection("dev-4", "Mock MultispeQ 4"),
       ];
       // Device 3 fails; the round still completes with the other three.
       mockExecuteProtocol
@@ -189,15 +198,20 @@ describe("useWorkbookExecution", () => {
       const outputCell = findOutput(updated);
       // Primary data mirrors the first successful device for macro cells.
       expect(outputCell?.data).toEqual({ device_id: "mock-1" });
+      const identified = (label: string) => ({
+        deviceLabel: label,
+        deviceName: label,
+        family: "multispeq",
+      });
       expect(outputCell?.deviceResults).toEqual([
-        { deviceId: "dev-1", deviceLabel: "Mock MultispeQ 1", data: { device_id: "mock-1" } },
-        { deviceId: "dev-2", deviceLabel: "Mock MultispeQ 2", data: { device_id: "mock-2" } },
+        { deviceId: "dev-1", ...identified("Mock MultispeQ 1"), data: { device_id: "mock-1" } },
+        { deviceId: "dev-2", ...identified("Mock MultispeQ 2"), data: { device_id: "mock-2" } },
         {
           deviceId: "dev-3",
-          deviceLabel: "Mock MultispeQ 3",
+          ...identified("Mock MultispeQ 3"),
           error: "Mock device failure (simulated)",
         },
-        { deviceId: "dev-4", deviceLabel: "Mock MultispeQ 4", data: { device_id: "mock-4" } },
+        { deviceId: "dev-4", ...identified("Mock MultispeQ 4"), data: { device_id: "mock-4" } },
       ]);
       expect(outputCell?.messages).toEqual(["Mock MultispeQ 3: Mock device failure (simulated)"]);
     });
@@ -230,8 +244,8 @@ describe("useWorkbookExecution", () => {
       });
       server.mount(contract.protocols.getProtocol, { body: protocol });
       mockConnections = [
-        { id: "dev-1", label: "Mock MultispeQ 1", driver: {} },
-        { id: "dev-2", label: "Mock MultispeQ 2", driver: {} },
+        mockConnection("dev-1", "Mock MultispeQ 1"),
+        mockConnection("dev-2", "Mock MultispeQ 2"),
       ];
       mockExecuteProtocol.mockRejectedValue(new Error("device not open"));
 
@@ -428,6 +442,108 @@ describe("useWorkbookExecution", () => {
       const updated = onCellsChange.mock.calls[0][0] as WorkbookCell[];
       const macroOutput = findOutput(updated, macro.id);
       expect(macroOutput?.data).toEqual({ result: 99 });
+    });
+
+    it("sends named upstream outputs and $device in the macro context", async () => {
+      setMockConnected(true);
+      const proto = createProtocolCell({
+        id: "proto-base",
+        payload: { protocolId: crypto.randomUUID(), version: 1, name: "Baseline" },
+      });
+      const output = createOutputCell({ producedBy: "proto-base", data: { value: 0.8 } });
+      const question = createQuestionCell({
+        id: "q-note",
+        name: "Note",
+        answer: "ok",
+        isAnswered: true,
+      });
+      const macro = createMacroCell();
+
+      let capturedContext: Record<string, unknown> | undefined;
+      server.use(
+        http.post(`${API_URL}/api/v1/macros/:id/execute`, async ({ request }) => {
+          const body = (await request.json()) as { context?: Record<string, unknown> };
+          capturedContext = body.context;
+          return HttpResponse.json({
+            macro_id: macro.payload.macroId,
+            success: true,
+            output: { done: true },
+          });
+        }),
+      );
+
+      const { result } = renderExecution([proto, output, question, macro]);
+      await act(() => result.current.runCell(macro.id));
+
+      expect(capturedContext?.baseline).toEqual({ value: 0.8 });
+      expect(capturedContext?.note).toEqual({ answer: "ok" });
+      expect(capturedContext?.$device).toMatchObject({ family: "multispeq", index: 0 });
+    });
+
+    it("runs a ctx-only macro without a preceding measurement", async () => {
+      const question = createQuestionCell({
+        id: "q-only",
+        name: "Threshold",
+        answer: "42",
+        isAnswered: true,
+      });
+      const macro = createMacroCell();
+
+      let capturedBody: { data?: unknown; context?: Record<string, unknown> } | undefined;
+      server.use(
+        http.post(`${API_URL}/api/v1/macros/:id/execute`, async ({ request }) => {
+          capturedBody = (await request.json()) as typeof capturedBody;
+          return HttpResponse.json({
+            macro_id: macro.payload.macroId,
+            success: true,
+            output: { threshold: 42 },
+          });
+        }),
+      );
+
+      const { result, onCellsChange } = renderExecution([question, macro]);
+      await act(() => result.current.runCell(macro.id));
+
+      expect(capturedBody?.data).toEqual({});
+      expect(capturedBody?.context?.threshold).toEqual({ answer: "42" });
+      const updated = onCellsChange.mock.calls[0][0] as WorkbookCell[];
+      expect(findOutput(updated, macro.id)?.data).toEqual({ threshold: 42 });
+    });
+
+    it("scopes each per-device macro run's ctx to that device's results", async () => {
+      const proto = createProtocolCell({
+        id: "proto-scan",
+        payload: { protocolId: crypto.randomUUID(), version: 1, name: "Scan" },
+      });
+      const output = createOutputCell({
+        producedBy: "proto-scan",
+        data: { device_id: "mock-1" },
+        deviceResults: [
+          { deviceId: "dev-1", deviceLabel: "Mock MultispeQ 1", data: { device_id: "mock-1" } },
+          { deviceId: "dev-2", deviceLabel: "Mock MultispeQ 2", data: { device_id: "mock-2" } },
+        ],
+      });
+      const macro = createMacroCell();
+
+      const contexts: Record<string, unknown>[] = [];
+      server.use(
+        http.post(`${API_URL}/api/v1/macros/:id/execute`, async ({ request }) => {
+          const body = (await request.json()) as { context?: Record<string, unknown> };
+          contexts.push(body.context ?? {});
+          return HttpResponse.json({
+            macro_id: macro.payload.macroId,
+            success: true,
+            output: { ok: true },
+          });
+        }),
+      );
+
+      const { result } = renderExecution([proto, output, macro]);
+      await act(() => result.current.runCell(macro.id));
+
+      expect(contexts).toHaveLength(2);
+      expect(contexts[0].scan).toEqual({ device_id: "mock-1" });
+      expect(contexts[1].scan).toEqual({ device_id: "mock-2" });
     });
 
     it("applies the macro to every device's measurement individually", async () => {
@@ -655,6 +771,201 @@ describe("useWorkbookExecution", () => {
       expect(outputCell?.messages).toEqual(
         expect.arrayContaining([expect.stringContaining("Yes path")]),
       );
+    });
+
+    function deviceBranch(targets: { multispeq: string; other: string }) {
+      return createBranchCell({
+        id: "branch-dev",
+        paths: [
+          {
+            id: "path-multispeq",
+            label: "MultispeQ path",
+            color: "#22c55e",
+            gotoCellId: targets.multispeq,
+            conditions: [
+              {
+                id: "cond-1",
+                sourceCellId: "$device",
+                field: "family",
+                operator: "eq",
+                value: "multispeq",
+              },
+            ],
+          },
+          {
+            id: "path-other",
+            label: "Other path",
+            color: "#0ea5e9",
+            gotoCellId: targets.other,
+            conditions: [
+              {
+                id: "cond-2",
+                sourceCellId: "$device",
+                field: "family",
+                operator: "neq",
+                value: "multispeq",
+              },
+            ],
+          },
+        ],
+      });
+    }
+
+    it("dispatches each device group to its resolved protocol/command target", async () => {
+      const proto = createProtocolCell({ id: "proto-ms" });
+      const command = createCommandCell({ id: "cmd-other" });
+      mockConnections = [
+        mockConnection("dev-1", "MultispeQ A"),
+        {
+          ...mockConnection("dev-2", "Ambit B"),
+          family: "ambit" as never,
+          identity: { family: "ambit" as never, name: "Ambit B", raw: {} },
+        },
+      ];
+      const protocol = createProtocol();
+      server.mount(contract.protocols.getProtocol, { body: protocol });
+      mockExecuteProtocol.mockResolvedValue({ device_id: "ms-1" });
+      mockExecuteCommand.mockResolvedValue("NEW Ambit B Ready");
+
+      const branch = deviceBranch({ multispeq: "proto-ms", other: "cmd-other" });
+      const { result, onCellsChange } = renderExecution([branch, proto, command]);
+      await act(() => result.current.runCell(branch.id));
+
+      // The protocol ran for the MultispeQ only, the command for the Ambit only.
+      expect(mockExecuteProtocol).toHaveBeenCalledTimes(1);
+      expect(mockExecuteCommand).toHaveBeenCalledTimes(1);
+      const updated = onCellsChange.mock.calls.at(-1)?.[0] as WorkbookCell[];
+      const protoOutput = findOutput(updated, "proto-ms");
+      const cmdOutput = findOutput(updated, "cmd-other");
+      expect(protoOutput?.data).toEqual({ device_id: "ms-1" });
+      expect(cmdOutput?.data).toEqual({ response: "NEW Ambit B Ready" });
+      const branchOutput = findOutput(updated, branch.id);
+      expect(branchOutput?.messages?.join("\n")).toContain("MultispeQ path");
+      expect(branchOutput?.messages?.join("\n")).toContain("Other path");
+    });
+
+    it("skips (not errors) devices whose branch resolves no measurement", async () => {
+      const proto = createProtocolCell({ id: "proto-ms" });
+      mockConnections = [
+        mockConnection("dev-1", "MultispeQ A"),
+        {
+          ...mockConnection("dev-2", "Ambit B"),
+          family: "ambit" as never,
+          identity: { family: "ambit" as never, name: "Ambit B", raw: {} },
+        },
+      ];
+      const protocol = createProtocol();
+      server.mount(contract.protocols.getProtocol, { body: protocol });
+      mockExecuteProtocol.mockResolvedValue({ device_id: "ms-1" });
+
+      // Only the multispeq path exists; the Ambit matches nothing.
+      const branch = createBranchCell({
+        id: "branch-dev",
+        paths: [
+          {
+            id: "path-multispeq",
+            label: "MultispeQ path",
+            color: "#22c55e",
+            gotoCellId: "proto-ms",
+            conditions: [
+              {
+                id: "cond-1",
+                sourceCellId: "$device",
+                field: "family",
+                operator: "eq",
+                value: "multispeq",
+              },
+            ],
+          },
+        ],
+      });
+      const { result, onCellsChange } = renderExecution([branch, proto]);
+      await act(() => result.current.runCell(branch.id));
+
+      const updated = onCellsChange.mock.calls.at(-1)?.[0] as WorkbookCell[];
+      const branchOutput = findOutput(updated, branch.id);
+      expect(branchOutput?.messages?.join("\n")).toContain(
+        "Ambit B (ambit): no measurement resolved this round",
+      );
+      const branchCell = updated.find((c) => c.id === branch.id);
+      expect(branchCell).toHaveProperty("evaluatedPathId", undefined);
+    });
+
+    it("runAll skips a dispatched target exactly once (no double run)", async () => {
+      const proto = createProtocolCell({ id: "proto-ms" });
+      mockConnections = [mockConnection("dev-1", "MultispeQ A")];
+      const protocol = createProtocol();
+      server.mount(contract.protocols.getProtocol, { body: protocol });
+      mockExecuteProtocol.mockResolvedValue({ device_id: "ms-1" });
+
+      const branch = createBranchCell({
+        id: "branch-dev",
+        paths: [
+          {
+            id: "path-multispeq",
+            label: "MultispeQ path",
+            color: "#22c55e",
+            gotoCellId: "proto-ms",
+            conditions: [
+              {
+                id: "cond-1",
+                sourceCellId: "$device",
+                field: "family",
+                operator: "eq",
+                value: "multispeq",
+              },
+            ],
+          },
+        ],
+      });
+
+      const { result } = renderExecution([branch, proto]);
+      await act(() => result.current.runAll());
+
+      expect(mockExecuteProtocol).toHaveBeenCalledTimes(1);
+    });
+
+    it("errors a device-scoped branch when no device is connected", async () => {
+      setMockConnected(false);
+      const proto = createProtocolCell({ id: "proto-ms" });
+      const branch = deviceBranch({ multispeq: "proto-ms", other: "proto-ms" });
+
+      const { result, onCellsChange } = renderExecution([branch, proto]);
+      await act(() => result.current.runCell(branch.id));
+
+      const updated = onCellsChange.mock.calls[0][0] as WorkbookCell[];
+      const branchOutput = findOutput(updated, branch.id);
+      expect(branchOutput?.messages?.join("\n")).toContain("No device connected");
+    });
+
+    it("rejects a device-scoped branch whose path lacks a measurement target", async () => {
+      setMockConnected(true);
+      const branch = createBranchCell({
+        id: "branch-dev",
+        paths: [
+          {
+            id: "path-multispeq",
+            label: "MultispeQ path",
+            color: "#22c55e",
+            conditions: [
+              {
+                id: "cond-1",
+                sourceCellId: "$device",
+                field: "family",
+                operator: "eq",
+                value: "multispeq",
+              },
+            ],
+          },
+        ],
+      });
+
+      const { result, onCellsChange } = renderExecution([branch]);
+      await act(() => result.current.runCell(branch.id));
+
+      const updated = onCellsChange.mock.calls[0][0] as WorkbookCell[];
+      const branchOutput = findOutput(updated, branch.id);
+      expect(branchOutput?.messages?.join("\n")).toMatch(/must jump to a protocol or command/);
     });
 
     it("reports validation errors for misconfigured branch", async () => {

--- a/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.ts
+++ b/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.ts
@@ -552,6 +552,7 @@ export function useWorkbookExecution({
       connections.forEach((connection, index) => {
         const path = evaluateBranch(cell, currentCells, {
           device: toDeviceContext(connection.identity, index),
+          deviceId: connection.id,
         });
         const target = path?.gotoCellId
           ? currentCells.find((c) => c.id === path.gotoCellId)

--- a/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.ts
+++ b/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.ts
@@ -21,12 +21,20 @@ import type {
   CommandCell,
   MacroCell,
   OutputCell,
+  OutputDeviceResult,
   ProtocolCell,
   QuestionCell,
   WorkbookCell,
 } from "@repo/api/domains/workbook/workbook-cells.schema";
+import { buildCellNamespace } from "@repo/api/transforms/build-cell-namespace";
 import { resolveInlineCommand } from "@repo/api/transforms/command-payload";
-import { evaluateBranch, validateBranchCell } from "@repo/api/transforms/evaluate-branch";
+import { toDeviceContext } from "@repo/api/transforms/device-context";
+import {
+  evaluateBranch,
+  isDeviceScopedBranch,
+  validateBranchCell,
+  validateDeviceBranch,
+} from "@repo/api/transforms/evaluate-branch";
 
 type CellExecutionStatus = "idle" | "running" | "completed" | "error";
 
@@ -158,8 +166,8 @@ export function useWorkbookExecution({
   const setCellState = useCallback(
     (cellId: string, state: Omit<CellExecutionState, "executionOrder">) => {
       setExecutionStates((prev) => {
-        const existing = prev[cellId];
-        return { ...prev, [cellId]: { ...state, executionOrder: existing.executionOrder } };
+        const existing = prev[cellId] as CellExecutionState | undefined;
+        return { ...prev, [cellId]: { ...state, executionOrder: existing?.executionOrder } };
       });
     },
     [],
@@ -180,13 +188,22 @@ export function useWorkbookExecution({
       fallbackMessage: string,
       normalize: (data: unknown) => Record<string, unknown>,
     ): WorkbookCell[] => {
-      const results = devices.map((d, i) => {
+      const results: {
+        deviceId: string;
+        deviceLabel: string;
+        family: SensorFamily;
+        deviceName?: string;
+        data?: Record<string, unknown>;
+        error?: string;
+      }[] = devices.map((d, i) => {
         const outcome = settled[i];
+        const identity = { family: d.family, deviceName: d.identity.name };
         return outcome.status === "fulfilled"
-          ? { deviceId: d.id, deviceLabel: d.label, data: normalize(outcome.value) }
+          ? { deviceId: d.id, deviceLabel: d.label, ...identity, data: normalize(outcome.value) }
           : {
               deviceId: d.id,
               deviceLabel: d.label,
+              ...identity,
               error:
                 outcome.reason instanceof Error
                   ? outcome.reason.message
@@ -224,7 +241,11 @@ export function useWorkbookExecution({
   );
 
   const runProtocolCell = useCallback(
-    async (cell: ProtocolCell, currentCells: WorkbookCell[]) => {
+    async (
+      cell: ProtocolCell,
+      currentCells: WorkbookCell[],
+      deviceSubset?: IotDeviceConnection[],
+    ) => {
       const protocolCode = await getProtocolCode(cell);
       if (!protocolCode) {
         setCellState(cell.id, { status: "error", error: "Invalid or missing protocol code" });
@@ -255,9 +276,9 @@ export function useWorkbookExecution({
 
       // Multi-device fan-out (see mobile Multi-scan): one protocol, every
       // connected device in parallel, per-device outcomes.
-      const devices = connectionsRef.current;
-      // Each driver runs with the family it was connected as; switching the
-      // toolbar family must not retarget live drivers.
+      const devices = deviceSubset ?? connectionsRef.current;
+      // Each driver runs with the family the handshake identified; switching
+      // the toolbar family must not retarget live drivers.
       const settled = await Promise.allSettled(
         devices.map((d) => executeProtocolWithDriver(d.driver, d.family, protocolCode)),
       );
@@ -275,7 +296,11 @@ export function useWorkbookExecution({
   );
 
   const runCommandCell = useCallback(
-    async (cell: CommandCell, currentCells: WorkbookCell[]) => {
+    async (
+      cell: CommandCell,
+      currentCells: WorkbookCell[],
+      deviceSubset?: IotDeviceConnection[],
+    ) => {
       let command: string | Record<string, unknown> | unknown[];
       try {
         command = resolveInlineCommand(cell.payload);
@@ -300,7 +325,7 @@ export function useWorkbookExecution({
       setCellState(cell.id, { status: "running" });
       const startTime = performance.now();
 
-      const devices = connectionsRef.current;
+      const devices = deviceSubset ?? connectionsRef.current;
       const settled = await Promise.allSettled(
         devices.map((d) => executeCommandWithDriver(d.driver, command)),
       );
@@ -318,24 +343,38 @@ export function useWorkbookExecution({
   );
 
   // Runs the macro once against one device's measurement; throws on failure.
-  const executeMacroOn = useCallback(async (macroId: string, data: Record<string, unknown>) => {
-    let result;
-    try {
-      result = await executeMacroMutationRef.current.mutateAsync({ id: macroId, data });
-    } catch (err) {
-      // oRPC throws an ORPCError on HTTP errors; surface the server's message.
-      throw new Error(parseApiError(err)?.message ?? "Macro execution failed");
-    }
-    if (!result.success) {
-      throw new Error(result.error ?? "Macro execution failed");
-    }
-    return result.output;
+  const executeMacroOn = useCallback(
+    async (macroId: string, data: Record<string, unknown>, context?: Record<string, unknown>) => {
+      let result;
+      try {
+        result = await executeMacroMutationRef.current.mutateAsync({ id: macroId, data, context });
+      } catch (err) {
+        // oRPC throws an ORPCError on HTTP errors; surface the server's message.
+        throw new Error(parseApiError(err)?.message ?? "Macro execution failed");
+      }
+      if (!result.success) {
+        throw new Error(result.error ?? "Macro execution failed");
+      }
+      return result.output;
+    },
+    [],
+  );
+
+  // The $device entry a macro run for this connection reads from ctx.
+  const deviceContextFor = useCallback((deviceId?: string) => {
+    const connections = connectionsRef.current;
+    const index = deviceId ? connections.findIndex((c) => c.id === deviceId) : 0;
+    const connection = connections.at(Math.max(index, 0));
+    return connection ? toDeviceContext(connection.identity, Math.max(index, 0)) : undefined;
   }, []);
 
   const runMacroCell = useCallback(
     async (cell: MacroCell, cellIndex: number, currentCells: WorkbookCell[]) => {
       const input = findPrecedingOutput(currentCells, cellIndex);
-      if (!input) {
+      const namespace = buildCellNamespace(currentCells, cellIndex);
+      // A macro can run from ctx alone; error only when there is neither a
+      // nearest measurement nor any upstream output to read.
+      if (!input && Object.keys(namespace.byId).length === 0) {
         setCellState(cell.id, { status: "error", error: "No input data available" });
         return insertOutputAfterCell(
           currentCells,
@@ -347,9 +386,9 @@ export function useWorkbookExecution({
       setCellState(cell.id, { status: "running" });
       const startTime = performance.now();
 
-      // Multi-device input: apply the macro to every device's measurement
-      // individually (serialized sandbox invocations); failed measurements carry their error through.
-      const inputResults = input.deviceResults;
+      // Multi-device input: the macro runs once per device's measurement,
+      // serialized; devices whose measurement failed carry their error through.
+      const inputResults = input?.deviceResults;
       if (inputResults && inputResults.length > 1) {
         const settled: PromiseSettledResult<unknown>[] = [];
         for (const r of inputResults) {
@@ -357,9 +396,19 @@ export function useWorkbookExecution({
             if (r.data == null) {
               throw new Error("No measurement data from this device");
             }
+            // Each device's run reads a ctx scoped to ITS results, plus its
+            // own $device entry.
+            const ns = buildCellNamespace(currentCells, cellIndex, {
+              deviceId: r.deviceId,
+              device: deviceContextFor(r.deviceId),
+            });
             settled.push({
               status: "fulfilled",
-              value: await executeMacroOn(cell.payload.macroId, r.data as Record<string, unknown>),
+              value: await executeMacroOn(
+                cell.payload.macroId,
+                r.data as Record<string, unknown>,
+                ns.ctx,
+              ),
             });
           } catch (err) {
             settled.push({ status: "rejected", reason: err });
@@ -367,13 +416,15 @@ export function useWorkbookExecution({
         }
         const executionTime = performance.now() - startTime;
 
-        const results = inputResults.map((r, i) => {
+        const results: OutputDeviceResult[] = inputResults.map((r, i) => {
           const outcome = settled[i];
+          const identity = { family: r.family, deviceName: r.deviceName };
           return outcome.status === "fulfilled"
-            ? { deviceId: r.deviceId, deviceLabel: r.deviceLabel, data: outcome.value }
+            ? { deviceId: r.deviceId, deviceLabel: r.deviceLabel, ...identity, data: outcome.value }
             : {
                 deviceId: r.deviceId,
                 deviceLabel: r.deviceLabel,
+                ...identity,
                 error:
                   outcome.reason instanceof Error
                     ? outcome.reason.message
@@ -408,9 +459,13 @@ export function useWorkbookExecution({
       }
 
       try {
+        const ns = buildCellNamespace(currentCells, cellIndex, {
+          device: deviceContextFor(),
+        });
         const output = await executeMacroOn(
           cell.payload.macroId,
-          input.data as Record<string, unknown>,
+          (input?.data ?? {}) as Record<string, unknown>,
+          ns.ctx,
         );
         const executionTime = performance.now() - startTime;
         setCellState(cell.id, { status: "completed" });
@@ -430,7 +485,7 @@ export function useWorkbookExecution({
         );
       }
     },
-    [setCellState, executeMacroOn],
+    [setCellState, executeMacroOn, deviceContextFor],
   );
 
   const runQuestionCell = useCallback(
@@ -469,11 +524,91 @@ export function useWorkbookExecution({
     [setCellState],
   );
 
+  // Target cells a device-scoped branch already executed this run; the linear
+  // walk skips each exactly once instead of re-running it.
+  const dispatchConsumedRef = useRef(new Set<string>());
+
+  /**
+   * Device-scoped branch = dispatcher: every connected device evaluates the
+   * branch with ITS identity, devices group by resolved path, and each path's
+   * protocol/command target runs against only its group. Devices matching no
+   * path are skipped with a message, never an error. No jump: execution
+   * continues after the branch, and consumed targets are skipped once.
+   */
+  const runDeviceDispatchBranch = useCallback(
+    async (cell: BranchCell, currentCells: WorkbookCell[]): Promise<WorkbookCell[]> => {
+      const connections = connectionsRef.current;
+      if (connections.length === 0) {
+        setCellState(cell.id, { status: "error", error: "No device connected" });
+        return insertOutputAfterCell(
+          currentCells,
+          cell.id,
+          makeErrorOutputCell(cell.id, "No device connected - connect devices to dispatch"),
+        );
+      }
+
+      const groups = new Map<string, IotDeviceConnection[]>();
+      const skipped: IotDeviceConnection[] = [];
+      connections.forEach((connection, index) => {
+        const path = evaluateBranch(cell, currentCells, {
+          device: toDeviceContext(connection.identity, index),
+        });
+        const target = path?.gotoCellId
+          ? currentCells.find((c) => c.id === path.gotoCellId)
+          : undefined;
+        if (path && target && (target.type === "protocol" || target.type === "command")) {
+          const group = groups.get(path.id);
+          if (group) group.push(connection);
+          else groups.set(path.id, [connection]);
+        } else {
+          skipped.push(connection);
+        }
+      });
+
+      let updated = currentCells;
+      const messages: string[] = [];
+      for (const path of cell.paths) {
+        const group = groups.get(path.id);
+        if (!group || group.length === 0 || !path.gotoCellId) continue;
+        const target = updated.find((c) => c.id === path.gotoCellId);
+        if (!target) continue;
+        messages.push(`${path.label || "Unnamed path"} -> ${group.map((g) => g.label).join(", ")}`);
+        dispatchConsumedRef.current.add(target.id);
+        updated =
+          target.type === "protocol"
+            ? await runProtocolCell(target, updated, group)
+            : target.type === "command"
+              ? await runCommandCell(target, updated, group)
+              : updated;
+      }
+      for (const s of skipped) {
+        messages.push(`${s.label} (${s.family}): no measurement resolved this round`);
+      }
+
+      setCellState(cell.id, { status: "completed" });
+      updated = insertOutputAfterCell(
+        updated,
+        cell.id,
+        makeOutputCell(cell.id, undefined, 0, messages),
+      );
+      // A dispatcher matches several paths at once; no single ACTIVE path.
+      return updated.map((c) => (c.id === cell.id ? { ...cell, evaluatedPathId: undefined } : c));
+    },
+    [setCellState, runProtocolCell, runCommandCell],
+  );
+
   const runBranchCell = useCallback(
-    (cell: BranchCell, currentCells: WorkbookCell[], pass?: number): WorkbookCell[] => {
+    async (
+      cell: BranchCell,
+      currentCells: WorkbookCell[],
+      pass?: number,
+    ): Promise<WorkbookCell[]> => {
       setCellState(cell.id, { status: "running" });
 
-      const configErrors = validateBranchCell(cell);
+      const configErrors = [
+        ...validateBranchCell(cell),
+        ...validateDeviceBranch(cell, currentCells),
+      ];
       if (configErrors.length > 0) {
         setCellState(cell.id, { status: "error", error: configErrors.join("; ") });
         return insertOutputAfterCell(
@@ -481,6 +616,10 @@ export function useWorkbookExecution({
           cell.id,
           makeOutputCell(cell.id, undefined, 0, configErrors),
         );
+      }
+
+      if (isDeviceScopedBranch(cell)) {
+        return runDeviceDispatchBranch(cell, currentCells);
       }
 
       const matchedPath = evaluateBranch(cell, currentCells);
@@ -500,7 +639,7 @@ export function useWorkbookExecution({
         c.id === cell.id ? { ...cell, evaluatedPathId: matchedPath?.id } : c,
       );
     },
-    [setCellState],
+    [setCellState, runDeviceDispatchBranch],
   );
 
   const dispatchCell = useCallback(
@@ -558,6 +697,7 @@ export function useWorkbookExecution({
       const cell = currentCells.find((c) => c.id === cellId);
       if (!cell) return;
 
+      dispatchConsumedRef.current.clear();
       currentCells = await dispatchCell(cell, currentCells);
       onCellsChangeRef.current(currentCells);
 
@@ -570,6 +710,11 @@ export function useWorkbookExecution({
           for (let i = jumpIndex; i < currentCells.length; i++) {
             const c = currentCells[i];
             if (c.type === "output" || c.type === "markdown") continue;
+
+            if (dispatchConsumedRef.current.has(c.id)) {
+              dispatchConsumedRef.current.delete(c.id);
+              continue;
+            }
 
             const count = visitCounts.get(c.id) ?? 0;
             if (count >= MAX_VISITS) continue;
@@ -601,6 +746,7 @@ export function useWorkbookExecution({
     let currentCells = [...cellsRef.current];
     const visitCounts = new Map<string, number>();
     const MAX_VISITS_PER_CELL = 100;
+    dispatchConsumedRef.current.clear();
 
     for (let i = 0; i < currentCells.length; i++) {
       if (shouldAbort()) break;
@@ -608,6 +754,13 @@ export function useWorkbookExecution({
       const cell = currentCells[i];
 
       if (cell.type === "output" || cell.type === "markdown") continue;
+
+      // A device-scoped branch already ran this target with its device group;
+      // skip it exactly once.
+      if (dispatchConsumedRef.current.has(cell.id)) {
+        dispatchConsumedRef.current.delete(cell.id);
+        continue;
+      }
 
       // Cap revisits to avoid infinite loops from branch jumps.
       const count = visitCounts.get(cell.id) ?? 0;
@@ -642,7 +795,7 @@ export function useWorkbookExecution({
   return {
     isConnected,
     isConnecting,
-    connectedDevices: connections.map(({ id, label }) => ({ id, label })),
+    connectedDevices: connections.map(({ id, label, family }) => ({ id, label, family })),
     sensorFamily,
     setSensorFamily,
     connectionType,

--- a/apps/web/lib/iot/mock-devices.test.ts
+++ b/apps/web/lib/iot/mock-devices.test.ts
@@ -4,6 +4,7 @@ import {
   FAILING_MOCK_DEVICE_INDEX,
   MockTransportAdapter,
   mockDevicesEnabled,
+  parseMockFamilies,
 } from "./mock-devices";
 
 describe("mockDevicesEnabled", () => {
@@ -83,5 +84,83 @@ describe("MockTransportAdapter", () => {
     expect(adapter.isConnected()).toBe(false);
     expect(status).toHaveBeenCalledWith(false);
     await expect(adapter.send("hello")).rejects.toThrow("device not open");
+  });
+});
+
+describe("parseMockFamilies", () => {
+  afterEach(() => {
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("defaults to a single multispeq for bare ?mockDevices=1", () => {
+    window.history.replaceState({}, "", "/?mockDevices=1");
+    expect(parseMockFamilies()).toEqual(["multispeq"]);
+  });
+
+  it("parses a comma-separated family list, dropping unknown entries", () => {
+    window.history.replaceState({}, "", "/?mockDevices=multispeq,ambit,minipar,ambyte,junk");
+    expect(parseMockFamilies()).toEqual(["multispeq", "ambit", "minipar"]);
+  });
+});
+
+describe("per-family mock replies", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function sendAndReceive(adapter: MockTransportAdapter, data: string): Promise<string> {
+    let received = "";
+    adapter.onDataReceived((chunk) => {
+      received += chunk;
+    });
+    await adapter.send(data);
+    await vi.runAllTimersAsync();
+    return received;
+  }
+
+  it("multispeq answers device_info with identity JSON", async () => {
+    const adapter = new MockTransportAdapter(2, "multispeq");
+    const reply = await sendAndReceive(adapter, "device_info\r\n");
+    const info = JSON.parse(reply) as Record<string, unknown>;
+    expect(info.device_name).toBe("Mock MultispeQ 2");
+    expect(info.device_id).toBe("mock-2");
+    expect(info.device_firmware).toBe("2.311-mock");
+  });
+
+  it("ambit answers hello with the NEW ... Ready sentinel and stays silent on writers", async () => {
+    const adapter = new MockTransportAdapter(1, "ambit");
+    expect(await sendAndReceive(adapter, "hello\r\n")).toBe("NEW Mock Ambit 1 Ready\n");
+    expect(await sendAndReceive(adapter, "set_spec,1.234\n")).toBe("");
+    expect(await sendAndReceive(adapter, "frobnicate\n")).toBe("BAD COMMAND\n");
+  });
+
+  it("ambit answers get_par with the two-line PAR + channels reply", async () => {
+    const adapter = new MockTransportAdapter(1, "ambit");
+    const reply = await sendAndReceive(adapter, "get_par\n");
+    const [par, channels] = reply.trim().split("\n");
+    expect(Number(par)).toBeCloseTo(121);
+    expect(channels.split(",")).toHaveLength(10);
+  });
+
+  it("minipar answers hello without a trailing newline, like the firmware", async () => {
+    const adapter = new MockTransportAdapter(1, "minipar");
+    const reply = await sendAndReceive(adapter, "hello\n");
+    expect(reply).toBe('{"device":"MiniPAR","version":"1.1"}');
+  });
+
+  it("minipar answers protocol JSON with the envelope plus 7A1E3AA1 footer", async () => {
+    const adapter = new MockTransportAdapter(2, "minipar");
+    const reply = await sendAndReceive(adapter, '[{"set":[{"label":"par"}]}]\n');
+    expect(reply.trimEnd().endsWith("7A1E3AA1")).toBe(true);
+    const envelope = JSON.parse(reply.trimEnd().slice(0, -8)) as Record<string, unknown>;
+    expect(envelope.device_name).toBe("Mock MiniPAR 2");
+  });
+
+  it("only the multispeq flaky index simulates a failure", async () => {
+    const ambit = new MockTransportAdapter(FAILING_MOCK_DEVICE_INDEX, "ambit");
+    await expect(ambit.send("hello\n")).resolves.toBeUndefined();
   });
 });

--- a/apps/web/lib/iot/mock-devices.test.ts
+++ b/apps/web/lib/iot/mock-devices.test.ts
@@ -151,6 +151,15 @@ describe("per-family mock replies", () => {
     expect(reply).toBe('{"device":"MiniPAR","version":"1.1"}');
   });
 
+  it("minipar mirrors its remaining LINE command responses", async () => {
+    const adapter = new MockTransportAdapter(2, "minipar");
+
+    expect(await sendAndReceive(adapter, "get_name\n")).toBe("Mock MiniPAR 2\n");
+    expect(await sendAndReceive(adapter, "par\n")).toBe("360.00\n");
+    expect(await sendAndReceive(adapter, "battery\n")).toBe("NaN\n");
+    expect(await sendAndReceive(adapter, "unknown\n")).toBe("error:unknown_command\n");
+  });
+
   it("minipar answers protocol JSON with the envelope plus 7A1E3AA1 footer", async () => {
     const adapter = new MockTransportAdapter(2, "minipar");
     const reply = await sendAndReceive(adapter, '[{"set":[{"label":"par"}]}]\n');

--- a/apps/web/lib/iot/mock-devices.ts
+++ b/apps/web/lib/iot/mock-devices.ts
@@ -1,18 +1,44 @@
 import { env } from "~/env";
 
+import type { SensorFamily } from "@repo/api/domains/protocol/protocol.schema";
 import type { ITransportAdapter } from "@repo/iot";
 
 /**
- * Dev-only escape hatch: fake MultispeQ devices behind the real driver, so the
+ * Dev-only escape hatch: fake devices behind the real drivers, so the
  * multi-device workbook flow can be exercised (and e2e-tested) without a hub
- * full of hardware. Activated per-page with `?mockDevices=1`, and only outside
- * production builds (or when explicitly enabled via env).
+ * full of hardware. Activated per-page with `?mockDevices=1` (MultispeQs) or
+ * `?mockDevices=multispeq,ambit,minipar` (one mock per listed family), and
+ * only outside production builds (or when explicitly enabled via env).
  */
 export function mockDevicesEnabled(): boolean {
   if (typeof window === "undefined") return false;
   const allowed = env.NODE_ENV !== "production" || env.NEXT_PUBLIC_ENABLE_MOCK_DEVICES === "true";
   if (!allowed) return false;
   return new URLSearchParams(window.location.search).has("mockDevices");
+}
+
+/** Families a mock transport can imitate (ambyte is never locally connectable). */
+export type MockDeviceFamily = Extract<SensorFamily, "multispeq" | "ambit" | "minipar">;
+
+const MOCK_FAMILIES: readonly MockDeviceFamily[] = ["multispeq", "ambit", "minipar"];
+
+function isMockFamily(value: string): value is MockDeviceFamily {
+  return (MOCK_FAMILIES as readonly string[]).includes(value);
+}
+
+/**
+ * Families listed in `?mockDevices=`. Successive connect clicks cycle through
+ * the list. Bare `?mockDevices=1` (or any non-family value) keeps the legacy
+ * behavior: every mock is a MultispeQ.
+ */
+export function parseMockFamilies(): MockDeviceFamily[] {
+  if (typeof window === "undefined") return ["multispeq"];
+  const value = new URLSearchParams(window.location.search).get("mockDevices") ?? "";
+  const families = value
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(isMockFamily);
+  return families.length > 0 ? families : ["multispeq"];
 }
 
 /** Mock device index whose FIRST protocol run fails (later ones succeed). */
@@ -39,10 +65,34 @@ function mockMeasurement(index: number): Record<string, unknown> {
   };
 }
 
+function multispeqDeviceInfo(index: number): Record<string, unknown> {
+  return {
+    device_name: `Mock MultispeQ ${index}`,
+    device_version: "2.0-mock",
+    device_id: `mock-${index}`,
+    device_battery: 80 + index,
+    device_firmware: "2.311-mock",
+  };
+}
+
+/** miniPAR JSON-mode measurement envelope, footer included (firmware appends `7A1E3AA1`). */
+function miniparEnvelope(index: number): string {
+  const envelope = {
+    device_name: `Mock MiniPAR ${index}`,
+    device_version: "1.1",
+    device_id: `mp:mock:${index}`,
+    device_battery: "NaN",
+    device_firmware: 1.04,
+    sample: [{ protocol_id: "NaN", set: [{ label: "par", par: 340 + index * 10 }] }],
+  };
+  return `${JSON.stringify(envelope)}7A1E3AA1`;
+}
+
 /**
- * MultispeQ-flavored transport: replies to any command with newline-terminated
- * JSON, which is exactly what the real `MultispeqDriver` parses. The driver,
- * command queue, timeouts and framing all run for real; only the wire is fake.
+ * Fake transport behind the real drivers: each family replies with its
+ * firmware's actual wire signatures (hello handshakes included), so
+ * `identifyDevice` and the drivers' framing all run for real; only the wire
+ * is fake.
  */
 export class MockTransportAdapter implements ITransportAdapter {
   private connected = true;
@@ -50,7 +100,10 @@ export class MockTransportAdapter implements ITransportAdapter {
   private statusCallback?: (connected: boolean, error?: Error) => void;
   private hasFailed = false;
 
-  constructor(private readonly index: number) {}
+  constructor(
+    private readonly index: number,
+    private readonly family: MockDeviceFamily = "multispeq",
+  ) {}
 
   isConnected(): boolean {
     return this.connected;
@@ -60,15 +113,56 @@ export class MockTransportAdapter implements ITransportAdapter {
     if (!this.connected) {
       return Promise.reject(new Error("device not open"));
     }
+    const payload = data.trim();
     // Protocols arrive as a JSON array; console commands as plain strings.
-    const isProtocol = data.trimStart().startsWith("[");
-    if (isProtocol && this.index === FAILING_MOCK_DEVICE_INDEX && !this.hasFailed) {
+    const isProtocol = payload.startsWith("[");
+    if (
+      isProtocol &&
+      this.family === "multispeq" &&
+      this.index === FAILING_MOCK_DEVICE_INDEX &&
+      !this.hasFailed
+    ) {
       this.hasFailed = true;
       return Promise.reject(new Error("Mock device failure (simulated)"));
     }
-    const reply = isProtocol ? JSON.stringify(mockMeasurement(this.index)) : "MultispeQ Ready";
-    setTimeout(() => this.dataCallback?.(`${reply}\n`), MOCK_REPLY_DELAY_MS);
+    const reply = this.buildReply(payload, isProtocol);
+    if (reply !== undefined) {
+      setTimeout(() => this.dataCallback?.(reply), MOCK_REPLY_DELAY_MS);
+    }
     return Promise.resolve();
+  }
+
+  /** Per-family reply table; `undefined` means the device stays silent. */
+  private buildReply(payload: string, isProtocol: boolean): string | undefined {
+    switch (this.family) {
+      case "multispeq": {
+        if (isProtocol) return `${JSON.stringify(mockMeasurement(this.index))}\n`;
+        if (payload === "device_info") {
+          return `${JSON.stringify(multispeqDeviceInfo(this.index))}\n`;
+        }
+        return "MultispeQ Ready\n";
+      }
+      case "ambit": {
+        if (payload === "hello") return `NEW Mock Ambit ${this.index} Ready\n`;
+        // Calibration writers reply with nothing at all, like the firmware.
+        if (payload.startsWith("set_")) return undefined;
+        if (payload === "get_par" || payload === "PAR") {
+          return `${(120 + this.index).toFixed(1)}\n415,388,402,390,377,365,401,388,352,343\n`;
+        }
+        if (payload === "temp") return "23.1\t22.4\t23.0\n";
+        return "BAD COMMAND\n";
+      }
+      case "minipar": {
+        // JSON mode: protocol arrays/objects get the measurement envelope + footer.
+        if (isProtocol || payload.startsWith("{")) return `${miniparEnvelope(this.index)}\n`;
+        // Firmware replies to hello via Serial.print: no trailing newline.
+        if (payload === "hello") return '{"device":"MiniPAR","version":"1.1"}';
+        if (payload === "get_name") return `Mock MiniPAR ${this.index}\n`;
+        if (payload === "par") return `${(340 + this.index * 10).toFixed(2)}\n`;
+        if (payload === "battery") return "NaN\n";
+        return "error:unknown_command\n";
+      }
+    }
   }
 
   onDataReceived(callback: (data: string) => void): void {

--- a/apps/web/util/sensor-family.test.ts
+++ b/apps/web/util/sensor-family.test.ts
@@ -38,10 +38,11 @@ describe("SENSOR_FAMILY_OPTIONS", () => {
     expect(ambyte?.disabled).toBe(true);
   });
 
-  it("should mark minipar as disabled", () => {
+  it("should mark minipar and ambit as enabled (locally connectable)", () => {
     const minipar = SENSOR_FAMILY_OPTIONS.find((o) => o.value === "minipar");
-    expect(minipar).toBeDefined();
-    expect(minipar?.disabled).toBe(true);
+    const ambit = SENSOR_FAMILY_OPTIONS.find((o) => o.value === "ambit");
+    expect(minipar?.disabled).toBe(false);
+    expect(ambit?.disabled).toBe(false);
   });
 
   it("should mark generic as enabled", () => {
@@ -96,8 +97,9 @@ describe("getSensorFamilyBadgeColor", () => {
     expect(getSensorFamilyBadgeColor("ambyte")).toBe("bg-badge-active");
   });
 
-  it("should fall back to the archived badge for any other family", () => {
+  it("gives minipar and ambit their own badges, archived for the rest", () => {
     expect(getSensorFamilyBadgeColor("generic")).toBe("bg-badge-archived");
-    expect(getSensorFamilyBadgeColor("minipar")).toBe("bg-badge-archived");
+    expect(getSensorFamilyBadgeColor("minipar")).toBe("bg-badge-stale");
+    expect(getSensorFamilyBadgeColor("ambit")).toBe("bg-badge-active");
   });
 });

--- a/apps/web/util/sensor-family.ts
+++ b/apps/web/util/sensor-family.ts
@@ -16,16 +16,18 @@ const SENSOR_FAMILY_LABELS: Record<SensorFamily, string> = {
   multispeq: "MultispeQ",
   ambyte: "Ambyte",
   minipar: "MiniPAR",
+  ambit: "Ambit",
 };
 
 /**
- * Families that are not yet available for local connection (ingest-only).
+ * Families that are not available for local connection (Ambyte is an
+ * MQTT-only gateway; its data arrives via ingest, never a local port).
  */
-const DISABLED_FAMILIES: ReadonlySet<SensorFamily> = new Set(["ambyte", "minipar"]);
+const DISABLED_FAMILIES: ReadonlySet<SensorFamily> = new Set(["ambyte"]);
 
 /**
  * Selectable sensor family options derived from the API enum.
- * Adding a new value to `zSensorFamily` automatically surfaces it here —
+ * Adding a new value to `zSensorFamily` automatically surfaces it here;
  * just add its label to `SENSOR_FAMILY_LABELS` and optionally disable it.
  */
 export const SENSOR_FAMILY_OPTIONS: SensorFamilyOption[] = zSensorFamily.options.map((value) => ({
@@ -50,7 +52,10 @@ export function getSensorFamilyBadgeColor(family: string): string {
     case "multispeq":
       return "bg-badge-published";
     case "ambyte":
+    case "ambit":
       return "bg-badge-active";
+    case "minipar":
+      return "bg-badge-stale";
     default:
       return "bg-badge-archived";
   }

--- a/packages/api/src/domains/macro/macro.schema.spec.ts
+++ b/packages/api/src/domains/macro/macro.schema.spec.ts
@@ -374,6 +374,22 @@ describe("Macro Schema", () => {
       const parsed = zMacroBatchExecutionItem.parse(item);
       expect(parsed.data).toEqual([{ trace: [1] }]);
     });
+
+    it("parses an optional workbook snapshot id and stringified context", () => {
+      const workbookVersionId = "550e8400-e29b-41d4-a716-446655440000";
+      const item = {
+        id: "m1",
+        macro_id: uuidA,
+        data: {},
+        workbook_version_id: workbookVersionId,
+        context: JSON.stringify({ baseline: { value: 3 } }),
+      };
+
+      expect(zMacroBatchExecutionItem.parse(item)).toEqual({
+        ...item,
+        context: { baseline: { value: 3 } },
+      });
+    });
   });
 
   describe("zMacroBatchExecutionRequestBody", () => {

--- a/packages/api/src/domains/macro/macro.schema.ts
+++ b/packages/api/src/domains/macro/macro.schema.ts
@@ -128,6 +128,10 @@ export const zMacroBatchExecutionItem = z.object({
   id: z.string(),
   macro_id: z.string().uuid(),
   data: jsonStringOrValue(z.union([z.record(z.unknown()), z.array(z.unknown())])),
+  // Published workbook version that owns the exact macro snapshot. Optional
+  // for legacy/non-workbook callers, which continue to resolve the live macro.
+  workbook_version_id: z.string().uuid().optional(),
+  context: jsonStringOrValue(z.record(z.unknown())).optional(),
 });
 
 export const zMacroBatchExecutionRequestBody = z.object({

--- a/packages/api/src/domains/macro/macro.schema.ts
+++ b/packages/api/src/domains/macro/macro.schema.ts
@@ -109,6 +109,9 @@ export const zMacroProtocolPathParams = z.object({
 
 export const zMacroExecutionRequestBody = z.object({
   data: jsonStringOrValue(z.union([z.record(z.unknown()), z.array(z.unknown())])),
+  // Upstream cell outputs keyed by canonical name, injected into the sandbox as
+  // read-only `ctx`. Additive: `data` still carries the nearest output (`json`).
+  context: jsonStringOrValue(z.record(z.unknown())).optional(),
   timeout: z.number().int().min(1).max(60).optional(),
 });
 
@@ -182,5 +185,6 @@ export interface MacroBatchExecutionWireBody {
 }
 export interface MacroExecutionWireBody {
   data: MacroExecutionRequestBody["data"] | string;
+  context?: MacroExecutionRequestBody["context"] | string;
   timeout?: number;
 }

--- a/packages/api/src/domains/protocol/protocol.schema.ts
+++ b/packages/api/src/domains/protocol/protocol.schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const zSensorFamily = z.enum(["multispeq", "ambyte", "minipar", "generic"]);
+export const zSensorFamily = z.enum(["multispeq", "ambyte", "minipar", "generic", "ambit"]);
 
 // Define Zod schemas for protocol models
 export const zProtocol = z.object({

--- a/packages/api/src/domains/workbook/workbook-cells.schema.ts
+++ b/packages/api/src/domains/workbook/workbook-cells.schema.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { sanitizeQuestionLabel } from "../../transforms/label-sanitization";
 import { zCommandFormat, zExperimentQuestionContent } from "../experiment/experiment.schema";
 import { zMacroLanguage } from "../macro/macro.schema";
+import { zSensorFamily } from "../protocol/protocol.schema";
 
 const zBaseCell = z.object({
   id: z.string().min(1, "Cell ID is required"),
@@ -94,6 +95,9 @@ export const zBranchCell = zBaseCell.extend({
 export const zOutputDeviceResult = z.object({
   deviceId: z.string(),
   deviceLabel: z.string().optional(),
+  // Identified sensor family and device-reported name, when the handshake resolved them.
+  family: zSensorFamily.optional(),
+  deviceName: z.string().optional(),
   data: z.unknown().optional(),
   error: z.string().optional(),
 });
@@ -161,3 +165,20 @@ export type WorkbookCell =
   | BranchCell
   | OutputCell
   | MarkdownCell;
+
+/**
+ * The author-facing name a cell contributes to the macro `ctx` namespace.
+ * Undefined for cell types that never produce a namespace entry.
+ */
+export function namespaceNameOf(cell: WorkbookCell): string | undefined {
+  switch (cell.type) {
+    case "question":
+      return cell.name;
+    case "protocol":
+    case "macro":
+    case "command":
+      return cell.payload.name;
+    default:
+      return undefined;
+  }
+}

--- a/packages/api/src/transforms/build-cell-namespace.spec.ts
+++ b/packages/api/src/transforms/build-cell-namespace.spec.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from "vitest";
+
+import type { WorkbookCell } from "../domains/workbook/workbook-cells.schema";
+import { buildCellNamespace, resolveOutputData } from "./build-cell-namespace";
+import { resolveConditionValue } from "./evaluate-branch";
+
+const uuid = "11111111-1111-1111-1111-111111111111";
+
+function protocol(id: string, name?: string): WorkbookCell {
+  return {
+    id,
+    type: "protocol",
+    isCollapsed: false,
+    payload: { protocolId: uuid, version: 1, name },
+  };
+}
+function macro(id: string, name?: string): WorkbookCell {
+  return {
+    id,
+    type: "macro",
+    isCollapsed: false,
+    payload: { macroId: uuid, language: "javascript", name },
+  };
+}
+function output(producedBy: string, data: unknown): WorkbookCell {
+  return { id: `out-${producedBy}`, type: "output", isCollapsed: false, producedBy, data };
+}
+function question(id: string, name: string, answer?: string): WorkbookCell {
+  return {
+    id,
+    type: "question",
+    isCollapsed: false,
+    name,
+    isAnswered: answer != null,
+    question: { kind: "open_ended", text: "?", required: false },
+    ...(answer != null ? { answer } : {}),
+  };
+}
+
+describe("buildCellNamespace", () => {
+  it("keys producer outputs by id and by canonical name", () => {
+    const cells = [protocol("p1", "Baseline"), output("p1", { value: 0.8 })];
+    const ns = buildCellNamespace(cells);
+    expect(ns.byId.p1).toEqual({ value: 0.8 });
+    expect(ns.ctx.baseline).toEqual({ value: 0.8 });
+    expect(ns.names.baseline).toBe("p1");
+  });
+
+  it("exposes an answered question as { answer }", () => {
+    const cells = [question("q1", "Soil moisture", "wet")];
+    const ns = buildCellNamespace(cells);
+    expect(ns.byId.q1).toEqual({ answer: "wet" });
+    expect(ns.ctx.soil_moisture).toEqual({ answer: "wet" });
+  });
+
+  it("omits unanswered questions and producers without output", () => {
+    const cells = [question("q1", "Unanswered"), protocol("p1", "NoRun")];
+    const ns = buildCellNamespace(cells);
+    expect(ns.byId).toEqual({});
+    expect(ns.ctx).toEqual({});
+  });
+
+  it("includes unnamed producers in byId but not ctx", () => {
+    const cells = [protocol("p1"), output("p1", { v: 1 })];
+    const ns = buildCellNamespace(cells);
+    expect(ns.byId.p1).toEqual({ v: 1 });
+    expect(ns.ctx).toEqual({});
+  });
+
+  it("unwraps a non-empty array output to its first element", () => {
+    const cells = [protocol("p1", "Scan"), output("p1", [{ value: 1 }, { value: 2 }])];
+    const ns = buildCellNamespace(cells);
+    expect(ns.ctx.scan).toEqual({ value: 1 });
+  });
+
+  it("only sees cells strictly before beforeIndex (upstream-only)", () => {
+    const cells = [
+      protocol("p1", "Up"),
+      output("p1", { value: 1 }),
+      macro("m1", "Self"),
+      output("m1", { value: 2 }),
+      protocol("p2", "Down"),
+      output("p2", { value: 3 }),
+    ];
+    // From the macro's position (index 2), only p1's output is visible.
+    const ns = buildCellNamespace(cells, 2);
+    expect(ns.ctx.up).toEqual({ value: 1 });
+    expect(ns.ctx.self).toBeUndefined();
+    expect(ns.ctx.down).toBeUndefined();
+  });
+
+  it("reads an upstream output many cells back", () => {
+    const cells = [
+      protocol("p1", "Baseline"),
+      output("p1", { value: 0.8 }),
+      { id: "md1", type: "markdown", isCollapsed: false, content: "note" } as WorkbookCell,
+      question("q1", "Note", "ok"),
+      protocol("p2", "Stress"),
+      output("p2", { value: 0.4 }),
+      macro("m1", "Compare"),
+    ];
+    const ns = buildCellNamespace(cells, cells.length - 1);
+    expect(ns.ctx.baseline).toEqual({ value: 0.8 });
+    expect(ns.ctx.stress).toEqual({ value: 0.4 });
+    expect(ns.ctx.note).toEqual({ answer: "ok" });
+  });
+});
+
+describe("resolveOutputData", () => {
+  it("returns undefined when no output exists", () => {
+    expect(resolveOutputData([protocol("p1")], "p1")).toBeUndefined();
+  });
+  it("returns undefined for an empty array output", () => {
+    expect(resolveOutputData([protocol("p1"), output("p1", [])], "p1")).toBeUndefined();
+  });
+});
+
+describe("parity with resolveConditionValue", () => {
+  // The namespace must project the same field value a branch condition reads,
+  // so branch routing and macro ctx can never disagree.
+  const cases: { data: unknown; field: string }[] = [
+    { data: { "Fv/Fm": 0.7 }, field: "Fv/Fm" },
+    { data: { label: "green" }, field: "label" },
+    { data: [{ value: 42 }], field: "value" },
+    { data: { nested: { a: 1 } }, field: "nested" },
+    { data: { value: 1 }, field: "missing" },
+  ];
+
+  it.each(cases)("field $field matches between ctx and branch resolver", ({ data, field }) => {
+    const cells = [protocol("p1", "Src"), output("p1", data)];
+    const fromBranch = resolveConditionValue(cells, "p1", field);
+    const nsData = buildCellNamespace(cells).byId.p1 as Record<string, unknown> | undefined;
+    const raw = nsData?.[field];
+    const fromNs =
+      typeof raw === "number" || typeof raw === "string"
+        ? raw
+        : raw != null
+          ? JSON.stringify(raw)
+          : undefined;
+    expect(fromNs).toEqual(fromBranch);
+  });
+});
+
+describe("device-scoped resolution", () => {
+  function multiOutput(producedBy: string): WorkbookCell {
+    return {
+      id: `out-${producedBy}`,
+      type: "output",
+      isCollapsed: false,
+      producedBy,
+      data: { value: 1, source: "primary" },
+      deviceResults: [
+        { deviceId: "dev-1", data: { value: 1, source: "primary" } },
+        { deviceId: "dev-2", data: { value: 2, source: "second" } },
+        { deviceId: "dev-3", error: "device not open" },
+      ],
+    };
+  }
+
+  it("resolves the matching device's data when deviceId is given", () => {
+    const cells = [protocol("p1", "Scan"), multiOutput("p1")];
+    expect(resolveOutputData(cells, "p1", "dev-2")).toEqual({ value: 2, source: "second" });
+    expect(buildCellNamespace(cells, cells.length, { deviceId: "dev-2" }).ctx.scan).toEqual({
+      value: 2,
+      source: "second",
+    });
+  });
+
+  it("falls back to primary data for unknown devices and errored entries", () => {
+    const cells = [protocol("p1", "Scan"), multiOutput("p1")];
+    expect(resolveOutputData(cells, "p1", "dev-9")).toEqual({ value: 1, source: "primary" });
+    expect(resolveOutputData(cells, "p1", "dev-3")).toEqual({ value: 1, source: "primary" });
+  });
+
+  it("keeps single-device semantics when no deviceId is given", () => {
+    const cells = [protocol("p1", "Scan"), multiOutput("p1")];
+    expect(resolveOutputData(cells, "p1")).toEqual({ value: 1, source: "primary" });
+  });
+});
+
+describe("ctx.$device injection", () => {
+  const device = { family: "ambit", id: "amb-1", name: "NEW Name Here", index: 1 };
+
+  it("injects the device context under the reserved key", () => {
+    const ns = buildCellNamespace([], 0, { device });
+    expect(ns.ctx.$device).toEqual(device);
+    expect(ns.byId).toEqual({});
+  });
+
+  it("is never shadowed by a cell named device ($ is unreachable via names)", () => {
+    const cells = [protocol("p1", "$device"), output("p1", { v: 1 })];
+    const ns = buildCellNamespace(cells, cells.length, { device });
+    // "$device" sanitizes to "device"; the reserved key keeps the runtime value.
+    expect(ns.ctx.$device).toEqual(device);
+    expect(ns.ctx.device).toEqual({ v: 1 });
+  });
+
+  it("omits $device when no device is supplied", () => {
+    const ns = buildCellNamespace([], 0);
+    expect(ns.ctx.$device).toBeUndefined();
+  });
+});
+
+describe("duplicate producer names", () => {
+  it("lets the nearest upstream producer win the ctx key", () => {
+    const cells = [
+      protocol("p1", "Scan"),
+      output("p1", { v: 1 }),
+      protocol("p2", "Scan"),
+      output("p2", { v: 2 }),
+    ];
+    const ns = buildCellNamespace(cells);
+    expect(ns.ctx.scan).toEqual({ v: 2 });
+    expect(ns.names.scan).toBe("p2");
+    expect(ns.byId.p1).toEqual({ v: 1 });
+  });
+});

--- a/packages/api/src/transforms/build-cell-namespace.ts
+++ b/packages/api/src/transforms/build-cell-namespace.ts
@@ -1,0 +1,102 @@
+import { namespaceNameOf } from "../domains/workbook/workbook-cells.schema";
+import type { WorkbookCell } from "../domains/workbook/workbook-cells.schema";
+import type { DeviceContext } from "./device-context";
+import { DEVICE_CONTEXT_KEY } from "./device-context";
+import { sanitizeQuestionLabel } from "./label-sanitization";
+
+export interface CellNamespace {
+  // Producer output (or `{ answer }` for a question) keyed by stable cell id.
+  // Populated for every upstream cell that has produced a value.
+  byId: Record<string, unknown>;
+  // The same values keyed by canonicalised author-facing name, for `ctx.<name>`
+  // access from macro code and for resolving branch sources by name.
+  ctx: Record<string, unknown>;
+  // Canonical name to cell id, for diagnostics and name-to-id resolution.
+  names: Record<string, string>;
+}
+
+export interface BuildCellNamespaceOptions {
+  /**
+   * Scope multi-device outputs to this device: when an output cell carries
+   * `deviceResults`, the entry matching this id contributes its data instead
+   * of the primary `data`. Values keep the exact single-device shape either
+   * way, so macro code never branches on shape.
+   */
+  deviceId?: string;
+  /** Injected as `ctx["$device"]`; reserved, cell names can never produce it. */
+  device?: DeviceContext;
+}
+
+function unwrapFirst(data: unknown): Record<string, unknown> | undefined {
+  if (data == null) return undefined;
+  if (Array.isArray(data)) {
+    return (data[0] as Record<string, unknown> | undefined) ?? undefined;
+  }
+  return data as Record<string, unknown>;
+}
+
+// Reads a producer cell's output, unwrapping arrays to the first element like
+// the macro sandbox's `unwrapMeasurement`. With a deviceId, a multi-device
+// output resolves to that device's own result (falling back to primary data).
+export function resolveOutputData(
+  cells: WorkbookCell[],
+  producedBy: string,
+  deviceId?: string,
+): Record<string, unknown> | undefined {
+  const outputCell = cells.find((c) => c.type === "output" && c.producedBy === producedBy);
+  if (outputCell?.type !== "output") return undefined;
+
+  if (deviceId !== undefined) {
+    const deviceResult = outputCell.deviceResults?.find((r) => r.deviceId === deviceId);
+    if (deviceResult?.data != null) return unwrapFirst(deviceResult.data);
+  }
+  return unwrapFirst(outputCell.data);
+}
+
+// The value a cell contributes to the namespace: `{ answer }` for an answered
+// question, the unwrapped output for a protocol/macro/command, or undefined for
+// other cell types and for producers that have not run yet.
+function cellValue(cells: WorkbookCell[], cell: WorkbookCell, deviceId?: string): unknown {
+  if (cell.type === "question") {
+    return cell.answer != null ? { answer: cell.answer } : undefined;
+  }
+  if (cell.type === "protocol" || cell.type === "macro" || cell.type === "command") {
+    return resolveOutputData(cells, cell.id, deviceId);
+  }
+  return undefined;
+}
+
+// The namespace a macro at `beforeIndex` can read: every upstream output,
+// addressable by id (`byId`) and canonical name (`ctx`). Upstream-only, so a
+// macro never reads its own or a later cell's output. Duplicate producer names
+// are legal in saved workbooks; on collision the nearest upstream wins.
+export function buildCellNamespace(
+  cells: WorkbookCell[],
+  beforeIndex: number = cells.length,
+  options?: BuildCellNamespaceOptions,
+): CellNamespace {
+  const byId: Record<string, unknown> = {};
+  const ctx: Record<string, unknown> = {};
+  const names: Record<string, string> = {};
+
+  const limit = Math.max(0, Math.min(beforeIndex, cells.length));
+  for (let i = 0; i < limit; i++) {
+    const cell = cells[i];
+    const value = cellValue(cells, cell, options?.deviceId);
+    if (value === undefined) continue;
+
+    byId[cell.id] = value;
+    const name = namespaceNameOf(cell);
+    if (name != null && name !== "") {
+      const canonical = sanitizeQuestionLabel(name);
+      ctx[canonical] = value;
+      names[canonical] = cell.id;
+    }
+  }
+
+  if (options?.device) {
+    ctx[DEVICE_CONTEXT_KEY] = options.device;
+  }
+
+  return { ctx, byId, names };
+}

--- a/packages/api/src/transforms/device-context.ts
+++ b/packages/api/src/transforms/device-context.ts
@@ -1,0 +1,42 @@
+/**
+ * The connected device as a workbook runtime value: branch conditions read it
+ * via the reserved `$device` source and macros will read it as `ctx["$device"]`.
+ * The `$` prefix is collision-proof because `sanitizeQuestionLabel` can never
+ * emit it into a cell name. Fields are structural strings; @repo/api must not
+ * import @repo/iot (its `DeviceIdentity` maps onto this shape by hand).
+ */
+export const DEVICE_CONTEXT_KEY = "$device";
+
+export const DEVICE_CONTEXT_FIELDS = ["family", "id", "name", "index", "firmwareVersion"] as const;
+
+export type DeviceContextField = (typeof DEVICE_CONTEXT_FIELDS)[number];
+
+export interface DeviceContext {
+  family: string;
+  id?: string;
+  name?: string;
+  firmwareVersion?: string;
+  batteryPercent?: number;
+  /** Position of the device in the host's connection list (0-based). */
+  index: number;
+}
+
+/** Shape-compatible subset of @repo/iot's DeviceIdentity (raw is dropped). */
+interface DeviceIdentityLike {
+  family: string;
+  name?: string;
+  deviceId?: string;
+  firmwareVersion?: string;
+  batteryPercent?: number;
+}
+
+export function toDeviceContext(identity: DeviceIdentityLike, index: number): DeviceContext {
+  return {
+    family: identity.family,
+    id: identity.deviceId,
+    name: identity.name,
+    firmwareVersion: identity.firmwareVersion,
+    batteryPercent: identity.batteryPercent,
+    index,
+  };
+}

--- a/packages/api/src/transforms/evaluate-branch.spec.ts
+++ b/packages/api/src/transforms/evaluate-branch.spec.ts
@@ -593,7 +593,27 @@ describe("$device runtime source", () => {
     expect(evaluateBranch(cell, [], { device: { ...device, index: 1 } })).toBeUndefined();
   });
 
-  it("leaves regular cell sources unaffected by runtime context", () => {
+  it("scopes regular output sources to the runtime device", () => {
+    const output: WorkbookCell = {
+      id: "out-1",
+      type: "output",
+      isCollapsed: false,
+      producedBy: "p1",
+      data: { value: 1 },
+      deviceResults: [
+        { deviceId: "host-a", data: { value: 10 } },
+        { deviceId: "host-b", data: { value: 20 } },
+      ],
+    };
+    const producer = { id: "p1", type: "protocol", isCollapsed: false } as WorkbookCell;
+    expect(resolveConditionValue([producer, output], "p1", "value", { device })).toBe(1);
+    expect(
+      resolveConditionValue([producer, output], "p1", "value", {
+        device,
+        deviceId: "host-b",
+      }),
+    ).toBe(20);
+
     const cells: WorkbookCell[] = [makeQuestionCell("q1", "42")];
     expect(resolveConditionValue(cells, "q1", "ignored", { device })).toBe("42");
   });

--- a/packages/api/src/transforms/evaluate-branch.spec.ts
+++ b/packages/api/src/transforms/evaluate-branch.spec.ts
@@ -4,8 +4,10 @@ import type { BranchCell, WorkbookCell } from "../domains/workbook/workbook-cell
 import {
   evaluateBranch,
   evaluatePathConditions,
+  isDeviceScopedBranch,
   resolveConditionValue,
   validateBranchCell,
+  validateDeviceBranch,
 } from "./evaluate-branch";
 
 function makeOutputCell(id: string, producedBy: string, data: unknown): WorkbookCell {
@@ -501,5 +503,141 @@ describe("validateBranchCell", () => {
     });
     const errors = validateBranchCell(cell);
     expect(errors[0]).toMatch(/^Unnamed path/);
+  });
+});
+
+describe("$device runtime source", () => {
+  const device = {
+    family: "multispeq",
+    id: "aa:bb:cc:dd",
+    name: "MultispeQ",
+    firmwareVersion: "2.311",
+    index: 0,
+  };
+
+  function deviceBranch(overrides?: Partial<BranchCell>): BranchCell {
+    return makeBranchCell({
+      id: "b1",
+      paths: [
+        {
+          id: "p1",
+          label: "MultispeQ path",
+          color: "",
+          gotoCellId: "prot1",
+          conditions: [
+            {
+              id: "c1",
+              sourceCellId: "$device",
+              field: "family",
+              operator: "eq",
+              value: "multispeq",
+            },
+          ],
+        },
+        {
+          id: "p2",
+          label: "Fallback",
+          color: "",
+          gotoCellId: "cmd1",
+          conditions: [
+            {
+              id: "c2",
+              sourceCellId: "$device",
+              field: "family",
+              operator: "neq",
+              value: "multispeq",
+            },
+          ],
+        },
+      ],
+      defaultPathId: "p2",
+      ...overrides,
+    });
+  }
+
+  it("resolves $device fields from the runtime context", () => {
+    expect(resolveConditionValue([], "$device", "family", { device })).toBe("multispeq");
+    expect(resolveConditionValue([], "$device", "id", { device })).toBe("aa:bb:cc:dd");
+    expect(resolveConditionValue([], "$device", "index", { device })).toBe(0);
+    expect(resolveConditionValue([], "$device", "firmwareVersion", { device })).toBe("2.311");
+  });
+
+  it("returns undefined for $device without runtime context or for unknown fields", () => {
+    expect(resolveConditionValue([], "$device", "family")).toBeUndefined();
+    expect(resolveConditionValue([], "$device", "family", {})).toBeUndefined();
+    expect(resolveConditionValue([], "$device", "nope", { device })).toBeUndefined();
+  });
+
+  it("routes by $device.family and falls to default without a device", () => {
+    const cell = deviceBranch();
+    expect(evaluateBranch(cell, [], { device })?.id).toBe("p1");
+    expect(evaluateBranch(cell, [], { device: { ...device, family: "ambit" } })?.id).toBe("p2");
+    expect(evaluateBranch(cell, [])?.id).toBe("p2");
+  });
+
+  it("compares $device.index numerically", () => {
+    const cell = makeBranchCell({
+      id: "b1",
+      paths: [
+        {
+          id: "p1",
+          label: "later devices",
+          color: "",
+          conditions: [
+            { id: "c1", sourceCellId: "$device", field: "index", operator: "gte", value: "2" },
+          ],
+        },
+      ],
+    });
+    expect(evaluateBranch(cell, [], { device: { ...device, index: 3 } })?.id).toBe("p1");
+    expect(evaluateBranch(cell, [], { device: { ...device, index: 1 } })).toBeUndefined();
+  });
+
+  it("leaves regular cell sources unaffected by runtime context", () => {
+    const cells: WorkbookCell[] = [makeQuestionCell("q1", "42")];
+    expect(resolveConditionValue(cells, "q1", "ignored", { device })).toBe("42");
+  });
+
+  it("detects device-scoped branches", () => {
+    expect(isDeviceScopedBranch(deviceBranch())).toBe(true);
+    const plain = makeBranchCell({
+      id: "b2",
+      paths: [
+        {
+          id: "p1",
+          label: "",
+          color: "",
+          conditions: [{ id: "c1", sourceCellId: "q1", field: "x", operator: "eq", value: "1" }],
+        },
+      ],
+    });
+    expect(isDeviceScopedBranch(plain)).toBe(false);
+  });
+
+  it("validateDeviceBranch requires protocol/command jump targets on every path", () => {
+    const cells: WorkbookCell[] = [
+      { id: "prot1", type: "protocol", isCollapsed: false } as WorkbookCell,
+      makeQuestionCell("q1", "x"),
+    ];
+
+    const missingTarget = deviceBranch();
+    missingTarget.paths[1].gotoCellId = undefined;
+    const errors = validateDeviceBranch(missingTarget, cells);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/Fallback: device-scoped paths must jump/);
+
+    const wrongTarget = deviceBranch();
+    wrongTarget.paths[1].gotoCellId = "q1";
+    expect(validateDeviceBranch(wrongTarget, cells)[0]).toMatch(
+      /jump target must be a protocol or command cell/,
+    );
+
+    const okBranch = deviceBranch();
+    okBranch.paths[1].gotoCellId = "prot1";
+    okBranch.paths[0].gotoCellId = "prot1";
+    expect(validateDeviceBranch(okBranch, cells)).toHaveLength(0);
+
+    const plain = makeBranchCell({ id: "b3", paths: [] });
+    expect(validateDeviceBranch(plain, cells)).toHaveLength(0);
   });
 });

--- a/packages/api/src/transforms/evaluate-branch.ts
+++ b/packages/api/src/transforms/evaluate-branch.ts
@@ -4,6 +4,47 @@ import type {
   BranchPath,
   WorkbookCell,
 } from "../domains/workbook/workbook-cells.schema";
+import { resolveOutputData } from "./build-cell-namespace";
+import type { DeviceContext } from "./device-context";
+import { DEVICE_CONTEXT_KEY } from "./device-context";
+
+/**
+ * Host-supplied values that only exist at run time. `device` is the connected
+ * device a `$device`-sourced condition evaluates against; without it those
+ * conditions are false and the branch falls to its default path.
+ */
+export interface BranchRuntimeContext {
+  device?: DeviceContext;
+}
+
+/** True when any condition of the branch reads the reserved `$device` source. */
+export function isDeviceScopedBranch(cell: BranchCell): boolean {
+  return cell.paths.some((path) =>
+    path.conditions.some((cond) => cond.sourceCellId === DEVICE_CONTEXT_KEY),
+  );
+}
+
+/**
+ * A device-scoped branch dispatches devices to measurement cells, so every
+ * path (and the default) must point at a protocol or command cell.
+ */
+export function validateDeviceBranch(cell: BranchCell, cells: WorkbookCell[]): string[] {
+  if (!isDeviceScopedBranch(cell)) return [];
+
+  const errors: string[] = [];
+  for (const path of cell.paths) {
+    const label = path.label || "Unnamed path";
+    if (!path.gotoCellId) {
+      errors.push(`${label}: device-scoped paths must jump to a protocol or command cell`);
+      continue;
+    }
+    const target = cells.find((c) => c.id === path.gotoCellId);
+    if (!target || (target.type !== "protocol" && target.type !== "command")) {
+      errors.push(`${label}: jump target must be a protocol or command cell`);
+    }
+  }
+  return errors;
+}
 
 export function validateBranchCell(cell: BranchCell): string[] {
   const errors: string[] = [];
@@ -44,7 +85,16 @@ export function resolveConditionValue(
   cells: WorkbookCell[],
   sourceCellId: string,
   field: string,
+  runtime?: BranchRuntimeContext,
 ): string | number | undefined {
+  if (sourceCellId === DEVICE_CONTEXT_KEY) {
+    const device = runtime?.device;
+    if (!device) return undefined;
+    const val = device[field as keyof DeviceContext];
+    if (typeof val === "number" || typeof val === "string") return val;
+    return undefined;
+  }
+
   const sourceCell = cells.find((c) => c.id === sourceCellId);
   if (!sourceCell) return undefined;
 
@@ -52,21 +102,8 @@ export function resolveConditionValue(
     return sourceCell.answer ?? undefined;
   }
 
-  const outputCell = cells.find((c) => c.type === "output" && c.producedBy === sourceCellId);
-  if (outputCell?.type !== "output" || outputCell.data == null) {
-    return undefined;
-  }
-
-  const data = outputCell.data as Record<string, unknown>;
-
-  if (Array.isArray(data)) {
-    const first = data[0] as Record<string, unknown> | undefined;
-    if (!first) return undefined;
-    const val = first[field];
-    if (typeof val === "number") return val;
-    if (typeof val === "string") return val;
-    return val != null ? JSON.stringify(val) : undefined;
-  }
+  const data = resolveOutputData(cells, sourceCellId);
+  if (data == null) return undefined;
 
   const val = data[field];
   if (typeof val === "number") return val;
@@ -74,8 +111,12 @@ export function resolveConditionValue(
   return val != null ? JSON.stringify(val) : undefined;
 }
 
-function evaluateCondition(cond: BranchCondition, cells: WorkbookCell[]): boolean {
-  const resolved = resolveConditionValue(cells, cond.sourceCellId, cond.field);
+function evaluateCondition(
+  cond: BranchCondition,
+  cells: WorkbookCell[],
+  runtime?: BranchRuntimeContext,
+): boolean {
+  const resolved = resolveConditionValue(cells, cond.sourceCellId, cond.field, runtime);
   if (resolved === undefined) return false;
 
   const left = typeof resolved === "number" ? resolved : Number(resolved);
@@ -101,14 +142,22 @@ function evaluateCondition(cond: BranchCondition, cells: WorkbookCell[]): boolea
 }
 
 // AND logic across conditions.
-export function evaluatePathConditions(path: BranchPath, cells: WorkbookCell[]): boolean {
+export function evaluatePathConditions(
+  path: BranchPath,
+  cells: WorkbookCell[],
+  runtime?: BranchRuntimeContext,
+): boolean {
   if (path.conditions.length === 0) return false;
-  return path.conditions.every((cond) => evaluateCondition(cond, cells));
+  return path.conditions.every((cond) => evaluateCondition(cond, cells, runtime));
 }
 
-export function evaluateBranch(cell: BranchCell, cells: WorkbookCell[]): BranchPath | undefined {
+export function evaluateBranch(
+  cell: BranchCell,
+  cells: WorkbookCell[],
+  runtime?: BranchRuntimeContext,
+): BranchPath | undefined {
   for (const path of cell.paths) {
-    if (evaluatePathConditions(path, cells)) {
+    if (evaluatePathConditions(path, cells, runtime)) {
       return path;
     }
   }

--- a/packages/api/src/transforms/evaluate-branch.ts
+++ b/packages/api/src/transforms/evaluate-branch.ts
@@ -15,6 +15,8 @@ import { DEVICE_CONTEXT_KEY } from "./device-context";
  */
 export interface BranchRuntimeContext {
   device?: DeviceContext;
+  /** Host connection id used to scope upstream multi-device outputs. */
+  deviceId?: string;
 }
 
 /** True when any condition of the branch reads the reserved `$device` source. */
@@ -102,7 +104,7 @@ export function resolveConditionValue(
     return sourceCell.answer ?? undefined;
   }
 
-  const data = resolveOutputData(cells, sourceCellId);
+  const data = resolveOutputData(cells, sourceCellId, runtime?.deviceId);
   if (data == null) return undefined;
 
   const val = data[field];

--- a/packages/database/drizzle/0038_amazing_exiles.sql
+++ b/packages/database/drizzle/0038_amazing_exiles.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."sensor_family" ADD VALUE IF NOT EXISTS 'ambit';

--- a/packages/database/drizzle/meta/0038_snapshot.json
+++ b/packages/database/drizzle/meta/0038_snapshot.json
@@ -1,0 +1,2783 @@
+{
+  "id": "4d8f238f-e4d5-4fd6-8921-40e1f4c8aa8a",
+  "prevId": "6b6ee61f-d305-4cf7-9974-6c53b49cf54e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_dashboards": {
+      "name": "experiment_dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"columns\":12,\"rowHeight\":80,\"gap\":16}'::jsonb"
+        },
+        "widgets": {
+          "name": "widgets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "experiment_dashboards_experiment_id_idx": {
+          "name": "experiment_dashboards_experiment_id_idx",
+          "columns": [
+            {
+              "expression": "experiment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiment_dashboards_experiment_id_experiments_id_fk": {
+          "name": "experiment_dashboards_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_dashboards",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_dashboards_created_by_users_id_fk": {
+          "name": "experiment_dashboards_created_by_users_id_fk",
+          "tableFrom": "experiment_dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_join_requests": {
+      "name": "experiment_join_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "join_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "experiment_join_requests_pending_uniq": {
+          "name": "experiment_join_requests_pending_uniq",
+          "columns": [
+            {
+              "expression": "experiment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"experiment_join_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "experiment_join_requests_experiment_idx": {
+          "name": "experiment_join_requests_experiment_idx",
+          "columns": [
+            {
+              "expression": "experiment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiment_join_requests_experiment_id_experiments_id_fk": {
+          "name": "experiment_join_requests_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_join_requests",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_join_requests_user_id_users_id_fk": {
+          "name": "experiment_join_requests_user_id_users_id_fk",
+          "tableFrom": "experiment_join_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_join_requests_decided_by_users_id_fk": {
+          "name": "experiment_join_requests_decided_by_users_id_fk",
+          "tableFrom": "experiment_join_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_locations": {
+      "name": "experiment_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "numeric(10, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "numeric(11, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "municipality": {
+          "name": "municipality",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_label": {
+          "name": "address_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_locations_experiment_id_experiments_id_fk": {
+          "name": "experiment_locations_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_locations",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_members": {
+      "name": "experiment_members",
+      "schema": "",
+      "columns": {
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "experiment_members_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_members_experiment_id_experiments_id_fk": {
+          "name": "experiment_members_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_members",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "experiment_members_user_id_users_id_fk": {
+          "name": "experiment_members_user_id_users_id_fk",
+          "tableFrom": "experiment_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "experiment_members_experiment_id_user_id_pk": {
+          "name": "experiment_members_experiment_id_user_id_pk",
+          "columns": [
+            "experiment_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_visualizations": {
+      "name": "experiment_visualizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chart_family": {
+          "name": "chart_family",
+          "type": "chart_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chart_type": {
+          "name": "chart_type",
+          "type": "chart_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_config": {
+          "name": "data_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_visualizations_experiment_id_experiments_id_fk": {
+          "name": "experiment_visualizations_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_visualizations",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_visualizations_created_by_users_id_fk": {
+          "name": "experiment_visualizations_created_by_users_id_fk",
+          "tableFrom": "experiment_visualizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiments": {
+      "name": "experiments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "experiment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "experiment_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "embargo_until": {
+          "name": "embargo_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "((now() AT TIME ZONE 'UTC') + interval '90 days')"
+        },
+        "anonymize_contributors": {
+          "name": "anonymize_contributors",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "workbook_id": {
+          "name": "workbook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workbook_version_id": {
+          "name": "workbook_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(\"experiments\".\"name\", '')), 'A') || setweight(to_tsvector('english', coalesce(\"experiments\".\"description\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiments_workbook_id_workbooks_id_fk": {
+          "name": "experiments_workbook_id_workbooks_id_fk",
+          "tableFrom": "experiments",
+          "tableTo": "workbooks",
+          "columnsFrom": [
+            "workbook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "experiments_workbook_version_id_workbook_versions_id_fk": {
+          "name": "experiments_workbook_version_id_workbook_versions_id_fk",
+          "tableFrom": "experiments",
+          "tableTo": "workbook_versions",
+          "columnsFrom": [
+            "workbook_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "experiments_created_by_users_id_fk": {
+          "name": "experiments_created_by_users_id_fk",
+          "tableFrom": "experiments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "experiments_name_unique": {
+          "name": "experiments_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flows": {
+      "name": "flows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "flows_experiment_id_experiments_id_fk": {
+          "name": "flows_experiment_id_experiments_id_fk",
+          "tableFrom": "flows",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flows_experiment_id_unique": {
+          "name": "flows_experiment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "experiment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "invitation_resource_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_invited_by_users_id_fk": {
+          "name": "invitations_invited_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "resource_id_check": {
+          "name": "resource_id_check",
+          "value": "(\"invitations\".\"resource_type\" = 'platform' AND \"invitations\".\"resource_id\" IS NULL) OR (\"invitations\".\"resource_type\" != 'platform' AND \"invitations\".\"resource_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.iot_devices": {
+      "name": "iot_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thing_name": {
+          "name": "thing_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thing_arn": {
+          "name": "thing_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "sensor_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "certificate_id": {
+          "name": "certificate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_arn": {
+          "name": "certificate_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "iot_devices_created_by_idx": {
+          "name": "iot_devices_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "iot_devices_created_by_users_id_fk": {
+          "name": "iot_devices_created_by_users_id_fk",
+          "tableFrom": "iot_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "iot_devices_thing_name_unique": {
+          "name": "iot_devices_thing_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "thing_name"
+          ]
+        },
+        "iot_devices_serial_number_unique": {
+          "name": "iot_devices_serial_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "serial_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.macros": {
+      "name": "macros",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "macro_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forked_from": {
+          "name": "forked_from",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(\"macros\".\"name\", '')), 'A') || setweight(to_tsvector('english', coalesce(\"macros\".\"description\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "macros_created_by_users_id_fk": {
+          "name": "macros_created_by_users_id_fk",
+          "tableFrom": "macros",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "macros_forked_from_macros_id_fk": {
+          "name": "macros_forked_from_macros_id_fk",
+          "tableFrom": "macros",
+          "tableTo": "macros",
+          "columnsFrom": [
+            "forked_from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "macros_name_unique": {
+          "name": "macros_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "macros_filename_unique": {
+          "name": "macros_filename_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "filename"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_invitations": {
+      "name": "organization_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_invitations_organization_id_organizations_id_fk": {
+          "name": "organization_invitations_organization_id_organizations_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_inviter_id_users_id_fk": {
+          "name": "organization_invitations_inviter_id_users_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_team_id_teams_id_fk": {
+          "name": "organization_invitations_team_id_teams_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_members": {
+      "name": "organization_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "organization_members_org_user_uniq": {
+          "name": "organization_members_org_user_uniq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "organization_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated": {
+          "name": "activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whats_new_last_seen_at": {
+          "name": "whats_new_last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_user_id_users_id_fk": {
+          "name": "profiles_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_user_id_unique": {
+          "name": "profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.protocol_macros": {
+      "name": "protocol_macros",
+      "schema": "",
+      "columns": {
+        "protocol_id": {
+          "name": "protocol_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "macro_id": {
+          "name": "macro_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "protocol_macros_protocol_id_protocols_id_fk": {
+          "name": "protocol_macros_protocol_id_protocols_id_fk",
+          "tableFrom": "protocol_macros",
+          "tableTo": "protocols",
+          "columnsFrom": [
+            "protocol_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "protocol_macros_macro_id_macros_id_fk": {
+          "name": "protocol_macros_macro_id_macros_id_fk",
+          "tableFrom": "protocol_macros",
+          "tableTo": "macros",
+          "columnsFrom": [
+            "macro_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "protocol_macros_protocol_id_macro_id_pk": {
+          "name": "protocol_macros_protocol_id_macro_id_pk",
+          "columns": [
+            "protocol_id",
+            "macro_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.protocols": {
+      "name": "protocols",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "sensor_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forked_from": {
+          "name": "forked_from",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(\"protocols\".\"name\", '')), 'A') || setweight(to_tsvector('english', coalesce(\"protocols\".\"description\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "protocols_created_by_users_id_fk": {
+          "name": "protocols_created_by_users_id_fk",
+          "tableFrom": "protocols",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "protocols_forked_from_protocols_id_fk": {
+          "name": "protocols_forked_from_protocols_id_fk",
+          "tableFrom": "protocols",
+          "tableTo": "protocols",
+          "columnsFrom": [
+            "forked_from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "protocols_name_unique": {
+          "name": "protocols_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rate_limits_key_unique": {
+          "name": "rate_limits_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_team_id": {
+          "name": "active_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_organizations_id_fk": {
+          "name": "sessions_active_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_active_team_id_teams_id_fk": {
+          "name": "sessions_active_team_id_teams_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "active_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "team_members_team_user_uniq": {
+          "name": "team_members_team_user_uniq",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_members_user_idx": {
+          "name": "team_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "teams_organization_idx": {
+          "name": "teams_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_organization_id_organizations_id_fk": {
+          "name": "teams_organization_id_organizations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered": {
+          "name": "registered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workbook_versions": {
+      "name": "workbook_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workbook_id": {
+          "name": "workbook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cells": {
+          "name": "cells",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "entity_snapshots": {
+          "name": "entity_snapshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"protocols\":{},\"macros\":{}}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workbook_versions_workbook_id_idx": {
+          "name": "workbook_versions_workbook_id_idx",
+          "columns": [
+            {
+              "expression": "workbook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workbook_versions_workbook_id_workbooks_id_fk": {
+          "name": "workbook_versions_workbook_id_workbooks_id_fk",
+          "tableFrom": "workbook_versions",
+          "tableTo": "workbooks",
+          "columnsFrom": [
+            "workbook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workbook_versions_created_by_users_id_fk": {
+          "name": "workbook_versions_created_by_users_id_fk",
+          "tableFrom": "workbook_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workbook_versions_workbook_version_uniq": {
+          "name": "workbook_versions_workbook_version_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workbook_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workbooks": {
+      "name": "workbooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cells": {
+          "name": "cells",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forked_from": {
+          "name": "forked_from",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(\"workbooks\".\"name\", '')), 'A') || setweight(to_tsvector('english', coalesce(\"workbooks\".\"description\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "workbooks_created_by_idx": {
+          "name": "workbooks_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workbooks_created_by_users_id_fk": {
+          "name": "workbooks_created_by_users_id_fk",
+          "tableFrom": "workbooks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workbooks_forked_from_workbooks_id_fk": {
+          "name": "workbooks_forked_from_workbooks_id_fk",
+          "tableFrom": "workbooks",
+          "tableTo": "workbooks",
+          "columnsFrom": [
+            "forked_from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.chart_family": {
+      "name": "chart_family",
+      "schema": "public",
+      "values": [
+        "basic",
+        "scientific",
+        "3d",
+        "statistical"
+      ]
+    },
+    "public.chart_type": {
+      "name": "chart_type",
+      "schema": "public",
+      "values": [
+        "line",
+        "scatter",
+        "bar",
+        "pie",
+        "area",
+        "dot-plot",
+        "bubble",
+        "lollipop",
+        "box-plot",
+        "histogram",
+        "violin-plot",
+        "density-plot",
+        "ridge-plot",
+        "histogram-2d",
+        "density-plot-2d",
+        "spc-control-chart",
+        "heatmap",
+        "contour",
+        "carpet",
+        "ternary",
+        "parallel-coordinates",
+        "wind-rose",
+        "radar",
+        "polar",
+        "correlation-matrix",
+        "alluvial"
+      ]
+    },
+    "public.device_status": {
+      "name": "device_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "rotating",
+        "revoked"
+      ]
+    },
+    "public.experiment_members_role": {
+      "name": "experiment_members_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member"
+      ]
+    },
+    "public.experiment_status": {
+      "name": "experiment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "stale",
+        "archived",
+        "published"
+      ]
+    },
+    "public.experiment_visibility": {
+      "name": "experiment_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "public"
+      ]
+    },
+    "public.invitation_resource_type": {
+      "name": "invitation_resource_type",
+      "schema": "public",
+      "values": [
+        "platform",
+        "experiment"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "revoked"
+      ]
+    },
+    "public.join_request_status": {
+      "name": "join_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "cancelled"
+      ]
+    },
+    "public.macro_language": {
+      "name": "macro_language",
+      "schema": "public",
+      "values": [
+        "python",
+        "r",
+        "javascript"
+      ]
+    },
+    "public.organization_type": {
+      "name": "organization_type",
+      "schema": "public",
+      "values": [
+        "research_institute",
+        "non_profit",
+        "private_company",
+        "government_agency",
+        "university"
+      ]
+    },
+    "public.sensor_family": {
+      "name": "sensor_family",
+      "schema": "public",
+      "values": [
+        "multispeq",
+        "ambyte",
+        "minipar",
+        "generic",
+        "ambit"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1784036223478,
       "tag": "0037_last_doctor_spectrum",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1784153396518,
+      "tag": "0038_amazing_exiles",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -118,6 +118,7 @@ export const sensorFamilyEnum = pgEnum("sensor_family", [
   "ambyte",
   "minipar",
   "generic",
+  "ambit",
 ]);
 
 // Profiles Table

--- a/packages/iot/src/core/families.ts
+++ b/packages/iot/src/core/families.ts
@@ -1,0 +1,24 @@
+/**
+ * Sensor families identifiable over a local (serial/BLE) connection. Kept in
+ * sync by hand with `zSensorFamily` in @repo/api (schemas/protocol.schema.ts)
+ * and the `sensor_family` pg enum in @repo/database; @repo/iot stays
+ * dependency-free, so the list is duplicated rather than imported. "ambyte"
+ * is deliberately absent: it is an MQTT-only gateway, never connected locally.
+ */
+export const SENSOR_FAMILIES = ["multispeq", "ambit", "minipar", "generic"] as const;
+
+export type SensorFamily = (typeof SENSOR_FAMILIES)[number];
+
+export function isSensorFamily(value: unknown): value is SensorFamily {
+  return typeof value === "string" && (SENSOR_FAMILIES as readonly string[]).includes(value);
+}
+
+export interface DeviceIdentity {
+  family: SensorFamily;
+  name?: string;
+  deviceId?: string;
+  firmwareVersion?: string;
+  batteryPercent?: number;
+  /** Raw probe / device_info payload for display and debugging. */
+  raw: Record<string, unknown>;
+}

--- a/packages/iot/src/core/identify-device.spec.ts
+++ b/packages/iot/src/core/identify-device.spec.ts
@@ -145,7 +145,7 @@ describe("identifyDevice", () => {
     expect(identified.family).toBe("ambit");
     expect(identified.connector).toBeInstanceOf(AmbitDriver);
     expect(identified.info.family).toBe("ambit");
-    expect(identified.info.name).toBe("NEW Name Here");
+    expect(identified.info.name).toBeUndefined();
     expect(identified.info.raw.helloReply).toBe("NEW Name Here Ready");
   });
 

--- a/packages/iot/src/core/identify-device.spec.ts
+++ b/packages/iot/src/core/identify-device.spec.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { AmbitDriver } from "../driver/ambit/driver";
+import { GenericCommandConnector } from "../driver/generic/command-connector";
+import { GenericDeviceDriver } from "../driver/generic/driver";
+import { MiniParDriver } from "../driver/minipar/driver";
+import { MultispeqDriver } from "../driver/multispeq/driver";
+import type { ITransportAdapter } from "../transport/interface";
+import { createConnectorForFamily, identifyDevice } from "./identify-device";
+
+const HELLO = "hello\r\n";
+const INFO = '{"command":"INFO"}\n';
+
+const MULTISPEQ_DEVICE_INFO =
+  '{"device_name":"MultispeQ","device_version":"2","device_id":"aa:bb:cc:dd","device_battery":87,"device_firmware":"2.311"}CAFEBABE\n';
+
+type MockTransport = ITransportAdapter & {
+  simulateData: (data: string) => void;
+  sent: string[];
+};
+
+/**
+ * Mock transport with the concrete adapters' single-callback replace
+ * semantics. `onSend` can reply asynchronously (setTimeout 0) per payload.
+ */
+function createMockTransport(
+  onSend?: (payload: string, reply: (data: string) => void) => void,
+): MockTransport {
+  let dataCallback: ((data: string) => void) | undefined;
+  const sent: string[] = [];
+
+  return {
+    sent,
+    isConnected: vi.fn().mockReturnValue(true),
+    send: vi.fn((payload: string) => {
+      sent.push(payload);
+      onSend?.(payload, (data) => {
+        setTimeout(() => dataCallback?.(data), 0);
+      });
+      return Promise.resolve();
+    }),
+    onDataReceived: vi.fn((cb: (data: string) => void) => {
+      dataCallback = cb;
+    }),
+    onStatusChanged: vi.fn(),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    simulateData(data: string) {
+      dataCallback?.(data);
+    },
+  };
+}
+
+const GENERIC_INFO = {
+  device_name: "WeatherBox",
+  device_type: "sensor",
+  device_id: "wb-01",
+  firmware_version: "1.2.3",
+};
+
+/** An onSend handler answering the INFO probe with a success envelope. */
+const infoReply =
+  (data: Record<string, unknown>) => (payload: string, reply: (d: string) => void) => {
+    if (payload === INFO) reply(JSON.stringify({ status: "success", data }) + "\n");
+  };
+
+describe("identifyDevice", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("identifies a MultispeQ from the hello probe, enriches via device_info, and hands the transport over", async () => {
+    const transport = createMockTransport((payload, reply) => {
+      if (payload === HELLO) reply("MultispeQ Ready\n");
+      if (payload === "device_info\r\n") reply(MULTISPEQ_DEVICE_INFO);
+      if (payload === "temp\r\n") reply('{"t":21}ABCD1234\n');
+    });
+
+    const identified = await identifyDevice(transport, { probeTimeoutMs: 100 });
+
+    expect(identified.family).toBe("multispeq");
+    expect(identified.connector).toBeInstanceOf(MultispeqDriver);
+    expect(identified.info.family).toBe("multispeq");
+    expect(identified.info.name).toBe("MultispeQ");
+    expect(identified.info.deviceId).toBe("aa:bb:cc:dd");
+    expect(identified.info.firmwareVersion).toBe("2.311");
+    expect(identified.info.batteryPercent).toBe(87);
+    expect(identified.info.raw.helloReply).toBe("MultispeQ Ready");
+
+    // execute() round-trips through the driver framing on the same transport.
+    const result = await identified.connector.execute("temp");
+    expect(transport.sent).toContain("temp\r\n");
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ t: 21 });
+    expect(result.checksum).toBe("ABCD1234");
+  });
+
+  it("classifies older firmware's 'Instrument Ready' as multispeq", async () => {
+    const transport = createMockTransport((payload, reply) => {
+      if (payload === HELLO) reply("Instrument Ready\n");
+      if (payload === "device_info\r\n") reply(MULTISPEQ_DEVICE_INFO);
+    });
+
+    const identified = await identifyDevice(transport, { probeTimeoutMs: 100 });
+
+    expect(identified.family).toBe("multispeq");
+    expect(identified.connector).toBeInstanceOf(MultispeqDriver);
+  });
+
+  it("classifies the miniPAR JSON hello (no trailing newline) as minipar", async () => {
+    const transport = createMockTransport((payload, reply) => {
+      if (payload === HELLO) reply('{"device":"MiniPAR","version":"1.1"}');
+      if (payload === "hello\n") reply("MiniPAR,1.1,1.04\n");
+      if (payload === "get_name\n") reply("Bench PAR 2\n");
+    });
+
+    const identified = await identifyDevice(transport, { probeTimeoutMs: 50 });
+
+    expect(identified.family).toBe("minipar");
+    expect(identified.connector).toBeInstanceOf(MiniParDriver);
+    expect(identified.info.name).toBe("Bench PAR 2");
+    expect(identified.info.firmwareVersion).toBe("1.04");
+  });
+
+  it("classifies the miniPAR CSV hello as minipar with the firmware column", async () => {
+    const transport = createMockTransport((payload, reply) => {
+      if (payload === HELLO) reply("MiniPAR,1.1,1.04");
+      if (payload === "hello\n") reply("MiniPAR,1.1,1.04\n");
+      if (payload === "get_name\n") reply("NoName\n");
+    });
+
+    const identified = await identifyDevice(transport, { probeTimeoutMs: 50 });
+
+    expect(identified.family).toBe("minipar");
+    expect(identified.info.name).toBe("MiniPAR");
+    expect(identified.info.firmwareVersion).toBe("1.04");
+  });
+
+  it("classifies the Ambit '<name> Ready' hello as ambit and enriches through the AmbitDriver", async () => {
+    const transport = createMockTransport((payload, reply) => {
+      if (payload === HELLO || payload === "hello\n") reply("NEW Name Here Ready\n");
+    });
+
+    const identified = await identifyDevice(transport, { probeTimeoutMs: 50 });
+
+    expect(identified.family).toBe("ambit");
+    expect(identified.connector).toBeInstanceOf(AmbitDriver);
+    expect(identified.info.family).toBe("ambit");
+    expect(identified.info.name).toBe("NEW Name Here");
+    expect(identified.info.raw.helloReply).toBe("NEW Name Here Ready");
+  });
+
+  it("falls through to the INFO probe and picks the generic driver", async () => {
+    const transport = createMockTransport(infoReply(GENERIC_INFO));
+
+    const identified = await identifyDevice(transport, { probeTimeoutMs: 30 });
+
+    expect(identified.family).toBe("generic");
+    expect(identified.connector).toBeInstanceOf(GenericDeviceDriver);
+    expect(identified.info.name).toBe("WeatherBox");
+    expect(identified.info.deviceId).toBe("wb-01");
+    expect(identified.info.firmwareVersion).toBe("1.2.3");
+    expect(identified.info.raw).toMatchObject(GENERIC_INFO);
+    // Default retry: hello went out twice before INFO; the generic driver's
+    // initialize() then re-probes INFO, so the mock answered it twice.
+    expect(transport.sent.filter((p) => p === HELLO)).toHaveLength(2);
+    expect(transport.sent.filter((p) => p === INFO)).toHaveLength(2);
+  });
+
+  it("maps INFO device_type ambit onto the ambit family", async () => {
+    const answerInfo = infoReply({ ...GENERIC_INFO, device_type: "ambit" });
+    const transport = createMockTransport((payload, reply) => {
+      answerInfo(payload, reply);
+      if (payload === "hello\n") reply("NEW WeatherBox Ready\n");
+    });
+
+    const identified = await identifyDevice(transport, { probeTimeoutMs: 30 });
+
+    expect(identified.family).toBe("ambit");
+    expect(identified.info.family).toBe("ambit");
+    expect(identified.connector).toBeInstanceOf(AmbitDriver);
+  });
+
+  it("falls back to the raw GenericCommandConnector on total silence without throwing", async () => {
+    vi.useFakeTimers();
+    const transport = createMockTransport();
+
+    const promise = identifyDevice(transport);
+    // Default budgets: hello (2000), hello retry (2000), INFO (2000).
+    for (let i = 0; i < 3; i++) await vi.advanceTimersByTimeAsync(2000);
+
+    const identified = await promise;
+
+    expect(identified.family).toBe("generic");
+    expect(identified.connector).toBeInstanceOf(GenericCommandConnector);
+    expect(identified.info).toEqual({ family: "generic", raw: {} });
+    expect(transport.disconnect).not.toHaveBeenCalled();
+  });
+
+  it("ignores unclassifiable hello noise and moves on to the INFO probe", async () => {
+    const answerInfo = infoReply(GENERIC_INFO);
+    const transport = createMockTransport((payload, reply) => {
+      // Boot garbage matches no signature and never completes the hello probe
+      if (payload === HELLO) reply("$$boot-garbage");
+      answerInfo(payload, reply);
+    });
+
+    const identified = await identifyDevice(transport, { probeTimeoutMs: 30, helloRetries: 0 });
+
+    // Were the accumulator not reset, the garbage would corrupt the INFO line.
+    expect(identified.family).toBe("generic");
+    expect(identified.connector).toBeInstanceOf(GenericDeviceDriver);
+  });
+
+  it("sends nothing when assumeFamily is given; transport send errors propagate", async () => {
+    const transport = createMockTransport();
+
+    const identified = await identifyDevice(transport, { assumeFamily: "multispeq" });
+
+    expect(transport.send).not.toHaveBeenCalled();
+    expect(identified.family).toBe("multispeq");
+    expect(identified.connector).toBeInstanceOf(MultispeqDriver);
+    expect(identified.info).toEqual({ family: "multispeq", raw: {} });
+    // The connector still took over the transport
+    expect(transport.onDataReceived).toHaveBeenCalled();
+
+    vi.mocked(transport.send).mockRejectedValue(new Error("port closed"));
+    await expect(identifyDevice(transport)).rejects.toThrow("port closed");
+    expect(transport.disconnect).not.toHaveBeenCalled();
+  });
+
+  it("retries a silent hello before giving up on multispeq", async () => {
+    let helloCount = 0;
+    const transport = createMockTransport((payload, reply) => {
+      if (payload === HELLO) {
+        helloCount++;
+        // Silent first attempt; answers from the retry onwards.
+        if (helloCount >= 2) reply("Instrument Ready\n");
+      }
+      if (payload === "device_info\r\n") reply(MULTISPEQ_DEVICE_INFO);
+    });
+
+    const identified = await identifyDevice(transport, { probeTimeoutMs: 30 });
+
+    expect(identified.family).toBe("multispeq");
+    expect(transport.sent[0]).toBe(HELLO);
+    expect(transport.sent[1]).toBe(HELLO);
+    expect(identified.info.batteryPercent).toBe(87);
+  });
+});
+
+describe("createConnectorForFamily", () => {
+  it("builds the concrete connector per family and stamps it with that family", () => {
+    expect(createConnectorForFamily("multispeq")).toBeInstanceOf(MultispeqDriver);
+    expect(createConnectorForFamily("ambit")).toBeInstanceOf(AmbitDriver);
+    expect(createConnectorForFamily("minipar")).toBeInstanceOf(MiniParDriver);
+    const generic = createConnectorForFamily("generic");
+    expect(generic).toBeInstanceOf(GenericDeviceDriver);
+    expect(generic).not.toBeInstanceOf(GenericCommandConnector);
+    for (const family of ["multispeq", "ambit", "minipar", "generic"] as const) {
+      expect(createConnectorForFamily(family).family).toBe(family);
+    }
+  });
+});

--- a/packages/iot/src/core/identify-device.ts
+++ b/packages/iot/src/core/identify-device.ts
@@ -1,0 +1,277 @@
+/**
+ * Device identification: probe an unidentified transport for a known sensor
+ * family and hand off to the matching connector. Never throws for silence;
+ * only transport send errors propagate. The transport is never disconnected.
+ */
+import { AmbitDriver } from "../driver/ambit/driver";
+import type { IDeviceDriver } from "../driver/driver-base";
+import { GenericCommandConnector } from "../driver/generic/command-connector";
+import { GenericDeviceDriver } from "../driver/generic/driver";
+import { MiniParDriver } from "../driver/minipar/driver";
+import { MultispeqDriver } from "../driver/multispeq/driver";
+import type { ITransportAdapter } from "../transport/interface";
+import type { Logger } from "../utils/logger/logger";
+import { defaultLogger } from "../utils/logger/logger";
+import type { DeviceIdentity, SensorFamily } from "./families";
+import { isSensorFamily } from "./families";
+
+export interface IdentifyDeviceOptions {
+  /** Per-probe reply timeout in ms (default 2000). */
+  probeTimeoutMs?: number;
+  /** Extra hello attempts after a silent first one (default 1). */
+  helloRetries?: number;
+  /** Skip probing entirely and connect as this family. */
+  assumeFamily?: SensorFamily;
+  logger?: Logger;
+}
+
+export interface IdentifiedDevice {
+  family: SensorFamily;
+  info: DeviceIdentity;
+  connector: IDeviceDriver;
+}
+
+const HELLO_PROBE = "hello\r\n";
+const INFO_PROBE = '{"command":"INFO"}\n';
+const DEFAULT_PROBE_TIMEOUT_MS = 2000;
+const DEFAULT_HELLO_RETRIES = 1;
+
+/** Instantiate the concrete connector for a known sensor family. */
+export function createConnectorForFamily(family: SensorFamily, logger?: Logger): IDeviceDriver {
+  switch (family) {
+    case "multispeq":
+      return new MultispeqDriver(logger);
+    case "ambit":
+      return new AmbitDriver(undefined, logger);
+    case "minipar":
+      return new MiniParDriver(undefined, logger);
+    case "generic":
+      return new GenericDeviceDriver(undefined, logger);
+  }
+}
+
+interface ProbeOptions {
+  timeoutMs: number;
+  isComplete: (buffer: string) => boolean;
+}
+
+/**
+ * Serial probe session over the transport's single data callback (concrete
+ * adapters use replace semantics, so the handoff connector's initialize()
+ * later displaces this listener). Resolves the buffered text once complete;
+ * on timeout it resolves whatever arrived (possibly ""), since some devices
+ * (miniPAR hello) reply without a trailing newline. Only send errors throw.
+ */
+function createProbeSession(transport: ITransportAdapter) {
+  let buffer = "";
+  let onChunk: (() => void) | undefined;
+  transport.onDataReceived((chunk) => {
+    buffer += chunk;
+    onChunk?.();
+  });
+
+  return async function probe(payload: string, options: ProbeOptions): Promise<string> {
+    buffer = "";
+    await transport.send(payload);
+    if (options.isComplete(buffer)) return buffer;
+    return new Promise<string>((resolve) => {
+      const timer = setTimeout(() => {
+        onChunk = undefined;
+        resolve(buffer);
+      }, options.timeoutMs);
+      onChunk = () => {
+        if (!options.isComplete(buffer)) return;
+        clearTimeout(timer);
+        onChunk = undefined;
+        resolve(buffer);
+      };
+    });
+  };
+}
+
+/**
+ * Classify a hello reply against the known firmware signatures, weakest
+ * signature last:
+ *  - miniPAR: `{"device":"MiniPAR","version":"1.1"}` (JSON mode) or
+ *    `MiniPAR,1.1,1.04` (line mode)
+ *  - MultispeQ: `MultispeQ Ready`, older firmware `Instrument Ready`
+ *  - Ambit: any other `<name> Ready` line (firmware prints a hardcoded
+ *    `NEW Name Here Ready`; never trust the name, only the sentinel)
+ */
+function classifyHelloReply(reply: string): DeviceIdentity | null {
+  const text = reply.trim();
+  if (!text) return null;
+  const raw = { helloReply: text };
+
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (
+        parsed !== null &&
+        typeof parsed === "object" &&
+        typeof (parsed as Record<string, unknown>).device === "string" &&
+        /minipar/i.test((parsed as Record<string, unknown>).device as string)
+      ) {
+        const version = (parsed as Record<string, unknown>).version;
+        return {
+          family: "minipar",
+          name: (parsed as Record<string, unknown>).device as string,
+          firmwareVersion: typeof version === "string" ? version : undefined,
+          raw,
+        };
+      }
+    } catch {
+      // not JSON, keep scanning
+    }
+  }
+
+  const csvMatch = /^minipar\s*,\s*([^,\s]+)\s*(?:,\s*([^,\s]+))?/im.exec(text);
+  if (csvMatch) {
+    return {
+      family: "minipar",
+      name: "MiniPAR",
+      firmwareVersion: csvMatch.at(2) ?? csvMatch.at(1),
+      raw,
+    };
+  }
+
+  if (/multispeq/i.test(text) || /instrument\s+ready/i.test(text)) {
+    return { family: "multispeq", raw };
+  }
+
+  const readyMatch = /^(.*?)\s*\bready\b\s*$/im.exec(text);
+  if (readyMatch) {
+    const name = readyMatch[1].trim();
+    return { family: "ambit", name: name === "" ? undefined : name, raw };
+  }
+
+  return null;
+}
+
+/** First buffered line that parses to an object with a "status" key, if any. */
+function parseInfoReply(buffer: string): Record<string, unknown> | null {
+  for (const line of buffer.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (parsed !== null && typeof parsed === "object" && "status" in parsed) {
+        return parsed;
+      }
+    } catch {
+      // not JSON, keep scanning
+    }
+  }
+  return null;
+}
+
+/**
+ * Best-effort getDeviceIdentity() merged over the probe identity. The probe
+ * classification stays the family of record: fallback connectors self-report
+ * "generic" and must not overwrite a probe-resolved family.
+ */
+async function enrichIdentity(
+  connector: IDeviceDriver,
+  probeIdentity: DeviceIdentity,
+): Promise<DeviceIdentity> {
+  if (!connector.getDeviceIdentity) return probeIdentity;
+  try {
+    const enriched = await connector.getDeviceIdentity();
+    return {
+      family: probeIdentity.family,
+      name: enriched.name ?? probeIdentity.name,
+      deviceId: enriched.deviceId ?? probeIdentity.deviceId,
+      firmwareVersion: enriched.firmwareVersion ?? probeIdentity.firmwareVersion,
+      batteryPercent: enriched.batteryPercent ?? probeIdentity.batteryPercent,
+      raw: { ...probeIdentity.raw, ...enriched.raw },
+    };
+  } catch {
+    return probeIdentity;
+  }
+}
+
+/**
+ * Probe the transport for a known family (console "hello" signatures, then
+ * the generic JSON INFO contract) and hand off to the matching connector.
+ * Both probes silent means the raw GenericCommandConnector fallback.
+ */
+export async function identifyDevice(
+  transport: ITransportAdapter,
+  options?: IdentifyDeviceOptions,
+): Promise<IdentifiedDevice> {
+  const log = options?.logger ?? defaultLogger;
+
+  if (options?.assumeFamily) {
+    const connector = createConnectorForFamily(options.assumeFamily, options.logger);
+    await connector.initialize(transport);
+    return {
+      family: options.assumeFamily,
+      info: { family: options.assumeFamily, raw: {} },
+      connector,
+    };
+  }
+
+  const timeoutMs = options?.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+  const helloRetries = options?.helloRetries ?? DEFAULT_HELLO_RETRIES;
+  const probe = createProbeSession(transport);
+
+  let probeIdentity: DeviceIdentity | undefined;
+  let connector: IDeviceDriver | undefined;
+
+  // Probe 1: every known console firmware answers "hello" with a signature.
+  for (let attempt = 0; attempt <= helloRetries; attempt++) {
+    const reply = await probe(HELLO_PROBE, {
+      timeoutMs,
+      isComplete: (buffer) => buffer.includes("\n") || classifyHelloReply(buffer) !== null,
+    });
+    if (reply.trim() === "") continue;
+    const classified = classifyHelloReply(reply);
+    if (classified) {
+      log.debug("identify: hello probe matched", { family: classified.family });
+      probeIdentity = classified;
+      connector = createConnectorForFamily(classified.family, options?.logger);
+    }
+    break;
+  }
+
+  // Probe 2: the openJII generic JSON contract answers INFO with a status object.
+  if (!connector) {
+    const reply = await probe(INFO_PROBE, {
+      timeoutMs,
+      isComplete: (buffer) => parseInfoReply(buffer) !== null,
+    });
+    const parsed = parseInfoReply(reply);
+    if (parsed) {
+      const data =
+        parsed.data !== null && typeof parsed.data === "object"
+          ? (parsed.data as Record<string, unknown>)
+          : {};
+      const family: SensorFamily = isSensorFamily(data.device_type) ? data.device_type : "generic";
+      log.debug("identify: INFO probe matched", { family });
+      probeIdentity = {
+        family,
+        name: typeof data.device_name === "string" ? data.device_name : undefined,
+        deviceId: typeof data.device_id === "string" ? data.device_id : undefined,
+        firmwareVersion:
+          typeof data.firmware_version === "string" ? data.firmware_version : undefined,
+        raw: data,
+      };
+      connector = createConnectorForFamily(family, options?.logger);
+    }
+  }
+
+  // Both probes silent: last-resort verbatim connector.
+  if (!connector || !probeIdentity) {
+    log.debug("identify: probes silent, falling back to raw command connector");
+    probeIdentity = { family: "generic", raw: {} };
+    connector = new GenericCommandConnector(undefined, options?.logger);
+  }
+
+  // Handoff: initialize() re-registers onDataReceived, replacing the probe listener.
+  await connector.initialize(transport);
+
+  const info = await enrichIdentity(connector, probeIdentity);
+  return { family: info.family, info, connector };
+}

--- a/packages/iot/src/core/identify-device.ts
+++ b/packages/iot/src/core/identify-device.ts
@@ -143,8 +143,10 @@ function classifyHelloReply(reply: string): DeviceIdentity | null {
 
   const readyMatch = /^(.*?)\s*\bready\b\s*$/im.exec(text);
   if (readyMatch) {
-    const name = readyMatch[1].trim();
-    return { family: "ambit", name: name === "" ? undefined : name, raw };
+    // Ambit firmware currently hardcodes the text before "Ready".  It is a
+    // family signature, not a device name, so do not leak the placeholder into
+    // $device.name.
+    return { family: "ambit", raw };
   }
 
   return null;

--- a/packages/iot/src/core/identify-device.ts
+++ b/packages/iot/src/core/identify-device.ts
@@ -127,12 +127,14 @@ function classifyHelloReply(reply: string): DeviceIdentity | null {
     }
   }
 
-  const csvMatch = /^minipar\s*,\s*([^,\s]+)\s*(?:,\s*([^,\s]+))?/im.exec(text);
+  const csvMatch = /^minipar\s*,\s*(?<version>[^,\s]+)\s*(?:,\s*(?<firmware>[^,\s]+))?/im.exec(
+    text,
+  );
   if (csvMatch) {
     return {
       family: "minipar",
       name: "MiniPAR",
-      firmwareVersion: csvMatch[2] ?? csvMatch[1],
+      firmwareVersion: csvMatch.groups?.firmware ?? csvMatch.groups?.version,
       raw,
     };
   }

--- a/packages/iot/src/core/identify-device.ts
+++ b/packages/iot/src/core/identify-device.ts
@@ -132,7 +132,7 @@ function classifyHelloReply(reply: string): DeviceIdentity | null {
     return {
       family: "minipar",
       name: "MiniPAR",
-      firmwareVersion: csvMatch.at(2) ?? csvMatch.at(1),
+      firmwareVersion: csvMatch[2] ?? csvMatch[1],
       raw,
     };
   }

--- a/packages/iot/src/core/types.ts
+++ b/packages/iot/src/core/types.ts
@@ -20,7 +20,7 @@ export type TransportType = "bluetooth-classic" | "ble" | "usb" | "web-bluetooth
 export type TransportCategory = "bluetooth" | "serial";
 
 /** Supported device types */
-export type DeviceType = "multispeq" | "generic";
+export type DeviceType = "multispeq" | "ambit" | "minipar" | "generic";
 
 /** Transport support declaration for a device type */
 export interface DeviceTransportSupport {
@@ -51,6 +51,18 @@ export const DEVICE_TRANSPORT_SUPPORT: Record<DeviceType, DeviceTransportSupport
     supportedTransports: ["serial"],
     supportsBLE: false,
     supportsBluetoothClassic: true,
+  },
+  // Ambit and MiniPAR are ESP32 sensors that expose only a USB-CDC serial
+  // console to hosts (the Ambit's radio talks to its Ambyte gateway, not us).
+  ambit: {
+    supportedTransports: ["serial"],
+    supportsBLE: false,
+    supportsBluetoothClassic: false,
+  },
+  minipar: {
+    supportedTransports: ["serial"],
+    supportsBLE: false,
+    supportsBluetoothClassic: false,
   },
   generic: {
     supportedTransports: ["bluetooth", "serial"],

--- a/packages/iot/src/driver/ambit/commands.ts
+++ b/packages/iot/src/driver/ambit/commands.ts
@@ -1,0 +1,51 @@
+/**
+ * Ambit console commands, sourced from the firmware's `do_command.h`
+ * (Jan-IngenHousz-Institute/ambit-iot) and the ambit-Calibratron bench tool.
+ * The text console is the only host-facing contract; the binary UART protocol
+ * (cmd 33 GET_INFO, arrun traces) is Ambyte-gateway-facing and out of scope.
+ */
+
+// prettier-ignore
+export const AMBIT_COMMANDS = {
+  // Connection / status
+  HELLO:     "hello",     // "NEW <name> Ready" (name hardcoded in firmware)
+  CHECK:     "check",     // multi-line hardware diagnostics
+  REBOOT:    "reboot",    // ESP.restart(); boot log + config dump follows
+  CLEAN_NVS: "clean_nvs", // wipe persisted calibration ("NVS cleaned")
+
+  // Measurements
+  GET_PAR:   "get_par",   // raw PAR float, then 10 CSV spectral channels
+  PAR:       "PAR",       // calibrated PAR (raw x spec coeff), then channels
+  TEMP:      "temp",      // "obj\tamb\tobj_r" (MLX90632, 3 floats)
+
+  // Calibration writers (persist to NVS; the firmware replies NOTHING)
+  SET_SPEC:  "set_spec",  // set_spec,<float>  PAR gain
+  SET_ACT:   "set_act",   // set_act,<float>   actinic LED gain
+  SET_EMIT:  "set_emit",  // set_emit,<float>
+  SET_NAME:  "set_name",  // set_name,<string <=15>
+} as const;
+
+/**
+ * Commands whose reply is silence: fire, settle, then re-verify with hello.
+ * Matched by prefix so `set_spec,1.234` hits `set_spec`.
+ */
+export const AMBIT_SILENT_COMMANDS: readonly string[] = [
+  AMBIT_COMMANDS.SET_SPEC,
+  AMBIT_COMMANDS.SET_ACT,
+  AMBIT_COMMANDS.SET_EMIT,
+  AMBIT_COMMANDS.SET_NAME,
+];
+
+/** Per-command overrides where the default quiet window / timeout is wrong. */
+export const AMBIT_COMMAND_OVERRIDES: Record<
+  string,
+  { quietWindowMs?: number; timeoutMs?: number }
+> = {
+  // Diagnostics and reboot dumps pause mid-output for longer than the
+  // default window while sensors are probed / the chip restarts.
+  [AMBIT_COMMANDS.CHECK]: { quietWindowMs: 1_000, timeoutMs: 15_000 },
+  [AMBIT_COMMANDS.REBOOT]: { quietWindowMs: 1_500, timeoutMs: 20_000 },
+};
+
+/** Firmware's reply to a command its hash switch does not know. */
+export const AMBIT_BAD_COMMAND = "BAD COMMAND";

--- a/packages/iot/src/driver/ambit/config.ts
+++ b/packages/iot/src/driver/ambit/config.ts
@@ -1,0 +1,35 @@
+/** Ambit serial defaults (ESP32 USB-CDC console). */
+export const AMBIT_SERIAL_DEFAULTS = {
+  baudRate: 115200,
+  dataBits: 8,
+  stopBits: 1,
+  parity: "none",
+} as const;
+
+export const AMBIT_FRAMING = {
+  /** Firmware reads command args with ~10ms timeouts; send everything in ONE write. */
+  LINE_ENDING: "\n",
+  /**
+   * Replies have no framing at all, so a reply is "complete" after this much
+   * RX silence. Long dumps (check, reboot) override per command.
+   */
+  QUIET_WINDOW_MS: 300,
+  /** Overall per-command reply timeout. */
+  DEFAULT_TIMEOUT: 5_000,
+  /** Settle delay after a silent writer before the hello re-verify. */
+  SETTLE_MS: 200,
+  /** Wake handshake: poll hello until the reply carries the ready sentinel. */
+  WAKE_RETRIES: 10,
+  WAKE_INTERVAL_MS: 100,
+  /** The firmware light-sleeps ~30s after console traffic stops. */
+  SLEEP_AFTER_IDLE_MS: 20_000,
+  /** `hello` replies `NEW <name> Ready`; the name is firmware-hardcoded, never trust it. */
+  READY_SENTINEL: "NEW",
+} as const;
+
+export interface AmbitDriverConfig {
+  /** Overall per-command reply timeout in ms (default 5000). */
+  timeoutMs?: number;
+  /** RX quiet window in ms that completes an unframed reply (default 300). */
+  quietWindowMs?: number;
+}

--- a/packages/iot/src/driver/ambit/driver.spec.ts
+++ b/packages/iot/src/driver/ambit/driver.spec.ts
@@ -128,13 +128,24 @@ describe("AmbitDriver", () => {
     expect(result.data).toBe("OK sensors");
   });
 
-  it("getDeviceIdentity captures the name before the Ready sentinel", async () => {
+  it("does not expose the firmware's hardcoded hello placeholder as a device name", async () => {
     const transport = tableTransport({ "hello\n": HELLO_REPLY });
     const driver = fastDriver();
     await driver.initialize(transport);
 
     const identity = await driver.getDeviceIdentity();
-    expect(identity).toMatchObject({ family: "ambit", name: "NEW Name Here" });
+    expect(identity).toEqual({ family: "ambit", raw: { helloReply: HELLO_REPLY.trim() } });
+  });
+
+  it("clears buffered state and disconnects when destroyed", async () => {
+    const transport = tableTransport({ "hello\n": HELLO_REPLY });
+    const driver = fastDriver();
+    await driver.initialize(transport);
+
+    await driver.destroy();
+
+    expect(transport.disconnect).toHaveBeenCalledOnce();
+    await expect(driver.execute("hello")).rejects.toThrow(/not initialized/);
   });
 
   it("times out with an error when a reply-carrying command stays silent", async () => {

--- a/packages/iot/src/driver/ambit/driver.spec.ts
+++ b/packages/iot/src/driver/ambit/driver.spec.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import type { MockTransport } from "../testing/mock-transport";
+import { createMockTransport } from "../testing/mock-transport";
+import { AmbitDriver } from "./driver";
+
+const HELLO_REPLY = "NEW Name Here Ready\n";
+
+/** Reply table keyed by the exact payload sent; missing entries stay silent. */
+function tableTransport(table: Partial<Record<string, string | string[]>>): MockTransport {
+  const transport = createMockTransport();
+  vi.mocked(transport.send).mockImplementation((payload: string) => {
+    const reply = table[payload];
+    if (reply !== undefined) {
+      const chunks = Array.isArray(reply) ? reply : [reply];
+      setTimeout(() => {
+        for (const chunk of chunks) transport.simulateData(chunk);
+      }, 0);
+    }
+    return Promise.resolve();
+  });
+  return transport;
+}
+
+/** Fast windows so quiet-window waits do not slow the suite down. */
+function fastDriver(): AmbitDriver {
+  return new AmbitDriver({ quietWindowMs: 20, timeoutMs: 500 });
+}
+
+describe("AmbitDriver", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("wakes the device during initialize and exposes the ambit family", async () => {
+    const transport = tableTransport({ "hello\n": HELLO_REPLY });
+    const driver = fastDriver();
+    await driver.initialize(transport);
+
+    expect(driver.family).toBe("ambit");
+    expect(vi.mocked(transport.send).mock.calls[0][0]).toBe("hello\n");
+  });
+
+  it("rejects protocol JSON with a command-cell hint", async () => {
+    const transport = tableTransport({ "hello\n": HELLO_REPLY });
+    const driver = fastDriver();
+    await driver.initialize(transport);
+
+    const result = await driver.execute([{ set: [] }]);
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/command cell/);
+  });
+
+  it("parses the two-line get_par reply into par + channels", async () => {
+    const transport = tableTransport({
+      "hello\n": HELLO_REPLY,
+      "get_par\n": ["123.4\n", "415,388,402,390,377,365,401,388,352,343\n"],
+    });
+    const driver = fastDriver();
+    await driver.initialize(transport);
+
+    const result = await driver.execute<{ par: number; channels: number[] }>("get_par");
+    expect(result.success).toBe(true);
+    expect(result.data?.par).toBeCloseTo(123.4);
+    expect(result.data?.channels).toHaveLength(10);
+  });
+
+  it("parses the tab-separated temp reply", async () => {
+    const transport = tableTransport({
+      "hello\n": HELLO_REPLY,
+      "temp\n": "23.1\t22.4\t23.0\n",
+    });
+    const driver = fastDriver();
+    await driver.initialize(transport);
+
+    const result = await driver.execute<Record<string, number>>("temp");
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ objectC: 23.1, ambientC: 22.4, objectRawC: 23.0 });
+  });
+
+  it("treats a silent set_spec as fire + settle + hello re-verify, in one write", async () => {
+    const transport = tableTransport({ "hello\n": HELLO_REPLY });
+    const driver = fastDriver();
+    await driver.initialize(transport);
+
+    const result = await driver.execute("set_spec,1.2340");
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({ acknowledged: "set_spec" });
+    // Multi-arg command went out as ONE write (firmware arg timeouts are 10ms).
+    expect(transport.send).toHaveBeenCalledWith("set_spec,1.2340\n");
+  });
+
+  it("fails a silent writer when the hello re-verify stays silent", async () => {
+    const transport = tableTransport({ "hello\n": HELLO_REPLY });
+    const driver = fastDriver();
+    await driver.initialize(transport);
+    // After init, only set_name's verify hello goes unanswered.
+    vi.mocked(transport.send).mockImplementation(() => Promise.resolve());
+
+    const result = await driver.execute("set_name,bench-3");
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/Response timeout|did not acknowledge/);
+  });
+
+  it("surfaces BAD COMMAND as a command error", async () => {
+    const transport = tableTransport({
+      "hello\n": HELLO_REPLY,
+      "frobnicate\n": "BAD COMMAND\n",
+    });
+    const driver = fastDriver();
+    await driver.initialize(transport);
+
+    const result = await driver.execute("frobnicate");
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/rejected/);
+  });
+
+  it("strips non-ASCII idle bytes from replies", async () => {
+    const transport = tableTransport({
+      "hello\n": HELLO_REPLY,
+      "check\n": "ÿOK sensors\n",
+    });
+    const driver = new AmbitDriver({ quietWindowMs: 20, timeoutMs: 500 });
+    await driver.initialize(transport);
+
+    const result = await driver.execute<string>("check", { timeoutMs: 500 });
+    expect(result.success).toBe(true);
+    expect(result.data).toBe("OK sensors");
+  });
+
+  it("getDeviceIdentity captures the name before the Ready sentinel", async () => {
+    const transport = tableTransport({ "hello\n": HELLO_REPLY });
+    const driver = fastDriver();
+    await driver.initialize(transport);
+
+    const identity = await driver.getDeviceIdentity();
+    expect(identity).toMatchObject({ family: "ambit", name: "NEW Name Here" });
+  });
+
+  it("times out with an error when a reply-carrying command stays silent", async () => {
+    const transport = tableTransport({ "hello\n": HELLO_REPLY });
+    const driver = new AmbitDriver({ quietWindowMs: 20, timeoutMs: 60 });
+    await driver.initialize(transport);
+
+    const result = await driver.execute("temp");
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toBe("Response timeout");
+  });
+});

--- a/packages/iot/src/driver/ambit/driver.spec.ts
+++ b/packages/iot/src/driver/ambit/driver.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+import { DEFAULT_MAX_BUFFER_SIZE } from "../driver-base";
 import type { MockTransport } from "../testing/mock-transport";
 import { createMockTransport } from "../testing/mock-transport";
 import { AmbitDriver } from "./driver";
@@ -39,6 +40,35 @@ describe("AmbitDriver", () => {
 
     expect(driver.family).toBe("ambit");
     expect(vi.mocked(transport.send).mock.calls[0][0]).toBe("hello\n");
+  });
+
+  it("keeps initialization best-effort when every wake attempt times out", async () => {
+    vi.useFakeTimers();
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const driver = new AmbitDriver({ quietWindowMs: 20, timeoutMs: 60 }, logger);
+    const initialize = driver.initialize(tableTransport({}));
+
+    await vi.runAllTimersAsync();
+    await initialize;
+
+    expect(logger.warn).toHaveBeenCalledWith("Ambit wake handshake failed during initialize");
+  });
+
+  it("discards an oversized receive buffer and emits its size", async () => {
+    const transport = tableTransport({ "hello\n": HELLO_REPLY });
+    const driver = fastDriver();
+    const overflow = vi.fn();
+    driver.on("bufferOverflow", overflow);
+    await driver.initialize(transport);
+
+    transport.simulateData("x".repeat(DEFAULT_MAX_BUFFER_SIZE + 1));
+
+    expect(overflow).toHaveBeenCalledWith({ discardedBytes: DEFAULT_MAX_BUFFER_SIZE + 1 });
   });
 
   it("rejects protocol JSON with a command-cell hint", async () => {
@@ -102,6 +132,25 @@ describe("AmbitDriver", () => {
     expect(result.error?.message).toMatch(/Response timeout|did not acknowledge/);
   });
 
+  it("fails a silent writer when hello replies without the ready sentinel", async () => {
+    const transport = createMockTransport();
+    let helloCalls = 0;
+    vi.mocked(transport.send).mockImplementation((payload: string) => {
+      if (payload === "hello\n") {
+        const reply = helloCalls++ === 0 ? HELLO_REPLY : "awake\n";
+        setTimeout(() => transport.simulateData(reply), 0);
+      }
+      return Promise.resolve();
+    });
+    const driver = fastDriver();
+    await driver.initialize(transport);
+
+    const result = await driver.execute("set_name,bench-3");
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/did not acknowledge set_name/);
+  });
+
   it("surfaces BAD COMMAND as a command error", async () => {
     const transport = tableTransport({
       "hello\n": HELLO_REPLY,
@@ -126,6 +175,38 @@ describe("AmbitDriver", () => {
     const result = await driver.execute<string>("check", { timeoutMs: 500 });
     expect(result.success).toBe(true);
     expect(result.data).toBe("OK sensors");
+  });
+
+  it("runs the wake handshake again after the console has idled", async () => {
+    const transport = tableTransport({
+      "hello\n": HELLO_REPLY,
+      "temp\n": "23.1\t22.4\t23.0\n",
+    });
+    const driver = fastDriver();
+    await driver.initialize(transport);
+    vi.mocked(transport.send).mockClear();
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + 30_000);
+
+    const result = await driver.execute("temp");
+
+    expect(result.success).toBe(true);
+    expect(vi.mocked(transport.send).mock.calls.map(([payload]) => payload)).toEqual([
+      "hello\n",
+      "temp\n",
+    ]);
+  });
+
+  it("returns a partial unframed reply at the overall timeout", async () => {
+    const transport = tableTransport({
+      "hello\n": HELLO_REPLY,
+      "check\n": "partial diagnostics",
+    });
+    const driver = new AmbitDriver({ quietWindowMs: 1_000, timeoutMs: 60 });
+    await driver.initialize(transport);
+
+    const result = await driver.execute<string>("check", { timeoutMs: 60 });
+
+    expect(result).toEqual({ success: true, data: "partial diagnostics" });
   });
 
   it("does not expose the firmware's hardcoded hello placeholder as a device name", async () => {

--- a/packages/iot/src/driver/ambit/driver.ts
+++ b/packages/iot/src/driver/ambit/driver.ts
@@ -1,0 +1,241 @@
+/**
+ * Ambit driver: plain-text serial console, command/response only.
+ *
+ * The firmware has NO reply framing (free-text lines, silent writers, no
+ * terminator), so replies are collected until an RX quiet window elapses.
+ * The device light-sleeps after console idle and prints a wake byte >127;
+ * `initialize()`/`ensureAwake()` run the Calibratron-style hello poll until
+ * the `NEW ... Ready` sentinel answers. Protocol JSON is rejected outright:
+ * an Ambit measures via its Ambyte gateway, a direct session is for
+ * calibration commands and spot readings.
+ */
+import type { DeviceIdentity, SensorFamily } from "../../core/families";
+import type { ITransportAdapter } from "../../transport/interface";
+import type { Logger } from "../../utils/logger/logger";
+import { DeviceDriver } from "../driver-base";
+import type { CommandResult, ExecuteOptions } from "../driver-base";
+import {
+  AMBIT_BAD_COMMAND,
+  AMBIT_COMMANDS,
+  AMBIT_COMMAND_OVERRIDES,
+  AMBIT_SILENT_COMMANDS,
+} from "./commands";
+import { AMBIT_FRAMING } from "./config";
+import type { AmbitDriverConfig } from "./config";
+import type { AmbitStreamEvents } from "./interface";
+import { AMBIT_REPLY_PARSERS } from "./response-parsers";
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class AmbitDriver extends DeviceDriver<AmbitStreamEvents> {
+  override readonly family: SensorFamily = "ambit";
+
+  private readonly defaultTimeoutMs: number;
+  private readonly quietWindowMs: number;
+
+  private rxBuffer = "";
+  private onChunk: (() => void) | undefined;
+  private lastTrafficAt = 0;
+
+  constructor(config?: AmbitDriverConfig, logger?: Logger) {
+    super(logger);
+    this.defaultTimeoutMs = config?.timeoutMs ?? AMBIT_FRAMING.DEFAULT_TIMEOUT;
+    this.quietWindowMs = config?.quietWindowMs ?? AMBIT_FRAMING.QUIET_WINDOW_MS;
+  }
+
+  override async initialize(transport: ITransportAdapter): Promise<void> {
+    await super.initialize(transport);
+    this.rxBuffer = "";
+    transport.onDataReceived((data) => this.handleDataReceived(data));
+
+    // Best-effort wake so the first real command does not race the sleep
+    // loop; a failure surfaces on that first command instead of here.
+    try {
+      await this.wake();
+    } catch {
+      this.log.warn("Ambit wake handshake failed during initialize");
+    }
+  }
+
+  private handleDataReceived(data: string): void {
+    // The sleep loop emits non-ASCII idle/boot bytes; strip them before they
+    // corrupt a reply.
+    let clean = "";
+    for (const ch of data) {
+      if (ch.charCodeAt(0) <= 127) clean += ch;
+    }
+    this.lastTrafficAt = Date.now();
+    this.rxBuffer += clean;
+
+    if (this.rxBuffer.length > this.maxBufferSize) {
+      this.log.error("Ambit receive buffer exceeded max size, discarding data");
+      void this.emitter.emit("bufferOverflow", { discardedBytes: this.rxBuffer.length });
+      this.rxBuffer = "";
+      return;
+    }
+    this.onChunk?.();
+  }
+
+  /**
+   * Send one payload and collect the unframed reply: resolves once data has
+   * arrived and `quietWindowMs` passes without more, rejects on `timeoutMs`
+   * with nothing received.
+   */
+  private async sendAndCollect(
+    payload: string,
+    quietWindowMs: number,
+    timeoutMs: number,
+  ): Promise<string> {
+    if (!this.transport) {
+      throw new Error("Transport not initialized");
+    }
+    this.rxBuffer = "";
+    this.lastTrafficAt = Date.now();
+    await this.transport.send(payload);
+
+    return new Promise<string>((resolve, reject) => {
+      let quietTimer: ReturnType<typeof setTimeout> | undefined;
+
+      const finish = () => {
+        cleanup();
+        const reply = this.rxBuffer;
+        this.rxBuffer = "";
+        void this.emitter.emit("receivedReply", reply);
+        resolve(reply);
+      };
+
+      const overallTimer = setTimeout(() => {
+        if (this.rxBuffer.trim().length > 0) {
+          finish();
+          return;
+        }
+        cleanup();
+        reject(new Error("Response timeout"));
+      }, timeoutMs);
+
+      const cleanup = () => {
+        clearTimeout(overallTimer);
+        if (quietTimer) clearTimeout(quietTimer);
+        this.onChunk = undefined;
+      };
+
+      this.onChunk = () => {
+        if (quietTimer) clearTimeout(quietTimer);
+        quietTimer = setTimeout(() => {
+          if (this.rxBuffer.trim().length > 0) finish();
+        }, quietWindowMs);
+      };
+    });
+  }
+
+  /** Poll hello until the ready sentinel answers (Calibratron's wake loop). */
+  private async wake(): Promise<void> {
+    for (let attempt = 0; attempt < AMBIT_FRAMING.WAKE_RETRIES; attempt++) {
+      try {
+        const reply = await this.sendAndCollect(
+          `${AMBIT_COMMANDS.HELLO}${AMBIT_FRAMING.LINE_ENDING}`,
+          100,
+          400,
+        );
+        if (reply.includes(AMBIT_FRAMING.READY_SENTINEL) || /\bready\b/i.test(reply)) {
+          return;
+        }
+      } catch {
+        // silent attempt; keep polling
+      }
+      await delay(AMBIT_FRAMING.WAKE_INTERVAL_MS);
+    }
+    throw new Error("Ambit did not wake (no hello reply)");
+  }
+
+  /** Re-run the wake poll when the console has idled past the sleep threshold. */
+  private async ensureAwake(): Promise<void> {
+    if (Date.now() - this.lastTrafficAt < AMBIT_FRAMING.SLEEP_AFTER_IDLE_MS) return;
+    await this.wake();
+  }
+
+  async execute<T = unknown>(
+    command: string | object,
+    options?: ExecuteOptions,
+  ): Promise<CommandResult<T>> {
+    this.ensureInitialized();
+
+    if (typeof command !== "string") {
+      return {
+        success: false,
+        error: new Error(
+          "Ambit does not accept protocol JSON. Use a command cell (hello, get_par, set_spec, ...)",
+        ),
+      };
+    }
+
+    return this.commandQueue.enqueue(async () => {
+      try {
+        await this.ensureAwake();
+
+        const trimmed = command.trim();
+        const token = trimmed.split(",")[0].trim();
+        const payload = `${trimmed}${AMBIT_FRAMING.LINE_ENDING}`;
+
+        // Calibration writers reply with nothing: fire, settle, re-verify.
+        if (AMBIT_SILENT_COMMANDS.includes(token)) {
+          if (!this.transport) throw new Error("Transport not initialized");
+          this.rxBuffer = "";
+          this.lastTrafficAt = Date.now();
+          await this.transport.send(payload);
+          await delay(AMBIT_FRAMING.SETTLE_MS);
+          const verify = await this.sendAndCollect(
+            `${AMBIT_COMMANDS.HELLO}${AMBIT_FRAMING.LINE_ENDING}`,
+            this.quietWindowMs,
+            this.defaultTimeoutMs,
+          );
+          if (!/\bready\b/i.test(verify)) {
+            throw new Error(`Ambit did not acknowledge ${token} (no ready reply)`);
+          }
+          return { success: true, data: { acknowledged: token } as T };
+        }
+
+        const override = AMBIT_COMMAND_OVERRIDES[token] ?? {};
+        const reply = await this.sendAndCollect(
+          payload,
+          override.quietWindowMs ?? this.quietWindowMs,
+          options?.timeoutMs ?? override.timeoutMs ?? this.defaultTimeoutMs,
+        );
+        const text = reply.trim();
+
+        if (text.includes(AMBIT_BAD_COMMAND)) {
+          throw new Error(`Ambit rejected the command: ${token}`);
+        }
+
+        const parsed = AMBIT_REPLY_PARSERS[token]?.(text);
+        return { success: true, data: (parsed ?? text) as T };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error : new Error(String(error)),
+        };
+      }
+    });
+  }
+
+  /** Identity from the hello sentinel line; the printed name is hardcoded upstream. */
+  async getDeviceIdentity(): Promise<DeviceIdentity> {
+    const result = await this.execute<unknown>(AMBIT_COMMANDS.HELLO);
+    const text = typeof result.data === "string" ? result.data : "";
+    const match = /^(.*?)\s*\bready\b\s*$/im.exec(text);
+    const name = match?.[1]?.trim();
+    return {
+      family: this.family,
+      name: name === "" ? undefined : name,
+      raw: { helloReply: text },
+    };
+  }
+
+  override async destroy(): Promise<void> {
+    this.rxBuffer = "";
+    this.onChunk = undefined;
+    await super.destroy();
+  }
+}

--- a/packages/iot/src/driver/ambit/driver.ts
+++ b/packages/iot/src/driver/ambit/driver.ts
@@ -224,11 +224,8 @@ export class AmbitDriver extends DeviceDriver<AmbitStreamEvents> {
   async getDeviceIdentity(): Promise<DeviceIdentity> {
     const result = await this.execute<unknown>(AMBIT_COMMANDS.HELLO);
     const text = typeof result.data === "string" ? result.data : "";
-    const match = /^(.*?)\s*\bready\b\s*$/im.exec(text);
-    const name = match?.[1]?.trim();
     return {
       family: this.family,
-      name: name === "" ? undefined : name,
       raw: { helloReply: text },
     };
   }

--- a/packages/iot/src/driver/ambit/interface.ts
+++ b/packages/iot/src/driver/ambit/interface.ts
@@ -1,0 +1,22 @@
+/** Events emitted by the Ambit driver */
+export interface AmbitStreamEvents extends Record<string, unknown> {
+  /** A reply finished collecting (quiet window elapsed). */
+  receivedReply: string;
+  bufferOverflow: { discardedBytes: number };
+}
+
+/** Parsed `get_par` / `PAR` reply. */
+export interface AmbitParReading {
+  par: number;
+  /** 10 spectral channel counts. */
+  channels: number[];
+  [key: string]: unknown;
+}
+
+/** Parsed `temp` reply (MLX90632). */
+export interface AmbitTempReading {
+  objectC: number;
+  ambientC: number;
+  objectRawC: number;
+  [key: string]: unknown;
+}

--- a/packages/iot/src/driver/ambit/response-parsers.ts
+++ b/packages/iot/src/driver/ambit/response-parsers.ts
@@ -1,0 +1,41 @@
+import type { AmbitParReading, AmbitTempReading } from "./interface";
+
+/**
+ * Upgrades known raw text replies into structured objects. Unknown commands
+ * (and unparseable replies) pass through as the raw text.
+ */
+
+/** `get_par`/`PAR`: line 1 = PAR float, line 2 = 10 CSV spectral counts. */
+export function parseParReply(text: string): AmbitParReading | null {
+  const lines = text
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  if (lines.length < 1) return null;
+  const par = Number(lines[0]);
+  if (Number.isNaN(par)) return null;
+  const channels = (lines[1] ?? "")
+    .split(",")
+    .map((c) => Number(c.trim()))
+    .filter((n) => !Number.isNaN(n));
+  return { par, channels };
+}
+
+/** `temp`: three tab-separated floats (object, ambient, object raw). */
+export function parseTempReply(text: string): AmbitTempReading | null {
+  const parts = text
+    .trim()
+    .split(/\t+/)
+    .map((p) => Number(p.trim()));
+  if (parts.length < 3 || parts.some((n) => Number.isNaN(n))) return null;
+  return { objectC: parts[0], ambientC: parts[1], objectRawC: parts[2] };
+}
+
+/** Parser table keyed by the command's leading token. */
+export const AMBIT_REPLY_PARSERS: Partial<
+  Record<string, (text: string) => Record<string, unknown> | null>
+> = {
+  get_par: parseParReply,
+  PAR: parseParReply,
+  temp: parseTempReply,
+};

--- a/packages/iot/src/driver/driver-base.ts
+++ b/packages/iot/src/driver/driver-base.ts
@@ -1,6 +1,7 @@
 /**
  * Device driver interface - handles device-specific command/response patterns
  */
+import type { DeviceIdentity, SensorFamily } from "../core/families";
 import type { ITransportAdapter } from "../transport/interface";
 import { CommandQueue } from "../utils/command-queue/command-queue";
 import { Emitter } from "../utils/emitter/emitter";
@@ -43,6 +44,12 @@ export interface IDeviceDriver {
   /** Get device information (battery, version, etc.) */
   getDeviceInfo?(): Promise<Record<string, unknown>>;
 
+  /** Sensor family this driver speaks, when known. */
+  readonly family?: SensorFamily;
+
+  /** Fetch the device's structured identity (name, id, firmware, battery). */
+  getDeviceIdentity?(): Promise<DeviceIdentity>;
+
   /** Cleanup and destroy driver */
   destroy(): Promise<void>;
 }
@@ -67,6 +74,9 @@ export abstract class DeviceDriver<
 {
   protected transport?: ITransportAdapter;
   protected initialized = false;
+
+  /** Sensor family this driver speaks; subclasses override. */
+  readonly family: SensorFamily = "generic";
 
   /** Override to change the maximum receive buffer size per driver */
   protected maxBufferSize = DEFAULT_MAX_BUFFER_SIZE;

--- a/packages/iot/src/driver/generic/command-connector.spec.ts
+++ b/packages/iot/src/driver/generic/command-connector.spec.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { DEFAULT_MAX_BUFFER_SIZE } from "../driver-base";
+import type { MockTransport } from "../testing/mock-transport";
+import { createMockTransport } from "../testing/mock-transport";
+import { GenericCommandConnector } from "./command-connector";
+
+describe("GenericCommandConnector", () => {
+  let connector: GenericCommandConnector;
+  let transport: MockTransport;
+
+  beforeEach(() => {
+    connector = new GenericCommandConnector();
+    transport = createMockTransport();
+    connector.initialize(transport);
+  });
+
+  /** Make the next send() reply with `chunks`, delivered asynchronously. */
+  function replyWith(...chunks: string[]) {
+    vi.mocked(transport.send).mockImplementation(() => {
+      setTimeout(() => {
+        for (const chunk of chunks) transport.simulateData(chunk);
+      }, 0);
+      return Promise.resolve();
+    });
+  }
+
+  it("exposes the generic family", () => {
+    expect(connector.family).toBe("generic");
+  });
+
+  it.each([
+    {
+      name: "sends string commands verbatim with a newline",
+      cmd: "RAW_CMD" as string | object,
+      chunks: ["OK\n"],
+      sent: "RAW_CMD\n",
+      data: "OK" as unknown,
+    },
+    {
+      name: "JSON-stringifies object commands",
+      cmd: { command: "GO", speed: 3 },
+      chunks: ["ack\n"],
+      sent: '{"command":"GO","speed":3}\n',
+      data: "ack",
+    },
+    {
+      name: "assembles a reply from multiple chunks up to the newline",
+      cmd: "cmd",
+      chunks: ['{"a"', ":1}", "\n"],
+      data: { a: 1 },
+    },
+    {
+      name: "parses JSON reply lines into objects",
+      cmd: "cmd",
+      chunks: ['{"status":"done","v":2}\n'],
+      data: { status: "done", v: 2 },
+    },
+    {
+      name: "returns plain-text reply lines as strings, stripping a trailing CR",
+      cmd: "cmd",
+      chunks: ["hello world\r\n"],
+      data: "hello world",
+    },
+  ])("$name", async ({ cmd, chunks, sent, data }) => {
+    replyWith(...chunks);
+
+    const result = await connector.execute(cmd);
+
+    if (sent) expect(transport.send).toHaveBeenCalledWith(sent);
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(data);
+  });
+
+  it("honours a custom line ending", async () => {
+    const crlf = new GenericCommandConnector({ lineEnding: "\r\n" });
+    crlf.initialize(transport);
+    replyWith("pong\n");
+
+    await crlf.execute("ping");
+
+    expect(transport.send).toHaveBeenCalledWith("ping\r\n");
+  });
+
+  it("fails with Response timeout when the device stays silent", async () => {
+    vi.useFakeTimers();
+    try {
+      const quick = new GenericCommandConnector({ timeoutMs: 500 });
+      quick.initialize(transport);
+
+      const resultPromise = quick.execute("cmd");
+      await vi.advanceTimersByTimeAsync(501);
+
+      const result = await resultPromise;
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toBe("Response timeout");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("honours a per-call timeout override", async () => {
+    vi.useFakeTimers();
+    try {
+      const resultPromise = connector.execute("cmd", { timeoutMs: 100 });
+      await vi.advanceTimersByTimeAsync(101);
+
+      const result = await resultPromise;
+      expect(result.success).toBe(false);
+      expect(result.error?.message).toBe("Response timeout");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("discards the buffer and emits bufferOverflow when it grows past the limit", () => {
+    const listener = vi.fn();
+    connector.on("bufferOverflow", listener);
+
+    transport.simulateData("x".repeat(DEFAULT_MAX_BUFFER_SIZE + 1));
+
+    expect(listener).toHaveBeenCalledWith({ discardedBytes: DEFAULT_MAX_BUFFER_SIZE + 1 });
+
+    // The connector still works after the discard
+    transport.simulateData("late\n");
+  });
+
+  it("identity is bare, execute before initialize throws", async () => {
+    await expect(connector.getDeviceIdentity()).resolves.toEqual({ family: "generic", raw: {} });
+    const fresh = new GenericCommandConnector();
+    await expect(fresh.execute("cmd")).rejects.toThrow(
+      "Driver not initialized. Call initialize() first.",
+    );
+  });
+});

--- a/packages/iot/src/driver/generic/command-connector.ts
+++ b/packages/iot/src/driver/generic/command-connector.ts
@@ -1,0 +1,131 @@
+/**
+ * Raw command connector, the last resort for unidentified devices.
+ *
+ * Unlike GenericDeviceDriver (structured openJII JSON contract: {"command"}
+ * envelopes, {"status","data","error"} replies, INFO capability probing),
+ * this connector is a verbatim passthrough: strings are sent as-is, objects
+ * JSON-stringified, plus a line ending; each newline-terminated reply line is
+ * returned unchanged (JSON-parsed when possible).
+ */
+import type { DeviceIdentity, SensorFamily } from "../../core/families";
+import type { ITransportAdapter } from "../../transport/interface";
+import { addLineEnding, stringifyIfObject, tryParseJson } from "../../utils/framing/framing";
+import type { Logger } from "../../utils/logger/logger";
+import { DeviceDriver } from "../driver-base";
+import type { CommandResult, ExecuteOptions } from "../driver-base";
+
+/** Default response timeout (ms) for raw line commands. */
+const DEFAULT_CONNECTOR_TIMEOUT_MS = 10_000;
+
+/** Events emitted by the raw command connector */
+export interface GenericCommandConnectorEvents extends Record<string, unknown> {
+  receivedLine: unknown;
+  bufferOverflow: { discardedBytes: number };
+}
+
+/** Construction options for the raw command connector */
+export interface GenericCommandConnectorConfig {
+  /** Response timeout in ms (default 10 000) */
+  timeoutMs?: number;
+  /** Line ending appended to every command (default "\n") */
+  lineEnding?: string;
+}
+
+export class GenericCommandConnector extends DeviceDriver<GenericCommandConnectorEvents> {
+  override readonly family: SensorFamily = "generic";
+
+  private readonly defaultTimeoutMs: number;
+  private readonly lineEnding: string;
+  private rxBuffer = "";
+
+  constructor(config?: GenericCommandConnectorConfig, logger?: Logger) {
+    super(logger);
+    this.defaultTimeoutMs = config?.timeoutMs ?? DEFAULT_CONNECTOR_TIMEOUT_MS;
+    this.lineEnding = config?.lineEnding ?? "\n";
+  }
+
+  override initialize(transport: ITransportAdapter): void {
+    void super.initialize(transport);
+    this.rxBuffer = "";
+    transport.onDataReceived((data) => this.handleDataReceived(data));
+  }
+
+  private handleDataReceived(data: string): void {
+    this.rxBuffer += data;
+
+    // Guard against unbounded buffer growth from malformed/chatty devices
+    if (this.rxBuffer.length > this.maxBufferSize) {
+      this.log.error("Command connector receive buffer exceeded max size, discarding data");
+      void this.emitter.emit("bufferOverflow", { discardedBytes: this.rxBuffer.length });
+      this.rxBuffer = "";
+      return;
+    }
+
+    if (!this.rxBuffer.includes("\n")) {
+      return;
+    }
+
+    // Emit each complete line (minus a trailing \r) as a response
+    const lines = this.rxBuffer.split("\n");
+    this.rxBuffer = lines.pop() ?? "";
+    for (const line of lines) {
+      const clean = line.endsWith("\r") ? line.slice(0, -1) : line;
+      if (clean.length === 0) continue;
+      void this.emitter.emit("receivedLine", tryParseJson(clean));
+    }
+  }
+
+  async execute<T = unknown>(
+    command: string | object,
+    options?: ExecuteOptions,
+  ): Promise<CommandResult<T>> {
+    this.ensureInitialized();
+
+    return this.commandQueue.enqueue(async () => {
+      try {
+        if (!this.transport) {
+          throw new Error("Transport not initialized");
+        }
+        const payload = addLineEnding(stringifyIfObject(command), this.lineEnding);
+        await this.transport.send(payload);
+        const line = await this.waitForLine(options?.timeoutMs ?? this.defaultTimeoutMs);
+        return { success: true, data: line as T };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error : new Error(String(error)),
+        };
+      }
+    });
+  }
+
+  private waitForLine(timeoutMs: number): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        cleanup();
+        reject(new Error("Response timeout"));
+      }, timeoutMs);
+
+      const handleLine = (line: unknown) => {
+        cleanup();
+        resolve(line);
+      };
+
+      const cleanup = () => {
+        clearTimeout(timeoutId);
+        this.emitter.off("receivedLine", handleLine);
+      };
+
+      this.emitter.on("receivedLine", handleLine);
+    });
+  }
+
+  getDeviceIdentity(): Promise<DeviceIdentity> {
+    return Promise.resolve({ family: this.family, raw: {} });
+  }
+
+  override async destroy(): Promise<void> {
+    this.rxBuffer = "";
+    await super.destroy();
+  }
+}

--- a/packages/iot/src/driver/generic/driver.spec.ts
+++ b/packages/iot/src/driver/generic/driver.spec.ts
@@ -75,6 +75,12 @@ describe("GenericDeviceDriver", () => {
     transport = createMockTransport();
   });
 
+  describe("getDeviceIdentity", () => {
+    it("returns a minimal identity when the INFO probe cannot run", async () => {
+      await expect(driver.getDeviceIdentity()).resolves.toEqual({ family: "generic", raw: {} });
+    });
+  });
+
   describe("initialize", () => {
     it("should set up data and status handlers", async () => {
       await initDriver(driver, transport);

--- a/packages/iot/src/driver/generic/driver.ts
+++ b/packages/iot/src/driver/generic/driver.ts
@@ -22,6 +22,7 @@
  * });
  * ```
  */
+import type { DeviceIdentity } from "../../core/families";
 import type { ITransportAdapter } from "../../transport/interface";
 import type { Logger } from "../../utils/logger/logger";
 import { DeviceDriver } from "../driver-base";
@@ -98,6 +99,26 @@ export class GenericDeviceDriver extends DeviceDriver<GenericDeviceEvents> {
   /** Cached device info from the INFO probe during initialize(), or `null` if unavailable */
   get cachedDeviceInfo(): Readonly<GenericDeviceInfo> | null {
     return this.deviceInfo;
+  }
+
+  /** Structured identity mapped from the cached INFO probe (re-probing if needed). */
+  async getDeviceIdentity(): Promise<DeviceIdentity> {
+    const info = this.deviceInfo ?? (await this.getDeviceInfo().catch(() => null));
+    if (!info) {
+      return { family: this.family, raw: {} };
+    }
+    return {
+      family: this.family,
+      name: typeof info.device_name === "string" ? info.device_name : undefined,
+      deviceId: typeof info.device_id === "string" ? info.device_id : undefined,
+      firmwareVersion:
+        typeof info.firmware_version === "string"
+          ? info.firmware_version
+          : typeof info.device_version === "string"
+            ? info.device_version
+            : undefined,
+      raw: { ...info },
+    };
   }
 
   private handleDataReceived(data: string): void {

--- a/packages/iot/src/driver/minipar/commands.ts
+++ b/packages/iot/src/driver/minipar/commands.ts
@@ -1,0 +1,42 @@
+/**
+ * MiniPAR console commands, sourced from the firmware's
+ * `Firmware/src/app/commands.cpp` (Jan-IngenHousz-Institute/miniPar).
+ *
+ * The firmware is dual-mode: a plain string runs in LINE mode (raw text
+ * reply); a JSON protocol (`[{"set":[{"label":"par","protocol_repeats":N}]}]`,
+ * labels = these command names) replies with a MultispeQ-shaped envelope plus
+ * the constant `7A1E3AA1` footer. Per-command errors appear inline as
+ * `{"error":"unknown_command"}` entries.
+ */
+
+// prettier-ignore
+export const MINIPAR_COMMANDS = {
+  // Connection / status
+  HELLO:    "hello",    // LINE: "MiniPAR,<version>,<firmware>"; JSON mode: {"device":"MiniPAR","version":...}
+  STATUS:   "status",   // "model=...,available=...,atime=...,astep=...,gain=..."
+  BATTERY:  "battery",  // always "NaN" (no battery)
+  REBOOT:   "reboot",   // echoes "reboot" then restarts
+
+  // Measurements
+  PAR:        "par",        // calibrated PAR float
+  PAR_RAW:    "par_raw",    // uncalibrated PAR float
+  SPEC:       "spec",       // "<model>,ch0,...,chN" basic counts
+  SPEC_RAW:   "spec_raw",   // raw counts
+  SPEC_FLASH: "spec_flash", // spec_flash,<mA<=20>: "dark:...;lit:...;diff:..."
+  TPH:        "tph",        // BME280 "t,p,h" CSV (blank channel = disabled)
+  DELAY_MS:   "delay_ms",   // delay_ms,<n>: echo; useful inside protocols
+
+  // Configuration
+  SET_LED:        "set_led",        // set_led,<mA>: replies actual mA
+  SPEC_SET_ATIME: "spec_set_atime", // 0-255 or "error:*"
+  SPEC_SET_ASTEP: "spec_set_astep",
+  SPEC_SET_GAIN:  "spec_set_gain",
+  SET_NAME:       "set_name",       // set_name,<string <=20>
+  GET_NAME:       "get_name",
+
+  // Calibration writers
+  CAL_PAR_SLOPE:     "cal_par_slope",     // cal_par_slope,<float>: echo
+  CAL_PAR_INTERCEPT: "cal_par_intercept", // cal_par_intercept,<float>: echo
+  SET_SPEC_COEFF:    "set_spec_coeff",    // set_spec_coeff,<ch>,<v>
+  GET_SPEC_COEFF:    "get_spec_coeff",
+} as const;

--- a/packages/iot/src/driver/minipar/config.ts
+++ b/packages/iot/src/driver/minipar/config.ts
@@ -1,0 +1,28 @@
+/** MiniPAR serial defaults (ESP32 USB-CDC console). */
+export const MINIPAR_SERIAL_DEFAULTS = {
+  baudRate: 115200,
+  dataBits: 8,
+  stopBits: 1,
+  parity: "none",
+} as const;
+
+export const MINIPAR_FRAMING = {
+  LINE_ENDING: "\n",
+  /**
+   * JSON-mode replies end with this constant sentinel before the newline
+   * (a fixed footer, not a computed checksum).
+   */
+  FRAME_FOOTER: "7A1E3AA1",
+  FOOTER_LENGTH: 8,
+  /** LINE-mode command timeout. */
+  DEFAULT_TIMEOUT: 10_000,
+  /** JSON protocol timeout; no estimator exists for MiniPAR protocols yet. */
+  PROTOCOL_TIMEOUT: 60_000,
+} as const;
+
+export interface MiniParDriverConfig {
+  /** LINE-mode reply timeout in ms (default 10000). */
+  timeoutMs?: number;
+  /** JSON protocol reply timeout in ms (default 60000). */
+  protocolTimeoutMs?: number;
+}

--- a/packages/iot/src/driver/minipar/driver.spec.ts
+++ b/packages/iot/src/driver/minipar/driver.spec.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import type { MockTransport } from "../testing/mock-transport";
+import { createMockTransport } from "../testing/mock-transport";
+import { MiniParDriver } from "./driver";
+
+const ENVELOPE = {
+  device_name: "MiniPAR",
+  device_version: "1.1",
+  device_id: "AA:BB:CC:DD:EE:FF",
+  device_battery: "NaN",
+  device_firmware: 1.04,
+  sample: [{ protocol_id: "NaN", set: [{ label: "par", par: 345.61 }] }],
+};
+const ENVELOPE_WIRE = `${JSON.stringify(ENVELOPE)}7A1E3AA1\n`;
+
+function tableTransport(table: Partial<Record<string, string | string[]>>): MockTransport {
+  const transport = createMockTransport();
+  vi.mocked(transport.send).mockImplementation((payload: string) => {
+    const reply = table[payload];
+    if (reply !== undefined) {
+      const chunks = Array.isArray(reply) ? reply : [reply];
+      setTimeout(() => {
+        for (const chunk of chunks) transport.simulateData(chunk);
+      }, 0);
+    }
+    return Promise.resolve();
+  });
+  return transport;
+}
+
+describe("MiniParDriver", () => {
+  let driver: MiniParDriver;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    driver = new MiniParDriver({ timeoutMs: 500, protocolTimeoutMs: 500 });
+  });
+
+  it("exposes the minipar family", () => {
+    expect(driver.family).toBe("minipar");
+  });
+
+  it("runs LINE commands and strips the firmware's blank-line echo", async () => {
+    driver.initialize(tableTransport({ "par\n": "\n345.61\n" }));
+
+    const result = await driver.execute<string>("par");
+    expect(result.success).toBe(true);
+    expect(result.data).toBe("345.61");
+  });
+
+  it("completes a newline-less LINE reply via the quiet window (hello)", async () => {
+    driver.initialize(tableTransport({ "hello\n": "MiniPAR,1.1,1.04" }));
+
+    const result = await driver.execute<string>("hello");
+    expect(result.success).toBe(true);
+    expect(result.data).toBe("MiniPAR,1.1,1.04");
+  });
+
+  it("surfaces error:* LINE replies as command errors", async () => {
+    driver.initialize(tableTransport({ "spec_set_gain,99\n": "error:invalid_gain\n" }));
+
+    const result = await driver.execute("spec_set_gain,99");
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/error:invalid_gain/);
+  });
+
+  it("sends a JSON protocol in one write and parses the footer-terminated envelope", async () => {
+    const protocol = [{ set: [{ label: "par", protocol_repeats: 3 }] }];
+    const transport = tableTransport({
+      [`${JSON.stringify(protocol)}\n`]: ENVELOPE_WIRE,
+    });
+    driver.initialize(transport);
+
+    const result = await driver.execute<typeof ENVELOPE>(protocol);
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(ENVELOPE);
+    expect(result.checksum).toBe("7A1E3AA1");
+    expect(transport.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("reassembles an envelope delivered in chunks", async () => {
+    const protocol = [{ set: [{ label: "par" }] }];
+    const wire = ENVELOPE_WIRE;
+    const transport = tableTransport({
+      [`${JSON.stringify(protocol)}\n`]: [wire.slice(0, 40), wire.slice(40, 90), wire.slice(90)],
+    });
+    driver.initialize(transport);
+
+    const result = await driver.execute<typeof ENVELOPE>(protocol);
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(ENVELOPE);
+  });
+
+  it("keeps inline unknown_command errors inside the parsed envelope", async () => {
+    const protocol = [{ set: [{ label: "frobnicate" }] }];
+    const withError = {
+      ...ENVELOPE,
+      sample: [{ protocol_id: "NaN", set: [{ error: "unknown_command" }] }],
+    };
+    driver.initialize(
+      tableTransport({
+        [`${JSON.stringify(protocol)}\n`]: `${JSON.stringify(withError)}7A1E3AA1\n`,
+      }),
+    );
+
+    const result = await driver.execute<typeof withError>(protocol);
+    expect(result.success).toBe(true);
+    expect(result.data?.sample[0]).toMatchObject({ set: [{ error: "unknown_command" }] });
+  });
+
+  it("times out when the device stays silent", async () => {
+    driver.initialize(tableTransport({}));
+
+    const result = await driver.execute("par", { timeoutMs: 60 });
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toBe("Response timeout");
+  });
+
+  it("getDeviceIdentity prefers the persisted name over the CSV product name", async () => {
+    driver.initialize(
+      tableTransport({
+        "hello\n": "MiniPAR,1.1,1.04\n",
+        "get_name\n": "Greenhouse PAR 7\n",
+      }),
+    );
+
+    const identity = await driver.getDeviceIdentity();
+    expect(identity).toMatchObject({
+      family: "minipar",
+      name: "Greenhouse PAR 7",
+      firmwareVersion: "1.04",
+    });
+  });
+
+  it("getDeviceIdentity falls back to MiniPAR when the persisted name is NoName", async () => {
+    driver.initialize(
+      tableTransport({
+        "hello\n": "MiniPAR,1.1,1.04\n",
+        "get_name\n": "NoName\n",
+      }),
+    );
+
+    const identity = await driver.getDeviceIdentity();
+    expect(identity.name).toBe("MiniPAR");
+  });
+});

--- a/packages/iot/src/driver/minipar/driver.spec.ts
+++ b/packages/iot/src/driver/minipar/driver.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+import { DEFAULT_MAX_BUFFER_SIZE } from "../driver-base";
 import type { MockTransport } from "../testing/mock-transport";
 import { createMockTransport } from "../testing/mock-transport";
 import { MiniParDriver } from "./driver";
@@ -39,6 +40,17 @@ describe("MiniParDriver", () => {
 
   it("exposes the minipar family", () => {
     expect(driver.family).toBe("minipar");
+  });
+
+  it("discards an oversized receive buffer and emits its size", () => {
+    const transport = tableTransport({});
+    const overflow = vi.fn();
+    driver.on("bufferOverflow", overflow);
+    driver.initialize(transport);
+
+    transport.simulateData("x".repeat(DEFAULT_MAX_BUFFER_SIZE + 1));
+
+    expect(overflow).toHaveBeenCalledWith({ discardedBytes: DEFAULT_MAX_BUFFER_SIZE + 1 });
   });
 
   it("runs LINE commands and strips the firmware's blank-line echo", async () => {

--- a/packages/iot/src/driver/minipar/driver.spec.ts
+++ b/packages/iot/src/driver/minipar/driver.spec.ts
@@ -117,6 +117,26 @@ describe("MiniParDriver", () => {
     expect(result.error?.message).toBe("Response timeout");
   });
 
+  it("returns a partial LINE reply at the overall timeout", async () => {
+    driver.initialize(tableTransport({ "par\n": "345.61" }));
+
+    const result = await driver.execute<string>("par", { timeoutMs: 60 });
+    expect(result).toEqual({ success: true, data: "345.61" });
+  });
+
+  it("reports a footer-terminated corrupt protocol envelope", async () => {
+    const protocol = [{ set: [{ label: "par" }] }];
+    driver.initialize(
+      tableTransport({
+        [`${JSON.stringify(protocol)}\n`]: "not-json7A1E3AA1\n",
+      }),
+    );
+
+    const result = await driver.execute(protocol, { timeoutMs: 60 });
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/complete measurement envelope/);
+  });
+
   it("getDeviceIdentity prefers the persisted name over the CSV product name", async () => {
     driver.initialize(
       tableTransport({
@@ -143,5 +163,31 @@ describe("MiniParDriver", () => {
 
     const identity = await driver.getDeviceIdentity();
     expect(identity.name).toBe("MiniPAR");
+  });
+
+  it("reads identity from the JSON hello form when no persisted name is available", async () => {
+    driver.initialize(
+      tableTransport({
+        "hello\n": '{"device":"MiniPAR","version":"2.3"}\n',
+        "get_name\n": "\n",
+      }),
+    );
+
+    const identity = await driver.getDeviceIdentity();
+    expect(identity).toMatchObject({
+      family: "minipar",
+      name: "MiniPAR",
+      firmwareVersion: "2.3",
+    });
+  });
+
+  it("clears buffered state and disconnects when destroyed", async () => {
+    const transport = tableTransport({});
+    driver.initialize(transport);
+
+    await driver.destroy();
+
+    expect(transport.disconnect).toHaveBeenCalledOnce();
+    await expect(driver.execute("hello")).rejects.toThrow(/not initialized/);
   });
 });

--- a/packages/iot/src/driver/minipar/driver.ts
+++ b/packages/iot/src/driver/minipar/driver.ts
@@ -1,0 +1,221 @@
+/**
+ * MiniPAR driver: dual-mode ESP32 serial console.
+ *
+ * LINE mode: a plain string command replies with raw text. Some replies are
+ * printed without a trailing newline (hello), so a short RX quiet window
+ * completes a reply that never sees one. JSON mode: a protocol array/object
+ * is sent in one write and the firmware replies a MultispeQ-shaped envelope
+ * terminated by the constant `7A1E3AA1` footer.
+ */
+import type { DeviceIdentity, SensorFamily } from "../../core/families";
+import type { ITransportAdapter } from "../../transport/interface";
+import { extractChecksum } from "../../utils/framing/framing";
+import type { Logger } from "../../utils/logger/logger";
+import { DeviceDriver } from "../driver-base";
+import type { CommandResult, ExecuteOptions } from "../driver-base";
+import { MINIPAR_COMMANDS } from "./commands";
+import { MINIPAR_FRAMING } from "./config";
+import type { MiniParDriverConfig } from "./config";
+import type { MiniParMeasurementEnvelope, MiniParStreamEvents } from "./interface";
+
+/** RX silence that completes a LINE-mode reply lacking a newline. */
+const LINE_QUIET_MS = 200;
+
+export class MiniParDriver extends DeviceDriver<MiniParStreamEvents> {
+  override readonly family: SensorFamily = "minipar";
+
+  private readonly defaultTimeoutMs: number;
+  private readonly protocolTimeoutMs: number;
+
+  private rxBuffer = "";
+  private onChunk: (() => void) | undefined;
+
+  constructor(config?: MiniParDriverConfig, logger?: Logger) {
+    super(logger);
+    this.defaultTimeoutMs = config?.timeoutMs ?? MINIPAR_FRAMING.DEFAULT_TIMEOUT;
+    this.protocolTimeoutMs = config?.protocolTimeoutMs ?? MINIPAR_FRAMING.PROTOCOL_TIMEOUT;
+  }
+
+  override initialize(transport: ITransportAdapter): void {
+    void super.initialize(transport);
+    this.rxBuffer = "";
+    transport.onDataReceived((data) => this.handleDataReceived(data));
+  }
+
+  private handleDataReceived(data: string): void {
+    this.rxBuffer += data;
+    if (this.rxBuffer.length > this.maxBufferSize) {
+      this.log.error("MiniPAR receive buffer exceeded max size, discarding data");
+      void this.emitter.emit("bufferOverflow", { discardedBytes: this.rxBuffer.length });
+      this.rxBuffer = "";
+      return;
+    }
+    this.onChunk?.();
+  }
+
+  /** Buffer until `isComplete` or a quiet window with data; reject on empty timeout. */
+  private collect(
+    isComplete: (buffer: string) => boolean,
+    timeoutMs: number,
+    quietMs?: number,
+  ): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      let quietTimer: ReturnType<typeof setTimeout> | undefined;
+
+      const finish = () => {
+        cleanup();
+        const reply = this.rxBuffer;
+        this.rxBuffer = "";
+        resolve(reply);
+      };
+
+      const overallTimer = setTimeout(() => {
+        if (this.rxBuffer.trim().length > 0) {
+          finish();
+          return;
+        }
+        cleanup();
+        reject(new Error("Response timeout"));
+      }, timeoutMs);
+
+      const cleanup = () => {
+        clearTimeout(overallTimer);
+        if (quietTimer) clearTimeout(quietTimer);
+        this.onChunk = undefined;
+      };
+
+      const check = () => {
+        if (isComplete(this.rxBuffer)) {
+          finish();
+          return;
+        }
+        if (quietMs !== undefined) {
+          if (quietTimer) clearTimeout(quietTimer);
+          quietTimer = setTimeout(() => {
+            if (this.rxBuffer.trim().length > 0) finish();
+          }, quietMs);
+        }
+      };
+
+      this.onChunk = check;
+      check();
+    });
+  }
+
+  /** Strip and verify the constant footer; null when the envelope is not complete yet. */
+  private static parseEnvelope(buffer: string): MiniParMeasurementEnvelope | null {
+    const trimmed = buffer.trim();
+    if (!trimmed.endsWith(MINIPAR_FRAMING.FRAME_FOOTER)) return null;
+    const { data } = extractChecksum(trimmed, MINIPAR_FRAMING.FOOTER_LENGTH);
+    try {
+      const parsed: unknown = JSON.parse(data);
+      if (parsed !== null && typeof parsed === "object") {
+        return parsed as MiniParMeasurementEnvelope;
+      }
+    } catch {
+      // footer seen but JSON incomplete/corrupt; keep buffering
+    }
+    return null;
+  }
+
+  async execute<T = unknown>(
+    command: string | object,
+    options?: ExecuteOptions,
+  ): Promise<CommandResult<T>> {
+    this.ensureInitialized();
+
+    return this.commandQueue.enqueue(async () => {
+      try {
+        if (!this.transport) {
+          throw new Error("Transport not initialized");
+        }
+        this.rxBuffer = "";
+
+        if (typeof command === "string") {
+          await this.transport.send(`${command.trim()}${MINIPAR_FRAMING.LINE_ENDING}`);
+          const reply = await this.collect(
+            (buffer) => /[^\s]\r?\n/.test(buffer),
+            options?.timeoutMs ?? this.defaultTimeoutMs,
+            LINE_QUIET_MS,
+          );
+          // The firmware echoes a blank line around LINE replies.
+          const text = reply
+            .split("\n")
+            .map((l) => l.trim())
+            .filter((l) => l.length > 0)
+            .join("\n");
+          void this.emitter.emit("receivedLine", text);
+          if (text.startsWith("error:")) {
+            throw new Error(`MiniPAR replied ${text}`);
+          }
+          return { success: true, data: text as T };
+        }
+
+        // JSON protocol: one write, envelope + footer reply.
+        await this.transport.send(`${JSON.stringify(command)}${MINIPAR_FRAMING.LINE_ENDING}`);
+        const reply = await this.collect(
+          (buffer) => MiniParDriver.parseEnvelope(buffer) !== null,
+          options?.timeoutMs ?? this.protocolTimeoutMs,
+        );
+        const envelope = MiniParDriver.parseEnvelope(reply);
+        if (!envelope) {
+          void this.emitter.emit("parseError", { line: reply, error: "incomplete envelope" });
+          throw new Error("MiniPAR reply was not a complete measurement envelope");
+        }
+        void this.emitter.emit("receivedEnvelope", envelope);
+        return {
+          success: true,
+          data: envelope as T,
+          checksum: MINIPAR_FRAMING.FRAME_FOOTER,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error : new Error(String(error)),
+        };
+      }
+    });
+  }
+
+  /** Identity from `hello` (`MiniPAR,<version>,<firmware>` or the JSON-mode form). */
+  async getDeviceIdentity(): Promise<DeviceIdentity> {
+    const result = await this.execute<string>(MINIPAR_COMMANDS.HELLO, { timeoutMs: 3_000 });
+    const text = typeof result.data === "string" ? result.data : "";
+
+    let name: string | undefined;
+    let firmwareVersion: string | undefined;
+    const csv = /^minipar\s*,\s*([^,\s]+)\s*(?:,\s*([^,\s]+))?/im.exec(text);
+    if (csv) {
+      name = "MiniPAR";
+      firmwareVersion = csv.at(2) ?? csv.at(1);
+    } else {
+      try {
+        const parsed = JSON.parse(text) as Record<string, unknown>;
+        if (typeof parsed.device === "string") name = parsed.device;
+        if (typeof parsed.version === "string") firmwareVersion = parsed.version;
+      } catch {
+        // unrecognized hello; identity stays minimal
+      }
+    }
+
+    // Best-effort persisted name; the default is "NoName".
+    const named = await this.execute<string>(MINIPAR_COMMANDS.GET_NAME, { timeoutMs: 2_000 });
+    const deviceName =
+      named.success && typeof named.data === "string" && named.data.trim() !== ""
+        ? named.data.trim()
+        : undefined;
+
+    return {
+      family: this.family,
+      name: deviceName && !/noname/i.test(deviceName) ? deviceName : name,
+      firmwareVersion,
+      raw: { helloReply: text, deviceName },
+    };
+  }
+
+  override async destroy(): Promise<void> {
+    this.rxBuffer = "";
+    this.onChunk = undefined;
+    await super.destroy();
+  }
+}

--- a/packages/iot/src/driver/minipar/driver.ts
+++ b/packages/iot/src/driver/minipar/driver.ts
@@ -187,7 +187,7 @@ export class MiniParDriver extends DeviceDriver<MiniParStreamEvents> {
     const csv = /^minipar\s*,\s*([^,\s]+)\s*(?:,\s*([^,\s]+))?/im.exec(text);
     if (csv) {
       name = "MiniPAR";
-      firmwareVersion = csv.at(2) ?? csv.at(1);
+      firmwareVersion = csv[2] ?? csv[1];
     } else {
       try {
         const parsed = JSON.parse(text) as Record<string, unknown>;

--- a/packages/iot/src/driver/minipar/driver.ts
+++ b/packages/iot/src/driver/minipar/driver.ts
@@ -184,10 +184,10 @@ export class MiniParDriver extends DeviceDriver<MiniParStreamEvents> {
 
     let name: string | undefined;
     let firmwareVersion: string | undefined;
-    const csv = /^minipar\s*,\s*([^,\s]+)\s*(?:,\s*([^,\s]+))?/im.exec(text);
+    const csv = /^minipar\s*,\s*(?<version>[^,\s]+)\s*(?:,\s*(?<firmware>[^,\s]+))?/im.exec(text);
     if (csv) {
       name = "MiniPAR";
-      firmwareVersion = csv[2] ?? csv[1];
+      firmwareVersion = csv.groups?.firmware ?? csv.groups?.version;
     } else {
       try {
         const parsed = JSON.parse(text) as Record<string, unknown>;

--- a/packages/iot/src/driver/minipar/interface.ts
+++ b/packages/iot/src/driver/minipar/interface.ts
@@ -1,0 +1,20 @@
+/** Events emitted by the MiniPAR driver */
+export interface MiniParStreamEvents extends Record<string, unknown> {
+  /** A complete LINE-mode reply line. */
+  receivedLine: string;
+  /** A complete JSON-mode envelope (footer verified and stripped). */
+  receivedEnvelope: MiniParMeasurementEnvelope;
+  parseError: { line: string; error: unknown };
+  bufferOverflow: { discardedBytes: number };
+}
+
+/** JSON-mode measurement envelope (MultispeQ-shaped device header + samples). */
+export interface MiniParMeasurementEnvelope {
+  device_name?: string;
+  device_version?: string;
+  device_id?: string;
+  device_battery?: string;
+  device_firmware?: number | string;
+  sample?: unknown[];
+  [key: string]: unknown;
+}

--- a/packages/iot/src/driver/multispeq/driver.spec.ts
+++ b/packages/iot/src/driver/multispeq/driver.spec.ts
@@ -245,6 +245,29 @@ describe("MultispeqDriver", () => {
     });
   });
 
+  describe("getDeviceIdentity", () => {
+    it("falls back to battery and hello on firmware without device_info", async () => {
+      driver.initialize(transport);
+      vi.mocked(transport.send).mockImplementation((payload: string) => {
+        const command = payload.trim();
+        const reply =
+          command === "device_info"
+            ? "BAD COMMAND\n"
+            : command === "battery"
+              ? "battery:77\n"
+              : "Legacy MultispeQ\n";
+        setTimeout(() => transport.simulateData(reply), 0);
+        return Promise.resolve();
+      });
+
+      await expect(driver.getDeviceIdentity()).resolves.toMatchObject({
+        family: "multispeq",
+        name: "Legacy MultispeQ",
+        batteryPercent: 77,
+      });
+    });
+  });
+
   describe("destroy", () => {
     it("should clean up emitter and buffer", async () => {
       driver.initialize(transport);

--- a/packages/iot/src/driver/multispeq/driver.ts
+++ b/packages/iot/src/driver/multispeq/driver.ts
@@ -5,6 +5,7 @@
  * Commands are sent as strings (or JSON) terminated with \r\n.
  * Responses are newline-terminated with an 8-char checksum before the newline.
  */
+import type { DeviceIdentity, SensorFamily } from "../../core/families";
 import type { ITransportAdapter } from "../../transport/interface";
 import {
   stringifyIfObject,
@@ -37,6 +38,8 @@ function summarizeCommand(commandStr: string, maxLength = 120): string {
  * Implements the MultispeQ device communication with checksums and JSON framing
  */
 export class MultispeqDriver extends DeviceDriver<MultispeqStreamEvents> {
+  override readonly family: SensorFamily = "multispeq";
+
   private dataBuffer: string[] = [];
   private bufferLength = 0;
 
@@ -189,6 +192,46 @@ export class MultispeqDriver extends DeviceDriver<MultispeqStreamEvents> {
     }
 
     return info;
+  }
+
+  /**
+   * Structured identity via `device_info` (JSON: name, version, id, battery,
+   * firmware); falls back to the battery+hello probe on older firmware.
+   */
+  async getDeviceIdentity(): Promise<DeviceIdentity> {
+    // Identity runs during connect; never let it hang on the 60s console default.
+    const result = await this.execute<Record<string, unknown>>(MULTISPEQ_COMMANDS.DEVICE_INFO, {
+      timeoutMs: 5_000,
+    });
+    if (result.success && typeof result.data === "object") {
+      const data = result.data;
+      const batteryRaw = data.device_battery;
+      const battery =
+        typeof batteryRaw === "number"
+          ? batteryRaw
+          : typeof batteryRaw === "string"
+            ? parseInt(batteryRaw, 10)
+            : NaN;
+      const fw = data.device_firmware;
+      return {
+        family: this.family,
+        name: typeof data.device_name === "string" ? data.device_name : undefined,
+        deviceId: typeof data.device_id === "string" ? data.device_id : undefined,
+        firmwareVersion: typeof fw === "string" ? fw : typeof fw === "number" ? `${fw}` : undefined,
+        batteryPercent: isNaN(battery) ? undefined : battery,
+        raw: data,
+      };
+    }
+
+    const info = await this.getDeviceInfo();
+    return {
+      family: this.family,
+      name: typeof info.device_name === "string" ? info.device_name : undefined,
+      deviceId: info.device_id,
+      firmwareVersion: info.device_version,
+      batteryPercent: info.device_battery,
+      raw: info,
+    };
   }
 
   private waitForResponse(timeoutMs: number): Promise<MultispeqCommandResult> {

--- a/packages/iot/src/driver/testing/mock-transport.ts
+++ b/packages/iot/src/driver/testing/mock-transport.ts
@@ -1,0 +1,23 @@
+import { vi } from "vitest";
+
+import type { ITransportAdapter } from "../../transport/interface";
+
+export type MockTransport = ITransportAdapter & { simulateData: (data: string) => void };
+
+/** Transport stub with the concrete adapters' single-callback replace semantics. */
+export function createMockTransport(): MockTransport {
+  let dataCallback: ((data: string) => void) | undefined;
+
+  return {
+    isConnected: vi.fn().mockReturnValue(true),
+    send: vi.fn().mockResolvedValue(undefined),
+    onDataReceived: vi.fn((cb: (data: string) => void) => {
+      dataCallback = cb;
+    }),
+    onStatusChanged: vi.fn(),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    simulateData(data: string) {
+      dataCallback?.(data);
+    },
+  };
+}

--- a/packages/iot/src/index.ts
+++ b/packages/iot/src/index.ts
@@ -84,6 +84,35 @@ export {
   GENERIC_SERIAL_DEFAULTS,
   GENERIC_FRAMING,
 } from "./driver/generic/config";
+export { GenericCommandConnector } from "./driver/generic/command-connector";
+export type {
+  GenericCommandConnectorConfig,
+  GenericCommandConnectorEvents,
+} from "./driver/generic/command-connector";
+
+// ── Ambit driver (text console, command/response) ───
+export { AmbitDriver } from "./driver/ambit/driver";
+export type { AmbitDriverConfig } from "./driver/ambit/config";
+export { AMBIT_SERIAL_DEFAULTS, AMBIT_FRAMING } from "./driver/ambit/config";
+export { AMBIT_COMMANDS, AMBIT_SILENT_COMMANDS } from "./driver/ambit/commands";
+export type {
+  AmbitParReading,
+  AmbitTempReading,
+  AmbitStreamEvents,
+} from "./driver/ambit/interface";
+
+// ── MiniPAR driver (LINE + JSON protocol modes) ─────
+export { MiniParDriver } from "./driver/minipar/driver";
+export type { MiniParDriverConfig } from "./driver/minipar/config";
+export { MINIPAR_SERIAL_DEFAULTS, MINIPAR_FRAMING } from "./driver/minipar/config";
+export { MINIPAR_COMMANDS } from "./driver/minipar/commands";
+export type { MiniParMeasurementEnvelope, MiniParStreamEvents } from "./driver/minipar/interface";
+
+// ── Device identity ─────────────────────────────────
+export type { DeviceIdentity, SensorFamily } from "./core/families";
+export { SENSOR_FAMILIES, isSensorFamily } from "./core/families";
+export type { IdentifiedDevice, IdentifyDeviceOptions } from "./core/identify-device";
+export { identifyDevice, createConnectorForFamily } from "./core/identify-device";
 
 // ── Logger (public DI contract) ─────────────────────
 export type { Logger } from "./utils/logger/logger";


### PR DESCRIPTION
## What

Multi-sensor workbooks need to know WHO they are talking to after a BLE/serial connect. This PR adds the whole global-device-context stack, one commit per slice:

1. **Identification handshake + \$device branch source** (OJD-1668, OJD-1658): \`identifyDevice()\` probes \`hello\` / \`{"command":"INFO"}\` and classifies against firmware-faithful signatures (MultispeQ \`MultispeQ Ready\` and legacy \`Instrument Ready\`, MiniPAR JSON/CSV, Ambit \`NEW ... Ready\` sentinel), returning a structured \`DeviceIdentity\` stored per connection on both hosts. The identified family outranks the toolbar selection (toast on mismatch). Branch cells gain the reserved \`\$device\` source (\`family/id/name/index/firmwareVersion\`) with a pinned "Connected device" entry in the condition editor. Adds the \`ambit\` sensor family (idempotent \`ADD VALUE\` migration; Ambit = leaf sensor, distinct from the Ambyte gateway that migration 0037 folded it into).
2. **ctx namespace** (OJD-1655): \`buildCellNamespace\` exposes every upstream output to macros as read-only \`ctx\` (by canonical name and \`byId\`), device-scoped for multi-device outputs, with \`ctx.\$device\` injected at run time. Threaded through the backend Lambda payload into all three sandbox wrappers (JS deep-freeze, Python MappingProxyType, R lockBinding) and both hosts, including mobile's Pyodide sandbox. \`resolveConditionValue\` delegates to the same resolver so branches and macros can never disagree. ctx-only macros run without a preceding measurement.
3. **Real Ambit + MiniPAR drivers** (OJD-1670, OJD-1671): AmbitDriver speaks the unframed text console (quiet-window collection, wake polling, silent writers with settle + hello re-verify, one-write multi-arg commands, parsed get_par/temp); protocol JSON is rejected with a command-cell hint. MiniParDriver is dual-mode (LINE with quiet-window fallback for newline-less replies, JSON protocol with the constant \`7A1E3AA1\` footer). Both register in \`identifyDevice\` and the web host; ambit/minipar become locally connectable (ambyte stays MQTT-only).
4. **Per-device dispatch** (OJD-1659): a \$device-conditioned branch is a dispatcher on both hosts: each connected device evaluates the branch with its own identity, devices group by resolved path, each path's protocol/command target runs against only its group, unmatched devices are skipped with a message, and consumed targets are skipped exactly once (no jump). Mobile rounds run per-device payloads via \`executeScanAssignments\` and upload per-result \`protocolId\` (own MQTT topic per family) under one shared \`workbook_run_id\`.

## Notes for review

- The widened name-uniqueness rule from the swartz prior art was deliberately NOT ported: \`zWorkbookCellArray\` validates loads too, so it would make existing workbooks with duplicate producer names unloadable. On ctx collisions the nearest upstream producer wins instead.
- Per-family mock devices: \`?mockDevices=multispeq,ambit,minipar\` (bare \`=1\` stays a MultispeQ); mocks answer the real handshake.
- Ambit firmware quirk: \`hello\` prints a hardcoded \`NEW Name Here\`, so classification keys on the sentinel, never the name.
- Macro-as-constructor, command-validator, calibration workbooks (OJD-1612/1613) and \`ctx.\$devices\` aggregates are out of scope.

## Verification

- packages/iot 313 tests, packages/api 675 tests, web 4703 tests (662 files), mobile 867 tests (82 files); lint + check-types green across all touched packages.
- Migration applied to local pg: enum extended, existing protocol rows untouched.
- Backend integration tests need the 5433 test DB (not running locally); backend typecheck green, execute-macro context threading covered by api schema tests.

Linear: OJD-1668, OJD-1658, OJD-1655, OJD-1670, OJD-1671, OJD-1659

Linear: [OJD-1680](https://linear.app/openjii/issue/OJD-1680/cloud-macro-execution-is-not-pinned-to-the-published-workbook-version)