### PR TITLE
fix(ci): stabilize OpenNext Lambda deployments under pnpm 11

### DIFF
--- a/.github/actions/opennext-build/action.yml
+++ b/.github/actions/opennext-build/action.yml
@@ -77,10 +77,7 @@ runs:
         fi
         echo "  [ok] open-next.output.json"
 
-        # A populated pnpm virtual store means the install was not hoisted at build
-        # time; the resulting bundle fails on Lambda with Runtime.ImportModuleError.
-        # -print -quit stops find at the first match: piping into `read` instead would
-        # SIGPIPE a chatty find under pipefail and silently pass a large bad store.
+        # A populated virtual store means the install was not hoisted; the bundle would crash at Lambda Init
         PNPM_STORE="apps/web/.open-next/server-functions/default/node_modules/.pnpm"
         if [[ -L "$PNPM_STORE" ]] || [[ -n "$(find "$PNPM_STORE" -mindepth 1 -maxdepth 1 -type d -print -quit 2>/dev/null)" ]]; then
           echo "::error::Server bundle contains a populated pnpm virtual store (${PNPM_STORE}) — node_modules was not hoisted when Next.js traced the build; this bundle would crash at Lambda Init"

--- a/.github/actions/opennext-build/action.yml
+++ b/.github/actions/opennext-build/action.yml
@@ -79,8 +79,10 @@ runs:
 
         # A populated pnpm virtual store means the install was not hoisted at build
         # time; the resulting bundle fails on Lambda with Runtime.ImportModuleError.
+        # -print -quit stops find at the first match: piping into `read` instead would
+        # SIGPIPE a chatty find under pipefail and silently pass a large bad store.
         PNPM_STORE="apps/web/.open-next/server-functions/default/node_modules/.pnpm"
-        if [[ -d "$PNPM_STORE" ]] && find "$PNPM_STORE" -mindepth 1 -maxdepth 1 -type d | read -r; then
+        if [[ -L "$PNPM_STORE" ]] || [[ -n "$(find "$PNPM_STORE" -mindepth 1 -maxdepth 1 -type d -print -quit 2>/dev/null)" ]]; then
           echo "::error::Server bundle contains a populated pnpm virtual store (${PNPM_STORE}) — node_modules was not hoisted when Next.js traced the build; this bundle would crash at Lambda Init"
           exit 1
         fi

--- a/.github/actions/opennext-build/action.yml
+++ b/.github/actions/opennext-build/action.yml
@@ -76,3 +76,12 @@ runs:
           exit 1
         fi
         echo "  [ok] open-next.output.json"
+
+        # A populated pnpm virtual store means the install was not hoisted at build
+        # time; the resulting bundle fails on Lambda with Runtime.ImportModuleError.
+        PNPM_STORE="apps/web/.open-next/server-functions/default/node_modules/.pnpm"
+        if [[ -d "$PNPM_STORE" ]] && find "$PNPM_STORE" -mindepth 1 -maxdepth 1 -type d | read -r; then
+          echo "::error::Server bundle contains a populated pnpm virtual store (${PNPM_STORE}) — node_modules was not hoisted when Next.js traced the build; this bundle would crash at Lambda Init"
+          exit 1
+        fi
+        echo "  [ok] no pnpm virtual store in server bundle"

--- a/.github/actions/setup-nodejs-pnpm/action.yml
+++ b/.github/actions/setup-nodejs-pnpm/action.yml
@@ -45,5 +45,5 @@ runs:
         # Persist the setting in pnpm-workspace.yaml (job-local checkout) instead of a
         # one-shot CLI flag: pnpm 11's verifyDepsBeforeRun otherwise treats the hoisted
         # tree as stale on the next `pnpm run` and silently reinstalls it symlinked.
-        printf '\nnodeLinker: hoisted\n' >> pnpm-workspace.yaml
+        pnpm config set --location project node-linker hoisted
         pnpm install --frozen-lockfile

--- a/.github/actions/setup-nodejs-pnpm/action.yml
+++ b/.github/actions/setup-nodejs-pnpm/action.yml
@@ -42,8 +42,6 @@ runs:
       shell: bash
       run: |
         echo "Installing dependencies with hoisted node linker (AWS Lambda compatible)..."
-        # Persist the setting in pnpm-workspace.yaml (job-local checkout) instead of a
-        # one-shot CLI flag: pnpm 11's verifyDepsBeforeRun otherwise treats the hoisted
-        # tree as stale on the next `pnpm run` and silently reinstalls it symlinked.
+        # Persisted, not a CLI flag: pnpm 11's verifyDepsBeforeRun would otherwise reinstall symlinked on the next pnpm run
         pnpm config set --location project node-linker hoisted
         pnpm install --frozen-lockfile

--- a/.github/actions/setup-nodejs-pnpm/action.yml
+++ b/.github/actions/setup-nodejs-pnpm/action.yml
@@ -42,7 +42,8 @@ runs:
       shell: bash
       run: |
         echo "Installing dependencies with hoisted node linker (AWS Lambda compatible)..."
-        # Install dependencies using pnpm with hoisted node linker
-        # This is because AWS lambdas do not support symlinks
-        # Read more at https://pnpm.io/settings#nodelinker
-        pnpm install --node-linker=hoisted --frozen-lockfile
+        # Persist the setting in pnpm-workspace.yaml (job-local checkout) instead of a
+        # one-shot CLI flag: pnpm 11's verifyDepsBeforeRun otherwise treats the hoisted
+        # tree as stale on the next `pnpm run` and silently reinstalls it symlinked.
+        printf '\nnodeLinker: hoisted\n' >> pnpm-workspace.yaml
+        pnpm install --frozen-lockfile

--- a/.github/workflows/deploy-nextjs-opennext.yml
+++ b/.github/workflows/deploy-nextjs-opennext.yml
@@ -164,13 +164,25 @@ jobs:
           cd apps/web/.open-next/server-functions/default
           zip -r ../../server-function.zip .
           cd -
+
+          # Direct --zip-file upload is capped at ~70MB (API request body limit); stage via S3 instead,
+          # which supports the full 250MB unzipped Lambda code size limit.
+          ASSETS_BUCKET="${{ env.ASSETS_BUCKET }}"
+          S3_KEY="_deploy-tmp/server-function-${{ steps.get-sha.outputs.sha }}.zip"
+          echo "Staging server function code in s3://${ASSETS_BUCKET}/${S3_KEY}..."
+          aws s3 cp apps/web/.open-next/server-function.zip "s3://${ASSETS_BUCKET}/${S3_KEY}"
+
           echo "Uploading server function code to Lambda..."
           UPDATE_OUTPUT=$(aws lambda update-function-code \
             --function-name "${{ env.SERVER_FUNCTION }}" \
-            --zip-file fileb://apps/web/.open-next/server-function.zip \
+            --s3-bucket "${ASSETS_BUCKET}" \
+            --s3-key "${S3_KEY}" \
             --publish)
           VERSION=$(echo "$UPDATE_OUTPUT" | jq -r '.Version')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          echo "Cleaning up staged deployment package..."
+          aws s3 rm "s3://${ASSETS_BUCKET}/${S3_KEY}" || true
 
       - name: Get Previous Server Alias Version
         id: get-server-alias

--- a/.github/workflows/deploy-nextjs-opennext.yml
+++ b/.github/workflows/deploy-nextjs-opennext.yml
@@ -36,9 +36,7 @@ jobs:
     name: Build & Deploy Next.js with OpenNext
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-    # Serialize deploys per environment: an overlapping run's asset `sync --delete`
-    # or failure revert would remove another run's staged server-function zip.
-    # Job-level because workflow-level concurrency is ignored under workflow_call.
+    # Job-level (workflow_call ignores workflow-level): overlapping runs' sync --delete would remove each other's staged zip
     concurrency:
       group: web-deploy-opennext-${{ inputs.environment }}
     permissions:
@@ -171,9 +169,7 @@ jobs:
           zip -r ../../server-function.zip .
           cd -
 
-          # Direct --zip-file upload is capped at ~70MB (API request body limit); stage via S3 instead,
-          # which supports the full 250MB unzipped Lambda code size limit. The key is
-          # per-run so retries and overlapping runs never share (or delete) each other's object.
+          # Direct --zip-file upload is capped at ~70MB; stage via S3 (250MB limit) under a per-run key
           ASSETS_BUCKET="${{ env.ASSETS_BUCKET }}"
           S3_KEY="_deploy-tmp/server-function-${{ steps.get-sha.outputs.sha }}-${{ github.run_id }}-${{ github.run_attempt }}.zip"
           echo "Staging server function code in s3://${ASSETS_BUCKET}/${S3_KEY}..."
@@ -183,9 +179,7 @@ jobs:
             --body apps/web/.open-next/server-function.zip \
             --query 'VersionId' --output text)
 
-          # EXIT trap so the staged zip is removed even if the Lambda update fails.
-          # The assets bucket is versioned, so `s3 rm` would only add a delete marker;
-          # delete exactly the version we uploaded to avoid leaking ~100MB zips.
+          # Versioned bucket: delete the exact uploaded version (s3 rm would only add a delete marker)
           cleanup_staged_zip() {
             echo "Cleaning up staged deployment package..."
             if [[ -n "$STAGED_VERSION_ID" && "$STAGED_VERSION_ID" != "None" ]]; then
@@ -319,8 +313,7 @@ jobs:
           ASSETS_BUCKET: ${{ env.ASSETS_BUCKET }}
         run: |
           echo "❌ Reverting latest S3 asset versions due to failed deployment..."
-          # List all latest versions and delete them to expose previous versions.
-          # _deploy-tmp/ holds staged Lambda zips owned by their own runs, not assets.
+          # List all latest versions and delete them to expose previous versions (skip _deploy-tmp/ staged zips)
           aws s3api list-object-versions \
             --bucket "$ASSETS_BUCKET" \
             --query 'Versions[?IsLatest==`true`].[Key,VersionId]' \

--- a/.github/workflows/deploy-nextjs-opennext.yml
+++ b/.github/workflows/deploy-nextjs-opennext.yml
@@ -172,6 +172,23 @@ jobs:
           echo "Staging server function code in s3://${ASSETS_BUCKET}/${S3_KEY}..."
           aws s3 cp apps/web/.open-next/server-function.zip "s3://${ASSETS_BUCKET}/${S3_KEY}"
 
+          # EXIT trap so the staged zip is removed even if the Lambda update fails.
+          # The assets bucket is versioned, so `s3 rm` would only add a delete marker;
+          # delete every version of the key explicitly to avoid accumulating ~100MB zips.
+          cleanup_staged_zip() {
+            echo "Cleaning up staged deployment package..."
+            VERSION_IDS=$(aws s3api list-object-versions --bucket "${ASSETS_BUCKET}" --prefix "${S3_KEY}" \
+              --query "Versions[?Key=='${S3_KEY}'].VersionId" --output text 2>/dev/null || true)
+            if [[ -n "$VERSION_IDS" && "$VERSION_IDS" != "None" ]]; then
+              for VID in $VERSION_IDS; do
+                aws s3api delete-object --bucket "${ASSETS_BUCKET}" --key "${S3_KEY}" --version-id "$VID" || true
+              done
+            else
+              aws s3 rm "s3://${ASSETS_BUCKET}/${S3_KEY}" || true
+            fi
+          }
+          trap cleanup_staged_zip EXIT
+
           echo "Uploading server function code to Lambda..."
           UPDATE_OUTPUT=$(aws lambda update-function-code \
             --function-name "${{ env.SERVER_FUNCTION }}" \
@@ -180,9 +197,6 @@ jobs:
             --publish)
           VERSION=$(echo "$UPDATE_OUTPUT" | jq -r '.Version')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-          echo "Cleaning up staged deployment package..."
-          aws s3 rm "s3://${ASSETS_BUCKET}/${S3_KEY}" || true
 
       - name: Get Previous Server Alias Version
         id: get-server-alias

--- a/.github/workflows/deploy-nextjs-opennext.yml
+++ b/.github/workflows/deploy-nextjs-opennext.yml
@@ -36,6 +36,11 @@ jobs:
     name: Build & Deploy Next.js with OpenNext
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
+    # Serialize deploys per environment: an overlapping run's asset `sync --delete`
+    # or failure revert would remove another run's staged server-function zip.
+    # Job-level because workflow-level concurrency is ignored under workflow_call.
+    concurrency:
+      group: web-deploy-opennext-${{ inputs.environment }}
     permissions:
       id-token: write
       contents: read
@@ -92,6 +97,7 @@ jobs:
             # Upload assets with appropriate cache headers
             aws s3 sync apps/web/.open-next/assets/ "s3://${ASSETS_BUCKET}/" \
               --delete \
+              --exclude "_deploy-tmp/*" \
               --exact-timestamps \
               --cache-control "public, max-age=31536000, immutable" \
               --metadata-directive REPLACE \
@@ -166,23 +172,24 @@ jobs:
           cd -
 
           # Direct --zip-file upload is capped at ~70MB (API request body limit); stage via S3 instead,
-          # which supports the full 250MB unzipped Lambda code size limit.
+          # which supports the full 250MB unzipped Lambda code size limit. The key is
+          # per-run so retries and overlapping runs never share (or delete) each other's object.
           ASSETS_BUCKET="${{ env.ASSETS_BUCKET }}"
-          S3_KEY="_deploy-tmp/server-function-${{ steps.get-sha.outputs.sha }}.zip"
+          S3_KEY="_deploy-tmp/server-function-${{ steps.get-sha.outputs.sha }}-${{ github.run_id }}-${{ github.run_attempt }}.zip"
           echo "Staging server function code in s3://${ASSETS_BUCKET}/${S3_KEY}..."
-          aws s3 cp apps/web/.open-next/server-function.zip "s3://${ASSETS_BUCKET}/${S3_KEY}"
+          STAGED_VERSION_ID=$(aws s3api put-object \
+            --bucket "${ASSETS_BUCKET}" \
+            --key "${S3_KEY}" \
+            --body apps/web/.open-next/server-function.zip \
+            --query 'VersionId' --output text)
 
           # EXIT trap so the staged zip is removed even if the Lambda update fails.
           # The assets bucket is versioned, so `s3 rm` would only add a delete marker;
-          # delete every version of the key explicitly to avoid accumulating ~100MB zips.
+          # delete exactly the version we uploaded to avoid leaking ~100MB zips.
           cleanup_staged_zip() {
             echo "Cleaning up staged deployment package..."
-            VERSION_IDS=$(aws s3api list-object-versions --bucket "${ASSETS_BUCKET}" --prefix "${S3_KEY}" \
-              --query "Versions[?Key=='${S3_KEY}'].VersionId" --output text 2>/dev/null || true)
-            if [[ -n "$VERSION_IDS" && "$VERSION_IDS" != "None" ]]; then
-              for VID in $VERSION_IDS; do
-                aws s3api delete-object --bucket "${ASSETS_BUCKET}" --key "${S3_KEY}" --version-id "$VID" || true
-              done
+            if [[ -n "$STAGED_VERSION_ID" && "$STAGED_VERSION_ID" != "None" ]]; then
+              aws s3api delete-object --bucket "${ASSETS_BUCKET}" --key "${S3_KEY}" --version-id "$STAGED_VERSION_ID" || true
             else
               aws s3 rm "s3://${ASSETS_BUCKET}/${S3_KEY}" || true
             fi
@@ -190,11 +197,16 @@ jobs:
           trap cleanup_staged_zip EXIT
 
           echo "Uploading server function code to Lambda..."
-          UPDATE_OUTPUT=$(aws lambda update-function-code \
-            --function-name "${{ env.SERVER_FUNCTION }}" \
-            --s3-bucket "${ASSETS_BUCKET}" \
-            --s3-key "${S3_KEY}" \
-            --publish)
+          UPDATE_ARGS=(
+            --function-name "${{ env.SERVER_FUNCTION }}"
+            --s3-bucket "${ASSETS_BUCKET}"
+            --s3-key "${S3_KEY}"
+            --publish
+          )
+          if [[ -n "$STAGED_VERSION_ID" && "$STAGED_VERSION_ID" != "None" ]]; then
+            UPDATE_ARGS+=(--s3-object-version "$STAGED_VERSION_ID")
+          fi
+          UPDATE_OUTPUT=$(aws lambda update-function-code "${UPDATE_ARGS[@]}")
           VERSION=$(echo "$UPDATE_OUTPUT" | jq -r '.Version')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
@@ -307,11 +319,15 @@ jobs:
           ASSETS_BUCKET: ${{ env.ASSETS_BUCKET }}
         run: |
           echo "❌ Reverting latest S3 asset versions due to failed deployment..."
-          # List all latest versions and delete them to expose previous versions
+          # List all latest versions and delete them to expose previous versions.
+          # _deploy-tmp/ holds staged Lambda zips owned by their own runs, not assets.
           aws s3api list-object-versions \
             --bucket "$ASSETS_BUCKET" \
             --query 'Versions[?IsLatest==`true`].[Key,VersionId]' \
             --output text | while read KEY VERSION; do
+              if [[ "$KEY" == _deploy-tmp/* ]]; then
+                continue
+              fi
               if [[ -n "$KEY" && -n "$VERSION" ]]; then
                 echo "Deleting latest version of $KEY ($VERSION)"
                 aws s3api delete-object \

--- a/infrastructure/modules/opennext/main.tf
+++ b/infrastructure/modules/opennext/main.tf
@@ -75,6 +75,45 @@ resource "aws_s3_bucket_versioning" "cache" {
   }
 }
 
+# _deploy-tmp/ holds server-function zips staged during deploys; backstop cleanup
+resource "aws_s3_bucket_lifecycle_configuration" "assets" {
+  bucket = aws_s3_bucket.assets.id
+
+  rule {
+    id     = "expire-deploy-tmp"
+    status = "Enabled"
+
+    filter {
+      prefix = "_deploy-tmp/"
+    }
+
+    expiration {
+      days = 1
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 1
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+
+  rule {
+    id     = "cleanup-deploy-tmp-delete-markers"
+    status = "Enabled"
+
+    filter {
+      prefix = "_deploy-tmp/"
+    }
+
+    expiration {
+      expired_object_delete_marker = true
+    }
+  }
+}
+
 resource "aws_s3_bucket_server_side_encryption_configuration" "assets" {
   bucket = aws_s3_bucket.assets.id
 


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Summary

Fixes the OpenNext Lambda deployment failure introduced by the pnpm 11 / Node 24 upgrade.

pnpm's one-shot `--node-linker=hoisted` setting did not survive the next pnpm command. `verifyDepsBeforeRun` silently rebuilt `node_modules` with the symlinked layout, causing Next.js to trace the `.pnpm` virtual store into the Lambda bundle. The bundle exceeded the direct-upload limit and then failed at Lambda Init because `@swc/helpers` was unreachable.

## Changes

- Persist `nodeLinker: hoisted` for the job with `pnpm config set --location project`.
- Fail the OpenNext build if a populated or symlinked `.pnpm` store reaches the server bundle.
- Stage the server zip in S3 and update Lambda from the pinned object version.
- Serialize deployments per environment and use per-run staging keys.
- Exclude `_deploy-tmp/` from asset sync deletion and rollback.
- Delete the exact staged object version from an `EXIT` trap.
- Expire current and noncurrent staged objects, incomplete multipart uploads, and delete markers after one day as a cleanup backstop.

## Validation

- [Dev deploy run 29734213948](https://github.com/Jan-IngenHousz-Institute/open-jii/actions/runs/29734213948) completed successfully; Lambda version 200 passed the health check.
- The rebased branch passes CodeQL, formatting, workspace lint, CodeRabbit, and OpenTofu plans for dev and prod.
- All review threads are resolved.

## Related Issues

- Related to #1795
