### PR TITLE
fix(ci): suppress npm-bundled tar/brace-expansion CVEs in migration image scan

### DIFF
--- a/.github/workflows/database-migrations.yml
+++ b/.github/workflows/database-migrations.yml
@@ -172,7 +172,7 @@ jobs:
           severity: CRITICAL,HIGH
           vuln-type: os,library
           ignore-unfixed: true
-          trivyignores: .trivyignore
+          trivyignores: .trivyignore.docker-images
 
       - name: Push image to Amazon ECR
         run: |

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -121,7 +121,7 @@ jobs:
           severity: CRITICAL,HIGH
           vuln-type: os,library
           ignore-unfixed: true
-          trivyignores: .trivyignore
+          trivyignores: .trivyignore.docker-images
 
       - name: Push image to Amazon ECR
         run: docker push ${{ steps.build-image.outputs.image }}

--- a/.github/workflows/production-checks.yml
+++ b/.github/workflows/production-checks.yml
@@ -24,6 +24,7 @@ jobs:
           image-name: open-jii-backend:pr-check
           dockerfile: apps/backend/Dockerfile
           build-args: PROJECT=backend
+          trivyignores: .trivyignore.docker-images
 
   database:
     name: Docker Build (Database Migrations)
@@ -35,6 +36,7 @@ jobs:
         with:
           image-name: open-jii-database:pr-check
           dockerfile: packages/database/Dockerfile
+          trivyignores: .trivyignore.docker-images
 
   macro-sandbox:
     name: Docker Build (Macro Sandbox - ${{ matrix.language }})

--- a/.trivyignore
+++ b/.trivyignore
@@ -16,21 +16,6 @@ CVE-2026-48815
 # Clears once the Node 24 base image bundles npm with undici >= 6.27.0.
 CVE-2026-12151
 
-# CVE-2026-13149: brace-expansion ReDoS via exponential-time complexity,
-# in system npm (usr/local/lib/node_modules/npm/node_modules/brace-expansion@5.0.6).
-# Bundled with the node:24 image's npm CLI, not in the app's runtime; the container
-# runs `node dist/...` and never invokes npm.
-# Clears once the Node 24 base image bundles npm with brace-expansion >= 5.0.7.
-CVE-2026-13149
-
-# CVE-2026-59873 / CVE-2026-59874: node-tar DoS via crafted gzip bomb / malformed
-# tar header, in system npm (usr/local/lib/node_modules/npm/node_modules/tar@7.5.15).
-# Bundled with the node:24 image's npm CLI, not in the app's runtime; the container
-# runs `node dist/...` and never invokes npm, so no untrusted archive is ever extracted.
-# Clears once the Node 24 base image bundles npm with tar >= 7.5.19.
-CVE-2026-59873
-CVE-2026-59874
-
 # CVE-2026-4926: path-to-regexp ReDoS via crafted route patterns
 # Affects path-to-regexp@8.3.0 pinned by Express 5's `router` package (exact version constraint).
 # The vulnerability requires an attacker to control route *definition* patterns, not URL paths.

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,21 +1,3 @@
-# CVE-2026-33671: picomatch ReDoS in system npm installation (usr/local/lib/node_modules/npm)
-# This is bundled with the Node.js Docker image's npm CLI, not in the app's runtime.
-# The app runs as `node dist/main` and never invokes npm at runtime.
-CVE-2026-33671
-
-# CVE-2026-48815: sigstore certificateOIDs constraints dropped, in system npm (usr/local/lib/node_modules/npm)
-# sigstore is bundled inside the Node.js Docker image's npm CLI (via libnpmpublish), not in the app's runtime.
-# The affected path is npm publish provenance signing; the container runs `node dist/...` and never invokes npm.
-# Clears once the Node base image bundles npm >= 11 (ships sigstore >= 4.1.1); Node 22 currently bundles npm 10.9.x.
-CVE-2026-48815
-
-# CVE-2026-12151: undici DoS via unbounded memory growth in WebSocket handling,
-# in system npm (usr/local/lib/node_modules/npm/node_modules/undici@6.26.0).
-# Bundled with the node:24 image's npm CLI, not in the app's runtime; the container
-# runs `node dist/...`, never invokes npm, and npm's CLI opens no WebSockets.
-# Clears once the Node 24 base image bundles npm with undici >= 6.27.0.
-CVE-2026-12151
-
 # CVE-2026-4926: path-to-regexp ReDoS via crafted route patterns
 # Affects path-to-regexp@8.3.0 pinned by Express 5's `router` package (exact version constraint).
 # The vulnerability requires an attacker to control route *definition* patterns, not URL paths.

--- a/.trivyignore
+++ b/.trivyignore
@@ -16,6 +16,21 @@ CVE-2026-48815
 # Clears once the Node 24 base image bundles npm with undici >= 6.27.0.
 CVE-2026-12151
 
+# CVE-2026-13149: brace-expansion ReDoS via exponential-time complexity,
+# in system npm (usr/local/lib/node_modules/npm/node_modules/brace-expansion@5.0.6).
+# Bundled with the node:24 image's npm CLI, not in the app's runtime; the container
+# runs `node dist/...` and never invokes npm.
+# Clears once the Node 24 base image bundles npm with brace-expansion >= 5.0.7.
+CVE-2026-13149
+
+# CVE-2026-59873 / CVE-2026-59874: node-tar DoS via crafted gzip bomb / malformed
+# tar header, in system npm (usr/local/lib/node_modules/npm/node_modules/tar@7.5.15).
+# Bundled with the node:24 image's npm CLI, not in the app's runtime; the container
+# runs `node dist/...` and never invokes npm, so no untrusted archive is ever extracted.
+# Clears once the Node 24 base image bundles npm with tar >= 7.5.19.
+CVE-2026-59873
+CVE-2026-59874
+
 # CVE-2026-4926: path-to-regexp ReDoS via crafted route patterns
 # Affects path-to-regexp@8.3.0 pinned by Express 5's `router` package (exact version constraint).
 # The vulnerability requires an attacker to control route *definition* patterns, not URL paths.

--- a/.trivyignore.docker-images
+++ b/.trivyignore.docker-images
@@ -7,6 +7,24 @@
 # Suppressing here only affects the built-image scans; a real vulnerable version
 # pulled in by the app itself would still be caught by the dependency-scan job.
 
+# CVE-2026-33671: picomatch ReDoS in system npm installation (usr/local/lib/node_modules/npm)
+# Bundled with the Node.js Docker image's npm CLI, not in either app's runtime.
+# The containers run `node dist/main` / `node dist/migrate.js` and never invoke npm.
+CVE-2026-33671
+
+# CVE-2026-48815: sigstore certificateOIDs constraints dropped, in system npm (usr/local/lib/node_modules/npm)
+# sigstore is bundled inside the Node.js Docker image's npm CLI (via libnpmpublish), not in either app's runtime.
+# The affected path is npm publish provenance signing; the containers never invoke npm.
+# Clears once the Node base image bundles npm >= 11 (ships sigstore >= 4.1.1); Node 22 currently bundles npm 10.9.x.
+CVE-2026-48815
+
+# CVE-2026-12151: undici DoS via unbounded memory growth in WebSocket handling,
+# in system npm (usr/local/lib/node_modules/npm/node_modules/undici@6.26.0).
+# Bundled with the node:24 image's npm CLI, not in either app's runtime; the containers
+# never invoke npm, and npm's CLI opens no WebSockets.
+# Clears once the Node 24 base image bundles npm with undici >= 6.27.0.
+CVE-2026-12151
+
 # CVE-2026-13149: brace-expansion ReDoS via exponential-time complexity,
 # in system npm (usr/local/lib/node_modules/npm/node_modules/brace-expansion@5.0.6).
 # Bundled with the node:24 image's npm CLI, not in either app's runtime; the containers

--- a/.trivyignore.docker-images
+++ b/.trivyignore.docker-images
@@ -1,0 +1,24 @@
+# Shared suppressions for Docker image scans (backend + database migration images).
+# Both are built FROM node:24-alpine with `RUN npm install turbo --global`, so both
+# inherit whatever npm/tar/brace-expansion versions that base image bundles.
+#
+# Do NOT merge these into the root .trivyignore: that file is also read by the
+# dependency-scan job (filesystem scan of this repo's own pnpm-lock.yaml/node_modules).
+# Suppressing here only affects the built-image scans; a real vulnerable version
+# pulled in by the app itself would still be caught by the dependency-scan job.
+
+# CVE-2026-13149: brace-expansion ReDoS via exponential-time complexity,
+# in system npm (usr/local/lib/node_modules/npm/node_modules/brace-expansion@5.0.6).
+# Bundled with the node:24 image's npm CLI, not in either app's runtime; the containers
+# run `node dist/main` / `node dist/migrate.js` and never invoke npm.
+# Clears once the Node 24 base image bundles npm with brace-expansion >= 5.0.7.
+CVE-2026-13149
+
+# CVE-2026-59873 / CVE-2026-59874: node-tar DoS via crafted gzip bomb / malformed
+# tar header, in system npm (usr/local/lib/node_modules/npm/node_modules/tar@7.5.15).
+# Bundled with the node:24 image's npm CLI, not in either app's runtime; the containers
+# run `node dist/main` / `node dist/migrate.js` and never invoke npm, so no untrusted
+# archive is ever extracted.
+# Clears once the Node 24 base image bundles npm with tar >= 7.5.19.
+CVE-2026-59873
+CVE-2026-59874

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ catalogs:
       specifier: 7.0.11
       version: 7.0.11
     axios:
-      specifier: 1.16.1
-      version: 1.16.1
+      specifier: 1.18.1
+      version: 1.18.1
     eslint:
       specifier: 9.39.4
       version: 9.39.4
@@ -204,7 +204,7 @@ importers:
         version: 3.1048.0
       '@nestjs/axios':
         specifier: ^4.0.1
-        version: 4.0.1(@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(axios@1.16.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1))(rxjs@7.8.2)
+        version: 4.0.1(@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(axios@1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1))(rxjs@7.8.2)
       '@nestjs/cache-manager':
         specifier: ^3.1.0
         version: 3.1.3(@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.27)(cache-manager@7.2.9)(keyv@5.6.0)(rxjs@7.8.2)
@@ -258,7 +258,7 @@ importers:
         version: 1.5.4
       axios:
         specifier: 'catalog:'
-        version: 1.16.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       better-auth:
         specifier: 1.6.23
         version: 1.6.23(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(expo-sqlite@57.0.1(expo@57.0.7)(react-native@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.86.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.14)(react@19.2.3)(supports-color@8.1.1))(react@19.2.3))(kysely@0.28.17)(postgres@3.4.9))(next@16.2.6(@babel/core@7.29.7(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(babel-plugin-macros@2.8.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.1.4)
@@ -532,7 +532,7 @@ importers:
         version: 5.95.2(@tanstack/react-query@5.95.2(react@19.2.3))(react@19.2.3)
       axios:
         specifier: 'catalog:'
-        version: 1.16.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1205,7 +1205,7 @@ importers:
         version: 0.7.1
       contentful:
         specifier: ^11.12.0
-        version: 11.12.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 11.12.6(supports-color@8.1.1)
       graphql-request:
         specifier: ^7.4.0
         version: 7.4.0(graphql@16.14.2)
@@ -8619,9 +8619,6 @@ packages:
   axe-core@4.12.1:
     resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
     engines: {node: '>=4'}
-
-  axios@1.16.1:
-    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
   axios@1.18.1:
     resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
@@ -23137,10 +23134,10 @@ snapshots:
       '@napi-rs/nice-win32-x64-msvc': 1.1.1
     optional: true
 
-  '@nestjs/axios@4.0.1(@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(axios@1.16.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1))(rxjs@7.8.2)':
+  '@nestjs/axios@4.0.1(@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(axios@1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1))(rxjs@7.8.2)':
     dependencies:
       '@nestjs/common': 11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1)
-      axios: 1.16.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      axios: 1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       rxjs: 7.8.2
 
   '@nestjs/cache-manager@3.1.3(@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)(supports-color@8.1.1))(@nestjs/core@11.1.27)(cache-manager@7.2.9)(keyv@5.6.0)(rxjs@7.8.2)':
@@ -27382,16 +27379,6 @@ snapshots:
 
   axe-core@4.12.1: {}
 
-  axios@1.16.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
-    dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
-      form-data: 4.0.6
-      https-proxy-agent: 5.0.1(supports-color@8.1.1)
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   axios@1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
@@ -28404,7 +28391,7 @@ snapshots:
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu': 4.62.2
 
-  contentful@11.12.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
+  contentful@11.12.6(supports-color@8.1.1):
     dependencies:
       '@contentful/content-source-maps': 0.11.44
       '@contentful/rich-text-types': 17.2.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,7 +38,7 @@ patchedDependencies:
   "@better-auth/expo@1.6.23": patches/@better-auth__expo@1.6.23.patch
 
 catalog:
-  axios: 1.16.1
+  axios: 1.18.1
   typescript: 6.0.3
   zod: 3.25.76
   eslint: 9.39.4


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description
## Summary
- The database migration Docker image build (`packages/database/Dockerfile`) started failing Trivy scans on `CVE-2026-13149` (brace-expansion ReDoS) and `CVE-2026-59873`/`CVE-2026-59874` (tar DoS via gzip bomb / malformed header).
- Confirmed these come from npm itself, not the app: `docker run node:24-alpine` shows npm@11.16.0 vendors `tar@7.5.15` and `brace-expansion@5.0.6` at `/usr/local/lib/node_modules/npm/node_modules/...`, matching the scan output exactly. The app's `pnpm-lock.yaml` has no `tar` dependency at all, and already pins `brace-expansion` to the fixed `5.0.7` via `minimatch`.
- Added both CVEs to `.trivyignore`, following the same convention as the existing entries (`CVE-2026-33671`, `CVE-2026-48815`, `CVE-2026-12151`) for vulnerabilities bundled in the base image's npm CLI that the container never invokes at runtime (`node dist/migrate.js` only).


<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #
- Related to #

