### PR TITLE
fix(backend): correct dist entry path broken by TS6 rootDir change

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -78,4 +78,4 @@ HEALTHCHECK --interval=60s --timeout=5s --start-period=30s --retries=3 \
 
 # Use tini as init process
 ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["node", "dist/main"]
+CMD ["node", "dist/src/main"]

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -8,7 +8,7 @@
     "start": "nest start",
     "dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "pretest": "cd ../../packages/database && pnpm run db:test:setup",
     "test": "pnpm run pretest && vitest run && pnpm run posttest",


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description
Backend has been crashing on boot in every deploy since the TypeScript 6
migration (`2b5be2917`), with:

    Error: Cannot find module '/app/apps/backend/dist/main'

Two failed Backend deployment. [First](https://github.com/Jan-IngenHousz-Institute/open-jii/actions/runs/29783605292/job/88491131907#step:18:1) and [second](https://github.com/Jan-IngenHousz-Institute/open-jii/actions/runs/29826310124/job/88620925349#step:18:1)

## Root cause
TypeScript 6 made `rootDir` inference stricter: without an explicit value,
the build now hard-fails with `TS5011`. The TS6 migration commit correctly
added `"rootDir": "src"` to `apps/backend/tsconfig.build.json` to satisfy
this - that part is required and stays as-is.

The side effect: NestJS's `swc` builder now emits output to
`dist/src/main.js` instead of the previous `dist/main.js`. Nothing updated
the two places that hardcoded the old path, so every production boot
(`node dist/main`) fails with `MODULE_NOT_FOUND`.

## Fix
Point both hardcoded references at the new build output location:
- `apps/backend/Dockerfile`: `CMD ["node", "dist/main"]` -> `CMD ["node", "dist/src/main"]`
- `apps/backend/package.json`: `start:prod` script, same path update

## Test plan
- [x] Built the full image locally (`docker build -f apps/backend/Dockerfile .`)
      and confirmed `dist/src/main.js` is the actual build output.
- [x] Ran the built image with no env vars - previously crashed immediately
      with `MODULE_NOT_FOUND`; now Nest boots and initializes all modules
      (DatabaseModule, ORPCModule, HealthModule, AuthModule, etc.), only
      exiting afterward on an unrelated missing-env-var config check.
- [ ] Deploy to dev/staging and confirm the ECS task passes its health check.

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #
- Related to #