### PR TITLE
feat(web): add workbook descriptions

### DIFF
--- a/apps/web/app/[locale]/platform/experiments/[id]/design/page.test.tsx
+++ b/apps/web/app/[locale]/platform/experiments/[id]/design/page.test.tsx
@@ -130,6 +130,7 @@ function mountWithWorkbook(overrides?: {
     body: createWorkbook({
       id: WB_ID,
       name: "Test Workbook",
+      description: "Measures canopy temperature",
       cells: [
         createProtocolCell({ id: "c1", payload: { protocolId: "p1", version: 1, name: "P1" } }),
       ],
@@ -218,6 +219,13 @@ describe("ExperimentDesignPage", () => {
     await waitFor(() => {
       expect(screen.getByTestId("workbook-editor")).toBeInTheDocument();
     });
+  });
+
+  it("displays the linked workbook description", async () => {
+    mountWithWorkbook();
+    render(<ExperimentDesignPage params={defaultProps.params} />);
+
+    expect(await screen.findByText("Measures canopy temperature")).toBeInTheDocument();
   });
 
   it("shows version badge when workbook is linked", async () => {

--- a/apps/web/app/[locale]/platform/experiments/[id]/design/page.tsx
+++ b/apps/web/app/[locale]/platform/experiments/[id]/design/page.tsx
@@ -170,18 +170,16 @@ export default function ExperimentDesignPage({ params }: ExperimentDesignPagePro
         />
 
         <NavTabs defaultValue="list">
-          <div className="border-border border-b">
-            <NavTabsList>
-              <NavTabsTrigger value="list">
-                <List className="h-4 w-4" />
-                {t("flow.viewList")}
-              </NavTabsTrigger>
-              <NavTabsTrigger value="graph">
-                <GitBranch className="h-4 w-4" />
-                {t("flow.viewGraph")}
-              </NavTabsTrigger>
-            </NavTabsList>
-          </div>
+          <NavTabsList>
+            <NavTabsTrigger value="list">
+              <List className="h-4 w-4" />
+              {t("flow.viewList")}
+            </NavTabsTrigger>
+            <NavTabsTrigger value="graph">
+              <GitBranch className="h-4 w-4" />
+              {t("flow.viewGraph")}
+            </NavTabsTrigger>
+          </NavTabsList>
 
           <NavTabsContent value="list" className="mt-6">
             {canEdit ? (

--- a/apps/web/components/experiment-flow/linked-workbook-card.test.tsx
+++ b/apps/web/components/experiment-flow/linked-workbook-card.test.tsx
@@ -58,6 +58,24 @@ describe("LinkedWorkbookCard", () => {
     expect(screen.getByRole("link")).toHaveAttribute("href", "/en-US/platform/workbooks/wb-1");
   });
 
+  it("renders a line-clamped plain-text description without a section heading", async () => {
+    server.mount(contract.workbooks.getWorkbook, {
+      body: {
+        ...workbook,
+        description: "<p>Measures <strong>chlorophyll</strong>&nbsp; fluorescence</p>",
+      },
+    });
+    server.mount(contract.workbooks.listWorkbookVersions, { body: [v2, v1] });
+    server.mount(contract.workbooks.listWorkbooks, { body: [workbook, otherWorkbook] });
+
+    render(<LinkedWorkbookCard {...defaultProps} />);
+
+    const description = await screen.findByText("Measures chlorophyll fluorescence");
+    expect(description).toHaveClass("line-clamp-2");
+    expect(screen.queryByText("workbooks.descriptionTitle")).not.toBeInTheDocument();
+    expect(screen.getByText(/workbooks.lastUpdate.*Test User/)).toBeInTheDocument();
+  });
+
   it("shows version badge for the pinned version", async () => {
     mountDefaults();
     render(<LinkedWorkbookCard {...defaultProps} />);

--- a/apps/web/components/experiment-flow/linked-workbook-card.tsx
+++ b/apps/web/components/experiment-flow/linked-workbook-card.tsx
@@ -9,9 +9,12 @@ import { useWorkbookList } from "@/hooks/workbook/useWorkbookList/useWorkbookLis
 import { useWorkbookUpdate } from "@/hooks/workbook/useWorkbookUpdate/useWorkbookUpdate";
 import { useWorkbookVersions } from "@/hooks/workbook/useWorkbookVersions/useWorkbookVersions";
 import { orpc } from "@/lib/orpc";
+import { formatDate } from "@/util/date";
+import { stripHtml } from "@/util/strip-html";
 import { useIsFetching, useIsMutating } from "@tanstack/react-query";
 import {
   ArrowUpCircle,
+  BookOpen,
   Check,
   ExternalLink,
   History,
@@ -38,6 +41,7 @@ import {
   AlertDialogTrigger,
 } from "@repo/ui/components/alert-dialog";
 import { Button } from "@repo/ui/components/button";
+import { Card, CardContent } from "@repo/ui/components/card";
 import { Input } from "@repo/ui/components/input";
 import { toast } from "@repo/ui/hooks/use-toast";
 import { cn } from "@repo/ui/lib/utils";
@@ -65,7 +69,7 @@ export function LinkedWorkbookCard({
   isWorkbookOwner = false,
 }: LinkedWorkbookCardProps) {
   const { t } = useTranslation("experiments");
-
+  const { t: tWorkbook } = useTranslation("workbook");
   const { data: workbook } = useWorkbook(workbookId, { enabled: !!workbookId });
 
   const { data: versionsData } = useWorkbookVersions(workbookId, {
@@ -113,6 +117,7 @@ export function LinkedWorkbookCard({
   const [isRenaming, setIsRenaming] = useState(false);
   const [nameDraft, setNameDraft] = useState("");
   const canRename = hasAccess && isWorkbookOwner;
+  const plainDescription = workbook?.description ? stripHtml(workbook.description) : "";
 
   const startRename = () => {
     setNameDraft(workbook?.name ?? "");
@@ -202,13 +207,16 @@ export function LinkedWorkbookCard({
   }, [experimentId, upgradeVersion, t]);
 
   return (
-    <div>
-      <div className="flex items-center justify-between gap-3 py-1">
-        <div className="flex min-w-0 items-center gap-3">
-          <div className="min-w-0">
-            <div className="flex items-center gap-2">
+    <Card className="overflow-hidden shadow-none">
+      <CardContent className="pb-6 pt-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="bg-muted flex h-10 w-10 shrink-0 items-center justify-center rounded-full">
+              <BookOpen className="text-muted-foreground h-5 w-5" />
+            </div>
+            <div className="min-w-0">
               {isRenaming ? (
-                <>
+                <div className="flex items-center gap-1">
                   <Input
                     value={nameDraft}
                     onChange={(e) => setNameDraft(e.target.value)}
@@ -246,90 +254,107 @@ export function LinkedWorkbookCard({
                   >
                     <X className="h-4 w-4" />
                   </Button>
-                </>
+                </div>
               ) : (
                 <>
-                  <NextLink
-                    href={`/${locale}/platform/workbooks/${workbookId}`}
-                    target="_blank"
-                    className="text-foreground truncate text-sm font-semibold hover:underline"
-                  >
-                    {workbook?.name ?? t("flow.title")}
-                    <ExternalLink className="ml-1 inline h-3 w-3 align-baseline opacity-50" />
-                  </NextLink>
-                  {pinnedVersion && (
-                    <span className={upgradeState === "success" ? "animate-version-pop" : ""}>
-                      <WorkbookVersionBadge
-                        currentVersion={pinnedVersion.version}
-                        latestVersion={latestVersion.version}
-                        showUpgrade={false}
-                      />
-                    </span>
-                  )}
-                  {pinnedVersion && (
-                    <button
-                      type="button"
-                      onClick={() => setHistoryOpen(true)}
-                      aria-label={t("flow.versionHistory.open")}
-                      title={t("flow.versionHistory.open")}
-                      className="text-muted-foreground hover:text-foreground shrink-0 rounded p-0.5 transition-colors"
+                  <div className="flex items-center gap-1.5">
+                    <NextLink
+                      href={`/${locale}/platform/workbooks/${workbookId}`}
+                      target="_blank"
+                      className="truncate text-sm font-semibold hover:underline"
                     >
-                      <History className="h-3.5 w-3.5" />
-                    </button>
-                  )}
-                  {canRename && (
-                    <button
-                      type="button"
-                      onClick={startRename}
-                      aria-label={t("flow.renameWorkbook")}
-                      className="text-muted-foreground hover:text-foreground shrink-0 rounded p-0.5 transition-colors"
-                    >
-                      <Pencil className="h-3.5 w-3.5" />
-                    </button>
-                  )}
+                      {workbook?.name ?? t("flow.title")}
+                      <ExternalLink className="ml-1 inline h-3 w-3 align-baseline opacity-50" />
+                    </NextLink>
+                    {canRename && (
+                      <button
+                        type="button"
+                        onClick={startRename}
+                        aria-label={t("flow.renameWorkbook")}
+                        className="text-muted-foreground hover:text-foreground shrink-0 rounded p-0.5 transition-colors"
+                      >
+                        <Pencil className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-2">
+                    {workbook && (
+                      <p className="text-muted-foreground text-xs">
+                        {tWorkbook("workbooks.lastUpdate")}: {formatDate(workbook.updatedAt)}
+                        {workbook.createdByName && <> · {workbook.createdByName}</>}
+                      </p>
+                    )}
+                    {pinnedVersion && (
+                      <span className={upgradeState === "success" ? "animate-version-pop" : ""}>
+                        <WorkbookVersionBadge
+                          currentVersion={pinnedVersion.version}
+                          latestVersion={latestVersion.version}
+                          showUpgrade={false}
+                        />
+                      </span>
+                    )}
+                    {pinnedVersion && (
+                      <button
+                        type="button"
+                        onClick={() => setHistoryOpen(true)}
+                        aria-label={t("flow.versionHistory.open")}
+                        title={t("flow.versionHistory.open")}
+                        className="text-muted-foreground hover:text-foreground shrink-0 rounded p-0.5 transition-colors"
+                      >
+                        <History className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+                  </div>
                 </>
               )}
             </div>
           </div>
-        </div>
-        {hasAccess && (
-          <div className="flex shrink-0 items-center gap-2">
-            <Button variant="outline" size="sm" onClick={() => setIsChanging(!isChanging)}>
-              {t("flow.changeWorkbook")}
-            </Button>
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button variant="outline" size="sm" disabled={detachWorkbook.isPending}>
-                  <Unlink className="mr-1.5 h-4 w-4" />
-                  {t("flow.detach")}
-                </Button>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>{t("flow.confirmDetachTitle")}</AlertDialogTitle>
-                  <AlertDialogDescription>{t("flow.confirmDetachMessage")}</AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
-                  <AlertDialogAction
-                    onClick={handleDetach}
-                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                  >
+          {hasAccess && (
+            <div className="flex shrink-0 items-center gap-2">
+              <Button variant="outline" size="sm" onClick={() => setIsChanging(!isChanging)}>
+                {t("flow.changeWorkbook")}
+              </Button>
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button variant="outline" size="sm" disabled={detachWorkbook.isPending}>
+                    <Unlink className="mr-1.5 h-4 w-4" />
                     {t("flow.detach")}
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          </div>
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>{t("flow.confirmDetachTitle")}</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      {t("flow.confirmDetachMessage")}
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={handleDetach}
+                      className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    >
+                      {t("flow.detach")}
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </div>
+          )}
+        </div>
+
+        {plainDescription && (
+          <p className="text-muted-foreground mt-3 line-clamp-2 text-sm">{plainDescription}</p>
         )}
-      </div>
+      </CardContent>
 
       {hasUpgrade && hasAccess && pinnedVersion && upgradeState !== "success" && (
         <div
           className={cn(
             "flex items-center justify-between gap-4 border-t px-4 py-2.5 transition-colors duration-300",
             upgradeState === "upgrading"
-              ? "animate-shimmer bg-gradient-to-r from-[#CCFCD8]/20 via-[#CCFCD8]/50 to-[#CCFCD8]/20 bg-[length:200%_100%]"
+              ? "animate-shimmer bg-linear-to-r bg-size-[200%_100%] from-[#CCFCD8]/20 via-[#CCFCD8]/50 to-[#CCFCD8]/20"
               : "bg-[#CCFCD8]/30",
           )}
         >
@@ -449,6 +474,6 @@ export function LinkedWorkbookCard({
         currentVersionId={workbookVersionId}
         canManage={hasAccess}
       />
-    </div>
+    </Card>
   );
 }

--- a/apps/web/components/experiment-overview/experiment-linked-workbook.test.tsx
+++ b/apps/web/components/experiment-overview/experiment-linked-workbook.test.tsx
@@ -56,6 +56,20 @@ describe("ExperimentLinkedWorkbook", () => {
     });
   });
 
+  it("renders a rich-text description without HTML tags", async () => {
+    const workbook = createWorkbook({
+      id: workbookId,
+      description: "<p>Measures <strong>chlorophyll</strong>&nbsp; fluorescence</p>",
+    });
+    server.mount(contract.workbooks.getWorkbook, { body: workbook });
+    server.mount(contract.workbooks.listWorkbookVersions, { body: [] });
+
+    render(<ExperimentLinkedWorkbook workbookId={workbookId} />);
+
+    expect(await screen.findByText("Measures chlorophyll fluorescence")).toBeInTheDocument();
+    expect(screen.queryByText(/<strong>/)).not.toBeInTheDocument();
+  });
+
   it("renders cell summary pills", async () => {
     const cells = [
       createProtocolCell({ id: "c1" }),

--- a/apps/web/components/experiment-overview/experiment-linked-workbook.tsx
+++ b/apps/web/components/experiment-overview/experiment-linked-workbook.tsx
@@ -9,6 +9,7 @@ import { useLocale } from "@/hooks/useLocale";
 import { useWorkbook } from "@/hooks/workbook/useWorkbook/useWorkbook";
 import { useWorkbookVersions } from "@/hooks/workbook/useWorkbookVersions/useWorkbookVersions";
 import { formatDate } from "@/util/date";
+import { stripHtml } from "@/util/strip-html";
 import { BookOpen } from "lucide-react";
 import Link from "next/link";
 
@@ -54,6 +55,7 @@ export function ExperimentLinkedWorkbook({
   if (!workbook) return null;
 
   const hasCells = getWorkbookCellSummary(workbook.cells).length > 0;
+  const plainDescription = workbook.description ? stripHtml(workbook.description) : "";
 
   return (
     <div className="space-y-4">
@@ -90,10 +92,8 @@ export function ExperimentLinkedWorkbook({
             </div>
           </div>
 
-          {workbook.description && (
-            <p className="text-muted-foreground mt-3 line-clamp-2 text-sm">
-              {workbook.description}
-            </p>
+          {plainDescription && (
+            <p className="text-muted-foreground mt-3 line-clamp-2 text-sm">{plainDescription}</p>
           )}
 
           {hasCells ? (

--- a/apps/web/components/workbook-overview/workbook-layout-content.test.tsx
+++ b/apps/web/components/workbook-overview/workbook-layout-content.test.tsx
@@ -52,6 +52,13 @@ describe("WorkbookLayoutContent", () => {
     expect(screen.getByTestId("children")).toBeInTheDocument();
   });
 
+  it("displays the workbook description", () => {
+    renderContent({ description: "Measures photosynthetic efficiency" });
+
+    expect(screen.getByText("Measures photosynthetic efficiency")).toBeInTheDocument();
+    expect(screen.getByText("workbooks.descriptionTitle")).toBeInTheDocument();
+  });
+
   it("lets the creator rename the workbook by clicking the title", async () => {
     const user = userEvent.setup();
     const updateSpy = server.mount(contract.workbooks.updateWorkbook, {

--- a/apps/web/components/workbook-overview/workbook-layout-content.tsx
+++ b/apps/web/components/workbook-overview/workbook-layout-content.tsx
@@ -3,6 +3,7 @@
 import { AutosaveIndicator } from "@/components/shared/autosave/autosave-indicator";
 import { useAutosaveStatus } from "@/components/shared/autosave/autosave-status-context";
 import { InlineEditableTitle } from "@/components/shared/inline-editable-title";
+import { WorkbookDescription } from "@/components/workbook/workbook-description";
 import { WorkbookVersionBadge } from "@/components/workbook/workbook-version-badge";
 import { useWorkbookUpdate } from "@/hooks/workbook/useWorkbookUpdate/useWorkbookUpdate";
 import { useWorkbookVersions } from "@/hooks/workbook/useWorkbookVersions/useWorkbookVersions";
@@ -59,15 +60,23 @@ export function WorkbookLayoutContent({ id, workbook, children }: WorkbookLayout
     <div className="flex flex-1 flex-col">
       {/* Title + metadata (fluid; the parent PageContainer controls overall width). */}
       <div className="flex w-full flex-col gap-8">
-        <div className="flex flex-col gap-2">
-          <InlineEditableTitle
-            name={workbook.name}
+        <div className="space-y-5">
+          <div className="flex flex-col gap-2">
+            <InlineEditableTitle
+              name={workbook.name}
+              hasAccess={isCreator}
+              onSave={handleTitleSave}
+              isPending={isUpdating}
+              icon={<BookOpen className="h-6 w-6" />}
+            />
+            <AutosaveIndicator status={indicatorStatus} />
+          </div>
+
+          <WorkbookDescription
+            workbookId={id}
+            description={workbook.description ?? ""}
             hasAccess={isCreator}
-            onSave={handleTitleSave}
-            isPending={isUpdating}
-            icon={<BookOpen className="h-6 w-6" />}
           />
-          <AutosaveIndicator status={indicatorStatus} />
         </div>
 
         <div className="flex items-start gap-10 border-b border-[#EDF2F6] pb-8">

--- a/apps/web/components/workbook/workbook-description.test.tsx
+++ b/apps/web/components/workbook/workbook-description.test.tsx
@@ -1,0 +1,76 @@
+import { createWorkbook } from "@/test/factories";
+import { server } from "@/test/msw/server";
+import { render, screen, userEvent, waitFor } from "@/test/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+import { contract } from "@repo/api/contract";
+
+import { WorkbookDescription } from "./workbook-description";
+
+vi.mock("@repo/ui/components/rich-textarea", () => ({
+  RichTextarea: ({
+    value,
+    onChange,
+    placeholder,
+    isDisabled,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    placeholder: string;
+    isDisabled: boolean;
+  }) => (
+    <textarea
+      data-testid="rich-textarea"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      placeholder={placeholder}
+      disabled={isDisabled}
+    />
+  ),
+}));
+
+vi.mock("@repo/ui/components/rich-text-renderer", () => ({
+  RichTextRenderer: ({ content }: { content: string }) => (
+    <div data-testid="rich-text-renderer">{content}</div>
+  ),
+}));
+
+describe("WorkbookDescription", () => {
+  it("renders the existing description", () => {
+    render(
+      <WorkbookDescription workbookId="wb-1" description="Measures chlorophyll fluorescence" />,
+    );
+
+    expect(screen.getByText("Measures chlorophyll fluorescence")).toBeInTheDocument();
+  });
+
+  it("does not enter edit mode without access", async () => {
+    const user = userEvent.setup();
+    render(<WorkbookDescription workbookId="wb-1" description="Read only" />);
+
+    const descriptionContainer = screen.getByTestId("rich-text-renderer").parentElement;
+    if (descriptionContainer) await user.click(descriptionContainer);
+
+    expect(screen.queryByTestId("rich-textarea")).not.toBeInTheDocument();
+  });
+
+  it("updates the workbook description", async () => {
+    const updateSpy = server.mount(contract.workbooks.updateWorkbook, {
+      body: createWorkbook({ id: "wb-1", description: "New description" }),
+    });
+    const user = userEvent.setup();
+    render(<WorkbookDescription workbookId="wb-1" description="Old description" hasAccess />);
+
+    const descriptionContainer = screen.getByTestId("rich-text-renderer").parentElement;
+    if (descriptionContainer) await user.click(descriptionContainer);
+
+    const textarea = screen.getByTestId("rich-textarea");
+    await user.clear(textarea);
+    await user.type(textarea, "New description");
+    await user.click(screen.getByRole("button", { name: "common.save" }));
+
+    await waitFor(() => expect(updateSpy.called).toBe(true));
+    expect(updateSpy.params).toMatchObject({ id: "wb-1" });
+    expect(updateSpy.body).toEqual({ description: "New description" });
+  });
+});

--- a/apps/web/components/workbook/workbook-description.tsx
+++ b/apps/web/components/workbook/workbook-description.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { InlineEditableDescription } from "@/components/shared/inline-editable-description";
+import { useWorkbookUpdate } from "@/hooks/workbook/useWorkbookUpdate/useWorkbookUpdate";
+import { parseApiError } from "@/util/apiError";
+
+import { useTranslation } from "@repo/i18n";
+import { toast } from "@repo/ui/hooks/use-toast";
+
+interface WorkbookDescriptionProps {
+  workbookId: string;
+  description: string;
+  hasAccess?: boolean;
+}
+
+/** Shared workbook description used by both the workbook and experiment-design pages. */
+export function WorkbookDescription({
+  workbookId,
+  description,
+  hasAccess = false,
+}: WorkbookDescriptionProps) {
+  const { t } = useTranslation(["workbook", "common"]);
+  const { mutateAsync: updateWorkbook, isPending: isUpdating } = useWorkbookUpdate(workbookId);
+
+  const handleSave = async (newDescription: string) => {
+    await updateWorkbook(
+      { id: workbookId, description: newDescription },
+      {
+        onSuccess: () => {
+          toast({ description: t("workbooks.workbookUpdated") });
+        },
+        onError: (err) => {
+          toast({ description: parseApiError(err)?.message, variant: "destructive" });
+        },
+      },
+    );
+  };
+
+  return (
+    <InlineEditableDescription
+      description={description}
+      hasAccess={hasAccess}
+      onSave={handleSave}
+      isPending={isUpdating}
+      title={t("workbooks.descriptionTitle")}
+      saveLabel={t("common.save")}
+      cancelLabel={t("common.cancel")}
+      placeholder={t("workbooks.descriptionPlaceholder")}
+    />
+  );
+}

--- a/packages/i18n/locales/de-DE/workbook.json
+++ b/packages/i18n/locales/de-DE/workbook.json
@@ -8,6 +8,8 @@
     "workbookUpdated": "Arbeitsmappe erfolgreich aktualisiert",
     "createError": "Fehler beim Erstellen der Arbeitsmappe. Bitte versuchen Sie es erneut.",
     "listDescription": "Ihre Mess-Notebooks anzeigen und verwalten.",
+    "descriptionTitle": "Beschreibung",
+    "descriptionPlaceholder": "Beschreibung hinzufügen...",
     "noDescription": "Keine Beschreibung vorhanden",
     "notFound": "Arbeitsmappe nicht gefunden",
     "searchPlaceholder": "Arbeitsmappen durchsuchen...",

--- a/packages/i18n/locales/en-US/workbook.json
+++ b/packages/i18n/locales/en-US/workbook.json
@@ -13,6 +13,8 @@
     "workbookUpdated": "Workbook updated successfully",
     "createError": "Failed to create workbook. Please try again.",
     "listDescription": "View and manage your measurement notebooks.",
+    "descriptionTitle": "Description",
+    "descriptionPlaceholder": "Add a description...",
     "noDescription": "No description provided",
     "notFound": "Workbook not found",
     "searchPlaceholder": "Search workbooks...",

--- a/packages/i18n/locales/nl-NL/workbook.json
+++ b/packages/i18n/locales/nl-NL/workbook.json
@@ -8,6 +8,8 @@
     "workbookUpdated": "Werkboek succesvol bijgewerkt",
     "createError": "Kan werkboek niet aanmaken. Probeer het opnieuw.",
     "listDescription": "Bekijk en beheer uw meetnotebooks.",
+    "descriptionTitle": "Beschrijving",
+    "descriptionPlaceholder": "Beschrijving toevoegen...",
     "noDescription": "Geen beschrijving beschikbaar",
     "notFound": "Werkboek niet gevonden",
     "searchPlaceholder": "Werkboeken zoeken...",


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Adds an editable **description** to workbooks and surfaces it consistently everywhere a workbook appears. Creators can edit a workbook's rich-text description inline on the workbook overview page; the description is also rendered (as safe plain text) on the experiment design page and in the experiment overview's linked-workbook views. The linked-workbook card was also restyled into a proper `Card` with an icon, last-updated/author metadata, and a line-clamped description.

## Changes Made

- New shared `WorkbookDescription` component wrapping `InlineEditableDescription` — inline rich-text editing wired to `useWorkbookUpdate` with success/error toasts; reused by both the workbook and experiment-design surfaces.
- Workbook overview page now renders the editable description under the title.
- Linked-workbook card restyled into a `Card` with a `BookOpen` icon, last-updated/author metadata, and a line-clamped plain-text description (via `stripHtml`); also migrated shimmer gradient classes to the newer Tailwind syntax (`bg-linear-to-r`).
- Experiment linked-workbook view now strips HTML from the description before rendering.
- Design page `NavTabs` markup cleanup (removed redundant bordered wrapper).
- Added `workbooks.descriptionTitle` / `workbooks.descriptionPlaceholder` i18n strings to en-US, nl-NL, and de-DE.
- Added tests for `WorkbookDescription` (render/edit/save, read-only) plus description-rendering assertions on the design page, linked-workbook card, experiment linked-workbook, and workbook layout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Jan-IngenHousz-Institute/codesmith/open-jii/pr/1792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786798343&installation_id=146274774&pr_number=1792&repository=Jan-IngenHousz-Institute%2Fopen-jii&return_to=https%3A%2F%2Fgithub.com%2FJan-IngenHousz-Institute%2Fopen-jii%2Fpull%2F1792&signature=e127cbcbe4e3ba6068cc4379a9c3254efac04ff6b317b44297b791cfd512304d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->