### PR TITLE
fix(ci): restore old build assets on failed OpenNext deploys, simplify Lambda deploy steps

### DIFF
--- a/.github/actions/deploy-lambda-zip/action.yml
+++ b/.github/actions/deploy-lambda-zip/action.yml
@@ -1,0 +1,67 @@
+name: "Deploy Lambda Function from Zip"
+description: "Zips a directory and deploys it to a Lambda function via S3-staged update-function-code, avoiding the ~70MB direct-upload request size limit. Cleans up the staged copy afterward."
+inputs:
+  function-name:
+    description: "Name of the Lambda function to update"
+    required: true
+  source-dir:
+    description: "Directory containing the function's code to zip"
+    required: true
+  zip-name:
+    description: "Basename for the zip file, created as a sibling of source-dir"
+    required: true
+  assets-bucket:
+    description: "S3 bucket used to stage the zip before update-function-code"
+    required: true
+  sha:
+    description: "Commit SHA, used to build a unique staging key"
+    required: true
+outputs:
+  version:
+    description: "Published Lambda version"
+    value: ${{ steps.deploy.outputs.version }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Zip, stage in S3, and deploy to Lambda
+      id: deploy
+      shell: bash
+      run: |
+        echo "Zipping ${{ inputs.source-dir }}..."
+        ZIP_PATH="$(pwd)/$(dirname "${{ inputs.source-dir }}")/${{ inputs.zip-name }}"
+        (cd "${{ inputs.source-dir }}" && zip -rq "$ZIP_PATH" .)
+
+        # Direct --zip-file upload is capped at ~70MB; stage via S3 (250MB limit) under a per-run key
+        S3_KEY="_deploy-tmp/${{ inputs.zip-name }}-${{ inputs.sha }}-${{ github.run_id }}-${{ github.run_attempt }}.zip"
+        echo "Staging code in s3://${{ inputs.assets-bucket }}/${S3_KEY}..."
+        STAGED_VERSION_ID=$(aws s3api put-object \
+          --bucket "${{ inputs.assets-bucket }}" \
+          --key "${S3_KEY}" \
+          --body "$ZIP_PATH" \
+          --query 'VersionId' --output text)
+
+        # Versioned bucket: delete the exact uploaded version (s3 rm would only add a delete marker)
+        cleanup_staged_zip() {
+          echo "Cleaning up staged deployment package..."
+          if [[ -n "$STAGED_VERSION_ID" && "$STAGED_VERSION_ID" != "None" ]]; then
+            aws s3api delete-object --bucket "${{ inputs.assets-bucket }}" --key "${S3_KEY}" --version-id "$STAGED_VERSION_ID" || true
+          else
+            aws s3 rm "s3://${{ inputs.assets-bucket }}/${S3_KEY}" || true
+          fi
+        }
+        trap cleanup_staged_zip EXIT
+
+        echo "Uploading code to Lambda function ${{ inputs.function-name }}..."
+        UPDATE_ARGS=(
+          --function-name "${{ inputs.function-name }}"
+          --s3-bucket "${{ inputs.assets-bucket }}"
+          --s3-key "${S3_KEY}"
+          --publish
+        )
+        if [[ -n "$STAGED_VERSION_ID" && "$STAGED_VERSION_ID" != "None" ]]; then
+          UPDATE_ARGS+=(--s3-object-version "$STAGED_VERSION_ID")
+        fi
+        UPDATE_OUTPUT=$(aws lambda update-function-code "${UPDATE_ARGS[@]}")
+        VERSION=$(echo "$UPDATE_OUTPUT" | jq -r '.Version')
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/actions/deploy-lambda-zip/action.yml
+++ b/.github/actions/deploy-lambda-zip/action.yml
@@ -62,6 +62,5 @@ runs:
         if [[ -n "$STAGED_VERSION_ID" && "$STAGED_VERSION_ID" != "None" ]]; then
           UPDATE_ARGS+=(--s3-object-version "$STAGED_VERSION_ID")
         fi
-        UPDATE_OUTPUT=$(aws lambda update-function-code "${UPDATE_ARGS[@]}")
-        VERSION=$(echo "$UPDATE_OUTPUT" | jq -r '.Version')
+        VERSION=$(aws lambda update-function-code "${UPDATE_ARGS[@]}" --query 'Version' --output text)
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/actions/prune-lambda-versions/action.yml
+++ b/.github/actions/prune-lambda-versions/action.yml
@@ -1,0 +1,30 @@
+name: "Prune old Lambda versions"
+description: "Deletes all published versions of a Lambda function except the newest N, leaving $LATEST untouched."
+inputs:
+  function-name:
+    description: "Name of the Lambda function to prune versions for"
+    required: true
+  keep:
+    description: "Number of most recent versions to keep"
+    required: false
+    default: "10"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Prune old versions
+      shell: bash
+      run: |
+        FUNCTION_NAME="${{ inputs.function-name }}"
+        KEEP="${{ inputs.keep }}"
+        echo "Pruning old Lambda versions for $FUNCTION_NAME (keeping $KEEP latest)..."
+        # Get all versions except $LATEST, sort by version number (numeric), skip the newest $KEEP, and delete the rest
+        aws lambda list-versions-by-function --function-name "$FUNCTION_NAME" \
+          --query 'Versions[?Version!=`$LATEST`].Version' --output text | \
+          tr '\t' '\n' | sort -n | head -n -"$KEEP" | while read VERSION; do
+            if [[ -n "$VERSION" ]]; then
+              echo "Deleting old version: $VERSION"
+              aws lambda delete-function --function-name "$FUNCTION_NAME" --qualifier "$VERSION"
+            fi
+          done
+        echo "✅ Version pruning complete"

--- a/.github/actions/prune-lambda-versions/action.yml
+++ b/.github/actions/prune-lambda-versions/action.yml
@@ -24,7 +24,7 @@ runs:
           tr '\t' '\n' | sort -n | head -n -"$KEEP" | while read VERSION; do
             if [[ -n "$VERSION" ]]; then
               echo "Deleting old version: $VERSION"
-              aws lambda delete-function --function-name "$FUNCTION_NAME" --qualifier "$VERSION"
+              aws lambda delete-function --function-name "$FUNCTION_NAME" --qualifier "$VERSION" || true
             fi
           done
         echo "✅ Version pruning complete"

--- a/.github/workflows/deploy-nextjs-opennext.yml
+++ b/.github/workflows/deploy-nextjs-opennext.yml
@@ -163,46 +163,13 @@ jobs:
       - name: Deploy Server Function
         id: deploy-server
         if: steps.check-server.outputs.exists == 'true'
-        run: |
-          echo "Zipping server function code..."
-          cd apps/web/.open-next/server-functions/default
-          zip -r ../../server-function.zip .
-          cd -
-
-          # Direct --zip-file upload is capped at ~70MB; stage via S3 (250MB limit) under a per-run key
-          ASSETS_BUCKET="${{ env.ASSETS_BUCKET }}"
-          S3_KEY="_deploy-tmp/server-function-${{ steps.get-sha.outputs.sha }}-${{ github.run_id }}-${{ github.run_attempt }}.zip"
-          echo "Staging server function code in s3://${ASSETS_BUCKET}/${S3_KEY}..."
-          STAGED_VERSION_ID=$(aws s3api put-object \
-            --bucket "${ASSETS_BUCKET}" \
-            --key "${S3_KEY}" \
-            --body apps/web/.open-next/server-function.zip \
-            --query 'VersionId' --output text)
-
-          # Versioned bucket: delete the exact uploaded version (s3 rm would only add a delete marker)
-          cleanup_staged_zip() {
-            echo "Cleaning up staged deployment package..."
-            if [[ -n "$STAGED_VERSION_ID" && "$STAGED_VERSION_ID" != "None" ]]; then
-              aws s3api delete-object --bucket "${ASSETS_BUCKET}" --key "${S3_KEY}" --version-id "$STAGED_VERSION_ID" || true
-            else
-              aws s3 rm "s3://${ASSETS_BUCKET}/${S3_KEY}" || true
-            fi
-          }
-          trap cleanup_staged_zip EXIT
-
-          echo "Uploading server function code to Lambda..."
-          UPDATE_ARGS=(
-            --function-name "${{ env.SERVER_FUNCTION }}"
-            --s3-bucket "${ASSETS_BUCKET}"
-            --s3-key "${S3_KEY}"
-            --publish
-          )
-          if [[ -n "$STAGED_VERSION_ID" && "$STAGED_VERSION_ID" != "None" ]]; then
-            UPDATE_ARGS+=(--s3-object-version "$STAGED_VERSION_ID")
-          fi
-          UPDATE_OUTPUT=$(aws lambda update-function-code "${UPDATE_ARGS[@]}")
-          VERSION=$(echo "$UPDATE_OUTPUT" | jq -r '.Version')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/deploy-lambda-zip
+        with:
+          function-name: ${{ env.SERVER_FUNCTION }}
+          source-dir: apps/web/.open-next/server-functions/default
+          zip-name: server-function.zip
+          assets-bucket: ${{ env.ASSETS_BUCKET }}
+          sha: ${{ steps.get-sha.outputs.sha }}
 
       - name: Get Previous Server Alias Version
         id: get-server-alias
@@ -313,7 +280,9 @@ jobs:
           ASSETS_BUCKET: ${{ env.ASSETS_BUCKET }}
         run: |
           echo "❌ Reverting latest S3 asset versions due to failed deployment..."
-          # List all latest versions and delete them to expose previous versions (skip _deploy-tmp/ staged zips)
+
+          # Files overwritten by the new build (same key, new version on top of old) -
+          # delete the new version to expose the previous one (skip _deploy-tmp/ staged zips)
           aws s3api list-object-versions \
             --bucket "$ASSETS_BUCKET" \
             --query 'Versions[?IsLatest==`true`].[Key,VersionId]' \
@@ -329,24 +298,32 @@ jobs:
                   --version-id "$VERSION"
               fi
             done
-          echo "✅ S3 asset revert complete"
 
-      - name: Prune old Lambda versions (keep 10 latest)
-        if: success()
-        run: |
-          FUNCTION_NAME="${{ env.SERVER_FUNCTION }}"
-          KEEP=10
-          echo "Pruning old Lambda versions (keeping $KEEP latest)..."
-          # Get all versions except $LATEST, sort by version number (numeric), skip the newest $KEEP, and delete the rest
-          aws lambda list-versions-by-function --function-name "$FUNCTION_NAME" \
-            --query 'Versions[?Version!=`$LATEST`].Version' --output text | \
-            tr '\t' '\n' | sort -n | head -n -$KEEP | while read VERSION; do
-              if [[ -n "$VERSION" ]]; then
-                echo "Deleting old version: $VERSION"
-                aws lambda delete-function --function-name "$FUNCTION_NAME" --qualifier "$VERSION"
+          # Files removed entirely by --delete (e.g. previous build's hashed _next/static chunks,
+          # which the still-live old Lambda alias depends on) - these are hidden behind a delete
+          # marker, not a Versions entry. Deleting the marker itself un-hides the real content.
+          aws s3api list-object-versions \
+            --bucket "$ASSETS_BUCKET" \
+            --query 'DeleteMarkers[?IsLatest==`true`].[Key,VersionId]' \
+            --output text | while read KEY VERSION; do
+              if [[ "$KEY" == _deploy-tmp/* ]]; then
+                continue
+              fi
+              if [[ -n "$KEY" && -n "$VERSION" ]]; then
+                echo "Removing delete marker for $KEY ($VERSION)"
+                aws s3api delete-object \
+                  --bucket "$ASSETS_BUCKET" \
+                  --key "$KEY" \
+                  --version-id "$VERSION"
               fi
             done
-          echo "✅ Version pruning complete"
+          echo "✅ S3 asset revert complete"
+
+      - name: Prune old Lambda versions (Server Function)
+        if: success()
+        uses: ./.github/actions/prune-lambda-versions
+        with:
+          function-name: ${{ env.SERVER_FUNCTION }}
 
       - name: Check Image Optimization Function
         id: check-image
@@ -374,22 +351,11 @@ jobs:
             --zip-file fileb://apps/web/.open-next/image-optimization-function.zip \
             --publish
 
-      - name: Prune old Lambda versions (keep 10 latest) from Image Optimization Function
+      - name: Prune old Lambda versions (Image Optimization Function)
         if: success()
-        run: |
-          FUNCTION_NAME="${{ env.IMAGE_FUNCTION }}"
-          KEEP=10
-          echo "Pruning old Lambda versions (keeping $KEEP latest)..."
-          # Get all versions except $LATEST, sort by version number (numeric), skip the newest $KEEP, and delete the rest
-          aws lambda list-versions-by-function --function-name "$FUNCTION_NAME" \
-            --query 'Versions[?Version!=`$LATEST`].Version' --output text | \
-            tr '\t' '\n' | sort -n | head -n -$KEEP | while read VERSION; do
-              if [[ -n "$VERSION" ]]; then
-                echo "Deleting old version: $VERSION"
-                aws lambda delete-function --function-name "$FUNCTION_NAME" --qualifier "$VERSION"
-              fi
-            done
-          echo "✅ Version pruning complete"
+        uses: ./.github/actions/prune-lambda-versions
+        with:
+          function-name: ${{ env.IMAGE_FUNCTION }}
 
       - name: Check Revalidation Function
         id: check-revalidation
@@ -417,22 +383,11 @@ jobs:
             --zip-file fileb://apps/web/.open-next/revalidation-function.zip \
             --publish
 
-      - name: Prune old Lambda versions (keep 10 latest) from Revalidation Function
+      - name: Prune old Lambda versions (Revalidation Function)
         if: success()
-        run: |
-          FUNCTION_NAME="${{ env.REVALIDATION_FUNCTION }}"
-          KEEP=10
-          echo "Pruning old Lambda versions (keeping $KEEP latest)..."
-          # Get all versions except $LATEST, sort by version number (numeric), skip the newest $KEEP, and delete the rest
-          aws lambda list-versions-by-function --function-name "$FUNCTION_NAME" \
-            --query 'Versions[?Version!=`$LATEST`].Version' --output text | \
-            tr '\t' '\n' | sort -n | head -n -$KEEP | while read VERSION; do
-              if [[ -n "$VERSION" ]]; then
-                echo "Deleting old version: $VERSION"
-                aws lambda delete-function --function-name "$FUNCTION_NAME" --qualifier "$VERSION"
-              fi
-            done
-          echo "✅ Version pruning complete"
+        uses: ./.github/actions/prune-lambda-versions
+        with:
+          function-name: ${{ env.REVALIDATION_FUNCTION }}
 
       - name: Check Warmer Function
         id: check-warmer
@@ -460,22 +415,11 @@ jobs:
             --zip-file fileb://apps/web/.open-next/warmer-function.zip \
             --publish
 
-      - name: Prune old Lambda versions (keep 10 latest) from Warmer Function
+      - name: Prune old Lambda versions (Warmer Function)
         if: success()
-        run: |
-          FUNCTION_NAME="${{ env.WARMER_FUNCTION }}"
-          KEEP=10
-          echo "Pruning old Lambda versions (keeping $KEEP latest)..."
-          # Get all versions except $LATEST, sort by version number (numeric), skip the newest $KEEP, and delete the rest
-          aws lambda list-versions-by-function --function-name "$FUNCTION_NAME" \
-            --query 'Versions[?Version!=`$LATEST`].Version' --output text | \
-            tr '\t' '\n' | sort -n | head -n -$KEEP | while read VERSION; do
-              if [[ -n "$VERSION" ]]; then
-                echo "Deleting old version: $VERSION"
-                aws lambda delete-function --function-name "$FUNCTION_NAME" --qualifier "$VERSION"
-              fi
-            done
-          echo "✅ Version pruning complete"
+        uses: ./.github/actions/prune-lambda-versions
+        with:
+          function-name: ${{ env.WARMER_FUNCTION }}
 
       - name: Finalize Lambda Deployments and Summarize Results
         id: update-lambdas

--- a/.github/workflows/deploy-nextjs-opennext.yml
+++ b/.github/workflows/deploy-nextjs-opennext.yml
@@ -286,7 +286,7 @@ jobs:
           aws s3api list-object-versions \
             --bucket "$ASSETS_BUCKET" \
             --query 'Versions[?IsLatest==`true`].[Key,VersionId]' \
-            --output text | while read KEY VERSION; do
+            --output text | while IFS=$'\t' read -r KEY VERSION; do
               if [[ "$KEY" == _deploy-tmp/* ]]; then
                 continue
               fi
@@ -305,7 +305,7 @@ jobs:
           aws s3api list-object-versions \
             --bucket "$ASSETS_BUCKET" \
             --query 'DeleteMarkers[?IsLatest==`true`].[Key,VersionId]' \
-            --output text | while read KEY VERSION; do
+            --output text | while IFS=$'\t' read -r KEY VERSION; do
               if [[ "$KEY" == _deploy-tmp/* ]]; then
                 continue
               fi


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description
The "Revert S3 Asset Uploads on Failure" step only undid overwritten files (Versions), not deleted ones (DeleteMarkers) — which is exactly what a failed deploy leaves behind for the previous build's hashed _next/static chunks. This is what caused dev to break after a failed deploy: the old Lambda alias stayed live, but its static assets were hidden behind unhandled delete markers. Fixed by also clearing DeleteMarkers for the affected keys.

Also extracted two reusable composite actions to cut down duplication:
- deploy-lambda-zip: zip + S3-stage + update-function-code, used for the server function (the one that actually needs S3 staging to avoid the ~70MB direct-upload limit)
- prune-lambda-versions: the version-pruning loop, now shared across all four Lambda functions instead of being duplicated 4x

Image-optimization, revalidation, and warmer function deploys are left on the direct --zip-file path since they're small and don't need S3 staging.

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #
- Related to #
