### PR TITLE
chore(infra): add Route53 health check alert for site availability

### DIFF
--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -2224,7 +2224,8 @@ module "grafana_dashboard" {
   large_iot_dlq_name                        = module.iot_core.large_iot_dlq_name
   large_iot_ingestion_lag_threshold_seconds = 10800 # 3 hours — pipeline disabled in dev
 
-  route53_health_check_id = module.route53.health_check_id
+  enable_site_availability_alert = true
+  route53_health_check_id        = module.route53.health_check_id
 
   providers = {
     grafana.amg = grafana.amg

--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -2031,6 +2031,8 @@ module "route53" {
     }
   }
 
+  enable_health_check = true
+
   tags = {
     Environment = var.environment
     ManagedBy   = "Terraform"
@@ -2221,6 +2223,8 @@ module "grafana_dashboard" {
   large_iot_notification_queue_name         = module.iot_core.large_iot_notification_queue_name
   large_iot_dlq_name                        = module.iot_core.large_iot_dlq_name
   large_iot_ingestion_lag_threshold_seconds = 10800 # 3 hours — pipeline disabled in dev
+
+  route53_health_check_id = module.route53.health_check_id
 
   providers = {
     grafana.amg = grafana.amg

--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -2192,7 +2192,8 @@ module "grafana_dashboard" {
   large_iot_notification_queue_name = module.iot_core.large_iot_notification_queue_name
   large_iot_dlq_name                = module.iot_core.large_iot_dlq_name
 
-  route53_health_check_id = module.route53.health_check_id
+  enable_site_availability_alert = true
+  route53_health_check_id        = module.route53.health_check_id
 
   providers = {
     grafana.amg = grafana.amg

--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -1989,6 +1989,8 @@ module "route53" {
     }
   }
 
+  enable_health_check = true
+
   tags = {
     Environment = var.environment
     ManagedBy   = "Terraform"
@@ -2189,6 +2191,8 @@ module "grafana_dashboard" {
 
   large_iot_notification_queue_name = module.iot_core.large_iot_notification_queue_name
   large_iot_dlq_name                = module.iot_core.large_iot_dlq_name
+
+  route53_health_check_id = module.route53.health_check_id
 
   providers = {
     grafana.amg = grafana.amg

--- a/infrastructure/modules/grafana/dashboard/main.tf
+++ b/infrastructure/modules/grafana/dashboard/main.tf
@@ -479,13 +479,14 @@ resource "grafana_rule_group" "site_availability" {
         namespace  = "AWS/Route53"
         metricName = "HealthCheckStatus"
         statistic  = "Minimum"
+        period     = 60
         dimensions = {
           HealthCheckId = var.route53_health_check_id
         }
       })
 
       relative_time_range {
-        from = 180
+        from = 300
         to   = 0
       }
     }

--- a/infrastructure/modules/grafana/dashboard/main.tf
+++ b/infrastructure/modules/grafana/dashboard/main.tf
@@ -454,6 +454,92 @@ resource "grafana_rule_group" "cloudfront_errors" {
   }
 }
 
+# Site Availability Alerts (active Route53 health check probe)
+resource "grafana_rule_group" "site_availability" {
+  count = var.enable_site_availability_alert ? 1 : 0
+
+  provider           = grafana.amg
+  name               = "Site Availability"
+  folder_uid         = grafana_folder.folder.uid
+  interval_seconds   = 60
+  disable_provenance = true
+
+  rule {
+    name      = "Site Down - Health Check Failing"
+    condition = "C"
+
+    data {
+      ref_id         = "A"
+      query_type     = ""
+      datasource_uid = grafana_data_source.cloudwatch_source.uid
+
+      model = jsonencode({
+        refId      = "A"
+        region     = "us-east-1"
+        namespace  = "AWS/Route53"
+        metricName = "HealthCheckStatus"
+        statistic  = "Minimum"
+        dimensions = {
+          HealthCheckId = var.route53_health_check_id
+        }
+      })
+
+      relative_time_range {
+        from = 180
+        to   = 0
+      }
+    }
+
+    data {
+      ref_id         = "B"
+      query_type     = ""
+      datasource_uid = "__expr__"
+
+      model = jsonencode({
+        expression = "A"
+        type       = "reduce"
+        reducer    = "last"
+        refId      = "B"
+      })
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+    }
+
+    data {
+      ref_id         = "C"
+      query_type     = ""
+      datasource_uid = "__expr__"
+
+      model = jsonencode({
+        expression = "$B < 1"
+        type       = "math"
+        refId      = "C"
+      })
+
+      relative_time_range {
+        from = 0
+        to   = 0
+      }
+    }
+
+    no_data_state  = "Alerting"
+    exec_err_state = "Alerting"
+    for            = "1m"
+
+    annotations = {
+      description = "Route53 health check reports the site is unreachable"
+      summary     = "Site is down: active health check failing"
+    }
+    labels = {
+      severity = "critical"
+      service  = "frontend"
+    }
+  }
+}
+
 # Lambda Alerts (using CloudWatch fill for missing data)
 resource "grafana_rule_group" "lambda_health" {
   provider         = grafana.amg

--- a/infrastructure/modules/grafana/dashboard/variables.tf
+++ b/infrastructure/modules/grafana/dashboard/variables.tf
@@ -94,9 +94,9 @@ variable "large_iot_ingestion_lag_threshold_seconds" {
 }
 
 variable "enable_site_availability_alert" {
-  description = "Whether to create the Route53 health-check-based site availability alert. Must be a static bool (not derived from health_check_id) since it gates a resource count."
+  description = "Whether to create the Route53 health-check-based site availability alert. Must be a static bool (not derived from health_check_id) since it gates a resource count. Defaults to false so environments without a Route53 health check configured don't get a permanently-alerting rule with an empty HealthCheckId."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "route53_health_check_id" {

--- a/infrastructure/modules/grafana/dashboard/variables.tf
+++ b/infrastructure/modules/grafana/dashboard/variables.tf
@@ -93,4 +93,16 @@ variable "large_iot_ingestion_lag_threshold_seconds" {
   default     = 900 # 15 minutes
 }
 
+variable "enable_site_availability_alert" {
+  description = "Whether to create the Route53 health-check-based site availability alert. Must be a static bool (not derived from health_check_id) since it gates a resource count."
+  type        = bool
+  default     = true
+}
+
+variable "route53_health_check_id" {
+  description = "Route53 health check ID for active site-up monitoring. Only used when enable_site_availability_alert is true."
+  type        = string
+  default     = ""
+}
+
 

--- a/infrastructure/modules/iam-oidc/main.tf
+++ b/infrastructure/modules/iam-oidc/main.tf
@@ -642,6 +642,12 @@ locals {
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:GetChange",
+        # Health checks (Terraform - site availability alert)
+        "route53:CreateHealthCheck",
+        "route53:DeleteHealthCheck",
+        "route53:GetHealthCheck",
+        "route53:UpdateHealthCheck",
+        "route53:ListHealthChecks",
         # Tags (Terraform)
         "route53:ListTagsForResource",
         "route53:ChangeTagsForResource",

--- a/infrastructure/modules/route53/main.tf
+++ b/infrastructure/modules/route53/main.tf
@@ -185,3 +185,22 @@ resource "aws_route53_record" "www_cname" {
   ttl     = 300
   records = [local.base_domain]
 }
+
+resource "aws_route53_health_check" "site_up" {
+  count = var.enable_health_check ? 1 : 0
+
+  fqdn              = local.base_domain
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/"
+  request_interval  = 30
+  failure_threshold = 3
+
+  tags = merge(
+    {
+      Name        = "${var.environment}-site-up"
+      Environment = var.environment
+    },
+    var.tags
+  )
+}

--- a/infrastructure/modules/route53/outputs.tf
+++ b/infrastructure/modules/route53/outputs.tf
@@ -41,3 +41,8 @@ output "cloudfront_certificate_arns" {
     for key, cert in aws_acm_certificate.cloudfront_certs : key => cert.arn
   }
 }
+
+output "health_check_id" {
+  description = "Route53 health check ID for active site-up monitoring (empty string when enable_health_check=false)"
+  value       = try(aws_route53_health_check.site_up[0].id, "")
+}

--- a/infrastructure/modules/route53/variables.tf
+++ b/infrastructure/modules/route53/variables.tf
@@ -55,3 +55,9 @@ variable "create_dns_records" {
   type        = bool
   default     = true
 }
+
+variable "enable_health_check" {
+  description = "Whether to create a Route53 health check that actively probes the base domain for active site-up monitoring."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description
Add an active Route53 health check (HTTPS, 30s interval) in the route53 module for dev and prod, and a new Grafana alert rule that fires when it fails 3 checks in a row.

Motivation: the existing CloudFront 5xx alert relies on traffic-derived CloudWatch metrics, which go sparse at low traffic and occasionally trigger DatasourceNoData false positives overnight. This adds a real active probe as a more reliable "is the site actually up" signal, alongside the existing rule.

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #
- Related to #

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Jan-IngenHousz-Institute/codesmith/open-jii/pr/1794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786869051&installation_id=146274774&pr_number=1794&repository=Jan-IngenHousz-Institute%2Fopen-jii&return_to=https%3A%2F%2Fgithub.com%2FJan-IngenHousz-Institute%2Fopen-jii%2Fpull%2F1794&signature=60ac90efb05246f758265daaa95dacd8a469d9328d851472aeb34b7b6be5996d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->