### PR TITLE
fix(infra): share one Python REPL across centrum DLT notebooks

### DIFF
--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -590,6 +590,8 @@ module "centrum_pipeline" {
     "LARGE_IOT_S3_PATH"          = "s3://${module.large_iot_s3.bucket_id}/"
     "LARGE_IOT_SQS_QUEUE_URL"    = module.iot_core.large_iot_sqs_queue_url
     "LARGE_IOT_INGEST_ENABLED"   = "false"
+    # One shared Python REPL for all 17 notebooks; per-notebook REPLs exhaust the r5d.large driver
+    "pipelines.enableSharedReplsForAllPythonPipeline" = "true"
   }
 
   continuous_mode  = false

--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -563,6 +563,8 @@ module "centrum_pipeline" {
     "LARGE_IOT_S3_PATH"          = "s3://${module.large_iot_s3.bucket_id}/"
     "LARGE_IOT_SQS_QUEUE_URL"    = module.iot_core.large_iot_sqs_queue_url
     "LARGE_IOT_INGEST_ENABLED"   = "true"
+    # One shared Python REPL for all 17 notebooks; per-notebook REPLs exhaust the r5d.large driver
+    "pipelines.enableSharedReplsForAllPythonPipeline" = "true"
   }
 
   continuous_mode  = true


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Centrum-DLT-Pipeline-DEV has failed every update since the first run after #1758 deployed (2026-07-20 06:00 UTC) with `PYTHON_REPL_CREATION_FAILED` during INITIALIZING.

**Root cause:** DLT creates a separate Python REPL for every explicitly-listed notebook and initializes them in parallel (`pipelines.parallelPythonReplInitialization=true`). The split turned 1 notebook into 17, so the pipeline now boots 17 REPLs at once on the `r5d.large` driver (2 vCPU / 16 GB, USER_ISOLATION), which dies during REPL creation. The pre-split monolith never hit this because 1 notebook = 1 REPL. Shared REPLs are the default only for glob-defined pipelines (`pipelines.enableSharedReplsForGlobPythonPipeline=true`), not explicit notebook lists.

**Fix:** set `pipelines.enableSharedReplsForAllPythonPipeline=true` on the centrum pipeline in dev and prod so all notebooks load in a single shared REPL. Prod has the same 17-notebook split and would fail identically on its next deploy.

## Verification

Applied the same flag out-of-band on the dev pipeline via the CLI and triggered an update: initialization went from dying after ~4 min to completing in ~80 s, and the update ran to COMPLETED (09:48-10:14 UTC, update `776e7a7c`), draining the backlog since Jul 17. This PR codifies that flag in Terraform so the next `tofu apply` doesn't revert it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)