### PR TITLE
feat(newsletter): Mailchimp newsletter subscription (footer, settings, registration)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -336,6 +336,12 @@ jobs:
       TF_VAR_contentful_access_token: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
       TF_VAR_contentful_preview_access_token: ${{ secrets.CONTENTFUL_PREVIEW_ACCESS_TOKEN }}
       TF_VAR_contentful_preview_secret: ${{ secrets.CONTENTFUL_PREVIEW_SECRET }}
+      TF_VAR_mailchimp_api_key: ${{ secrets.MAILCHIMP_API_KEY }}
+      TF_VAR_mailchimp_server_prefix: ${{ secrets.MAILCHIMP_SERVER_PREFIX }}
+      TF_VAR_mailchimp_audience_id: ${{ secrets.MAILCHIMP_AUDIENCE_ID }}
+      TF_VAR_mailchimp_community_kind: ${{ secrets.MAILCHIMP_COMMUNITY_KIND }}
+      TF_VAR_mailchimp_community_id: ${{ secrets.MAILCHIMP_COMMUNITY_ID }}
+      TF_VAR_mailchimp_community_name: ${{ secrets.MAILCHIMP_COMMUNITY_NAME }}
       TF_VAR_api_cloudfront_header_value: ${{ secrets.API_CLOUDFRONT_HEADER_VALUE }}
       TF_VAR_orcid_oauth_client_id: ${{ secrets.ORCID_OAUTH_CLIENT_ID }}
       TF_VAR_orcid_oauth_client_secret: ${{ secrets.ORCID_OAUTH_CLIENT_SECRET }}

--- a/.github/workflows/tofu.yml
+++ b/.github/workflows/tofu.yml
@@ -67,6 +67,12 @@ jobs:
       TF_VAR_contentful_access_token: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
       TF_VAR_contentful_preview_access_token: ${{ secrets.CONTENTFUL_PREVIEW_ACCESS_TOKEN }}
       TF_VAR_contentful_preview_secret: ${{ secrets.CONTENTFUL_PREVIEW_SECRET }}
+      TF_VAR_mailchimp_api_key: ${{ secrets.MAILCHIMP_API_KEY }}
+      TF_VAR_mailchimp_server_prefix: ${{ secrets.MAILCHIMP_SERVER_PREFIX }}
+      TF_VAR_mailchimp_audience_id: ${{ secrets.MAILCHIMP_AUDIENCE_ID }}
+      TF_VAR_mailchimp_community_kind: ${{ secrets.MAILCHIMP_COMMUNITY_KIND }}
+      TF_VAR_mailchimp_community_id: ${{ secrets.MAILCHIMP_COMMUNITY_ID }}
+      TF_VAR_mailchimp_community_name: ${{ secrets.MAILCHIMP_COMMUNITY_NAME }}
       TF_VAR_api_cloudfront_header_value: ${{ secrets.API_CLOUDFRONT_HEADER_VALUE }}
       TF_VAR_orcid_oauth_client_id: ${{ secrets.ORCID_OAUTH_CLIENT_ID }}
       TF_VAR_orcid_oauth_client_secret: ${{ secrets.ORCID_OAUTH_CLIENT_SECRET }}
@@ -139,6 +145,12 @@ jobs:
       TF_VAR_contentful_access_token: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
       TF_VAR_contentful_preview_access_token: ${{ secrets.CONTENTFUL_PREVIEW_ACCESS_TOKEN }}
       TF_VAR_contentful_preview_secret: ${{ secrets.CONTENTFUL_PREVIEW_SECRET }}
+      TF_VAR_mailchimp_api_key: ${{ secrets.MAILCHIMP_API_KEY }}
+      TF_VAR_mailchimp_server_prefix: ${{ secrets.MAILCHIMP_SERVER_PREFIX }}
+      TF_VAR_mailchimp_audience_id: ${{ secrets.MAILCHIMP_AUDIENCE_ID }}
+      TF_VAR_mailchimp_community_kind: ${{ secrets.MAILCHIMP_COMMUNITY_KIND }}
+      TF_VAR_mailchimp_community_id: ${{ secrets.MAILCHIMP_COMMUNITY_ID }}
+      TF_VAR_mailchimp_community_name: ${{ secrets.MAILCHIMP_COMMUNITY_NAME }}
       TF_VAR_api_cloudfront_header_value: ${{ secrets.API_CLOUDFRONT_HEADER_VALUE }}
       TF_VAR_orcid_oauth_client_id: ${{ secrets.ORCID_OAUTH_CLIENT_ID }}
       TF_VAR_orcid_oauth_client_secret: ${{ secrets.ORCID_OAUTH_CLIENT_SECRET }}

--- a/apps/backend/.env.test
+++ b/apps/backend/.env.test
@@ -52,6 +52,14 @@ EMAIL_BASE_URL=http://localhost:3000
 EMAIL_SERVER=smtp://localhost:1025
 EMAIL_FROM=noreply@localhost
 
+# Mailchimp newsletter integration
+MAILCHIMP_API_KEY=test-mailchimp-api-key
+MAILCHIMP_SERVER_PREFIX=us1
+MAILCHIMP_AUDIENCE_ID=test-audience-id
+MAILCHIMP_COMMUNITY_KIND=group
+MAILCHIMP_COMMUNITY_ID=test-community-interest-id
+MAILCHIMP_COMMUNITY_NAME=Community
+
 # PostHog configuration for testing
 POSTHOG_KEY=phc_test_key_123
 POSTHOG_HOST=https://eu.i.posthog.com

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -35,6 +35,7 @@
     "@nestjs/core": "^11.1.18",
     "@nestjs/platform-express": "^11.1.18",
     "@nestjs/schedule": "^6.1.1",
+    "@nestjs/throttler": "^6.5.0",
     "@orpc/client": "catalog:orpc",
     "@orpc/contract": "catalog:orpc",
     "@orpc/nest": "catalog:orpc",

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -15,12 +15,14 @@ import awsConfig from "./common/config/aws.config";
 import databaseConfig from "./common/config/database.config";
 import databricksConfig from "./common/config/databricks.config";
 import emailConfig from "./common/config/email.config";
+import mailchimpConfig from "./common/config/mailchimp.config";
 import { DatabaseModule } from "./common/database/database.module";
 import { AnalyticsModule } from "./common/modules/analytics/analytics.module";
 import { ExperimentModule } from "./experiments/experiment.module";
 import { HealthModule } from "./health/health.module";
 import { IotModule } from "./iot/iot.module";
 import { MacroModule } from "./macros/macro.module";
+import { NewsletterModule } from "./newsletter/newsletter.module";
 import { ProtocolModule } from "./protocols/protocol.module";
 import { SearchModule } from "./search/search.module";
 import { UserModule } from "./users/user.module";
@@ -30,7 +32,14 @@ import { WorkbookModule } from "./workbooks/workbook.module";
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      load: [databaseConfig, databricksConfig, awsConfig, emailConfig, analyticsConfig],
+      load: [
+        databaseConfig,
+        databricksConfig,
+        awsConfig,
+        emailConfig,
+        mailchimpConfig,
+        analyticsConfig,
+      ],
     }),
     LoggerModule.forRoot({
       pinoHttp: {
@@ -49,6 +58,7 @@ import { WorkbookModule } from "./workbooks/workbook.module";
     ExperimentModule,
     IotModule,
     MacroModule,
+    NewsletterModule,
     ProtocolModule,
     SearchModule,
     UserModule,

--- a/apps/backend/src/common/config/mailchimp.config.ts
+++ b/apps/backend/src/common/config/mailchimp.config.ts
@@ -1,0 +1,12 @@
+import { registerAs } from "@nestjs/config";
+
+export default registerAs("mailchimp", () => ({
+  apiKey: process.env.MAILCHIMP_API_KEY,
+  serverPrefix: process.env.MAILCHIMP_SERVER_PREFIX,
+  audienceId: process.env.MAILCHIMP_AUDIENCE_ID,
+  community: {
+    kind: process.env.MAILCHIMP_COMMUNITY_KIND,
+    id: process.env.MAILCHIMP_COMMUNITY_ID,
+    name: process.env.MAILCHIMP_COMMUNITY_NAME,
+  },
+}));

--- a/apps/backend/src/common/modules/mailchimp/config/config.service.spec.ts
+++ b/apps/backend/src/common/modules/mailchimp/config/config.service.spec.ts
@@ -51,6 +51,18 @@ describe("MailchimpConfigService", () => {
       const service = makeService(FULL_ENV);
       expect(service.baseUrl).toBe("https://us1.api.mailchimp.com/3.0");
     });
+
+    it("accepts a merge field as the Community classification", () => {
+      const service = makeService({
+        ...FULL_ENV,
+        "mailchimp.community.kind": "merge_field",
+        "mailchimp.community.id": "MMERGE10",
+      });
+
+      expect(service.communityKind).toBe("merge_field");
+      expect(service.communityId).toBe("MMERGE10");
+      expect(service.communityName).toBe("Community");
+    });
   });
 
   describe("misconfigured (partial/invalid)", () => {

--- a/apps/backend/src/common/modules/mailchimp/config/config.service.spec.ts
+++ b/apps/backend/src/common/modules/mailchimp/config/config.service.spec.ts
@@ -1,0 +1,69 @@
+import type { ConfigService } from "@nestjs/config";
+
+import { MailchimpConfigService } from "./config.service";
+
+const FULL_ENV: Record<string, string> = {
+  "mailchimp.apiKey": "test-mailchimp-api-key",
+  "mailchimp.serverPrefix": "us1",
+  "mailchimp.audienceId": "test-audience-id",
+  "mailchimp.community.kind": "group",
+  "mailchimp.community.id": "test-community-interest-id",
+  "mailchimp.community.name": "Community",
+};
+
+function makeService(values: Record<string, string | undefined>): MailchimpConfigService {
+  const configService = {
+    get: <T>(key: string): T | undefined => values[key] as T | undefined,
+  } as unknown as ConfigService;
+  return new MailchimpConfigService(configService);
+}
+
+describe("MailchimpConfigService", () => {
+  describe("unconfigured", () => {
+    it("boots without throwing when no Mailchimp env vars are present", () => {
+      let service: MailchimpConfigService | undefined;
+      expect(() => {
+        service = makeService({});
+      }).not.toThrow();
+      expect(service?.isConfigured).toBe(false);
+    });
+
+    it("throws from value getters when accessed while unconfigured", () => {
+      const service = makeService({});
+      expect(() => service.apiKey).toThrow("Mailchimp is not configured");
+    });
+  });
+
+  describe("configured", () => {
+    it("is configured and exposes the values", () => {
+      const service = makeService(FULL_ENV);
+
+      expect(service.isConfigured).toBe(true);
+      expect(service.apiKey).toBe(FULL_ENV["mailchimp.apiKey"]);
+      expect(service.serverPrefix).toBe(FULL_ENV["mailchimp.serverPrefix"]);
+      expect(service.audienceId).toBe(FULL_ENV["mailchimp.audienceId"]);
+      expect(service.communityKind).toBe(FULL_ENV["mailchimp.community.kind"]);
+      expect(service.communityId).toBe(FULL_ENV["mailchimp.community.id"]);
+      expect(service.communityName).toBe(FULL_ENV["mailchimp.community.name"]);
+    });
+
+    it("derives the api base url from the server prefix", () => {
+      const service = makeService(FULL_ENV);
+      expect(service.baseUrl).toBe("https://us1.api.mailchimp.com/3.0");
+    });
+  });
+
+  describe("misconfigured (partial/invalid)", () => {
+    it("throws for an invalid community kind when other values are present", () => {
+      expect(() => makeService({ ...FULL_ENV, "mailchimp.community.kind": "list" })).toThrow(
+        "Mailchimp configuration validation failed",
+      );
+    });
+
+    it("throws when configuration is partial (a required value is missing)", () => {
+      const partial = { ...FULL_ENV };
+      delete partial["mailchimp.audienceId"];
+      expect(() => makeService(partial)).toThrow("Mailchimp configuration validation failed");
+    });
+  });
+});

--- a/apps/backend/src/common/modules/mailchimp/config/config.service.ts
+++ b/apps/backend/src/common/modules/mailchimp/config/config.service.ts
@@ -1,0 +1,108 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+
+import { ErrorCodes } from "../../../utils/error-codes";
+import { MailchimpConfig, MailchimpCommunityKind, mailchimpConfigSchema } from "./config.types";
+
+@Injectable()
+export class MailchimpConfigService {
+  private readonly logger = new Logger(MailchimpConfigService.name);
+  private readonly config: MailchimpConfig | null;
+
+  constructor(private readonly configService: ConfigService) {
+    this.config = this.loadConfig();
+  }
+
+  /**
+   * Loads and validates Mailchimp configuration. Returns `null` when no
+   * Mailchimp env vars are present so the backend boots cleanly on
+   * environments where the integration has not been provisioned yet. When any
+   * value is present the whole config must be valid, otherwise startup fails
+   * loudly (a partial/misconfigured integration is a deploy error).
+   */
+  private loadConfig(): MailchimpConfig | null {
+    const raw = {
+      apiKey: this.configService.get<string>("mailchimp.apiKey"),
+      serverPrefix: this.configService.get<string>("mailchimp.serverPrefix"),
+      audienceId: this.configService.get<string>("mailchimp.audienceId"),
+      community: {
+        kind: this.configService.get<MailchimpCommunityKind>("mailchimp.community.kind"),
+        id: this.configService.get<string>("mailchimp.community.id"),
+        name: this.configService.get<string>("mailchimp.community.name"),
+      },
+    };
+
+    const anyPresent = [
+      raw.apiKey,
+      raw.serverPrefix,
+      raw.audienceId,
+      raw.community.kind,
+      raw.community.id,
+      raw.community.name,
+    ].some((value) => value != null && value !== "");
+
+    if (!anyPresent) {
+      this.logger.warn({
+        msg: "Mailchimp is not configured; newsletter operations will be unavailable",
+        operation: "loadConfig",
+      });
+      return null;
+    }
+
+    const parsed = mailchimpConfigSchema.safeParse(raw);
+    if (!parsed.success) {
+      this.logger.error({
+        msg: "Invalid Mailchimp configuration",
+        errorCode: ErrorCodes.MAILCHIMP_CONFIG_INVALID,
+        operation: "loadConfig",
+      });
+      throw new Error("Mailchimp configuration validation failed");
+    }
+
+    this.logger.debug({
+      msg: "Mailchimp configuration validated successfully",
+      operation: "loadConfig",
+      status: "success",
+    });
+    return parsed.data;
+  }
+
+  get isConfigured(): boolean {
+    return this.config !== null;
+  }
+
+  private getOrThrow(): MailchimpConfig {
+    if (!this.config) {
+      throw new Error("Mailchimp is not configured");
+    }
+    return this.config;
+  }
+
+  get apiKey(): string {
+    return this.getOrThrow().apiKey;
+  }
+
+  get serverPrefix(): string {
+    return this.getOrThrow().serverPrefix;
+  }
+
+  get audienceId(): string {
+    return this.getOrThrow().audienceId;
+  }
+
+  get communityKind(): MailchimpCommunityKind {
+    return this.getOrThrow().community.kind;
+  }
+
+  get communityId(): string {
+    return this.getOrThrow().community.id;
+  }
+
+  get communityName(): string {
+    return this.getOrThrow().community.name;
+  }
+
+  get baseUrl(): string {
+    return `https://${this.getOrThrow().serverPrefix}.api.mailchimp.com/3.0`;
+  }
+}

--- a/apps/backend/src/common/modules/mailchimp/config/config.types.ts
+++ b/apps/backend/src/common/modules/mailchimp/config/config.types.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export type MailchimpCommunityKind = "group" | "tag";
+
+export interface MailchimpConfig {
+  apiKey: string;
+  serverPrefix: string;
+  audienceId: string;
+  community: {
+    kind: MailchimpCommunityKind;
+    id: string;
+    name: string;
+  };
+}
+
+export const mailchimpConfigSchema = z.object({
+  apiKey: z.string().min(1),
+  serverPrefix: z.string().min(1),
+  audienceId: z.string().min(1),
+  community: z.object({
+    kind: z.enum(["group", "tag"]),
+    id: z.string().min(1),
+    name: z.string().min(1),
+  }),
+});

--- a/apps/backend/src/common/modules/mailchimp/config/config.types.ts
+++ b/apps/backend/src/common/modules/mailchimp/config/config.types.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export type MailchimpCommunityKind = "group" | "tag";
+export type MailchimpCommunityKind = "group" | "tag" | "merge_field";
 
 export interface MailchimpConfig {
   apiKey: string;
@@ -18,7 +18,7 @@ export const mailchimpConfigSchema = z.object({
   serverPrefix: z.string().min(1),
   audienceId: z.string().min(1),
   community: z.object({
-    kind: z.enum(["group", "tag"]),
+    kind: z.enum(["group", "tag", "merge_field"]),
     id: z.string().min(1),
     name: z.string().min(1),
   }),

--- a/apps/backend/src/common/modules/mailchimp/mailchimp.adapter.spec.ts
+++ b/apps/backend/src/common/modules/mailchimp/mailchimp.adapter.spec.ts
@@ -1,0 +1,322 @@
+import type { HttpService } from "@nestjs/axios";
+import { createHash } from "crypto";
+
+import { assertFailure, assertSuccess } from "../../utils/fp-utils";
+import type { MailchimpConfigService } from "./config/config.service";
+import type { MailchimpCommunityKind } from "./config/config.types";
+import { MailchimpAdapter } from "./mailchimp.adapter";
+
+const SERVER_PREFIX = "us1";
+const AUDIENCE_ID = "test-audience-id";
+const API_KEY = "test-mailchimp-api-key";
+const COMMUNITY_ID = "community-interest-id";
+const COMMUNITY_NAME = "Community";
+const EMAIL = "Person@Example.com";
+
+const expectedHash = createHash("md5").update(EMAIL.toLowerCase()).digest("hex");
+const expectedMemberUrl = `https://${SERVER_PREFIX}.api.mailchimp.com/3.0/lists/${AUDIENCE_ID}/members/${expectedHash}`;
+
+interface MockAxiosRef {
+  put: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+}
+
+type RequestCall = [
+  string,
+  Record<string, unknown>,
+  { auth: { username: string; password: string } },
+];
+
+const putCall = (axiosRef: MockAxiosRef, index: number): RequestCall =>
+  axiosRef.put.mock.calls[index] as RequestCall;
+
+function buildConfig(kind: MailchimpCommunityKind, isConfigured = true): MailchimpConfigService {
+  return {
+    isConfigured,
+    apiKey: API_KEY,
+    serverPrefix: SERVER_PREFIX,
+    audienceId: AUDIENCE_ID,
+    communityKind: kind,
+    communityId: COMMUNITY_ID,
+    communityName: COMMUNITY_NAME,
+    baseUrl: `https://${SERVER_PREFIX}.api.mailchimp.com/3.0`,
+  } as unknown as MailchimpConfigService;
+}
+
+function buildAdapter(kind: MailchimpCommunityKind = "group", isConfigured = true) {
+  const axiosRef: MockAxiosRef = {
+    put: vi.fn().mockResolvedValue({ data: {} }),
+    get: vi.fn().mockResolvedValue({ data: { status: "subscribed" } }),
+    patch: vi.fn().mockResolvedValue({ data: {} }),
+    post: vi.fn().mockResolvedValue({ data: {} }),
+  };
+  const httpService = { axiosRef } as unknown as HttpService;
+  const adapter = new MailchimpAdapter(buildConfig(kind, isConfigured), httpService);
+  return { adapter, axiosRef };
+}
+
+function axiosError(status: number, data: unknown) {
+  return { isAxiosError: true, message: `HTTP ${status}`, response: { status, data } };
+}
+
+describe("MailchimpAdapter", () => {
+  describe("subscribePending", () => {
+    it("upserts a pending member with the Community interest group when the address is unknown", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.get.mockRejectedValue(axiosError(404, { title: "Resource Not Found" }));
+
+      const result = await adapter.subscribePending(EMAIL);
+
+      assertSuccess(result);
+      expect(axiosRef.put).toHaveBeenCalledTimes(1);
+      const [url, body, config] = putCall(axiosRef, 0);
+      expect(url).toBe(expectedMemberUrl);
+      expect(body).toMatchObject({
+        email_address: EMAIL,
+        status_if_new: "pending",
+        status: "pending",
+        interests: { [COMMUNITY_ID]: true },
+      });
+      expect(config).toMatchObject({ auth: { username: "anystring", password: API_KEY } });
+      expect(axiosRef.post).not.toHaveBeenCalled();
+    });
+
+    it("applies the Community tag via the tags endpoint (no interests in the body)", async () => {
+      const { adapter, axiosRef } = buildAdapter("tag");
+      axiosRef.get.mockRejectedValue(axiosError(404, { title: "Resource Not Found" }));
+
+      const result = await adapter.subscribePending(EMAIL);
+
+      assertSuccess(result);
+      const [, body] = putCall(axiosRef, 0);
+      expect(body).not.toHaveProperty("interests");
+      expect(axiosRef.post).toHaveBeenCalledWith(
+        `${expectedMemberUrl}/tags`,
+        { tags: [{ name: COMMUNITY_NAME, status: "active" }] },
+        expect.objectContaining({ auth: { username: "anystring", password: API_KEY } }),
+      );
+    });
+
+    it("is a no-op for an already-subscribed member (never downgrades to pending)", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.get.mockResolvedValue({ data: { status: "subscribed" } });
+
+      const result = await adapter.subscribePending(EMAIL);
+
+      assertSuccess(result);
+      expect(axiosRef.put).not.toHaveBeenCalled();
+      expect(axiosRef.post).not.toHaveBeenCalled();
+    });
+
+    it("re-enters the pending flow for a previously unsubscribed member", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.get.mockResolvedValue({ data: { status: "unsubscribed" } });
+
+      const result = await adapter.subscribePending(EMAIL);
+
+      assertSuccess(result);
+      expect(axiosRef.put).toHaveBeenCalledTimes(1);
+      const [, body] = putCall(axiosRef, 0);
+      expect(body).toMatchObject({ status_if_new: "pending", status: "pending" });
+    });
+
+    it("re-issues the pending upsert for a member already in pending state", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.get.mockResolvedValue({ data: { status: "pending" } });
+
+      const result = await adapter.subscribePending(EMAIL);
+
+      assertSuccess(result);
+      expect(axiosRef.put).toHaveBeenCalledTimes(1);
+      const [, body] = putCall(axiosRef, 0);
+      expect(body).toMatchObject({ status_if_new: "pending", status: "pending" });
+    });
+
+    it("returns failure without upserting when the status lookup fails", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.get.mockRejectedValue(axiosError(500, { detail: "lookup boom" }));
+
+      const result = await adapter.subscribePending(EMAIL);
+
+      assertFailure(result);
+      expect(axiosRef.put).not.toHaveBeenCalled();
+    });
+
+    it("returns failure when the upsert request fails", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.get.mockRejectedValue(axiosError(404, { title: "Resource Not Found" }));
+      axiosRef.put.mockRejectedValue(axiosError(500, { detail: "boom" }));
+
+      const result = await adapter.subscribePending(EMAIL);
+
+      assertFailure(result);
+    });
+  });
+
+  describe("subscribeDirect", () => {
+    it("upserts a subscribed member and returns subscribed", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+
+      const result = await adapter.subscribeDirect(EMAIL);
+
+      assertSuccess(result);
+      expect(result.value).toBe("subscribed");
+      const [, body] = putCall(axiosRef, 0);
+      expect(body).toMatchObject({ status_if_new: "subscribed", status: "subscribed" });
+    });
+
+    it("falls back to pending when Mailchimp rejects with a compliance state", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.put
+        .mockRejectedValueOnce(axiosError(400, { title: "Member In Compliance State" }))
+        .mockResolvedValueOnce({ data: {} });
+
+      const result = await adapter.subscribeDirect(EMAIL);
+
+      assertSuccess(result);
+      expect(result.value).toBe("pending");
+      expect(axiosRef.put).toHaveBeenCalledTimes(2);
+      const [, secondBody] = putCall(axiosRef, 1);
+      expect(secondBody).toMatchObject({ status_if_new: "pending", status: "pending" });
+    });
+
+    it("returns failure for a non-compliance error", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.put.mockRejectedValue(axiosError(500, { detail: "server error" }));
+
+      const result = await adapter.subscribeDirect(EMAIL);
+
+      assertFailure(result);
+      expect(axiosRef.put).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("getStatus", () => {
+    it.each([
+      ["subscribed", "subscribed"],
+      ["pending", "pending"],
+      ["unsubscribed", "unsubscribed"],
+      ["cleaned", "unsubscribed"],
+      ["transactional", "unsubscribed"],
+      ["archived", "unsubscribed"],
+    ])("maps Mailchimp status %s to %s", async (mailchimpStatus, expected) => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.get.mockResolvedValue({ data: { status: mailchimpStatus } });
+
+      const result = await adapter.getStatus(EMAIL);
+
+      assertSuccess(result);
+      expect(result.value).toBe(expected);
+      expect(axiosRef.get).toHaveBeenCalledWith(expectedMemberUrl, expect.anything());
+    });
+
+    it("fails closed for an unknown provider status instead of guessing", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.get.mockResolvedValue({ data: { status: "quantum-superposition" } });
+
+      const result = await adapter.getStatus(EMAIL);
+
+      assertFailure(result);
+    });
+
+    it("fails closed when the response is missing a status field", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.get.mockResolvedValue({ data: {} });
+
+      const result = await adapter.getStatus(EMAIL);
+
+      assertFailure(result);
+    });
+
+    it("returns none when the member does not exist", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.get.mockRejectedValue(axiosError(404, { title: "Resource Not Found" }));
+
+      const result = await adapter.getStatus(EMAIL);
+
+      assertSuccess(result);
+      expect(result.value).toBe("none");
+    });
+
+    it("returns failure on non-404 errors", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.get.mockRejectedValue(axiosError(500, { detail: "boom" }));
+
+      const result = await adapter.getStatus(EMAIL);
+
+      assertFailure(result);
+    });
+  });
+
+  describe("unsubscribe", () => {
+    it("patches the member to unsubscribed", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+
+      const result = await adapter.unsubscribe(EMAIL);
+
+      assertSuccess(result);
+      expect(axiosRef.patch).toHaveBeenCalledWith(
+        expectedMemberUrl,
+        { status: "unsubscribed" },
+        expect.anything(),
+      );
+    });
+
+    it("treats a missing member as a successful no-op", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.patch.mockRejectedValue(axiosError(404, { title: "Resource Not Found" }));
+
+      const result = await adapter.unsubscribe(EMAIL);
+
+      assertSuccess(result);
+    });
+  });
+
+  describe("deleteMember", () => {
+    it("permanently deletes the member", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+
+      const result = await adapter.deleteMember(EMAIL);
+
+      assertSuccess(result);
+      expect(axiosRef.post).toHaveBeenCalledWith(
+        `${expectedMemberUrl}/actions/delete-permanent`,
+        undefined,
+        expect.anything(),
+      );
+    });
+
+    it("treats a missing member as already erased", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.post.mockRejectedValue(axiosError(404, { title: "Resource Not Found" }));
+
+      const result = await adapter.deleteMember(EMAIL);
+
+      assertSuccess(result);
+    });
+  });
+
+  describe("when Mailchimp is not configured", () => {
+    it("returns failure from every operation without making any HTTP call", async () => {
+      const { adapter, axiosRef } = buildAdapter("group", false);
+
+      const results = [
+        await adapter.subscribePending(EMAIL),
+        await adapter.subscribeDirect(EMAIL),
+        await adapter.unsubscribe(EMAIL),
+        await adapter.getStatus(EMAIL),
+        await adapter.deleteMember(EMAIL),
+      ];
+
+      for (const result of results) {
+        assertFailure(result);
+      }
+      expect(axiosRef.get).not.toHaveBeenCalled();
+      expect(axiosRef.put).not.toHaveBeenCalled();
+      expect(axiosRef.patch).not.toHaveBeenCalled();
+      expect(axiosRef.post).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/backend/src/common/modules/mailchimp/mailchimp.adapter.spec.ts
+++ b/apps/backend/src/common/modules/mailchimp/mailchimp.adapter.spec.ts
@@ -1,6 +1,7 @@
 import type { HttpService } from "@nestjs/axios";
 import { createHash } from "crypto";
 
+import { ErrorCodes } from "../../utils/error-codes";
 import { assertFailure, assertSuccess } from "../../utils/fp-utils";
 import type { MailchimpConfigService } from "./config/config.service";
 import type { MailchimpCommunityKind } from "./config/config.types";
@@ -61,6 +62,15 @@ function buildAdapter(kind: MailchimpCommunityKind = "group", isConfigured = tru
 function axiosError(status: number, data: unknown) {
   return { isAxiosError: true, message: `HTTP ${status}`, response: { status, data } };
 }
+
+// Shape Mailchimp returns after an address was permanently deleted ("forgotten").
+const forgottenEmailError = () =>
+  axiosError(400, {
+    title: "Forgotten Email Not Subscribed",
+    detail:
+      "person@example.com was permanently deleted and cannot be re-imported. " +
+      "The contact must re-subscribe to get back on the list.",
+  });
 
 describe("MailchimpAdapter", () => {
   describe("subscribePending", () => {
@@ -220,6 +230,17 @@ describe("MailchimpAdapter", () => {
 
       assertFailure(result);
     });
+
+    it("surfaces the forgotten-email code when the pending upsert is rejected", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.get.mockRejectedValue(axiosError(404, { title: "Resource Not Found" }));
+      axiosRef.put.mockRejectedValue(forgottenEmailError());
+
+      const result = await adapter.subscribePending(EMAIL);
+
+      assertFailure(result);
+      expect(result.error.code).toBe(ErrorCodes.MAILCHIMP_FORGOTTEN_EMAIL);
+    });
   });
 
   describe("subscribeDirect", () => {
@@ -277,6 +298,62 @@ describe("MailchimpAdapter", () => {
 
       assertFailure(result);
       expect(axiosRef.put).toHaveBeenCalledTimes(1);
+    });
+
+    it("surfaces the forgotten-email code without a pending fallback", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.put.mockRejectedValue(forgottenEmailError());
+
+      const result = await adapter.subscribeDirect(EMAIL);
+
+      assertFailure(result);
+      expect(result.error.code).toBe(ErrorCodes.MAILCHIMP_FORGOTTEN_EMAIL);
+      // The forgotten-email 400 is not a compliance state, so no pending retry.
+      expect(axiosRef.put).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("domain error-code propagation", () => {
+    it("carries the operation code and the mapped HTTP status through toFailure", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.put.mockRejectedValue(axiosError(500, { detail: "server error" }));
+
+      const result = await adapter.subscribeDirect(EMAIL);
+
+      assertFailure(result);
+      expect(result.error.code).toBe(ErrorCodes.MAILCHIMP_SUBSCRIBE_FAILED);
+      expect(result.error.statusCode).toBe(500);
+      expect(result.error.message).toContain("Mailchimp");
+    });
+
+    it("maps getStatus failures to the status code", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.get.mockRejectedValue(axiosError(500, { detail: "boom" }));
+
+      const result = await adapter.getStatus(EMAIL);
+
+      assertFailure(result);
+      expect(result.error.code).toBe(ErrorCodes.MAILCHIMP_STATUS_FAILED);
+    });
+
+    it("maps unsubscribe failures to the unsubscribe code", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.patch.mockRejectedValue(axiosError(500, { detail: "boom" }));
+
+      const result = await adapter.unsubscribe(EMAIL);
+
+      assertFailure(result);
+      expect(result.error.code).toBe(ErrorCodes.MAILCHIMP_UNSUBSCRIBE_FAILED);
+    });
+
+    it("maps deleteMember failures to the delete code", async () => {
+      const { adapter, axiosRef } = buildAdapter("group");
+      axiosRef.post.mockRejectedValue(axiosError(500, { detail: "boom" }));
+
+      const result = await adapter.deleteMember(EMAIL);
+
+      assertFailure(result);
+      expect(result.error.code).toBe(ErrorCodes.MAILCHIMP_DELETE_FAILED);
     });
   });
 

--- a/apps/backend/src/common/modules/mailchimp/mailchimp.adapter.spec.ts
+++ b/apps/backend/src/common/modules/mailchimp/mailchimp.adapter.spec.ts
@@ -10,6 +10,7 @@ const SERVER_PREFIX = "us1";
 const AUDIENCE_ID = "test-audience-id";
 const API_KEY = "test-mailchimp-api-key";
 const COMMUNITY_ID = "community-interest-id";
+const MERGE_FIELD_ID = "MMERGE10";
 const COMMUNITY_NAME = "Community";
 const EMAIL = "Person@Example.com";
 
@@ -39,7 +40,7 @@ function buildConfig(kind: MailchimpCommunityKind, isConfigured = true): Mailchi
     serverPrefix: SERVER_PREFIX,
     audienceId: AUDIENCE_ID,
     communityKind: kind,
-    communityId: COMMUNITY_ID,
+    communityId: kind === "merge_field" ? MERGE_FIELD_ID : COMMUNITY_ID,
     communityName: COMMUNITY_NAME,
     baseUrl: `https://${SERVER_PREFIX}.api.mailchimp.com/3.0`,
   } as unknown as MailchimpConfigService;
@@ -99,7 +100,25 @@ describe("MailchimpAdapter", () => {
       );
     });
 
-    it("is a no-op for an already-subscribed member (never downgrades to pending)", async () => {
+    it("includes the Community merge field when upserting an unknown member", async () => {
+      const { adapter, axiosRef } = buildAdapter("merge_field");
+      axiosRef.get.mockRejectedValue(axiosError(404, { title: "Resource Not Found" }));
+
+      const result = await adapter.subscribePending(EMAIL);
+
+      assertSuccess(result);
+      const [, body] = putCall(axiosRef, 0);
+      expect(body).toMatchObject({
+        status_if_new: "pending",
+        status: "pending",
+        merge_fields: { [MERGE_FIELD_ID]: COMMUNITY_NAME },
+      });
+      expect(body).not.toHaveProperty("interests");
+      expect(axiosRef.patch).not.toHaveBeenCalled();
+      expect(axiosRef.post).not.toHaveBeenCalled();
+    });
+
+    it("preserves subscribed status and patches only the Community interest group", async () => {
       const { adapter, axiosRef } = buildAdapter("group");
       axiosRef.get.mockResolvedValue({ data: { status: "subscribed" } });
 
@@ -107,7 +126,55 @@ describe("MailchimpAdapter", () => {
 
       assertSuccess(result);
       expect(axiosRef.put).not.toHaveBeenCalled();
+      expect(axiosRef.patch).toHaveBeenCalledWith(
+        expectedMemberUrl,
+        { interests: { [COMMUNITY_ID]: true } },
+        expect.objectContaining({ auth: { username: "anystring", password: API_KEY } }),
+      );
       expect(axiosRef.post).not.toHaveBeenCalled();
+    });
+
+    it("preserves subscribed status and patches only the Community merge field", async () => {
+      const { adapter, axiosRef } = buildAdapter("merge_field");
+      axiosRef.get.mockResolvedValue({ data: { status: "subscribed" } });
+
+      const result = await adapter.subscribePending(EMAIL);
+
+      assertSuccess(result);
+      expect(axiosRef.put).not.toHaveBeenCalled();
+      expect(axiosRef.patch).toHaveBeenCalledWith(
+        expectedMemberUrl,
+        { merge_fields: { [MERGE_FIELD_ID]: COMMUNITY_NAME } },
+        expect.objectContaining({ auth: { username: "anystring", password: API_KEY } }),
+      );
+      expect(axiosRef.post).not.toHaveBeenCalled();
+    });
+
+    it("preserves subscribed status and applies the Community tag", async () => {
+      const { adapter, axiosRef } = buildAdapter("tag");
+      axiosRef.get.mockResolvedValue({ data: { status: "subscribed" } });
+
+      const result = await adapter.subscribePending(EMAIL);
+
+      assertSuccess(result);
+      expect(axiosRef.put).not.toHaveBeenCalled();
+      expect(axiosRef.patch).not.toHaveBeenCalled();
+      expect(axiosRef.post).toHaveBeenCalledWith(
+        `${expectedMemberUrl}/tags`,
+        { tags: [{ name: COMMUNITY_NAME, status: "active" }] },
+        expect.objectContaining({ auth: { username: "anystring", password: API_KEY } }),
+      );
+    });
+
+    it("returns failure when subscribed-member classification fails", async () => {
+      const { adapter, axiosRef } = buildAdapter("merge_field");
+      axiosRef.get.mockResolvedValue({ data: { status: "subscribed" } });
+      axiosRef.patch.mockRejectedValue(axiosError(500, { detail: "classification failed" }));
+
+      const result = await adapter.subscribePending(EMAIL);
+
+      assertFailure(result);
+      expect(axiosRef.put).not.toHaveBeenCalled();
     });
 
     it("re-enters the pending flow for a previously unsubscribed member", async () => {
@@ -167,8 +234,24 @@ describe("MailchimpAdapter", () => {
       expect(body).toMatchObject({ status_if_new: "subscribed", status: "subscribed" });
     });
 
+    it("includes the Community merge field in a direct subscribed upsert", async () => {
+      const { adapter, axiosRef } = buildAdapter("merge_field");
+
+      const result = await adapter.subscribeDirect(EMAIL);
+
+      assertSuccess(result);
+      expect(result.value).toBe("subscribed");
+      const [, body] = putCall(axiosRef, 0);
+      expect(body).toMatchObject({
+        status_if_new: "subscribed",
+        status: "subscribed",
+        merge_fields: { [MERGE_FIELD_ID]: COMMUNITY_NAME },
+      });
+      expect(body).not.toHaveProperty("interests");
+    });
+
     it("falls back to pending when Mailchimp rejects with a compliance state", async () => {
-      const { adapter, axiosRef } = buildAdapter("group");
+      const { adapter, axiosRef } = buildAdapter("merge_field");
       axiosRef.put
         .mockRejectedValueOnce(axiosError(400, { title: "Member In Compliance State" }))
         .mockResolvedValueOnce({ data: {} });
@@ -179,7 +262,11 @@ describe("MailchimpAdapter", () => {
       expect(result.value).toBe("pending");
       expect(axiosRef.put).toHaveBeenCalledTimes(2);
       const [, secondBody] = putCall(axiosRef, 1);
-      expect(secondBody).toMatchObject({ status_if_new: "pending", status: "pending" });
+      expect(secondBody).toMatchObject({
+        status_if_new: "pending",
+        status: "pending",
+        merge_fields: { [MERGE_FIELD_ID]: COMMUNITY_NAME },
+      });
     });
 
     it("returns failure for a non-compliance error", async () => {

--- a/apps/backend/src/common/modules/mailchimp/mailchimp.adapter.ts
+++ b/apps/backend/src/common/modules/mailchimp/mailchimp.adapter.ts
@@ -34,15 +34,20 @@ export class MailchimpAdapter implements NewsletterPort {
       return this.notConfigured("subscribePending");
     }
     // Branch on current state so the anonymous footer path never regresses an
-    // existing member: an already-subscribed address is a no-op (keep them
-    // subscribed), while unsubscribed/pending/absent addresses (re)enter the
-    // double opt-in confirmation flow.
+    // existing member: an already-subscribed address keeps its status and only
+    // receives the Community classification, while unsubscribed/pending/absent
+    // addresses (re)enter the double opt-in confirmation flow.
     const statusResult = await this.getStatus(email);
     if (statusResult.isFailure()) {
       return failure(statusResult.error);
     }
     if (statusResult.value === "subscribed") {
-      return success(undefined);
+      try {
+        await this.applyCommunityClassification(email);
+        return success(undefined);
+      } catch (error) {
+        return this.toFailure(error, ErrorCodes.MAILCHIMP_SUBSCRIBE_FAILED, "subscribePending");
+      }
     }
 
     try {
@@ -163,10 +168,12 @@ export class MailchimpAdapter implements NewsletterPort {
       status,
     };
 
-    // A Community interest group is set inline on the member; a Community tag is
-    // applied through the dedicated tags endpoint after the upsert.
+    // Groups and merge fields are set inline because Mailchimp may require the
+    // classification when creating the member. Tags use their dedicated endpoint.
     if (this.config.communityKind === "group") {
       body.interests = { [this.config.communityId]: true };
+    } else if (this.config.communityKind === "merge_field") {
+      body.merge_fields = { [this.config.communityId]: this.config.communityName };
     }
 
     await this.httpService.axiosRef.put(this.memberUrl(email), body, this.requestConfig());
@@ -178,6 +185,28 @@ export class MailchimpAdapter implements NewsletterPort {
         this.requestConfig(),
       );
     }
+  }
+
+  private async applyCommunityClassification(email: string): Promise<void> {
+    if (this.config.communityKind === "tag") {
+      await this.httpService.axiosRef.post(
+        `${this.memberUrl(email)}/tags`,
+        { tags: [{ name: this.config.communityName, status: "active" }] },
+        this.requestConfig(),
+      );
+      return;
+    }
+
+    const classification =
+      this.config.communityKind === "group"
+        ? { interests: { [this.config.communityId]: true } }
+        : { merge_fields: { [this.config.communityId]: this.config.communityName } };
+
+    await this.httpService.axiosRef.patch(
+      this.memberUrl(email),
+      classification,
+      this.requestConfig(),
+    );
   }
 
   // Returns null for unknown/malformed statuses so the caller can fail closed

--- a/apps/backend/src/common/modules/mailchimp/mailchimp.adapter.ts
+++ b/apps/backend/src/common/modules/mailchimp/mailchimp.adapter.ts
@@ -1,0 +1,241 @@
+import { HttpService } from "@nestjs/axios";
+import { Injectable, Logger } from "@nestjs/common";
+import { isAxiosError } from "axios";
+import { createHash } from "crypto";
+
+import type {
+  NewsletterPort,
+  NewsletterStatus,
+} from "../../../newsletter/core/ports/newsletter.port";
+import { getAxiosErrorMessage } from "../../utils/axios-error";
+import { ErrorCodes } from "../../utils/error-codes";
+import { AppError, apiErrorMapper, failure, Result, success } from "../../utils/fp-utils";
+import { MailchimpConfigService } from "./config/config.service";
+
+interface MailchimpMemberResponse {
+  status?: string;
+}
+
+// Provider states intentionally collapsed to our "unsubscribed" status. Any
+// value outside the known set is treated as an error rather than guessed.
+const UNSUBSCRIBED_STATES = new Set(["unsubscribed", "cleaned", "transactional", "archived"]);
+
+@Injectable()
+export class MailchimpAdapter implements NewsletterPort {
+  private readonly logger = new Logger(MailchimpAdapter.name);
+
+  constructor(
+    private readonly config: MailchimpConfigService,
+    private readonly httpService: HttpService,
+  ) {}
+
+  async subscribePending(email: string): Promise<Result<void>> {
+    if (!this.config.isConfigured) {
+      return this.notConfigured("subscribePending");
+    }
+    // Branch on current state so the anonymous footer path never regresses an
+    // existing member: an already-subscribed address is a no-op (keep them
+    // subscribed), while unsubscribed/pending/absent addresses (re)enter the
+    // double opt-in confirmation flow.
+    const statusResult = await this.getStatus(email);
+    if (statusResult.isFailure()) {
+      return failure(statusResult.error);
+    }
+    if (statusResult.value === "subscribed") {
+      return success(undefined);
+    }
+
+    try {
+      await this.upsertMember(email, "pending");
+      return success(undefined);
+    } catch (error) {
+      return this.toFailure(error, ErrorCodes.MAILCHIMP_SUBSCRIBE_FAILED, "subscribePending");
+    }
+  }
+
+  async subscribeDirect(email: string): Promise<Result<NewsletterStatus>> {
+    if (!this.config.isConfigured) {
+      return this.notConfigured("subscribeDirect");
+    }
+    try {
+      await this.upsertMember(email, "subscribed");
+      return success("subscribed");
+    } catch (error) {
+      // Mailchimp refuses to directly re-subscribe an address in a compliance
+      // state (e.g. a prior unsubscribe); fall back to double opt-in.
+      if (this.isComplianceError(error)) {
+        this.logger.warn({
+          msg: "Direct subscribe rejected by compliance state, falling back to pending",
+          operation: "subscribeDirect",
+        });
+        try {
+          await this.upsertMember(email, "pending");
+          return success("pending");
+        } catch (fallbackError) {
+          return this.toFailure(
+            fallbackError,
+            ErrorCodes.MAILCHIMP_SUBSCRIBE_FAILED,
+            "subscribeDirect",
+          );
+        }
+      }
+      return this.toFailure(error, ErrorCodes.MAILCHIMP_SUBSCRIBE_FAILED, "subscribeDirect");
+    }
+  }
+
+  async unsubscribe(email: string): Promise<Result<void>> {
+    if (!this.config.isConfigured) {
+      return this.notConfigured("unsubscribe");
+    }
+    try {
+      await this.httpService.axiosRef.patch(
+        this.memberUrl(email),
+        { status: "unsubscribed" },
+        this.requestConfig(),
+      );
+      return success(undefined);
+    } catch (error) {
+      // Unsubscribing an address that was never a member is a no-op success.
+      if (this.isStatus(error, 404)) {
+        return success(undefined);
+      }
+      return this.toFailure(error, ErrorCodes.MAILCHIMP_UNSUBSCRIBE_FAILED, "unsubscribe");
+    }
+  }
+
+  async getStatus(email: string): Promise<Result<NewsletterStatus>> {
+    if (!this.config.isConfigured) {
+      return this.notConfigured("getStatus");
+    }
+    try {
+      const response = await this.httpService.axiosRef.get<MailchimpMemberResponse>(
+        this.memberUrl(email),
+        this.requestConfig(),
+      );
+      const status = this.mapStatus(response.data.status);
+      if (status === null) {
+        this.logger.error({
+          msg: "Unknown Mailchimp member status",
+          errorCode: ErrorCodes.MAILCHIMP_STATUS_FAILED,
+          operation: "getStatus",
+          providerStatus: response.data.status,
+        });
+        return failure(
+          AppError.internal(
+            "Mailchimp returned an unrecognized member status",
+            ErrorCodes.MAILCHIMP_STATUS_FAILED,
+          ),
+        );
+      }
+      return success(status);
+    } catch (error) {
+      if (this.isStatus(error, 404)) {
+        return success("none");
+      }
+      return this.toFailure(error, ErrorCodes.MAILCHIMP_STATUS_FAILED, "getStatus");
+    }
+  }
+
+  async deleteMember(email: string): Promise<Result<void>> {
+    if (!this.config.isConfigured) {
+      return this.notConfigured("deleteMember");
+    }
+    try {
+      await this.httpService.axiosRef.post(
+        `${this.memberUrl(email)}/actions/delete-permanent`,
+        undefined,
+        this.requestConfig(),
+      );
+      return success(undefined);
+    } catch (error) {
+      // Already absent counts as erased.
+      if (this.isStatus(error, 404)) {
+        return success(undefined);
+      }
+      return this.toFailure(error, ErrorCodes.MAILCHIMP_DELETE_FAILED, "deleteMember");
+    }
+  }
+
+  private async upsertMember(email: string, status: "pending" | "subscribed"): Promise<void> {
+    const body: Record<string, unknown> = {
+      email_address: email,
+      status_if_new: status,
+      status,
+    };
+
+    // A Community interest group is set inline on the member; a Community tag is
+    // applied through the dedicated tags endpoint after the upsert.
+    if (this.config.communityKind === "group") {
+      body.interests = { [this.config.communityId]: true };
+    }
+
+    await this.httpService.axiosRef.put(this.memberUrl(email), body, this.requestConfig());
+
+    if (this.config.communityKind === "tag") {
+      await this.httpService.axiosRef.post(
+        `${this.memberUrl(email)}/tags`,
+        { tags: [{ name: this.config.communityName, status: "active" }] },
+        this.requestConfig(),
+      );
+    }
+  }
+
+  // Returns null for unknown/malformed statuses so the caller can fail closed
+  // instead of guessing a state the settings UI would render as fact.
+  private mapStatus(status: string | undefined): NewsletterStatus | null {
+    if (status === "subscribed" || status === "pending") {
+      return status;
+    }
+    if (status != null && UNSUBSCRIBED_STATES.has(status)) {
+      return "unsubscribed";
+    }
+    return null;
+  }
+
+  private memberUrl(email: string): string {
+    return `${this.config.baseUrl}/lists/${this.config.audienceId}/members/${this.subscriberHash(email)}`;
+  }
+
+  private subscriberHash(email: string): string {
+    return createHash("md5").update(email.trim().toLowerCase()).digest("hex");
+  }
+
+  private requestConfig() {
+    return {
+      auth: { username: "anystring", password: this.config.apiKey },
+    };
+  }
+
+  private isStatus(error: unknown, status: number): boolean {
+    return isAxiosError(error) && error.response?.status === status;
+  }
+
+  private isComplianceError(error: unknown): boolean {
+    if (!isAxiosError(error)) {
+      return false;
+    }
+    const data = error.response?.data as { title?: string; detail?: string } | undefined;
+    return /compliance/i.test(`${data?.title ?? ""} ${data?.detail ?? ""}`);
+  }
+
+  private notConfigured(operation: string): Result<never> {
+    this.logger.warn({
+      msg: "Mailchimp is not configured; newsletter operation unavailable",
+      errorCode: ErrorCodes.MAILCHIMP_NOT_CONFIGURED,
+      operation,
+    });
+    return failure(
+      AppError.internal("Newsletter is not configured", ErrorCodes.MAILCHIMP_NOT_CONFIGURED),
+    );
+  }
+
+  private toFailure(error: unknown, errorCode: ErrorCodes, operation: string): Result<never> {
+    this.logger.error({
+      msg: "Mailchimp operation failed",
+      errorCode,
+      operation,
+      error: getAxiosErrorMessage(error),
+    });
+    return failure(apiErrorMapper(error, "Mailchimp"));
+  }
+}

--- a/apps/backend/src/common/modules/mailchimp/mailchimp.adapter.ts
+++ b/apps/backend/src/common/modules/mailchimp/mailchimp.adapter.ts
@@ -46,7 +46,7 @@ export class MailchimpAdapter implements NewsletterPort {
         await this.applyCommunityClassification(email);
         return success(undefined);
       } catch (error) {
-        return this.toFailure(error, ErrorCodes.MAILCHIMP_SUBSCRIBE_FAILED, "subscribePending");
+        return this.toFailure(error, this.subscribeFailureCode(error), "subscribePending");
       }
     }
 
@@ -54,7 +54,7 @@ export class MailchimpAdapter implements NewsletterPort {
       await this.upsertMember(email, "pending");
       return success(undefined);
     } catch (error) {
-      return this.toFailure(error, ErrorCodes.MAILCHIMP_SUBSCRIBE_FAILED, "subscribePending");
+      return this.toFailure(error, this.subscribeFailureCode(error), "subscribePending");
     }
   }
 
@@ -79,12 +79,12 @@ export class MailchimpAdapter implements NewsletterPort {
         } catch (fallbackError) {
           return this.toFailure(
             fallbackError,
-            ErrorCodes.MAILCHIMP_SUBSCRIBE_FAILED,
+            this.subscribeFailureCode(fallbackError),
             "subscribeDirect",
           );
         }
       }
-      return this.toFailure(error, ErrorCodes.MAILCHIMP_SUBSCRIBE_FAILED, "subscribeDirect");
+      return this.toFailure(error, this.subscribeFailureCode(error), "subscribeDirect");
     }
   }
 
@@ -247,6 +247,28 @@ export class MailchimpAdapter implements NewsletterPort {
     return /compliance/i.test(`${data?.title ?? ""} ${data?.detail ?? ""}`);
   }
 
+  // A permanently deleted ("forgotten", GDPR-erased) address is suppressed by
+  // Mailchimp: every API re-add (subscribed or pending) returns 400 with a
+  // "Forgotten Email Not Subscribed" title. Detect it so the failure is legible
+  // instead of a generic bad request.
+  private isForgottenEmailError(error: unknown): boolean {
+    if (!isAxiosError(error) || error.response?.status !== 400) {
+      return false;
+    }
+    const data = error.response.data as { title?: string; detail?: string } | undefined;
+    return /forgotten email|permanently deleted|cannot be re-imported/i.test(
+      `${data?.title ?? ""} ${data?.detail ?? ""}`,
+    );
+  }
+
+  // Subscribe paths share one failure code, upgraded to the forgotten-email code
+  // when the provider reports the address as permanently deleted.
+  private subscribeFailureCode(error: unknown): ErrorCodes {
+    return this.isForgottenEmailError(error)
+      ? ErrorCodes.MAILCHIMP_FORGOTTEN_EMAIL
+      : ErrorCodes.MAILCHIMP_SUBSCRIBE_FAILED;
+  }
+
   private notConfigured(operation: string): Result<never> {
     this.logger.warn({
       msg: "Mailchimp is not configured; newsletter operation unavailable",
@@ -265,6 +287,9 @@ export class MailchimpAdapter implements NewsletterPort {
       operation,
       error: getAxiosErrorMessage(error),
     });
-    return failure(apiErrorMapper(error, "Mailchimp"));
+    // Preserve the operation-specific domain error code so callers/clients can
+    // branch on it, while keeping the mapped HTTP status/message/details.
+    const mapped = apiErrorMapper(error, "Mailchimp");
+    return failure(new AppError(mapped.message, errorCode, mapped.statusCode, mapped.details));
   }
 }

--- a/apps/backend/src/common/modules/mailchimp/mailchimp.module.spec.ts
+++ b/apps/backend/src/common/modules/mailchimp/mailchimp.module.spec.ts
@@ -1,0 +1,50 @@
+import { ConfigModule } from "@nestjs/config";
+import { Test } from "@nestjs/testing";
+
+import mailchimpConfig from "../../config/mailchimp.config";
+import { MailchimpConfigService } from "./config/config.service";
+import { MailchimpModule } from "./mailchimp.module";
+
+// Guards the boot regression: on environments with no Mailchimp secrets the
+// module must still compile so the rest of the backend serves normally.
+describe("MailchimpModule boot without configuration", () => {
+  const ENV_KEYS = [
+    "MAILCHIMP_API_KEY",
+    "MAILCHIMP_SERVER_PREFIX",
+    "MAILCHIMP_AUDIENCE_ID",
+    "MAILCHIMP_COMMUNITY_KIND",
+    "MAILCHIMP_COMMUNITY_ID",
+    "MAILCHIMP_COMMUNITY_NAME",
+  ];
+  const saved: Record<string, string | undefined> = {};
+
+  beforeAll(() => {
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterAll(() => {
+    for (const key of ENV_KEYS) {
+      if (saved[key] !== undefined) {
+        process.env[key] = saved[key];
+      }
+    }
+  });
+
+  it("compiles the module and reports itself unconfigured", async () => {
+    // compile() rejecting (the old getOrThrow crash) would fail this test.
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({ isGlobal: true, ignoreEnvFile: true, load: [mailchimpConfig] }),
+        MailchimpModule,
+      ],
+    }).compile();
+
+    const config = moduleRef.get(MailchimpConfigService);
+    expect(config.isConfigured).toBe(false);
+
+    await moduleRef.close();
+  });
+});

--- a/apps/backend/src/common/modules/mailchimp/mailchimp.module.ts
+++ b/apps/backend/src/common/modules/mailchimp/mailchimp.module.ts
@@ -1,0 +1,12 @@
+import { HttpModule } from "@nestjs/axios";
+import { Module } from "@nestjs/common";
+
+import { MailchimpConfigService } from "./config/config.service";
+import { MailchimpAdapter } from "./mailchimp.adapter";
+
+@Module({
+  imports: [HttpModule],
+  providers: [MailchimpAdapter, MailchimpConfigService],
+  exports: [MailchimpAdapter],
+})
+export class MailchimpModule {}

--- a/apps/backend/src/common/utils/error-codes.ts
+++ b/apps/backend/src/common/utils/error-codes.ts
@@ -62,6 +62,7 @@ export enum ErrorCodes {
   // Location: src/common/modules/mailchimp/
   MAILCHIMP_NOT_CONFIGURED = "MAILCHIMP_NOT_CONFIGURED", // Newsletter provider not configured on this environment
   MAILCHIMP_SUBSCRIBE_FAILED = "MAILCHIMP_SUBSCRIBE_FAILED", // Subscribe/upsert member failed
+  MAILCHIMP_FORGOTTEN_EMAIL = "MAILCHIMP_FORGOTTEN_EMAIL", // Address was permanently deleted (GDPR erasure) and cannot be re-added via the API
   MAILCHIMP_UNSUBSCRIBE_FAILED = "MAILCHIMP_UNSUBSCRIBE_FAILED", // Unsubscribe member failed
   MAILCHIMP_STATUS_FAILED = "MAILCHIMP_STATUS_FAILED", // Member status lookup failed
   MAILCHIMP_DELETE_FAILED = "MAILCHIMP_DELETE_FAILED", // Permanent member delete failed

--- a/apps/backend/src/common/utils/error-codes.ts
+++ b/apps/backend/src/common/utils/error-codes.ts
@@ -24,6 +24,7 @@ export enum ErrorCodes {
   DATABRICKS_CONFIG_INVALID = "DATABRICKS_CONFIG_INVALID", // Databricks config specific
   AWS_CONFIG_INVALID = "AWS_CONFIG_INVALID", // AWS config specific
   EMAIL_CONFIG_INVALID = "EMAIL_CONFIG_INVALID", // Email config specific
+  MAILCHIMP_CONFIG_INVALID = "MAILCHIMP_CONFIG_INVALID", // Mailchimp config specific
   ANALYTICS_CONFIG_INVALID = "ANALYTICS_CONFIG_INVALID", // Analytics config specific
 
   // ==================== Databricks Operations ====================
@@ -56,6 +57,14 @@ export enum ErrorCodes {
   // ==================== Email Operations ====================
   // Location: src/common/modules/email/
   EMAIL_SEND_FAILED = "EMAIL_SEND_FAILED", // Email sending failed
+
+  // ==================== Mailchimp / Newsletter ====================
+  // Location: src/common/modules/mailchimp/
+  MAILCHIMP_NOT_CONFIGURED = "MAILCHIMP_NOT_CONFIGURED", // Newsletter provider not configured on this environment
+  MAILCHIMP_SUBSCRIBE_FAILED = "MAILCHIMP_SUBSCRIBE_FAILED", // Subscribe/upsert member failed
+  MAILCHIMP_UNSUBSCRIBE_FAILED = "MAILCHIMP_UNSUBSCRIBE_FAILED", // Unsubscribe member failed
+  MAILCHIMP_STATUS_FAILED = "MAILCHIMP_STATUS_FAILED", // Member status lookup failed
+  MAILCHIMP_DELETE_FAILED = "MAILCHIMP_DELETE_FAILED", // Permanent member delete failed
 
   // ==================== Analytics & Feature Flags ====================
   // Location: src/common/modules/analytics/

--- a/apps/backend/src/newsletter/core/ports/newsletter.port.ts
+++ b/apps/backend/src/newsletter/core/ports/newsletter.port.ts
@@ -1,0 +1,48 @@
+import type { Result } from "../../../common/utils/fp-utils";
+
+/**
+ * Injection token for the Newsletter port
+ */
+export const NEWSLETTER_PORT = Symbol("NEWSLETTER_PORT");
+
+/**
+ * Live subscription status of an address in the newsletter provider.
+ * `none` means the address is not a member at all.
+ */
+export type NewsletterStatus = "subscribed" | "pending" | "unsubscribed" | "none";
+
+/**
+ * Port interface for newsletter subscription operations. Mailchimp is the
+ * source of truth; no subscription state is persisted locally.
+ */
+export interface NewsletterPort {
+  /**
+   * Double opt-in path (anonymous footer). Upserts the member as `pending` so
+   * the provider sends a confirmation email, and applies the Community group/tag.
+   */
+  subscribePending(email: string): Promise<Result<void>>;
+
+  /**
+   * Direct subscribe (authenticated surfaces, email already verified). Upserts
+   * the member as `subscribed`; falls back to `pending` when the provider
+   * rejects the direct subscribe due to a compliance state. Returns the
+   * resulting status.
+   */
+  subscribeDirect(email: string): Promise<Result<NewsletterStatus>>;
+
+  /**
+   * Sets the member to `unsubscribed` (the member is kept, per the provider's
+   * compliance model).
+   */
+  unsubscribe(email: string): Promise<Result<void>>;
+
+  /**
+   * Reads the live subscription status of the given address.
+   */
+  getStatus(email: string): Promise<Result<NewsletterStatus>>;
+
+  /**
+   * Permanently deletes the member (GDPR erasure).
+   */
+  deleteMember(email: string): Promise<Result<void>>;
+}

--- a/apps/backend/src/newsletter/newsletter.module.ts
+++ b/apps/backend/src/newsletter/newsletter.module.ts
@@ -1,0 +1,22 @@
+import { Module } from "@nestjs/common";
+import { ThrottlerModule } from "@nestjs/throttler";
+
+import { MailchimpAdapter } from "../common/modules/mailchimp/mailchimp.adapter";
+import { MailchimpModule } from "../common/modules/mailchimp/mailchimp.module";
+import { NEWSLETTER_PORT } from "./core/ports/newsletter.port";
+import { NewsletterSubscribeController } from "./presentation/newsletter-subscribe.controller";
+import { NewsletterThrottlerGuard } from "./presentation/newsletter-throttler.guard";
+import { NewsletterController } from "./presentation/newsletter.controller";
+
+@Module({
+  imports: [MailchimpModule, ThrottlerModule.forRoot([{ ttl: 60_000, limit: 5 }])],
+  controllers: [NewsletterController, NewsletterSubscribeController],
+  providers: [
+    NewsletterThrottlerGuard,
+    {
+      provide: NEWSLETTER_PORT,
+      useExisting: MailchimpAdapter,
+    },
+  ],
+})
+export class NewsletterModule {}

--- a/apps/backend/src/newsletter/presentation/newsletter-subscribe.controller.spec.ts
+++ b/apps/backend/src/newsletter/presentation/newsletter-subscribe.controller.spec.ts
@@ -1,0 +1,178 @@
+import { StatusCodes } from "http-status-codes";
+
+import { contract } from "@repo/api/contract";
+import type { NewsletterSubscribeResponse } from "@repo/api/domains/newsletter/newsletter.schema";
+
+import { MailchimpAdapter } from "../../common/modules/mailchimp/mailchimp.adapter";
+import { AppError, failure, success } from "../../common/utils/fp-utils";
+import type { SuperTestResponse } from "../../test/test-harness";
+import { TestHarness } from "../../test/test-harness";
+
+describe("NewsletterSubscribeController", () => {
+  const testApp = TestHarness.App;
+  const subscribePath = () => testApp.resolveOrpcPath(contract.newsletter.subscribe);
+  const statusPath = () => testApp.resolveOrpcPath(contract.newsletter.getStatus);
+  let mailchimp: MailchimpAdapter;
+
+  beforeAll(async () => {
+    await testApp.setup();
+  });
+
+  beforeEach(async () => {
+    await testApp.beforeEach();
+    mailchimp = testApp.module.get(MailchimpAdapter);
+  });
+
+  afterEach(() => {
+    testApp.afterEach();
+  });
+
+  afterAll(async () => {
+    await testApp.teardown();
+  });
+
+  it("subscribes without a session and returns a generic response", async () => {
+    const spy = vi.spyOn(mailchimp, "subscribePending").mockResolvedValue(success(undefined));
+
+    const response: SuperTestResponse<NewsletterSubscribeResponse> = await testApp
+      .post(subscribePath())
+      .withoutAuth()
+      .set("X-Forwarded-For", "203.0.113.10")
+      .send({ email: "visitor@example.com" })
+      .expect(StatusCodes.OK);
+
+    expect(response.body).toEqual({ success: true });
+    expect(spy).toHaveBeenCalledWith("visitor@example.com");
+  });
+
+  it("returns the same generic response when the provider returns a failure", async () => {
+    vi.spyOn(mailchimp, "subscribePending").mockResolvedValue(
+      failure(AppError.internal("Mailchimp down")),
+    );
+
+    const response: SuperTestResponse<NewsletterSubscribeResponse> = await testApp
+      .post(subscribePath())
+      .withoutAuth()
+      .set("X-Forwarded-For", "203.0.113.11")
+      .send({ email: "visitor2@example.com" })
+      .expect(StatusCodes.OK);
+
+    expect(response.body).toEqual({ success: true });
+  });
+
+  it("returns the same generic response when the provider throws (no enumeration signal)", async () => {
+    vi.spyOn(mailchimp, "subscribePending").mockRejectedValue(new Error("unexpected boom"));
+
+    const response: SuperTestResponse<NewsletterSubscribeResponse> = await testApp
+      .post(subscribePath())
+      .withoutAuth()
+      .set("X-Forwarded-For", "203.0.113.12")
+      .send({ email: "visitor3@example.com" })
+      .expect(StatusCodes.OK);
+
+    expect(response.body).toEqual({ success: true });
+  });
+
+  it("rejects an invalid email address", async () => {
+    await testApp
+      .post(subscribePath())
+      .withoutAuth()
+      .set("X-Forwarded-For", "203.0.113.13")
+      .send({ email: "not-an-email" })
+      .expect(StatusCodes.BAD_REQUEST);
+  });
+
+  // Deployed header shape: `<client-supplied...>, <viewer-IP by CloudFront>, <edge-IP by ALB>`.
+  // The client key is the second-from-right entry.
+  const EDGE_IP = "70.132.0.1";
+
+  it("allows exactly five requests per client per window, then returns 429", async () => {
+    vi.spyOn(mailchimp, "subscribePending").mockResolvedValue(success(undefined));
+
+    const statuses: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const response = await testApp
+        .post(subscribePath())
+        .withoutAuth()
+        .set("X-Forwarded-For", `198.51.100.1, ${EDGE_IP}`)
+        .send({ email: `flood${i}@example.com` });
+      statuses.push(response.status);
+    }
+
+    expect(statuses).toEqual([
+      StatusCodes.OK,
+      StatusCodes.OK,
+      StatusCodes.OK,
+      StatusCodes.OK,
+      StatusCodes.OK,
+      StatusCodes.TOO_MANY_REQUESTS,
+    ]);
+  });
+
+  it("keys the limit per client IP so distinct forwarded clients are independent", async () => {
+    vi.spyOn(mailchimp, "subscribePending").mockResolvedValue(success(undefined));
+
+    // Exhaust client A's bucket (A is the second-from-right entry).
+    for (let i = 0; i < 5; i++) {
+      await testApp
+        .post(subscribePath())
+        .withoutAuth()
+        .set("X-Forwarded-For", `198.51.100.2, ${EDGE_IP}`)
+        .send({ email: `a${i}@example.com` })
+        .expect(StatusCodes.OK);
+    }
+    await testApp
+      .post(subscribePath())
+      .withoutAuth()
+      .set("X-Forwarded-For", `198.51.100.2, ${EDGE_IP}`)
+      .send({ email: "a-blocked@example.com" })
+      .expect(StatusCodes.TOO_MANY_REQUESTS);
+
+    // A different forwarded client is unaffected.
+    await testApp
+      .post(subscribePath())
+      .withoutAuth()
+      .set("X-Forwarded-For", `198.51.100.3, ${EDGE_IP}`)
+      .send({ email: "b@example.com" })
+      .expect(StatusCodes.OK);
+  });
+
+  it("cannot be bypassed by spoofing the leftmost X-Forwarded-For entry", async () => {
+    vi.spyOn(mailchimp, "subscribePending").mockResolvedValue(success(undefined));
+
+    // Same real client (second-from-right = 198.51.100.4) but a different
+    // attacker-controlled leftmost entry on every request. They must all land
+    // in the same bucket, so the sixth is still throttled.
+    const statuses: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const response = await testApp
+        .post(subscribePath())
+        .withoutAuth()
+        .set("X-Forwarded-For", `10.0.0.${i}, 198.51.100.4, ${EDGE_IP}`)
+        .send({ email: `spoof${i}@example.com` });
+      statuses.push(response.status);
+    }
+
+    expect(statuses.slice(0, 5)).toEqual([
+      StatusCodes.OK,
+      StatusCodes.OK,
+      StatusCodes.OK,
+      StatusCodes.OK,
+      StatusCodes.OK,
+    ]);
+    expect(statuses[5]).toBe(StatusCodes.TOO_MANY_REQUESTS);
+  });
+
+  it("does not throttle the authenticated newsletter routes", async () => {
+    vi.spyOn(mailchimp, "getStatus").mockResolvedValue(success("subscribed"));
+
+    // Well beyond the anonymous limit, all from one address, all authenticated.
+    for (let i = 0; i < 8; i++) {
+      await testApp
+        .get(statusPath())
+        .withAuth("11111111-1111-1111-1111-111111111111")
+        .set("X-Forwarded-For", "198.51.100.9")
+        .expect(StatusCodes.OK);
+    }
+  });
+});

--- a/apps/backend/src/newsletter/presentation/newsletter-subscribe.controller.ts
+++ b/apps/backend/src/newsletter/presentation/newsletter-subscribe.controller.ts
@@ -1,0 +1,50 @@
+import { Controller, Inject, Logger, UseGuards } from "@nestjs/common";
+import { Throttle } from "@nestjs/throttler";
+import { Implement, implement } from "@orpc/nest";
+import { AllowAnonymous } from "@thallesp/nestjs-better-auth";
+
+import { newsletterContract } from "@repo/api/domains/newsletter/newsletter.contract";
+
+import { NEWSLETTER_PORT } from "../core/ports/newsletter.port";
+import type { NewsletterPort } from "../core/ports/newsletter.port";
+import { NewsletterThrottlerGuard } from "./newsletter-throttler.guard";
+
+/**
+ * Public, unauthenticated newsletter subscribe endpoint. Rate-limited per IP
+ * and enumeration-safe: it always returns the same generic response regardless
+ * of whether the address is new, known, or the upsert failed.
+ */
+@Controller()
+@AllowAnonymous()
+@UseGuards(NewsletterThrottlerGuard)
+@Throttle({ default: { limit: 5, ttl: 60_000 } })
+export class NewsletterSubscribeController {
+  private readonly logger = new Logger(NewsletterSubscribeController.name);
+
+  constructor(@Inject(NEWSLETTER_PORT) private readonly newsletter: NewsletterPort) {}
+
+  @Implement(newsletterContract.subscribe)
+  subscribe() {
+    return implement(newsletterContract.subscribe).handler(async ({ input }) => {
+      // Enumeration-safe: every outcome (failure, or an unexpected throw from
+      // the port) yields the same generic response so membership never leaks.
+      try {
+        const result = await this.newsletter.subscribePending(input.email);
+        if (result.isFailure()) {
+          this.logger.warn({
+            msg: "Newsletter subscribe failed; returning generic response",
+            operation: "subscribe",
+            errorCode: result.error.code,
+          });
+        }
+      } catch (error) {
+        this.logger.error({
+          msg: "Newsletter subscribe threw; returning generic response",
+          operation: "subscribe",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      return { success: true as const };
+    });
+  }
+}

--- a/apps/backend/src/newsletter/presentation/newsletter-throttler.guard.ts
+++ b/apps/backend/src/newsletter/presentation/newsletter-throttler.guard.ts
@@ -1,0 +1,30 @@
+import { Injectable } from "@nestjs/common";
+import { ThrottlerGuard } from "@nestjs/throttler";
+
+interface ThrottledRequest {
+  headers?: Record<string, string | string[] | undefined>;
+  ip?: string;
+}
+
+// Keys the throttle on the second-from-right X-Forwarded-For entry: the viewer IP
+// CloudFront appends. req.ip is the proxy (one shared bucket) and the leftmost entry
+// is client-supplied (rotating it would mint a fresh bucket per request).
+@Injectable()
+export class NewsletterThrottlerGuard extends ThrottlerGuard {
+  protected getTracker(req: ThrottledRequest): Promise<string> {
+    const header = req.headers?.["x-forwarded-for"];
+    const raw = Array.isArray(header) ? header.join(",") : header;
+    const chain = (raw ?? "")
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+
+    if (chain.length >= 2) {
+      return Promise.resolve(chain[chain.length - 2]);
+    }
+    if (chain.length === 1) {
+      return Promise.resolve(chain[0]);
+    }
+    return Promise.resolve(req.ip ?? "");
+  }
+}

--- a/apps/backend/src/newsletter/presentation/newsletter.controller.spec.ts
+++ b/apps/backend/src/newsletter/presentation/newsletter.controller.spec.ts
@@ -1,0 +1,113 @@
+import { StatusCodes } from "http-status-codes";
+
+import { contract } from "@repo/api/contract";
+import type { NewsletterStatusResponse } from "@repo/api/domains/newsletter/newsletter.schema";
+
+import { MailchimpAdapter } from "../../common/modules/mailchimp/mailchimp.adapter";
+import { AppError, failure, success } from "../../common/utils/fp-utils";
+import type { SuperTestResponse } from "../../test/test-harness";
+import { TestHarness } from "../../test/test-harness";
+
+// The mocked Better Auth session always resolves to this email.
+const SESSION_EMAIL = "test@example.com";
+
+describe("NewsletterController", () => {
+  const testApp = TestHarness.App;
+  let userId: string;
+  let mailchimp: MailchimpAdapter;
+
+  const statusPath = () => testApp.resolveOrpcPath(contract.newsletter.getStatus);
+  const subscriptionPath = () => testApp.resolveOrpcPath(contract.newsletter.subscribeDirect);
+  const unsubscribePath = () => testApp.resolveOrpcPath(contract.newsletter.unsubscribe);
+
+  beforeAll(async () => {
+    await testApp.setup();
+  });
+
+  beforeEach(async () => {
+    await testApp.beforeEach();
+    userId = await testApp.createTestUser({ email: SESSION_EMAIL });
+    mailchimp = testApp.module.get(MailchimpAdapter);
+  });
+
+  afterEach(() => {
+    testApp.afterEach();
+  });
+
+  afterAll(async () => {
+    await testApp.teardown();
+  });
+
+  describe("getStatus", () => {
+    it("returns the live status of the session user's email", async () => {
+      const spy = vi.spyOn(mailchimp, "getStatus").mockResolvedValue(success("pending"));
+
+      const response: SuperTestResponse<NewsletterStatusResponse> = await testApp
+        .get(statusPath())
+        .withAuth(userId)
+        .expect(StatusCodes.OK);
+
+      expect(response.body).toEqual({ status: "pending" });
+      expect(spy).toHaveBeenCalledWith(SESSION_EMAIL);
+    });
+
+    it("returns 401 for anonymous callers", async () => {
+      await testApp.get(statusPath()).withoutAuth().expect(StatusCodes.UNAUTHORIZED);
+    });
+
+    it("returns 500 when the provider lookup fails", async () => {
+      vi.spyOn(mailchimp, "getStatus").mockResolvedValue(
+        failure(AppError.internal("Mailchimp unreachable")),
+      );
+
+      await testApp.get(statusPath()).withAuth(userId).expect(StatusCodes.INTERNAL_SERVER_ERROR);
+    });
+  });
+
+  describe("subscribeDirect", () => {
+    it("directly subscribes the session user and returns the resulting status", async () => {
+      const spy = vi.spyOn(mailchimp, "subscribeDirect").mockResolvedValue(success("subscribed"));
+
+      const response: SuperTestResponse<NewsletterStatusResponse> = await testApp
+        .post(subscriptionPath())
+        .withAuth(userId)
+        .expect(StatusCodes.OK);
+
+      expect(response.body).toEqual({ status: "subscribed" });
+      expect(spy).toHaveBeenCalledWith(SESSION_EMAIL);
+    });
+
+    it("surfaces the pending fallback status", async () => {
+      vi.spyOn(mailchimp, "subscribeDirect").mockResolvedValue(success("pending"));
+
+      const response: SuperTestResponse<NewsletterStatusResponse> = await testApp
+        .post(subscriptionPath())
+        .withAuth(userId)
+        .expect(StatusCodes.OK);
+
+      expect(response.body).toEqual({ status: "pending" });
+    });
+
+    it("returns 401 for anonymous callers", async () => {
+      await testApp.post(subscriptionPath()).withoutAuth().expect(StatusCodes.UNAUTHORIZED);
+    });
+  });
+
+  describe("unsubscribe", () => {
+    it("unsubscribes the session user", async () => {
+      const spy = vi.spyOn(mailchimp, "unsubscribe").mockResolvedValue(success(undefined));
+
+      const response: SuperTestResponse<NewsletterStatusResponse> = await testApp
+        .delete(unsubscribePath())
+        .withAuth(userId)
+        .expect(StatusCodes.OK);
+
+      expect(response.body).toEqual({ status: "unsubscribed" });
+      expect(spy).toHaveBeenCalledWith(SESSION_EMAIL);
+    });
+
+    it("returns 401 for anonymous callers", async () => {
+      await testApp.delete(unsubscribePath()).withoutAuth().expect(StatusCodes.UNAUTHORIZED);
+    });
+  });
+});

--- a/apps/backend/src/newsletter/presentation/newsletter.controller.ts
+++ b/apps/backend/src/newsletter/presentation/newsletter.controller.ts
@@ -1,0 +1,75 @@
+import { Controller, Inject, Logger } from "@nestjs/common";
+import { Implement, implement } from "@orpc/nest";
+import { Session } from "@thallesp/nestjs-better-auth";
+import type { UserSession } from "@thallesp/nestjs-better-auth";
+
+import { newsletterContract } from "@repo/api/domains/newsletter/newsletter.contract";
+
+import { AppError } from "../../common/utils/fp-utils";
+import { throwOrpcError, throwOrpcFailure } from "../../common/utils/orpc-fp";
+import { NEWSLETTER_PORT } from "../core/ports/newsletter.port";
+import type { NewsletterPort } from "../core/ports/newsletter.port";
+
+/**
+ * Authenticated newsletter endpoints. All operate on the session user's own
+ * email only; Mailchimp is the source of truth for the reported status.
+ */
+@Controller()
+export class NewsletterController {
+  private readonly logger = new Logger(NewsletterController.name);
+
+  constructor(@Inject(NEWSLETTER_PORT) private readonly newsletter: NewsletterPort) {}
+
+  @Implement(newsletterContract.getStatus)
+  getStatus(@Session() session: UserSession) {
+    return implement(newsletterContract.getStatus).handler(async () => {
+      const email = this.requireEmail(session);
+      const result = await this.newsletter.getStatus(email);
+      if (result.isSuccess()) {
+        return { status: result.value };
+      }
+      return throwOrpcFailure(result, this.logger, "getStatus");
+    });
+  }
+
+  @Implement(newsletterContract.subscribeDirect)
+  subscribeDirect(@Session() session: UserSession) {
+    return implement(newsletterContract.subscribeDirect).handler(async () => {
+      const email = this.requireEmail(session);
+      const result = await this.newsletter.subscribeDirect(email);
+      if (result.isSuccess()) {
+        this.logger.log({
+          msg: "Newsletter direct subscribe",
+          operation: "subscribeDirect",
+          status: result.value,
+        });
+        return { status: result.value };
+      }
+      return throwOrpcFailure(result, this.logger, "subscribeDirect");
+    });
+  }
+
+  @Implement(newsletterContract.unsubscribe)
+  unsubscribe(@Session() session: UserSession) {
+    return implement(newsletterContract.unsubscribe).handler(async () => {
+      const email = this.requireEmail(session);
+      const result = await this.newsletter.unsubscribe(email);
+      if (result.isSuccess()) {
+        return { status: "unsubscribed" as const };
+      }
+      return throwOrpcFailure(result, this.logger, "unsubscribe");
+    });
+  }
+
+  private requireEmail(session: UserSession): string {
+    const email = session.user.email;
+    if (!email) {
+      return throwOrpcError(
+        AppError.badRequest("No email address on the current session"),
+        this.logger,
+        "newsletter",
+      );
+    }
+    return email;
+  }
+}

--- a/apps/backend/src/users/application/use-cases/delete-user/delete-user.spec.ts
+++ b/apps/backend/src/users/application/use-cases/delete-user/delete-user.spec.ts
@@ -1,6 +1,14 @@
 import { eq, users } from "@repo/database";
 
-import { assertFailure, assertSuccess, failure, AppError } from "../../../../common/utils/fp-utils";
+import { MailchimpAdapter } from "../../../../common/modules/mailchimp/mailchimp.adapter";
+import { ErrorCodes } from "../../../../common/utils/error-codes";
+import {
+  assertFailure,
+  assertSuccess,
+  failure,
+  AppError,
+  success,
+} from "../../../../common/utils/fp-utils";
 import { TestHarness } from "../../../../test/test-harness";
 import { UserRepository } from "../../../core/repositories/user.repository";
 import { DeleteUserUseCase } from "./delete-user";
@@ -9,6 +17,7 @@ describe("DeleteUserUseCase", () => {
   const testApp = TestHarness.App;
   let useCase: DeleteUserUseCase;
   let userRepository: UserRepository;
+  let mailchimp: MailchimpAdapter;
 
   beforeAll(async () => {
     await testApp.setup();
@@ -18,6 +27,7 @@ describe("DeleteUserUseCase", () => {
     await testApp.beforeEach();
     useCase = testApp.module.get(DeleteUserUseCase);
     userRepository = testApp.module.get(UserRepository);
+    mailchimp = testApp.module.get(MailchimpAdapter);
   });
 
   afterEach(() => {
@@ -55,6 +65,56 @@ describe("DeleteUserUseCase", () => {
     expect(deletedUser.name).toBe("Deleted User");
   });
 
+  it("should permanently delete the newsletter member using the original email", async () => {
+    const email = "newsletter-erasure@example.com";
+    const userId = await testApp.createTestUser({ email });
+    const deleteMember = vi.spyOn(mailchimp, "deleteMember").mockResolvedValue(success(undefined));
+
+    const result = await useCase.execute(userId);
+
+    assertSuccess(result);
+    expect(deleteMember).toHaveBeenCalledWith(email);
+  });
+
+  it("should complete account deletion when newsletter erasure returns a failure", async () => {
+    const email = "newsletter-failure@example.com";
+    const userId = await testApp.createTestUser({ email });
+    vi.spyOn(mailchimp, "deleteMember").mockResolvedValue(
+      failure(AppError.internal("Mailchimp deletion failed", ErrorCodes.MAILCHIMP_DELETE_FAILED)),
+    );
+
+    const result = await useCase.execute(userId);
+
+    assertSuccess(result);
+    await expectUserToBeAnonymized(userId, email);
+  });
+
+  it("should complete account deletion when newsletter erasure throws", async () => {
+    const email = "newsletter-throws@example.com";
+    const userId = await testApp.createTestUser({ email });
+    vi.spyOn(mailchimp, "deleteMember").mockRejectedValue(new Error("Mailchimp unavailable"));
+
+    const result = await useCase.execute(userId);
+
+    assertSuccess(result);
+    await expectUserToBeAnonymized(userId, email);
+  });
+
+  it("should complete account deletion when Mailchimp is not configured", async () => {
+    const email = "newsletter-unconfigured@example.com";
+    const userId = await testApp.createTestUser({ email });
+    vi.spyOn(mailchimp, "deleteMember").mockResolvedValue(
+      failure(
+        AppError.internal("Newsletter is not configured", ErrorCodes.MAILCHIMP_NOT_CONFIGURED),
+      ),
+    );
+
+    const result = await useCase.execute(userId);
+
+    assertSuccess(result);
+    await expectUserToBeAnonymized(userId, email);
+  });
+
   it("should return NOT_FOUND error when user does not exist", async () => {
     // Arrange
     const nonExistentId = "00000000-0000-0000-0000-000000000000";
@@ -90,6 +150,7 @@ describe("DeleteUserUseCase", () => {
 
   it("should handle repository deletion failure", async () => {
     const userId = await testApp.createTestUser({});
+    const deleteMember = vi.spyOn(mailchimp, "deleteMember");
 
     // Mock failure
     vi.spyOn(userRepository, "delete").mockResolvedValue(failure(AppError.internal("DB Error")));
@@ -98,5 +159,14 @@ describe("DeleteUserUseCase", () => {
 
     assertFailure(result);
     expect(result.error.code).toBe("INTERNAL_ERROR");
+    expect(deleteMember).not.toHaveBeenCalled();
   });
+
+  async function expectUserToBeAnonymized(userId: string, originalEmail: string) {
+    const [deletedUser] = await testApp.database.select().from(users).where(eq(users.id, userId));
+
+    expect(deletedUser).toBeDefined();
+    expect(deletedUser.email).not.toBe(originalEmail);
+    expect(deletedUser.email).toMatch(/^deleted-/);
+  }
 });

--- a/apps/backend/src/users/application/use-cases/delete-user/delete-user.ts
+++ b/apps/backend/src/users/application/use-cases/delete-user/delete-user.ts
@@ -2,6 +2,8 @@ import { Injectable, Logger, Inject } from "@nestjs/common";
 
 import { ErrorCodes } from "../../../../common/utils/error-codes";
 import { success, Result, failure, AppError } from "../../../../common/utils/fp-utils";
+import type { NewsletterPort } from "../../../../newsletter/core/ports/newsletter.port";
+import { NEWSLETTER_PORT } from "../../../../newsletter/core/ports/newsletter.port";
 import { UserDto } from "../../../core/models/user.model";
 import type { DatabricksPort } from "../../../core/ports/databricks.port";
 import { DATABRICKS_PORT } from "../../../core/ports/databricks.port";
@@ -14,6 +16,7 @@ export class DeleteUserUseCase {
   constructor(
     private readonly userRepository: UserRepository,
     @Inject(DATABRICKS_PORT) private readonly databricksPort: DatabricksPort,
+    @Inject(NEWSLETTER_PORT) private readonly newsletterPort: NewsletterPort,
   ) {}
 
   async execute(id: string): Promise<Result<void>> {
@@ -73,6 +76,35 @@ export class DeleteUserUseCase {
           userId: id,
           status: "success",
         });
+
+        // Erase the newsletter member only after the local transaction has completed. This is
+        // deliberately best-effort: a provider outage must not leave the account half-deleted or
+        // prevent the local GDPR deletion from completing.
+        try {
+          const newsletterDeleteResult = await this.newsletterPort.deleteMember(user.email);
+
+          if (newsletterDeleteResult.isFailure()) {
+            this.logger.error({
+              msg: "Account deleted, but newsletter member erasure is incomplete",
+              errorCode: newsletterDeleteResult.error.code,
+              operation: "deleteUserNewsletterErasure",
+              userId: id,
+              error: newsletterDeleteResult.error.message,
+              gdprErasureComplete: false,
+              requiresManualIntervention: true,
+            });
+          }
+        } catch (error) {
+          this.logger.error({
+            msg: "Account deleted, but newsletter member erasure threw unexpectedly",
+            errorCode: ErrorCodes.MAILCHIMP_DELETE_FAILED,
+            operation: "deleteUserNewsletterErasure",
+            userId: id,
+            error: error instanceof Error ? error.message : String(error),
+            gdprErasureComplete: false,
+            requiresManualIntervention: true,
+          });
+        }
 
         this.logger.log({
           msg: "User deletion completed",

--- a/apps/backend/src/users/user.module.ts
+++ b/apps/backend/src/users/user.module.ts
@@ -4,7 +4,10 @@ import { DatabricksAdapter } from "../common/modules/databricks/databricks.adapt
 import { DatabricksModule } from "../common/modules/databricks/databricks.module";
 import { EmailAdapter } from "../common/modules/email/services/email.adapter";
 import { EmailModule } from "../common/modules/email/services/email.module";
+import { MailchimpAdapter } from "../common/modules/mailchimp/mailchimp.adapter";
+import { MailchimpModule } from "../common/modules/mailchimp/mailchimp.module";
 import { ExperimentModule } from "../experiments/experiment.module";
+import { NEWSLETTER_PORT } from "../newsletter/core/ports/newsletter.port";
 import { AcceptPendingInvitationsUseCase } from "./application/use-cases/accept-pending-invitations/accept-pending-invitations";
 import { CreateInvitationUseCase } from "./application/use-cases/create-invitation/create-invitation";
 import { CreateUserProfileUseCase } from "./application/use-cases/create-user-profile/create-user-profile";
@@ -31,7 +34,7 @@ import { UserController } from "./presentation/user.controller";
 import { WhatsNewController } from "./presentation/whats-new.controller";
 
 @Module({
-  imports: [DatabricksModule, EmailModule, forwardRef(() => ExperimentModule)],
+  imports: [DatabricksModule, EmailModule, MailchimpModule, forwardRef(() => ExperimentModule)],
   controllers: [UserController, UserWebhookController, InvitationController, WhatsNewController],
   providers: [
     // Repositories
@@ -46,6 +49,10 @@ import { WhatsNewController } from "./presentation/whats-new.controller";
     {
       provide: EMAIL_PORT,
       useExisting: EmailAdapter,
+    },
+    {
+      provide: NEWSLETTER_PORT,
+      useExisting: MailchimpAdapter,
     },
 
     // Use case providers

--- a/apps/web/app/[locale]/(info)/layout.tsx
+++ b/apps/web/app/[locale]/(info)/layout.tsx
@@ -1,4 +1,5 @@
 import { UnifiedNavbar } from "@/components/navigation/unified-navbar/unified-navbar";
+import { NewsletterSubscribeForm } from "@/components/newsletter/newsletter-subscribe-form";
 import { draftMode } from "next/headers";
 import React from "react";
 import { auth } from "~/app/actions/auth";
@@ -34,7 +35,14 @@ export default async function InfoGroupLayout({ children, params }: InfoLayoutPr
       <div className="mx-auto flex w-full max-w-7xl justify-center">
         <main className="flex min-h-screen w-full flex-col px-2">{children}</main>
       </div>
-      {footerData && <HomeFooter footerData={footerData} preview={preview} locale={locale} />}
+      {footerData && (
+        <HomeFooter
+          footerData={footerData}
+          preview={preview}
+          locale={locale}
+          newsletterSlot={<NewsletterSubscribeForm />}
+        />
+      )}
       <Toaster />
     </>
   );

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -1,4 +1,5 @@
 import { UnifiedNavbar } from "@/components/navigation/unified-navbar/unified-navbar";
+import { NewsletterSubscribeForm } from "@/components/newsletter/newsletter-subscribe-form";
 import type { Metadata } from "next";
 import { draftMode } from "next/headers";
 import { cache } from "react";
@@ -83,7 +84,12 @@ export default async function Home({ params }: HomePageProps) {
         <HomeKeyFeatures featuresData={features} preview={preview} locale={locale} />
 
         {/* Footer */}
-        <HomeFooter locale={locale} footerData={footer} preview={preview} />
+        <HomeFooter
+          locale={locale}
+          footerData={footer}
+          preview={preview}
+          newsletterSlot={<NewsletterSubscribeForm />}
+        />
       </main>
     </>
   );

--- a/apps/web/components/account-settings/account-settings.test.tsx
+++ b/apps/web/components/account-settings/account-settings.test.tsx
@@ -67,6 +67,10 @@ vi.mock("./profile-information-card", () => ({
   ),
 }));
 
+vi.mock("./newsletter-subscription-card", () => ({
+  NewsletterSubscriptionCard: () => <div data-testid="newsletter-subscription-card" />,
+}));
+
 const session: Session = {
   user: {
     id: "u-1",
@@ -149,6 +153,7 @@ describe("<AccountSettings />", () => {
       "https://example.com/ada.png",
     );
     expect(within(pictureCard).getByTestId("email")).toHaveTextContent("hello@example.com");
+    expect(screen.getByTestId("newsletter-subscription-card")).toBeInTheDocument();
   });
 
   it("saves an inline name edit", async () => {

--- a/apps/web/components/account-settings/account-settings.tsx
+++ b/apps/web/components/account-settings/account-settings.tsx
@@ -13,6 +13,7 @@ import { toast } from "@repo/ui/hooks/use-toast";
 import { ErrorDisplay } from "../error-display";
 import { AccountIdentityCard } from "./account-identity-card";
 import { DangerZoneCard } from "./danger-zone/danger-zone-card";
+import { NewsletterSubscriptionCard } from "./newsletter-subscription-card";
 import { ProfileInformationCard } from "./profile-information-card";
 
 export function AccountSettings({ session }: { session: Session | null }) {
@@ -123,6 +124,7 @@ function AccountSettingsContent({
         isPending={isPending}
       />
       <ProfileInformationCard profile={profile} onSaveBio={saveBio} isPending={isPending} />
+      <NewsletterSubscriptionCard />
       <DangerZoneCard profile={profile} userId={userId} />
     </div>
   );

--- a/apps/web/components/account-settings/newsletter-subscription-card.test.tsx
+++ b/apps/web/components/account-settings/newsletter-subscription-card.test.tsx
@@ -1,0 +1,76 @@
+import { server } from "@/test/msw/server";
+import { render, screen, userEvent, waitFor } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import { contract } from "@repo/api/contract";
+
+import { NewsletterSubscriptionCard } from "./newsletter-subscription-card";
+
+describe("<NewsletterSubscriptionCard />", () => {
+  it("renders subscribed with the toggle on", async () => {
+    server.mount(contract.newsletter.getStatus, { body: { status: "subscribed" } });
+
+    render(<NewsletterSubscriptionCard />);
+
+    expect(await screen.findByText("settings.NewsletterSubscriptionCard.subscribed")).toBeVisible();
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("renders pending as a distinct confirmation-email state", async () => {
+    server.mount(contract.newsletter.getStatus, { body: { status: "pending" } });
+
+    render(<NewsletterSubscriptionCard />);
+
+    expect(await screen.findByText("settings.NewsletterSubscriptionCard.pending")).toBeVisible();
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+  });
+
+  it.each(["unsubscribed", "none"] as const)("renders %s with the toggle off", async (status) => {
+    server.mount(contract.newsletter.getStatus, { body: { status } });
+
+    render(<NewsletterSubscriptionCard />);
+
+    expect(
+      await screen.findByText("settings.NewsletterSubscriptionCard.unsubscribed"),
+    ).toBeVisible();
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("renders a card-local error without a guessed toggle value", async () => {
+    server.mount(contract.newsletter.getStatus, { status: 503 });
+
+    render(<NewsletterSubscriptionCard />);
+
+    expect(await screen.findByText("settings.NewsletterSubscriptionCard.error")).toBeVisible();
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "settings.NewsletterSubscriptionCard.retry" }),
+    ).toBeVisible();
+  });
+
+  it("subscribes through the direct route", async () => {
+    server.mount(contract.newsletter.getStatus, { body: { status: "none" } });
+    const request = server.mount(contract.newsletter.subscribeDirect, {
+      body: { status: "pending" },
+    });
+    const user = userEvent.setup();
+    render(<NewsletterSubscriptionCard />);
+
+    await user.click(await screen.findByRole("switch"));
+
+    await waitFor(() => expect(request.called).toBe(true));
+  });
+
+  it("unsubscribes through the authenticated delete route", async () => {
+    server.mount(contract.newsletter.getStatus, { body: { status: "subscribed" } });
+    const request = server.mount(contract.newsletter.unsubscribe, {
+      body: { status: "unsubscribed" },
+    });
+    const user = userEvent.setup();
+    render(<NewsletterSubscriptionCard />);
+
+    await user.click(await screen.findByRole("switch"));
+
+    await waitFor(() => expect(request.called).toBe(true));
+  });
+});

--- a/apps/web/components/account-settings/newsletter-subscription-card.test.tsx
+++ b/apps/web/components/account-settings/newsletter-subscription-card.test.tsx
@@ -61,6 +61,35 @@ describe("<NewsletterSubscriptionCard />", () => {
     await waitFor(() => expect(request.called).toBe(true));
   });
 
+  it("shows forgotten-email guidance when the direct subscribe is rejected as forgotten", async () => {
+    server.mount(contract.newsletter.getStatus, { body: { status: "none" } });
+    server.mount(contract.newsletter.subscribeDirect, {
+      status: 400,
+      body: { code: "MAILCHIMP_FORGOTTEN_EMAIL", message: "forgotten", statusCode: 400 },
+    });
+    const user = userEvent.setup();
+    render(<NewsletterSubscriptionCard />);
+
+    await user.click(await screen.findByRole("switch"));
+
+    expect(
+      await screen.findByText("settings.NewsletterSubscriptionCard.forgottenEmailError"),
+    ).toBeVisible();
+  });
+
+  it("keeps the generic update error for other subscribe failures", async () => {
+    server.mount(contract.newsletter.getStatus, { body: { status: "none" } });
+    server.mount(contract.newsletter.subscribeDirect, { status: 500 });
+    const user = userEvent.setup();
+    render(<NewsletterSubscriptionCard />);
+
+    await user.click(await screen.findByRole("switch"));
+
+    expect(
+      await screen.findByText("settings.NewsletterSubscriptionCard.updateError"),
+    ).toBeVisible();
+  });
+
   it("unsubscribes through the authenticated delete route", async () => {
     server.mount(contract.newsletter.getStatus, { body: { status: "subscribed" } });
     const request = server.mount(contract.newsletter.unsubscribe, {

--- a/apps/web/components/account-settings/newsletter-subscription-card.tsx
+++ b/apps/web/components/account-settings/newsletter-subscription-card.tsx
@@ -3,6 +3,7 @@
 import { useNewsletterStatus } from "@/hooks/newsletter/useNewsletterStatus/useNewsletterStatus";
 import { useSubscribeNewsletter } from "@/hooks/newsletter/useSubscribeNewsletter/useSubscribeNewsletter";
 import { useUnsubscribeNewsletter } from "@/hooks/newsletter/useUnsubscribeNewsletter/useUnsubscribeNewsletter";
+import { parseApiError } from "@/util/apiError";
 import { AlertCircle, Loader2, Mail } from "lucide-react";
 
 import { useTranslation } from "@repo/i18n";
@@ -23,6 +24,9 @@ export function NewsletterSubscriptionCard() {
   const unsubscribe = useUnsubscribeNewsletter();
   const isUpdating = subscribe.isPending || unsubscribe.isPending;
   const mutationFailed = subscribe.isError || unsubscribe.isError;
+  // The forgotten-email case can only arise on the subscribe path (Mailchimp
+  // suppresses a permanently deleted address); unsubscribe never hits it.
+  const isForgottenEmail = parseApiError(subscribe.error)?.code === "MAILCHIMP_FORGOTTEN_EMAIL";
 
   const handleCheckedChange = (checked: boolean) => {
     subscribe.reset();
@@ -103,7 +107,11 @@ export function NewsletterSubscriptionCard() {
 
         {mutationFailed && (
           <p className="text-destructive text-sm" role="alert">
-            {t("settings.NewsletterSubscriptionCard.updateError")}
+            {t(
+              isForgottenEmail
+                ? "settings.NewsletterSubscriptionCard.forgottenEmailError"
+                : "settings.NewsletterSubscriptionCard.updateError",
+            )}
           </p>
         )}
         {isUpdating && (

--- a/apps/web/components/account-settings/newsletter-subscription-card.tsx
+++ b/apps/web/components/account-settings/newsletter-subscription-card.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useNewsletterStatus } from "@/hooks/newsletter/useNewsletterStatus/useNewsletterStatus";
+import { useSubscribeNewsletter } from "@/hooks/newsletter/useSubscribeNewsletter/useSubscribeNewsletter";
+import { useUnsubscribeNewsletter } from "@/hooks/newsletter/useUnsubscribeNewsletter/useUnsubscribeNewsletter";
+import { AlertCircle, Loader2, Mail } from "lucide-react";
+
+import { useTranslation } from "@repo/i18n";
+import { Button } from "@repo/ui/components/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@repo/ui/components/card";
+import { Switch } from "@repo/ui/components/switch";
+
+export function NewsletterSubscriptionCard() {
+  const { t } = useTranslation("account");
+  const statusQuery = useNewsletterStatus();
+  const subscribe = useSubscribeNewsletter();
+  const unsubscribe = useUnsubscribeNewsletter();
+  const isUpdating = subscribe.isPending || unsubscribe.isPending;
+  const mutationFailed = subscribe.isError || unsubscribe.isError;
+
+  const handleCheckedChange = (checked: boolean) => {
+    subscribe.reset();
+    unsubscribe.reset();
+
+    if (checked) {
+      subscribe.mutate(undefined);
+    } else {
+      unsubscribe.mutate(undefined);
+    }
+  };
+
+  const renderContent = () => {
+    if (statusQuery.isLoading) {
+      return (
+        <div className="text-muted-foreground flex items-center gap-2 text-sm" role="status">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+          {t("settings.NewsletterSubscriptionCard.loading")}
+        </div>
+      );
+    }
+
+    if (statusQuery.isError || !statusQuery.data) {
+      return (
+        <div className="border-destructive/30 bg-destructive/5 rounded-md border p-4">
+          <div className="text-destructive flex items-start gap-2 text-sm" role="alert">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+            <span>{t("settings.NewsletterSubscriptionCard.error")}</span>
+          </div>
+          <Button
+            className="mt-3"
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={statusQuery.isFetching}
+            onClick={() => void statusQuery.refetch()}
+          >
+            {statusQuery.isFetching
+              ? t("settings.NewsletterSubscriptionCard.retrying")
+              : t("settings.NewsletterSubscriptionCard.retry")}
+          </Button>
+        </div>
+      );
+    }
+
+    const { status } = statusQuery.data;
+    const isSubscribed = status === "subscribed";
+    const isPendingConfirmation = status === "pending";
+    const descriptionKey = isSubscribed
+      ? "settings.NewsletterSubscriptionCard.subscribed"
+      : isPendingConfirmation
+        ? "settings.NewsletterSubscriptionCard.pending"
+        : "settings.NewsletterSubscriptionCard.unsubscribed";
+
+    return (
+      <div className="space-y-3">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <div className="text-sm font-medium">
+              {t("settings.NewsletterSubscriptionCard.toggleLabel")}
+            </div>
+            <p
+              className={
+                isPendingConfirmation ? "text-primary text-sm" : "text-muted-foreground text-sm"
+              }
+              role={isPendingConfirmation ? "status" : undefined}
+            >
+              {t(descriptionKey)}
+            </p>
+          </div>
+          <Switch
+            checked={isSubscribed}
+            onCheckedChange={handleCheckedChange}
+            disabled={isUpdating}
+            aria-label={t("settings.NewsletterSubscriptionCard.toggleLabel")}
+          />
+        </div>
+
+        {mutationFailed && (
+          <p className="text-destructive text-sm" role="alert">
+            {t("settings.NewsletterSubscriptionCard.updateError")}
+          </p>
+        )}
+        {isUpdating && (
+          <p className="text-muted-foreground text-sm" role="status">
+            {t("settings.NewsletterSubscriptionCard.updating")}
+          </p>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <Card className="rounded-md shadow-sm">
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-2">
+          <Mail className="text-primary h-5 w-5" aria-hidden />
+          <CardTitle>{t("settings.NewsletterSubscriptionCard.title")}</CardTitle>
+        </div>
+        <CardDescription>{t("settings.NewsletterSubscriptionCard.description")}</CardDescription>
+      </CardHeader>
+      <CardContent>{renderContent()}</CardContent>
+    </Card>
+  );
+}

--- a/apps/web/components/auth/registration-fields.test.tsx
+++ b/apps/web/components/auth/registration-fields.test.tsx
@@ -27,6 +27,7 @@ function Wrapper({
       lastName: "",
       email: "",
       acceptedTerms: false,
+      newsletterOptIn: false,
       otp: "",
       ...defaultValues,
     },
@@ -67,10 +68,13 @@ describe("RegistrationFields", () => {
     expect(screen.getByText("registration.emailDescription")).toBeInTheDocument();
   });
 
-  it("renders terms checkbox unchecked by default", () => {
+  it("renders terms and newsletter checkboxes unchecked by default", () => {
     render(<Wrapper />);
 
-    expect(screen.getByRole("checkbox")).not.toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "registration.acceptTerms" })).not.toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: "registration.newsletterOptIn" }),
+    ).not.toBeChecked();
   });
 
   it("renders terms and conditions trigger", () => {
@@ -79,6 +83,15 @@ describe("RegistrationFields", () => {
     const trigger = screen.getByText("auth.terms");
     expect(trigger).toBeInTheDocument();
     expect(trigger.closest("button")).toHaveClass("cursor-pointer", "underline");
+  });
+
+  it("allows opting in by clicking the newsletter consent wording", async () => {
+    const user = userEvent.setup();
+    render(<Wrapper />);
+
+    await user.click(screen.getByText("registration.newsletterOptIn"));
+
+    expect(screen.getByRole("checkbox", { name: "registration.newsletterOptIn" })).toBeChecked();
   });
 
   it("opens terms dialog when trigger is clicked", async () => {
@@ -98,7 +111,8 @@ describe("RegistrationFields", () => {
 
     expect(screen.getByLabelText("registration.firstName")).toBeDisabled();
     expect(screen.getByLabelText("registration.lastName")).toBeDisabled();
-    expect(screen.getByRole("checkbox")).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: "registration.acceptTerms" })).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: "registration.newsletterOptIn" })).toBeDisabled();
   });
 
   it("reflects default values in inputs", () => {

--- a/apps/web/components/auth/registration-fields.tsx
+++ b/apps/web/components/auth/registration-fields.tsx
@@ -122,6 +122,7 @@ export function RegistrationFields({
                 <Checkbox
                   id={field.name}
                   name={field.name}
+                  aria-label={t("registration.acceptTerms")}
                   checked={!!field.value}
                   onCheckedChange={field.onChange}
                   ref={field.ref}
@@ -129,7 +130,7 @@ export function RegistrationFields({
                   onBlur={field.onBlur}
                 />
               </FormControl>
-              <FormLabel className="left text-sm font-medium leading-none">
+              <FormLabel htmlFor={field.name} className="left text-sm font-medium leading-none">
                 {t("auth.termsPrefix")}
                 <Dialog>
                   <DialogTrigger asChild>
@@ -147,6 +148,34 @@ export function RegistrationFields({
                     </ScrollArea>
                   </DialogContent>
                 </Dialog>
+              </FormLabel>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      )}
+
+      {/* Newsletter — explicit, optional consent and unchecked by default */}
+      {!emailOnly && (
+        <FormField
+          control={form.control}
+          name="newsletterOptIn"
+          render={({ field }) => (
+            <FormItem className="flex items-end space-x-2">
+              <FormControl>
+                <Checkbox
+                  id={field.name}
+                  name={field.name}
+                  aria-label={t("registration.newsletterOptIn")}
+                  checked={!!field.value}
+                  onCheckedChange={field.onChange}
+                  ref={field.ref}
+                  disabled={isPending}
+                  onBlur={field.onBlur}
+                />
+              </FormControl>
+              <FormLabel htmlFor={field.name} className="left text-sm font-medium leading-none">
+                {t("registration.newsletterOptIn")}
               </FormLabel>
               <FormMessage />
             </FormItem>

--- a/apps/web/components/auth/registration-form.test.tsx
+++ b/apps/web/components/auth/registration-form.test.tsx
@@ -6,6 +6,22 @@ import { RegistrationForm } from "../auth/registration-form";
 
 // --- Mocks ---
 const pushMock = vi.fn();
+const { mockSubscribeNewsletter, toastMock } = vi.hoisted(() => ({
+  mockSubscribeNewsletter: vi.fn(),
+  toastMock: vi.fn(),
+}));
+
+vi.mock("~/lib/orpc", () => ({
+  orpc: {
+    newsletter: {
+      subscribeDirect: {
+        mutationOptions: () => ({ mutationFn: mockSubscribeNewsletter }),
+      },
+    },
+  },
+}));
+
+vi.mock("@repo/ui/hooks/use-toast", () => ({ toast: toastMock }));
 
 const mockUpdateUserMutate = vi.fn();
 vi.mock("~/hooks/auth/useUpdateUser/useUpdateUser", () => ({
@@ -25,14 +41,14 @@ vi.mock("~/hooks/auth/useVerifyEmail/useVerifyEmail", () => ({
 
 const createUserProfileMock = vi.fn();
 vi.mock("~/hooks/profile/useCreateUserProfile/useCreateUserProfile", () => ({
-  useCreateUserProfile: (opts: { onSuccess: () => Promise<void> | void }) => ({
+  useCreateUserProfile: (opts: { onSuccess?: () => Promise<void> | void }) => ({
     mutateAsync: async (args: unknown) => {
       const result = createUserProfileMock(args) as unknown;
       if (result instanceof Promise) {
         await result;
       }
       // simulate success callback
-      await Promise.resolve(opts.onSuccess());
+      if (opts.onSuccess) await Promise.resolve(opts.onSuccess());
       return Promise.resolve();
     },
   }),
@@ -57,6 +73,8 @@ describe("RegistrationForm", () => {
     mockUpdateUserMutate.mockResolvedValue({});
     mockSendOtpMutate.mockResolvedValue({});
     mockVerifyOtpMutate.mockResolvedValue({});
+    createUserProfileMock.mockResolvedValue(undefined);
+    mockSubscribeNewsletter.mockResolvedValue({ status: "subscribed" });
   });
 
   it("renders the registration form with title and description", () => {
@@ -121,7 +139,7 @@ describe("RegistrationForm", () => {
     await user.type(screen.getByLabelText("registration.firstName"), "Jane");
     await user.type(screen.getByLabelText("registration.lastName"), "Doe");
 
-    await user.click(screen.getByRole("checkbox"));
+    await user.click(screen.getByRole("checkbox", { name: "registration.acceptTerms" }));
     await user.click(screen.getByRole("button", { name: "registration.register" }));
 
     await waitFor(() => {
@@ -140,13 +158,66 @@ describe("RegistrationForm", () => {
     await user.type(screen.getByLabelText("registration.firstName"), "Bob");
     await user.type(screen.getByLabelText("registration.lastName"), "Builder");
 
-    await user.click(screen.getByRole("checkbox"));
+    await user.click(screen.getByRole("checkbox", { name: "registration.acceptTerms" }));
     await user.click(screen.getByRole("button", { name: "registration.register" }));
 
     await waitFor(() => {
       expect(createUserProfileMock).toHaveBeenCalled();
       expect(mockUpdateUserMutate).toHaveBeenCalledWith({ registered: true });
       expect(pushMock).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("subscribes to the newsletter when the user opts in", async () => {
+    render(<RegistrationForm {...defaultProps} />);
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("registration.firstName"), "News");
+    await user.type(screen.getByLabelText("registration.lastName"), "Reader");
+    await user.click(screen.getByRole("checkbox", { name: "registration.acceptTerms" }));
+    await user.click(screen.getByRole("checkbox", { name: "registration.newsletterOptIn" }));
+    await user.click(screen.getByRole("button", { name: "registration.register" }));
+
+    await waitFor(() => {
+      expect(mockSubscribeNewsletter).toHaveBeenCalledTimes(1);
+      expect(pushMock).toHaveBeenCalledWith("/dashboard");
+    });
+    expect(createUserProfileMock.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSubscribeNewsletter.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
+  it("does not call the newsletter endpoint when the user leaves the opt-in unchecked", async () => {
+    render(<RegistrationForm {...defaultProps} />);
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("registration.firstName"), "No");
+    await user.type(screen.getByLabelText("registration.lastName"), "Newsletter");
+    await user.click(screen.getByRole("checkbox", { name: "registration.acceptTerms" }));
+    await user.click(screen.getByRole("button", { name: "registration.register" }));
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/dashboard");
+    });
+    expect(mockSubscribeNewsletter).not.toHaveBeenCalled();
+  });
+
+  it("completes registration when the newsletter subscription fails", async () => {
+    mockSubscribeNewsletter.mockRejectedValueOnce(new Error("Mailchimp unavailable"));
+    render(<RegistrationForm {...defaultProps} />);
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("registration.firstName"), "Still");
+    await user.type(screen.getByLabelText("registration.lastName"), "Registered");
+    await user.click(screen.getByRole("checkbox", { name: "registration.acceptTerms" }));
+    await user.click(screen.getByRole("checkbox", { name: "registration.newsletterOptIn" }));
+    await user.click(screen.getByRole("button", { name: "registration.register" }));
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/dashboard");
+      expect(toastMock).toHaveBeenCalledWith({
+        description: "registration.newsletterOptInError",
+      });
     });
   });
 
@@ -161,7 +232,7 @@ describe("RegistrationForm", () => {
     await user.type(screen.getByLabelText("registration.firstName"), "No");
     await user.type(screen.getByLabelText("registration.lastName"), "Callback");
 
-    await user.click(screen.getByRole("checkbox"));
+    await user.click(screen.getByRole("checkbox", { name: "registration.acceptTerms" }));
     await user.click(screen.getByRole("button", { name: "registration.register" }));
 
     await waitFor(() => {
@@ -182,7 +253,10 @@ describe("RegistrationForm", () => {
 
     expect(screen.getByLabelText("registration.firstName")).toHaveValue("");
     expect(screen.getByLabelText("registration.lastName")).toHaveValue("");
-    expect(screen.getByRole("checkbox")).not.toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "registration.acceptTerms" })).not.toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: "registration.newsletterOptIn" }),
+    ).not.toBeChecked();
   });
 
   it("renders the submit button enabled by default", () => {
@@ -224,7 +298,7 @@ describe("RegistrationForm", () => {
     await user.type(screen.getByLabelText("registration.firstName"), "Test");
     await user.type(screen.getByLabelText("registration.lastName"), "User");
 
-    await user.click(screen.getByRole("checkbox"));
+    await user.click(screen.getByRole("checkbox", { name: "registration.acceptTerms" }));
     await user.click(screen.getByRole("button", { name: "registration.register" }));
 
     await waitFor(() => {
@@ -246,7 +320,7 @@ describe("RegistrationForm", () => {
     await user.type(screen.getByLabelText("registration.firstName"), "Error");
     await user.type(screen.getByLabelText("registration.lastName"), "Test");
 
-    await user.click(screen.getByRole("checkbox"));
+    await user.click(screen.getByRole("checkbox", { name: "registration.acceptTerms" }));
     const submitButton = screen.getByRole("button", { name: "registration.register" });
 
     expect(submitButton).not.toBeDisabled();
@@ -275,7 +349,7 @@ describe("RegistrationForm", () => {
     await user.type(screen.getByLabelText("registration.firstName"), "Multi");
     await user.type(screen.getByLabelText("registration.lastName"), "Submit");
 
-    await user.click(screen.getByRole("checkbox"));
+    await user.click(screen.getByRole("checkbox", { name: "registration.acceptTerms" }));
     const submitButton = screen.getByRole("button", { name: "registration.register" });
 
     // First click
@@ -297,7 +371,7 @@ describe("RegistrationForm", () => {
     const user = userEvent.setup();
     await user.type(screen.getByLabelText("registration.firstName"), "A");
     await user.type(screen.getByLabelText("registration.lastName"), "Smith");
-    await user.click(screen.getByRole("checkbox"));
+    await user.click(screen.getByRole("checkbox", { name: "registration.acceptTerms" }));
     await user.click(screen.getByRole("button", { name: "registration.register" }));
 
     await waitFor(() => {
@@ -312,7 +386,7 @@ describe("RegistrationForm", () => {
     const user = userEvent.setup();
     await user.type(screen.getByLabelText("registration.firstName"), "Alice");
     await user.type(screen.getByLabelText("registration.lastName"), "S");
-    await user.click(screen.getByRole("checkbox"));
+    await user.click(screen.getByRole("checkbox", { name: "registration.acceptTerms" }));
     await user.click(screen.getByRole("button", { name: "registration.register" }));
 
     await waitFor(() => {

--- a/apps/web/components/auth/registration-form.test.tsx
+++ b/apps/web/components/auth/registration-form.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, userEvent, waitFor } from "@/test/test-utils";
+import { ORPCError } from "@orpc/client";
 import { useRouter } from "next/navigation";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
@@ -217,6 +218,31 @@ describe("RegistrationForm", () => {
       expect(pushMock).toHaveBeenCalledWith("/dashboard");
       expect(toastMock).toHaveBeenCalledWith({
         description: "registration.newsletterOptInError",
+      });
+    });
+  });
+
+  it("shows forgotten-email guidance when the subscription is rejected as forgotten", async () => {
+    mockSubscribeNewsletter.mockRejectedValueOnce(
+      new ORPCError("BAD_REQUEST", {
+        status: 400,
+        message: "forgotten",
+        data: { code: "MAILCHIMP_FORGOTTEN_EMAIL" },
+      }),
+    );
+    render(<RegistrationForm {...defaultProps} />);
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("registration.firstName"), "Forgotten");
+    await user.type(screen.getByLabelText("registration.lastName"), "Reader");
+    await user.click(screen.getByRole("checkbox", { name: "registration.acceptTerms" }));
+    await user.click(screen.getByRole("checkbox", { name: "registration.newsletterOptIn" }));
+    await user.click(screen.getByRole("button", { name: "registration.register" }));
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/dashboard");
+      expect(toastMock).toHaveBeenCalledWith({
+        description: "registration.newsletterForgottenEmail",
       });
     });
   });

--- a/apps/web/components/auth/registration-form.tsx
+++ b/apps/web/components/auth/registration-form.tsx
@@ -1,15 +1,17 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
 import { Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import z from "zod";
 import { useSignInEmail } from "~/hooks/auth/useSignInEmail/useSignInEmail";
 import { useUpdateUser } from "~/hooks/auth/useUpdateUser/useUpdateUser";
 import { useVerifyEmail } from "~/hooks/auth/useVerifyEmail/useVerifyEmail";
 import { useCreateUserProfile } from "~/hooks/profile/useCreateUserProfile/useCreateUserProfile";
+import { orpc } from "~/lib/orpc";
 
 import { useSession } from "@repo/auth/client";
 import { useTranslation } from "@repo/i18n";
@@ -25,6 +27,7 @@ export interface Registration {
   lastName?: string;
   email?: string;
   acceptedTerms?: boolean;
+  newsletterOptIn?: boolean;
   otp?: string;
 }
 
@@ -44,10 +47,12 @@ export function RegistrationForm({
   const [isPending, setIsPending] = useState(false);
   const [showOTPInput, setShowOTPInput] = useState(false);
   const [pendingEmail, setPendingEmail] = useState("");
+  const newsletterOptInRef = useRef(false);
   const { data: session } = useSession();
   const updateUser = useUpdateUser();
   const sendOtpRegistration = useSignInEmail();
   const verifyOtpRegistration = useVerifyEmail();
+  const subscribeNewsletter = useMutation(orpc.newsletter.subscribeDirect.mutationOptions());
 
   const isValidEmailCheck = z.string().email().safeParse(userEmail).success;
   const needsEmailVerification = !isValidEmailCheck;
@@ -59,6 +64,7 @@ export function RegistrationForm({
       lastName: z.string().optional(),
       email: z.string().optional(),
       acceptedTerms: z.boolean().optional(),
+      newsletterOptIn: z.boolean().optional(),
       otp: z.string().optional(),
     })
     .superRefine((data, ctx) => {
@@ -92,11 +98,12 @@ export function RegistrationForm({
       lastName: "",
       email: "",
       acceptedTerms: false,
+      newsletterOptIn: false,
       otp: "",
     },
   });
 
-  const completeRegistration = async () => {
+  const completeRegistration = async (newsletterOptIn = false) => {
     const res = await updateUser.mutateAsync({ registered: true });
 
     if (res.error) {
@@ -105,12 +112,18 @@ export function RegistrationForm({
       return;
     }
 
+    if (newsletterOptIn) {
+      void subscribeNewsletter.mutateAsync(undefined).catch(() => {
+        toast({ description: t("registration.newsletterOptInError") });
+      });
+    }
+
     toast({ description: t("registration.successMessage") });
     router.push(callbackUrl ?? "/platform");
   };
 
   const { mutateAsync: createUserProfile } = useCreateUserProfile({
-    onSuccess: completeRegistration,
+    onSuccess: () => completeRegistration(newsletterOptInRef.current),
   });
 
   useEffect(() => {
@@ -167,6 +180,7 @@ export function RegistrationForm({
         }
       }
 
+      newsletterOptInRef.current = data.newsletterOptIn === true;
       await createUserProfile({
         firstName: data.firstName ?? "",
         lastName: data.lastName ?? "",

--- a/apps/web/components/auth/registration-form.tsx
+++ b/apps/web/components/auth/registration-form.tsx
@@ -12,6 +12,7 @@ import { useUpdateUser } from "~/hooks/auth/useUpdateUser/useUpdateUser";
 import { useVerifyEmail } from "~/hooks/auth/useVerifyEmail/useVerifyEmail";
 import { useCreateUserProfile } from "~/hooks/profile/useCreateUserProfile/useCreateUserProfile";
 import { orpc } from "~/lib/orpc";
+import { parseApiError } from "~/util/apiError";
 
 import { useSession } from "@repo/auth/client";
 import { useTranslation } from "@repo/i18n";
@@ -113,8 +114,13 @@ export function RegistrationForm({
     }
 
     if (newsletterOptIn) {
-      void subscribeNewsletter.mutateAsync(undefined).catch(() => {
-        toast({ description: t("registration.newsletterOptInError") });
+      void subscribeNewsletter.mutateAsync(undefined).catch((error: unknown) => {
+        const isForgottenEmail = parseApiError(error)?.code === "MAILCHIMP_FORGOTTEN_EMAIL";
+        toast({
+          description: isForgottenEmail
+            ? t("registration.newsletterForgottenEmail")
+            : t("registration.newsletterOptInError"),
+        });
       });
     }
 

--- a/apps/web/components/newsletter/newsletter-subscribe-form.test.tsx
+++ b/apps/web/components/newsletter/newsletter-subscribe-form.test.tsx
@@ -34,7 +34,10 @@ describe("NewsletterSubscribeForm", () => {
 
     expect(screen.getByText("footer.title")).toBeInTheDocument();
     expect(screen.getByLabelText("footer.emailLabel")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "footer.submit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "footer.submit" })).toHaveClass(
+      "bg-quaternary",
+      "text-primary",
+    );
   });
 
   it("submits exactly { email } to the subscribe endpoint", async () => {

--- a/apps/web/components/newsletter/newsletter-subscribe-form.test.tsx
+++ b/apps/web/components/newsletter/newsletter-subscribe-form.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen, userEvent, waitFor, fireEvent } from "@/test/test-utils";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { NewsletterSubscribeForm } from "./newsletter-subscribe-form";
+
+// The public subscribe mutation. `mutationOptions` forwards the onSuccess/onError
+// the component passes so the real useMutation (from test-utils' QueryClient)
+// drives the success/error state transitions.
+const { mockSubscribe } = vi.hoisted(() => ({ mockSubscribe: vi.fn() }));
+
+vi.mock("@/lib/orpc", () => ({
+  orpc: {
+    newsletter: {
+      subscribe: {
+        mutationOptions: (opts: Record<string, unknown>) => ({
+          mutationFn: mockSubscribe,
+          ...opts,
+        }),
+      },
+    },
+  },
+}));
+
+const VALID_EMAIL = "visitor@example.com";
+
+describe("NewsletterSubscribeForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSubscribe.mockResolvedValue({ success: true });
+  });
+
+  it("renders the idle form with heading, email input and submit button", () => {
+    render(<NewsletterSubscribeForm />);
+
+    expect(screen.getByText("footer.title")).toBeInTheDocument();
+    expect(screen.getByLabelText("footer.emailLabel")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "footer.submit" })).toBeInTheDocument();
+  });
+
+  it("submits exactly { email } to the subscribe endpoint", async () => {
+    const user = userEvent.setup();
+    render(<NewsletterSubscribeForm />);
+
+    await user.type(screen.getByLabelText("footer.emailLabel"), VALID_EMAIL);
+    await user.click(screen.getByRole("button", { name: "footer.submit" }));
+
+    await waitFor(() => {
+      expect(mockSubscribe).toHaveBeenCalledTimes(1);
+    });
+    // react-query passes a context object as the second arg; assert the payload only.
+    expect(mockSubscribe.mock.calls[0]?.[0]).toEqual({ email: VALID_EMAIL });
+  });
+
+  it("shows the check-inbox success copy (never 'subscribed') in a polite live region", async () => {
+    const user = userEvent.setup();
+    render(<NewsletterSubscribeForm />);
+
+    await user.type(screen.getByLabelText("footer.emailLabel"), VALID_EMAIL);
+    await user.click(screen.getByRole("button", { name: "footer.submit" }));
+
+    const status = await screen.findByRole("status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(screen.getByText("footer.successTitle")).toBeInTheDocument();
+    expect(screen.getByText("footer.successMessage")).toBeInTheDocument();
+    // Double opt-in: the form must never claim the address is already subscribed.
+    expect(screen.queryByText(/subscribed/i)).not.toBeInTheDocument();
+    // Form is replaced, so no submit button remains.
+    expect(screen.queryByRole("button", { name: "footer.submit" })).not.toBeInTheDocument();
+  });
+
+  it("renders the same generic error for a 429 rate limit", async () => {
+    mockSubscribe.mockRejectedValueOnce(
+      Object.assign(new Error("Too Many Requests"), { status: 429 }),
+    );
+    const user = userEvent.setup();
+    render(<NewsletterSubscribeForm />);
+
+    await user.type(screen.getByLabelText("footer.emailLabel"), VALID_EMAIL);
+    await user.click(screen.getByRole("button", { name: "footer.submit" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("footer.errorMessage");
+    // Generic only: no rate-limit-specific copy leaks through.
+    expect(screen.queryByText(/429|rate|limit/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the same generic error for a network failure", async () => {
+    mockSubscribe.mockRejectedValueOnce(new Error("Network down"));
+    const user = userEvent.setup();
+    render(<NewsletterSubscribeForm />);
+
+    await user.type(screen.getByLabelText("footer.emailLabel"), VALID_EMAIL);
+    await user.click(screen.getByRole("button", { name: "footer.submit" }));
+
+    expect(await screen.findByText("footer.errorMessage")).toBeInTheDocument();
+  });
+
+  it("shows the translated invalid-email validation message as an alert and does not submit", async () => {
+    render(<NewsletterSubscribeForm />);
+
+    const input = screen.getByLabelText("footer.emailLabel");
+    fireEvent.change(input, { target: { value: "not-an-email" } });
+    // fireEvent.submit bypasses jsdom HTML5 email validation, matching repo convention.
+    const form = input.closest("form");
+    if (!form) throw new Error("form not found");
+    fireEvent.submit(form);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("footer.invalidEmail");
+    expect(mockSubscribe).not.toHaveBeenCalled();
+  });
+
+  it("trims surrounding whitespace on keyboard (Enter) submit", async () => {
+    const user = userEvent.setup();
+    render(<NewsletterSubscribeForm />);
+
+    // Type padded value and submit with Enter (no blur); schema trim must apply.
+    await user.type(screen.getByLabelText("footer.emailLabel"), `   ${VALID_EMAIL}   {Enter}`);
+
+    await waitFor(() => {
+      expect(mockSubscribe).toHaveBeenCalledTimes(1);
+    });
+    expect(mockSubscribe.mock.calls[0]?.[0]).toEqual({ email: VALID_EMAIL });
+  });
+
+  it("disables the input and button while the request is pending", async () => {
+    // Never resolves, so the mutation stays pending.
+    mockSubscribe.mockReturnValue(new Promise(() => undefined));
+    const user = userEvent.setup();
+    render(<NewsletterSubscribeForm />);
+
+    await user.type(screen.getByLabelText("footer.emailLabel"), VALID_EMAIL);
+    await user.click(screen.getByRole("button", { name: "footer.submit" }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("footer.emailLabel")).toBeDisabled();
+    });
+    expect(screen.getByRole("button", { name: "footer.submitting" })).toBeDisabled();
+  });
+});

--- a/apps/web/components/newsletter/newsletter-subscribe-form.tsx
+++ b/apps/web/components/newsletter/newsletter-subscribe-form.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { orpc } from "@/lib/orpc";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import { CheckCircle2, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { useTranslation } from "@repo/i18n";
+import { Button } from "@repo/ui/components/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@repo/ui/components/form";
+import { Input } from "@repo/ui/components/input";
+
+// Public footer subscribe form. The anonymous double-opt-in endpoint always
+// returns generic success, so the success state is "check your inbox to
+// confirm". Any error (incl. 429 rate limit) collapses to one generic message.
+export function NewsletterSubscribeForm() {
+  const { t } = useTranslation("newsletter");
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [hasError, setHasError] = useState(false);
+
+  // Trim in the schema (not only via the Input's onBlur `trim`) so pressing
+  // Enter with surrounding whitespace validates the same as a mouse submit.
+  const schema = z.object({
+    email: z.string().trim().email(t("footer.invalidEmail")),
+  });
+  type FormValues = z.infer<typeof schema>;
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { email: "" },
+  });
+
+  const { mutate: subscribe, isPending } = useMutation(
+    orpc.newsletter.subscribe.mutationOptions({
+      onSuccess: () => {
+        setHasError(false);
+        setIsSuccess(true);
+        form.reset();
+      },
+      onError: () => {
+        setHasError(true);
+      },
+    }),
+  );
+
+  const onSubmit = (data: FormValues) => {
+    setHasError(false);
+    subscribe(data);
+  };
+
+  if (isSuccess) {
+    return (
+      <div role="status" aria-live="polite" className="flex items-start gap-2 text-sm text-white">
+        <CheckCircle2
+          className="text-jii-bright-green mt-0.5 h-5 w-5 shrink-0"
+          aria-hidden="true"
+        />
+        <div>
+          <p className="font-semibold">{t("footer.successTitle")}</p>
+          <p className="text-white/80">{t("footer.successMessage")}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h4 className="mb-1 font-extrabold text-white">{t("footer.title")}</h4>
+      <p className="mb-3 text-sm text-white/80">{t("footer.description")}</p>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-2" noValidate>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <FormField
+              control={form.control}
+              name="email"
+              disabled={isPending}
+              render={({ field }) => (
+                <FormItem className="flex-1">
+                  <FormLabel className="sr-only">{t("footer.emailLabel")}</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      autoComplete="email"
+                      placeholder={t("footer.emailPlaceholder")}
+                      className="bg-white text-gray-900 placeholder:text-gray-500"
+                      trim
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage role="alert" className="text-jii-bright-green" />
+                </FormItem>
+              )}
+            />
+            <Button
+              type="submit"
+              disabled={isPending}
+              className="bg-jii-bright-green text-jii-dark-green hover:bg-jii-bright-green/90 shrink-0 font-semibold"
+            >
+              {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />}
+              {isPending ? t("footer.submitting") : t("footer.submit")}
+            </Button>
+          </div>
+          {hasError && (
+            <p role="alert" className="text-sm text-red-300">
+              {t("footer.errorMessage")}
+            </p>
+          )}
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/apps/web/components/newsletter/newsletter-subscribe-form.tsx
+++ b/apps/web/components/newsletter/newsletter-subscribe-form.tsx
@@ -103,8 +103,9 @@ export function NewsletterSubscribeForm() {
             />
             <Button
               type="submit"
+              variant="secondary"
               disabled={isPending}
-              className="bg-jii-bright-green text-jii-dark-green hover:bg-jii-bright-green/90 shrink-0 font-semibold"
+              className="shrink-0 font-semibold"
             >
               {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />}
               {isPending ? t("footer.submitting") : t("footer.submit")}

--- a/apps/web/hooks/newsletter/newsletter-hooks.test.tsx
+++ b/apps/web/hooks/newsletter/newsletter-hooks.test.tsx
@@ -1,0 +1,72 @@
+import { orpc } from "@/lib/orpc";
+import { server } from "@/test/msw/server";
+import { act, createTestQueryClient, renderHook, waitFor } from "@/test/test-utils";
+import { describe, expect, it, vi } from "vitest";
+
+import { contract } from "@repo/api/contract";
+
+import { useNewsletterStatus } from "./useNewsletterStatus/useNewsletterStatus";
+import { useSubscribeNewsletter } from "./useSubscribeNewsletter/useSubscribeNewsletter";
+import { useUnsubscribeNewsletter } from "./useUnsubscribeNewsletter/useUnsubscribeNewsletter";
+
+describe("newsletter hooks", () => {
+  it("reads the live newsletter status", async () => {
+    server.mount(contract.newsletter.getStatus, { body: { status: "pending" } });
+
+    const { result } = renderHook(() => useNewsletterStatus());
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: "pending" });
+  });
+
+  it("uses the direct-subscribe route and invalidates status", async () => {
+    const request = server.mount(contract.newsletter.subscribeDirect, {
+      body: { status: "subscribed" },
+    });
+    server.mount(contract.newsletter.getStatus, { body: { status: "subscribed" } });
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useSubscribeNewsletter(), { queryClient });
+
+    act(() => result.current.mutate(undefined));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(request.called).toBe(true);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: orpc.newsletter.getStatus.key(),
+    });
+  });
+
+  it("uses the unsubscribe route and invalidates status", async () => {
+    const request = server.mount(contract.newsletter.unsubscribe, {
+      body: { status: "unsubscribed" },
+    });
+    server.mount(contract.newsletter.getStatus, { body: { status: "unsubscribed" } });
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUnsubscribeNewsletter(), { queryClient });
+
+    act(() => result.current.mutate(undefined));
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(request.called).toBe(true);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: orpc.newsletter.getStatus.key(),
+    });
+  });
+
+  it("invalidates status when a mutation fails", async () => {
+    server.mount(contract.newsletter.subscribeDirect, { status: 503 });
+    server.mount(contract.newsletter.getStatus, { body: { status: "none" } });
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useSubscribeNewsletter(), { queryClient });
+
+    act(() => result.current.mutate(undefined));
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: orpc.newsletter.getStatus.key(),
+    });
+  });
+});

--- a/apps/web/hooks/newsletter/useNewsletterStatus/useNewsletterStatus.ts
+++ b/apps/web/hooks/newsletter/useNewsletterStatus/useNewsletterStatus.ts
@@ -1,0 +1,9 @@
+"use client";
+
+import { orpc } from "@/lib/orpc";
+import { useQuery } from "@tanstack/react-query";
+
+/** Reads the signed-in user's live newsletter membership status from Mailchimp. */
+export function useNewsletterStatus() {
+  return useQuery(orpc.newsletter.getStatus.queryOptions());
+}

--- a/apps/web/hooks/newsletter/useSubscribeNewsletter/useSubscribeNewsletter.ts
+++ b/apps/web/hooks/newsletter/useSubscribeNewsletter/useSubscribeNewsletter.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { orpc } from "@/lib/orpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+/** Directly subscribes the signed-in user's verified email address. */
+export function useSubscribeNewsletter() {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    orpc.newsletter.subscribeDirect.mutationOptions({
+      onSettled: async () => {
+        await queryClient.invalidateQueries({ queryKey: orpc.newsletter.getStatus.key() });
+      },
+    }),
+  );
+}

--- a/apps/web/hooks/newsletter/useUnsubscribeNewsletter/useUnsubscribeNewsletter.ts
+++ b/apps/web/hooks/newsletter/useUnsubscribeNewsletter/useUnsubscribeNewsletter.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { orpc } from "@/lib/orpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+/** Unsubscribes the signed-in user's email address from the newsletter. */
+export function useUnsubscribeNewsletter() {
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    orpc.newsletter.unsubscribe.mutationOptions({
+      onSettled: async () => {
+        await queryClient.invalidateQueries({ queryKey: orpc.newsletter.getStatus.key() });
+      },
+    }),
+  );
+}

--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -1354,6 +1354,32 @@ module "contentful_secrets" {
   }
 }
 
+# Mailchimp secrets
+module "mailchimp_secrets" {
+  source = "../../modules/secrets-manager"
+
+  name        = "openjii-mailchimp-secrets-${var.environment}"
+  description = "Mailchimp API secrets for the openJII backend service"
+
+  # Store secrets as JSON using variables
+  secret_string = jsonencode({
+    MAILCHIMP_API_KEY        = var.mailchimp_api_key
+    MAILCHIMP_SERVER_PREFIX  = var.mailchimp_server_prefix
+    MAILCHIMP_AUDIENCE_ID    = var.mailchimp_audience_id
+    MAILCHIMP_COMMUNITY_KIND = var.mailchimp_community_kind
+    MAILCHIMP_COMMUNITY_ID   = var.mailchimp_community_id
+    MAILCHIMP_COMMUNITY_NAME = var.mailchimp_community_name
+  })
+
+  tags = {
+    Environment = var.environment
+    Project     = "open-jii"
+    ManagedBy   = "terraform"
+    Component   = "backend"
+    SecretType  = "mailchimp"
+  }
+}
+
 # SES Email Service for transactional emails
 module "ses" {
   source = "../../modules/ses"
@@ -1783,6 +1809,30 @@ module "backend_ecs" {
     {
       name      = "CONTENTFUL_ACCESS_TOKEN"
       valueFrom = "${module.contentful_secrets.secret_arn}:CONTENTFUL_ACCESS_TOKEN::"
+    },
+    {
+      name      = "MAILCHIMP_API_KEY"
+      valueFrom = "${module.mailchimp_secrets.secret_arn}:MAILCHIMP_API_KEY::"
+    },
+    {
+      name      = "MAILCHIMP_SERVER_PREFIX"
+      valueFrom = "${module.mailchimp_secrets.secret_arn}:MAILCHIMP_SERVER_PREFIX::"
+    },
+    {
+      name      = "MAILCHIMP_AUDIENCE_ID"
+      valueFrom = "${module.mailchimp_secrets.secret_arn}:MAILCHIMP_AUDIENCE_ID::"
+    },
+    {
+      name      = "MAILCHIMP_COMMUNITY_KIND"
+      valueFrom = "${module.mailchimp_secrets.secret_arn}:MAILCHIMP_COMMUNITY_KIND::"
+    },
+    {
+      name      = "MAILCHIMP_COMMUNITY_ID"
+      valueFrom = "${module.mailchimp_secrets.secret_arn}:MAILCHIMP_COMMUNITY_ID::"
+    },
+    {
+      name      = "MAILCHIMP_COMMUNITY_NAME"
+      valueFrom = "${module.mailchimp_secrets.secret_arn}:MAILCHIMP_COMMUNITY_NAME::"
     },
   ]
 

--- a/infrastructure/env/dev/variables.tf
+++ b/infrastructure/env/dev/variables.tf
@@ -157,6 +157,43 @@ variable "contentful_preview_secret" {
   sensitive   = true
 }
 
+# Mailchimp configuration variables
+variable "mailchimp_api_key" {
+  description = "Mailchimp API key"
+  type        = string
+  sensitive   = true
+}
+
+variable "mailchimp_server_prefix" {
+  description = "Mailchimp server prefix"
+  type        = string
+  sensitive   = true
+}
+
+variable "mailchimp_audience_id" {
+  description = "Mailchimp audience ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "mailchimp_community_kind" {
+  description = "Mailchimp community member type"
+  type        = string
+  sensitive   = true
+}
+
+variable "mailchimp_community_id" {
+  description = "Mailchimp community identifier"
+  type        = string
+  sensitive   = true
+}
+
+variable "mailchimp_community_name" {
+  description = "Mailchimp community name"
+  type        = string
+  sensitive   = true
+}
+
 variable "centralized_metastore_bucket_name" {
   description = "Name of the centralized S3 bucket for Unity Catalog metastore storage in data governance account"
   type        = string

--- a/infrastructure/env/dr/main.tf
+++ b/infrastructure/env/dr/main.tf
@@ -305,6 +305,30 @@ module "contentful_secrets" {
   }
 }
 
+module "mailchimp_secrets" {
+  source = "../../modules/secrets-manager"
+
+  name        = "openjii-mailchimp-secrets-${var.environment}"
+  description = "Mailchimp API secrets for the openJII backend service"
+
+  secret_string = jsonencode({
+    MAILCHIMP_API_KEY        = var.mailchimp_api_key
+    MAILCHIMP_SERVER_PREFIX  = var.mailchimp_server_prefix
+    MAILCHIMP_AUDIENCE_ID    = var.mailchimp_audience_id
+    MAILCHIMP_COMMUNITY_KIND = var.mailchimp_community_kind
+    MAILCHIMP_COMMUNITY_ID   = var.mailchimp_community_id
+    MAILCHIMP_COMMUNITY_NAME = var.mailchimp_community_name
+  })
+
+  tags = {
+    Environment = var.environment
+    Project     = "open-jii"
+    ManagedBy   = "terraform"
+    Component   = "backend"
+    SecretType  = "mailchimp"
+  }
+}
+
 # NOTE: SES creates DKIM TXT records in the prod Route53 zone.
 # This is gated behind var.enable_ses_cutover to prevent drill runs from
 # overwriting prod DKIM records and disrupting live transactional email.
@@ -514,6 +538,12 @@ module "backend_ecs" {
     { name = "DB_CREDENTIALS", valueFrom = module.aurora_db.master_user_secret_arn },
     { name = "EMAIL_SERVER", valueFrom = "${module.ses_secrets.secret_arn}:BACKEND_EMAIL_SERVER::" },
     { name = "EMAIL_FROM", valueFrom = "${module.ses_secrets.secret_arn}:BACKEND_EMAIL_FROM::" },
+    { name = "MAILCHIMP_API_KEY", valueFrom = "${module.mailchimp_secrets.secret_arn}:MAILCHIMP_API_KEY::" },
+    { name = "MAILCHIMP_SERVER_PREFIX", valueFrom = "${module.mailchimp_secrets.secret_arn}:MAILCHIMP_SERVER_PREFIX::" },
+    { name = "MAILCHIMP_AUDIENCE_ID", valueFrom = "${module.mailchimp_secrets.secret_arn}:MAILCHIMP_AUDIENCE_ID::" },
+    { name = "MAILCHIMP_COMMUNITY_KIND", valueFrom = "${module.mailchimp_secrets.secret_arn}:MAILCHIMP_COMMUNITY_KIND::" },
+    { name = "MAILCHIMP_COMMUNITY_ID", valueFrom = "${module.mailchimp_secrets.secret_arn}:MAILCHIMP_COMMUNITY_ID::" },
+    { name = "MAILCHIMP_COMMUNITY_NAME", valueFrom = "${module.mailchimp_secrets.secret_arn}:MAILCHIMP_COMMUNITY_NAME::" },
   ]
 
   environment_variables = [

--- a/infrastructure/env/dr/variables.tf
+++ b/infrastructure/env/dr/variables.tf
@@ -201,6 +201,43 @@ variable "contentful_preview_secret" {
   sensitive   = true
 }
 
+# Mailchimp configuration variables
+variable "mailchimp_api_key" {
+  description = "Mailchimp API key"
+  type        = string
+  sensitive   = true
+}
+
+variable "mailchimp_server_prefix" {
+  description = "Mailchimp server prefix"
+  type        = string
+  sensitive   = true
+}
+
+variable "mailchimp_audience_id" {
+  description = "Mailchimp audience ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "mailchimp_community_kind" {
+  description = "Mailchimp community member type"
+  type        = string
+  sensitive   = true
+}
+
+variable "mailchimp_community_id" {
+  description = "Mailchimp community identifier"
+  type        = string
+  sensitive   = true
+}
+
+variable "mailchimp_community_name" {
+  description = "Mailchimp community name"
+  type        = string
+  sensitive   = true
+}
+
 variable "posthog_key" {
   description = "PostHog project API key"
   type        = string

--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -1311,6 +1311,32 @@ module "contentful_secrets" {
   }
 }
 
+# Mailchimp secrets
+module "mailchimp_secrets" {
+  source = "../../modules/secrets-manager"
+
+  name        = "openjii-mailchimp-secrets-${var.environment}"
+  description = "Mailchimp API secrets for the openJII backend service"
+
+  # Store secrets as JSON using variables
+  secret_string = jsonencode({
+    MAILCHIMP_API_KEY        = var.mailchimp_api_key
+    MAILCHIMP_SERVER_PREFIX  = var.mailchimp_server_prefix
+    MAILCHIMP_AUDIENCE_ID    = var.mailchimp_audience_id
+    MAILCHIMP_COMMUNITY_KIND = var.mailchimp_community_kind
+    MAILCHIMP_COMMUNITY_ID   = var.mailchimp_community_id
+    MAILCHIMP_COMMUNITY_NAME = var.mailchimp_community_name
+  })
+
+  tags = {
+    Environment = var.environment
+    Project     = "open-jii"
+    ManagedBy   = "terraform"
+    Component   = "backend"
+    SecretType  = "mailchimp"
+  }
+}
+
 # SES Email Service for transactional emails
 module "ses" {
   source = "../../modules/ses"
@@ -1741,6 +1767,30 @@ module "backend_ecs" {
     {
       name      = "CONTENTFUL_ACCESS_TOKEN"
       valueFrom = "${module.contentful_secrets.secret_arn}:CONTENTFUL_ACCESS_TOKEN::"
+    },
+    {
+      name      = "MAILCHIMP_API_KEY"
+      valueFrom = "${module.mailchimp_secrets.secret_arn}:MAILCHIMP_API_KEY::"
+    },
+    {
+      name      = "MAILCHIMP_SERVER_PREFIX"
+      valueFrom = "${module.mailchimp_secrets.secret_arn}:MAILCHIMP_SERVER_PREFIX::"
+    },
+    {
+      name      = "MAILCHIMP_AUDIENCE_ID"
+      valueFrom = "${module.mailchimp_secrets.secret_arn}:MAILCHIMP_AUDIENCE_ID::"
+    },
+    {
+      name      = "MAILCHIMP_COMMUNITY_KIND"
+      valueFrom = "${module.mailchimp_secrets.secret_arn}:MAILCHIMP_COMMUNITY_KIND::"
+    },
+    {
+      name      = "MAILCHIMP_COMMUNITY_ID"
+      valueFrom = "${module.mailchimp_secrets.secret_arn}:MAILCHIMP_COMMUNITY_ID::"
+    },
+    {
+      name      = "MAILCHIMP_COMMUNITY_NAME"
+      valueFrom = "${module.mailchimp_secrets.secret_arn}:MAILCHIMP_COMMUNITY_NAME::"
     },
   ]
 

--- a/infrastructure/env/prod/variables.tf
+++ b/infrastructure/env/prod/variables.tf
@@ -168,6 +168,43 @@ variable "contentful_preview_secret" {
   sensitive   = true
 }
 
+# Mailchimp configuration variables
+variable "mailchimp_api_key" {
+  description = "Mailchimp API key"
+  type        = string
+  sensitive   = true
+}
+
+variable "mailchimp_server_prefix" {
+  description = "Mailchimp server prefix"
+  type        = string
+  sensitive   = true
+}
+
+variable "mailchimp_audience_id" {
+  description = "Mailchimp audience ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "mailchimp_community_kind" {
+  description = "Mailchimp community member type"
+  type        = string
+  sensitive   = true
+}
+
+variable "mailchimp_community_id" {
+  description = "Mailchimp community identifier"
+  type        = string
+  sensitive   = true
+}
+
+variable "mailchimp_community_name" {
+  description = "Mailchimp community name"
+  type        = string
+  sensitive   = true
+}
+
 variable "centralized_metastore_bucket_name" {
   description = "Name of the centralized S3 bucket for Unity Catalog metastore storage in data governance account"
   type        = string

--- a/packages/api/src/contract.spec.ts
+++ b/packages/api/src/contract.spec.ts
@@ -53,6 +53,7 @@ describe("orpc contract surface", () => {
       "health",
       "iot",
       "macros",
+      "newsletter",
       "protocols",
       "search",
       "users",

--- a/packages/api/src/contract.ts
+++ b/packages/api/src/contract.ts
@@ -16,6 +16,7 @@ import { experimentWorkbooksContract } from "./domains/experiment/workbooks/expe
 import { healthContract } from "./domains/health/health.contract";
 import { iotContract } from "./domains/iot/iot.contract";
 import { macroContract } from "./domains/macro/macro.contract";
+import { newsletterContract } from "./domains/newsletter/newsletter.contract";
 import { protocolContract } from "./domains/protocol/protocol.contract";
 import { searchContract } from "./domains/search/search.contract";
 import { userContract } from "./domains/user/user.contract";
@@ -46,6 +47,7 @@ export const contract = {
   health: healthContract,
   iot: iotContract,
   macros: macroContract,
+  newsletter: newsletterContract,
   protocols: protocolContract,
   search: searchContract,
   users: userContract,

--- a/packages/api/src/domains/newsletter/newsletter.contract.ts
+++ b/packages/api/src/domains/newsletter/newsletter.contract.ts
@@ -1,0 +1,23 @@
+import { oc } from "@orpc/contract";
+
+import {
+  zNewsletterStatusResponse,
+  zNewsletterSubscribeBody,
+  zNewsletterSubscribeResponse,
+} from "./newsletter.schema";
+
+export const newsletterContract = {
+  subscribe: oc
+    .route({ method: "POST", path: "/api/v1/newsletter/subscribe", successStatus: 200 })
+    .input(zNewsletterSubscribeBody)
+    .output(zNewsletterSubscribeResponse),
+  getStatus: oc
+    .route({ method: "GET", path: "/api/v1/newsletter/status", successStatus: 200 })
+    .output(zNewsletterStatusResponse),
+  subscribeDirect: oc
+    .route({ method: "POST", path: "/api/v1/newsletter/subscription", successStatus: 200 })
+    .output(zNewsletterStatusResponse),
+  unsubscribe: oc
+    .route({ method: "DELETE", path: "/api/v1/newsletter/subscription", successStatus: 200 })
+    .output(zNewsletterStatusResponse),
+};

--- a/packages/api/src/domains/newsletter/newsletter.schema.ts
+++ b/packages/api/src/domains/newsletter/newsletter.schema.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const zNewsletterStatus = z.enum(["subscribed", "pending", "unsubscribed", "none"]);
+
+export type NewsletterStatus = z.infer<typeof zNewsletterStatus>;
+
+export const zNewsletterSubscribeBody = z.object({
+  email: z.string().email().describe("Email address to subscribe to the newsletter"),
+});
+
+export type NewsletterSubscribeBody = z.infer<typeof zNewsletterSubscribeBody>;
+
+// Deliberately generic: the public endpoint never reveals membership state, so
+// the response is the same regardless of whether the address is new or known.
+export const zNewsletterSubscribeResponse = z.object({
+  success: z.literal(true),
+});
+
+export type NewsletterSubscribeResponse = z.infer<typeof zNewsletterSubscribeResponse>;
+
+export const zNewsletterStatusResponse = z.object({
+  status: zNewsletterStatus,
+});
+
+export type NewsletterStatusResponse = z.infer<typeof zNewsletterStatusResponse>;

--- a/packages/cms/src/features/footer.tsx
+++ b/packages/cms/src/features/footer.tsx
@@ -14,9 +14,17 @@ interface HomeFooterProps {
   footerData: FooterFieldsFragment;
   preview: boolean;
   locale: string;
+  // Optional app-owned slot (e.g. the newsletter subscribe form) rendered
+  // inside the footer layout without touching the Contentful content model.
+  newsletterSlot?: React.ReactNode;
 }
 
-export const HomeFooter: React.FC<HomeFooterProps> = ({ footerData, preview, locale }) => {
+export const HomeFooter: React.FC<HomeFooterProps> = ({
+  footerData,
+  preview,
+  locale,
+  newsletterSlot,
+}) => {
   const liveFooter = useContentfulLiveUpdates<FooterFieldsFragment>(footerData, {
     skip: !preview,
     locale,
@@ -90,6 +98,7 @@ export const HomeFooter: React.FC<HomeFooterProps> = ({ footerData, preview, loc
                 {currentFooter.badge}
               </span>
             </div>
+            {newsletterSlot && <div className="mt-6 w-full max-w-sm">{newsletterSlot}</div>}
           </div>
 
           {/* Centered Menu and Support aligned right */}

--- a/packages/i18n/locales/de-DE/account.json
+++ b/packages/i18n/locales/de-DE/account.json
@@ -36,6 +36,20 @@
       "institutionPlaceholder": "Institution oder Organisation eingeben",
       "emptyInstitution": "Keine Institution hinzugefügt"
     },
+    "NewsletterSubscriptionCard": {
+      "title": "Newsletter",
+      "description": "Verwalten Sie Ihr Abonnement des openJII-Community-Newsletters.",
+      "toggleLabel": "Community-Newsletter",
+      "subscribed": "Sie haben den Community-Newsletter abonniert.",
+      "pending": "Bestätigungs-E-Mail gesendet. Prüfen Sie Ihren Posteingang, um das Abonnement abzuschließen.",
+      "unsubscribed": "Abonnieren Sie Neuigkeiten und Updates aus der Community.",
+      "loading": "Ihr Newsletter-Abonnement wird geprüft…",
+      "error": "Ihr Newsletter-Abonnement konnte nicht geladen werden. Ihre anderen Einstellungen sind weiterhin verfügbar.",
+      "retry": "Erneut versuchen",
+      "retrying": "Erneuter Versuch…",
+      "updating": "Ihr Newsletter-Abonnement wird aktualisiert…",
+      "updateError": "Ihr Newsletter-Abonnement konnte nicht aktualisiert werden. Bitte versuchen Sie es erneut."
+    },
     "status": {
       "active": "Konto aktiv",
       "deactivated": "Konto deaktiviert"

--- a/packages/i18n/locales/de-DE/account.json
+++ b/packages/i18n/locales/de-DE/account.json
@@ -48,7 +48,8 @@
       "retry": "Erneut versuchen",
       "retrying": "Erneuter Versuch…",
       "updating": "Ihr Newsletter-Abonnement wird aktualisiert…",
-      "updateError": "Ihr Newsletter-Abonnement konnte nicht aktualisiert werden. Bitte versuchen Sie es erneut."
+      "updateError": "Ihr Newsletter-Abonnement konnte nicht aktualisiert werden. Bitte versuchen Sie es erneut.",
+      "forgottenEmailError": "Diese E-Mail-Adresse wurde auf Ihren früheren Wunsch aus unserem Newsletter entfernt und kann nicht automatisch wieder hinzugefügt werden. Bitte wenden Sie sich an den Support, wenn Sie sich erneut anmelden möchten."
     },
     "status": {
       "active": "Konto aktiv",

--- a/packages/i18n/locales/de-DE/common.json
+++ b/packages/i18n/locales/de-DE/common.json
@@ -329,6 +329,7 @@
     "acceptTermsError": "Sie müssen die allgemeinen Geschäftsbedingungen akzeptieren",
     "newsletterOptIn": "Ich möchte den openJII-Newsletter erhalten",
     "newsletterOptInError": "Die Newsletter-Anmeldung ist fehlgeschlagen. Sie können sich später in den Kontoeinstellungen anmelden.",
+    "newsletterForgottenEmail": "Diese E-Mail-Adresse wurde auf Ihren früheren Wunsch aus unserem Newsletter entfernt und kann nicht automatisch wieder hinzugefügt werden. Bitte wenden Sie sich an den Support, wenn Sie sich erneut anmelden möchten.",
     "register": "Registrieren",
     "successMessage": "Registrierung erfolgreich",
     "signOutTitle": "Abmelden",

--- a/packages/i18n/locales/de-DE/common.json
+++ b/packages/i18n/locales/de-DE/common.json
@@ -327,6 +327,8 @@
     "termsAndConditions": "Allgemeine Geschäftsbedingungen",
     "acceptTerms": "Ich akzeptiere die allgemeinen Geschäftsbedingungen",
     "acceptTermsError": "Sie müssen die allgemeinen Geschäftsbedingungen akzeptieren",
+    "newsletterOptIn": "Ich möchte den openJII-Newsletter erhalten",
+    "newsletterOptInError": "Die Newsletter-Anmeldung ist fehlgeschlagen. Sie können sich später in den Kontoeinstellungen anmelden.",
     "register": "Registrieren",
     "successMessage": "Registrierung erfolgreich",
     "signOutTitle": "Abmelden",

--- a/packages/i18n/locales/de-DE/newsletter.json
+++ b/packages/i18n/locales/de-DE/newsletter.json
@@ -1,0 +1,14 @@
+{
+  "footer": {
+    "title": "Abonnieren Sie unseren Newsletter",
+    "description": "Neuigkeiten aus der openJII-Community, direkt in Ihr Postfach. Jederzeit abbestellbar.",
+    "emailLabel": "E-Mail-Adresse",
+    "emailPlaceholder": "sie@beispiel.de",
+    "invalidEmail": "Bitte geben Sie eine gültige E-Mail-Adresse ein.",
+    "submit": "Abonnieren",
+    "submitting": "Wird abonniert…",
+    "successTitle": "Fast geschafft!",
+    "successMessage": "Bitte prüfen Sie Ihr Postfach, um Ihr Abonnement zu bestätigen.",
+    "errorMessage": "Etwas ist schiefgelaufen. Bitte versuchen Sie es gleich noch einmal."
+  }
+}

--- a/packages/i18n/locales/en-US/account.json
+++ b/packages/i18n/locales/en-US/account.json
@@ -48,7 +48,8 @@
       "retry": "Try again",
       "retrying": "Trying again…",
       "updating": "Updating your newsletter subscription…",
-      "updateError": "We couldn't update your newsletter subscription. Please try again."
+      "updateError": "We couldn't update your newsletter subscription. Please try again.",
+      "forgottenEmailError": "This email was removed from our newsletter at your earlier request and can't be re-added automatically. Please contact support if you'd like to subscribe again."
     },
     "status": {
       "active": "Account active",

--- a/packages/i18n/locales/en-US/account.json
+++ b/packages/i18n/locales/en-US/account.json
@@ -36,6 +36,20 @@
       "institutionPlaceholder": "Enter your institution or organization",
       "emptyInstitution": "No institution added"
     },
+    "NewsletterSubscriptionCard": {
+      "title": "Newsletter",
+      "description": "Manage your subscription to the openJII community newsletter.",
+      "toggleLabel": "Community newsletter",
+      "subscribed": "You are subscribed to the community newsletter.",
+      "pending": "Confirmation email sent. Check your inbox to finish subscribing.",
+      "unsubscribed": "Subscribe to receive community news and updates.",
+      "loading": "Checking your newsletter subscription…",
+      "error": "We couldn't load your newsletter subscription. Your other settings are still available.",
+      "retry": "Try again",
+      "retrying": "Trying again…",
+      "updating": "Updating your newsletter subscription…",
+      "updateError": "We couldn't update your newsletter subscription. Please try again."
+    },
     "status": {
       "active": "Account active",
       "deactivated": "Account deactivated"

--- a/packages/i18n/locales/en-US/common.json
+++ b/packages/i18n/locales/en-US/common.json
@@ -474,6 +474,8 @@
     "termsAndConditions": "Terms and conditions",
     "acceptTerms": "I accept the terms and conditions",
     "acceptTermsError": "You must accept the terms and conditions",
+    "newsletterOptIn": "I'd like to receive the openJII newsletter",
+    "newsletterOptInError": "Newsletter subscription failed. You can subscribe later in account settings.",
     "registering": "Registering...",
     "register": "Register",
     "verifyAndRegister": "Verify & Register",

--- a/packages/i18n/locales/en-US/common.json
+++ b/packages/i18n/locales/en-US/common.json
@@ -476,6 +476,7 @@
     "acceptTermsError": "You must accept the terms and conditions",
     "newsletterOptIn": "I'd like to receive the openJII newsletter",
     "newsletterOptInError": "Newsletter subscription failed. You can subscribe later in account settings.",
+    "newsletterForgottenEmail": "This email was removed from our newsletter at your earlier request and can't be re-added automatically. Please contact support if you'd like to subscribe again.",
     "registering": "Registering...",
     "register": "Register",
     "verifyAndRegister": "Verify & Register",

--- a/packages/i18n/locales/en-US/newsletter.json
+++ b/packages/i18n/locales/en-US/newsletter.json
@@ -1,0 +1,14 @@
+{
+  "footer": {
+    "title": "Subscribe to our newsletter",
+    "description": "Community updates from openJII, straight to your inbox. Unsubscribe anytime.",
+    "emailLabel": "Email address",
+    "emailPlaceholder": "you@example.com",
+    "invalidEmail": "Please enter a valid email address.",
+    "submit": "Subscribe",
+    "submitting": "Subscribing…",
+    "successTitle": "Almost there!",
+    "successMessage": "Check your inbox to confirm your subscription.",
+    "errorMessage": "Something went wrong. Please try again in a moment."
+  }
+}

--- a/packages/i18n/locales/nl-NL/account.json
+++ b/packages/i18n/locales/nl-NL/account.json
@@ -48,7 +48,8 @@
       "retry": "Opnieuw proberen",
       "retrying": "Opnieuw proberen…",
       "updating": "Je nieuwsbriefabonnement wordt bijgewerkt…",
-      "updateError": "Je nieuwsbriefabonnement kon niet worden bijgewerkt. Probeer het opnieuw."
+      "updateError": "Je nieuwsbriefabonnement kon niet worden bijgewerkt. Probeer het opnieuw.",
+      "forgottenEmailError": "Dit e-mailadres is op je eerdere verzoek uit onze nieuwsbrief verwijderd en kan niet automatisch opnieuw worden toegevoegd. Neem contact op met support als je je opnieuw wilt aanmelden."
     },
     "status": {
       "active": "Account actief",

--- a/packages/i18n/locales/nl-NL/account.json
+++ b/packages/i18n/locales/nl-NL/account.json
@@ -1,0 +1,135 @@
+{
+  "mobileNavAriaLabel": "Instellingennavigatie",
+  "overview": {
+    "title": "Overzicht"
+  },
+  "security": {
+    "title": "Beveiliging"
+  },
+  "notifications": {
+    "title": "Meldingen"
+  },
+  "team": {
+    "title": "Team"
+  },
+  "activity": {
+    "title": "Activiteit"
+  },
+  "settings": {
+    "AccountIdentityCard": {
+      "title": "Profielfoto",
+      "upload": "Nieuwe foto uploaden",
+      "description": "Plak een link naar een afbeelding om die als avatar te gebruiken.",
+      "urlLabel": "Afbeeldings-URL",
+      "urlPlaceholder": "https://example.com/avatar.png",
+      "emptyUrl": "Geen aangepaste afbeeldings-URL"
+    },
+    "ProfileInformationCard": {
+      "title": "Profielinformatie",
+      "description": "Profielgegevens die binnen OpenJII worden weergegeven.",
+      "emptyName": "Stel je profiel in",
+      "nameValidation": "Vul minimaal een voor- en achternaam in.",
+      "bio": "Bio",
+      "bioPlaceholder": "Vertel iets over jezelf",
+      "emptyBio": "Geen bio toegevoegd",
+      "institution": "Instelling/organisatie",
+      "institutionPlaceholder": "Vul je instelling of organisatie in",
+      "emptyInstitution": "Geen instelling toegevoegd"
+    },
+    "NewsletterSubscriptionCard": {
+      "title": "Nieuwsbrief",
+      "description": "Beheer je abonnement op de openJII-communitynieuwsbrief.",
+      "toggleLabel": "Communitynieuwsbrief",
+      "subscribed": "Je bent geabonneerd op de communitynieuwsbrief.",
+      "pending": "Bevestigingsmail verzonden. Controleer je inbox om je abonnement af te ronden.",
+      "unsubscribed": "Abonneer je om nieuws en updates van de community te ontvangen.",
+      "loading": "Je nieuwsbriefabonnement wordt gecontroleerd…",
+      "error": "Je nieuwsbriefabonnement kon niet worden geladen. Je andere instellingen blijven beschikbaar.",
+      "retry": "Opnieuw proberen",
+      "retrying": "Opnieuw proberen…",
+      "updating": "Je nieuwsbriefabonnement wordt bijgewerkt…",
+      "updateError": "Je nieuwsbriefabonnement kon niet worden bijgewerkt. Probeer het opnieuw."
+    },
+    "status": {
+      "active": "Account actief",
+      "deactivated": "Account gedeactiveerd"
+    },
+    "disabled": "Uitgeschakeld",
+    "title": "Instellingen",
+    "accountsettings": "Accountinstellingen",
+    "loading": "Accountinstellingen laden...",
+    "errorTitle": "Fout bij het laden van accountinstellingen",
+    "cancel": "Annuleren",
+    "save": "Wijzigingen opslaan",
+    "saving": "Opslaan...",
+    "saved": "Accountinstellingen opgeslagen"
+  },
+  "dangerZone": {
+    "title": "Gevarenzone",
+    "deactivate": {
+      "title": "Account deactiveren",
+      "description": "Schakel je account tijdelijk uit.",
+      "button": "Deactiveren",
+      "buttonDeactivated": "Gedeactiveerd",
+      "dialogTitle": "Account deactiveren",
+      "dialogDescription": "Hiermee wordt je account tijdelijk uitgeschakeld en je profiel voor andere gebruikers verborgen.",
+      "warningTitle": "Wat er gebeurt wanneer je deactiveert:",
+      "warningList": {
+        "profileHidden": "Je profiel wordt verborgen voor andere onderzoekers",
+        "noRequests": "Je ontvangt geen samenwerkingsverzoeken meer",
+        "contentAccessible": "Je experimenten, macro's en protocollen blijven beschikbaar voor medewerkers",
+        "loggedOut": "Je wordt uitgelogd",
+        "canReactivate": "Je kunt je account opnieuw activeren door weer in te loggen"
+      },
+      "confirmPrompt": "Typ",
+      "confirmWord": "deactiveren",
+      "confirmSuffix": "om te bevestigen:",
+      "confirmPlaceholder": "Typ hier 'deactiveren'",
+      "buttonSaving": "Opslaan...",
+      "buttonConfirm": "Account deactiveren",
+      "successMessage": "Account gedeactiveerd"
+    },
+    "delete": {
+      "title": "Account verwijderen",
+      "description": "Verwijder je account en alle bijbehorende gegevens permanent. Dit kan niet ongedaan worden gemaakt.",
+      "button": "Account verwijderen",
+      "dialogTitle": "Account verwijderen",
+      "dialogDescription": "Deze actie kan niet ongedaan worden gemaakt. Je persoonlijke gegevens worden permanent gewist, maar je gepubliceerde bijdragen blijven behouden.",
+      "warningEraseTitle": "Dit wordt gewist:",
+      "warningEraseList": {
+        "profile": "Je profiel en persoonlijke gegevens",
+        "email": "Je e-mailadres en contactgegevens",
+        "teams": "Je teamlidmaatschappen"
+      },
+      "warningPreserveTitle": "Je inhoud blijft behouden:",
+      "warningPreserveList": {
+        "content": "Experimenten, macro's en protocollen blijven intact"
+      },
+      "confirmPrompt": "Typ",
+      "confirmWord": "verwijderen",
+      "confirmSuffix": "om te bevestigen:",
+      "confirmPlaceholder": "Typ hier 'verwijderen'",
+      "buttonDeleting": "Verwijderen...",
+      "buttonConfirm": "Account verwijderen",
+      "successMessage": "Account verwijderd. Je persoonlijke gegevens zijn gewist.",
+      "blockers": {
+        "title": "Draag eerst je experimenten over",
+        "description": "Je bent de enige beheerder van de onderstaande experimenten, waardoor ze zonder eigenaar achterblijven. Kies wie de beheerdersrechten overneemt en draag ze hier over.",
+        "loading": "Je experimenten worden gecontroleerd…",
+        "applyToAllLabel": "Alles aan één persoon overdragen",
+        "applyToAllPlaceholder": "Zoek iemand die alles overneemt…",
+        "rowPlaceholder": "Zoek een persoon…",
+        "noCandidatesHint": "Nog geen medewerkers. Zoek hierboven naar iemand of nodig iemand uit via de medewerkerspagina van het experiment.",
+        "manageLink": "Medewerkers openen",
+        "transferAll": "Beheerdersrechten overdragen",
+        "transferring": "Overdragen…",
+        "transferSuccess": "Beheerdersrechten overgedragen.",
+        "transferPartial": "Sommige experimenten konden niet worden bijgewerkt. Controleer ze en probeer het opnieuw.",
+        "transferError": "Beheerdersrechten konden niet worden overgedragen. Probeer het opnieuw.",
+        "expand": "Vergroten naar volledig scherm",
+        "collapse": "Volledig scherm verlaten"
+      }
+    },
+    "cancel": "Annuleren"
+  }
+}

--- a/packages/i18n/locales/nl-NL/common.json
+++ b/packages/i18n/locales/nl-NL/common.json
@@ -225,7 +225,8 @@
   },
   "registration": {
     "newsletterOptIn": "Ik wil graag de openJII-nieuwsbrief ontvangen",
-    "newsletterOptInError": "Aanmelden voor de nieuwsbrief is mislukt. Je kunt je later aanmelden via de accountinstellingen."
+    "newsletterOptInError": "Aanmelden voor de nieuwsbrief is mislukt. Je kunt je later aanmelden via de accountinstellingen.",
+    "newsletterForgottenEmail": "Dit e-mailadres is op je eerdere verzoek uit onze nieuwsbrief verwijderd en kan niet automatisch opnieuw worden toegevoegd. Neem contact op met support als je je opnieuw wilt aanmelden."
   },
   "signout": {
     "title": "Uitloggen",

--- a/packages/i18n/locales/nl-NL/common.json
+++ b/packages/i18n/locales/nl-NL/common.json
@@ -223,6 +223,10 @@
     "errorGoHome": "Naar Homepage",
     "errorSupport": "Als dit probleem aanhoudt, neem dan contact op met ons ondersteuningsteam."
   },
+  "registration": {
+    "newsletterOptIn": "Ik wil graag de openJII-nieuwsbrief ontvangen",
+    "newsletterOptInError": "Aanmelden voor de nieuwsbrief is mislukt. Je kunt je later aanmelden via de accountinstellingen."
+  },
   "signout": {
     "title": "Uitloggen",
     "description": "Weet je zeker dat je wilt uitloggen van je account?",

--- a/packages/i18n/locales/nl-NL/newsletter.json
+++ b/packages/i18n/locales/nl-NL/newsletter.json
@@ -1,0 +1,14 @@
+{
+  "footer": {
+    "title": "Abonneer je op onze nieuwsbrief",
+    "description": "Community-updates van openJII, rechtstreeks in je inbox. Je kunt je altijd afmelden.",
+    "emailLabel": "E-mailadres",
+    "emailPlaceholder": "jij@voorbeeld.nl",
+    "invalidEmail": "Voer een geldig e-mailadres in.",
+    "submit": "Abonneren",
+    "submitting": "Bezig met abonneren…",
+    "successTitle": "Bijna klaar!",
+    "successMessage": "Controleer je inbox om je abonnement te bevestigen.",
+    "errorMessage": "Er is iets misgegaan. Probeer het zo meteen opnieuw."
+  }
+}

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -34,6 +34,7 @@ export const namespaces = [
   "experimentVisualizations",
   "experimentDashboards",
   "iot",
+  "newsletter",
 ] as const;
 
 export type Namespace = (typeof namespaces)[number];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
       '@nestjs/schedule':
         specifier: ^6.1.1
         version: 6.1.3(@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.27)
+      '@nestjs/throttler':
+        specifier: ^6.5.0
+        version: 6.5.0(@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.27)(reflect-metadata@0.2.2)
       '@orpc/client':
         specifier: catalog:orpc
         version: 1.14.6(@opentelemetry/api@1.9.1)
@@ -5340,6 +5343,13 @@ packages:
         optional: true
       '@nestjs/platform-express':
         optional: true
+
+  '@nestjs/throttler@6.5.0':
+    resolution: {integrity: sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==}
+    peerDependencies:
+      '@nestjs/common': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+      reflect-metadata: ^0.1.13 || ^0.2.0
 
   '@next/env@16.2.6':
     resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
@@ -23271,6 +23281,12 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@nestjs/platform-express': 11.1.27(@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.27)(supports-color@8.1.1)
+
+  '@nestjs/throttler@6.5.0(@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.27)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1)
+      '@nestjs/core': 11.1.27(@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/platform-express@11.1.27)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      reflect-metadata: 0.2.2
 
   '@next/env@16.2.6': {}
 


### PR DESCRIPTION
Implements [OJD-1393](https://linear.app/openjii/issue/OJD-1393/account-page-newsletter-opt-inunsubscribe-gdpr-blocker) (newsletter opt-in/unsubscribe, GDPR blocker). Unblocks OPENJII-16 / OPENJII-12.

## What

Mailchimp-backed newsletter subscription with **no local persistence** (Mailchimp is the source of truth), offered in three places:

- **Public footer** (home + info pages): anonymous email form, double opt-in (`pending` + Mailchimp confirmation email)
- **Account settings**: toggle with live Mailchimp status (subscribed / pending "check your inbox" / unsubscribed / provider-error)
- **Registration**: opt-in checkbox, unchecked by default; direct subscribe after signup (email just OTP-verified), fire-and-forget so it never blocks registration
- **Account deletion** permanently deletes the Mailchimp member (GDPR erasure)

## How

- New `newsletter` oRPC domain + NestJS Mailchimp module (config/adapter/port, mirrors the email/aws modules)
- Anonymous subscribe route is rate-limited (scoped `@nestjs/throttler`, keyed on the CloudFront-appended `X-Forwarded-For` entry, spoof-tested) and always returns a generic response (no email enumeration)
- Read-then-act subscribe: an existing subscriber re-entering their email in the footer is a no-op, never downgraded to pending
- Backend boots with zero `MAILCHIMP_*` env vars (feature dormant); strict zod validation once any are present
- "Community" group-vs-tag is pure config (`MAILCHIMP_COMMUNITY_KIND`)

## Verification

- backend 2164 tests / packages/api 1240 + typecheck / web lint + check-types + 57 focused tests, all green
- Three independent review passes (2x Codex, 1x Opus cohesive) - all findings fixed

## Operational verification

- [x] All six `MAILCHIMP_*` values configured in GitHub dev/prod environments; Terraform, CI, Secrets Manager, and ECS plumbing added. Applied successfully in dev; production resources will be created by the next production deploy.
- [x] Real Mailchimp end-to-end verification completed: local existing-member classification preserved `subscribed`; deployed dev anonymous subscription created `pending` with `MMERGE10=Community`. Disposable verification contacts were removed afterward.
- [x] Confirmed request chain: CloudFront appends the viewer IP and ALB's default append mode adds the CloudFront edge IP. Terraform does not override that ALB default; the guard selects the second-from-right entry and spoof-resistance is tested.
- [ ] Native review of de-DE copy. nl-NL remains disabled; its machine-authored copy must be reviewed before that locale is enabled.