### PR TITLE
ci: run production build checks on Dependabot PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -208,12 +208,14 @@ jobs:
     needs: detect
     # Always invoke for Dependabot so the per-job dependabot gates in
     # production-checks.yml can run the full builds, even when a lockfile bump
-    # marks no app as affected.
-    if: needs.detect.outputs.has_affected_apps == 'true' || github.actor == 'dependabot[bot]'
+    # marks no app as affected. Key off the PR author (stable across re-runs),
+    # not github.actor (drifts to a human on re-run / push / edit).
+    if: needs.detect.outputs.has_affected_apps == 'true' || github.event.pull_request.user.login == 'dependabot[bot]'
     uses: ./.github/workflows/production-checks.yml
     secrets: inherit
     with:
       affected-apps: ${{ needs.detect.outputs.affected_apps || '[]' }}
+      is-dependabot: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
 
   release_preview:
     name: Release Preview (dry run)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -206,7 +206,10 @@ jobs:
   production_checks:
     name: Production Checks
     needs: detect
-    if: needs.detect.outputs.has_affected_apps == 'true'
+    # Always invoke for Dependabot so the per-job dependabot gates in
+    # production-checks.yml can run the full builds, even when a lockfile bump
+    # marks no app as affected.
+    if: needs.detect.outputs.has_affected_apps == 'true' || github.actor == 'dependabot[bot]'
     uses: ./.github/workflows/production-checks.yml
     secrets: inherit
     with:

--- a/.github/workflows/production-checks.yml
+++ b/.github/workflows/production-checks.yml
@@ -16,7 +16,9 @@ jobs:
   backend:
     name: Docker Build (Backend)
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || contains(fromJSON(inputs.affected-apps), 'backend')
+    # Dependabot lockfile bumps don't mark deployable apps as affected; run the
+    # full build anyway so the bump's blast radius is actually exercised.
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' || contains(fromJSON(inputs.affected-apps), 'backend')
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/docker-build-check
@@ -29,7 +31,7 @@ jobs:
   database:
     name: Docker Build (Database Migrations)
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || contains(fromJSON(inputs.affected-apps), '@repo/database')
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' || contains(fromJSON(inputs.affected-apps), '@repo/database')
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/docker-build-check
@@ -41,7 +43,7 @@ jobs:
   macro-sandbox:
     name: Docker Build (Macro Sandbox - ${{ matrix.language }})
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || contains(fromJSON(inputs.affected-apps), 'macro-sandbox')
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' || contains(fromJSON(inputs.affected-apps), 'macro-sandbox')
     strategy:
       fail-fast: false
       matrix:
@@ -59,7 +61,7 @@ jobs:
   web-opennext:
     name: OpenNext Build (Web)
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || contains(fromJSON(inputs.affected-apps), 'web')
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' || contains(fromJSON(inputs.affected-apps), 'web')
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/opennext-build
@@ -70,7 +72,7 @@ jobs:
   mobile:
     name: Expo Prebuild Check (Mobile)
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || contains(fromJSON(inputs.affected-apps), 'mobile')
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' || contains(fromJSON(inputs.affected-apps), 'mobile')
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nodejs-pnpm

--- a/.github/workflows/production-checks.yml
+++ b/.github/workflows/production-checks.yml
@@ -7,6 +7,11 @@ on:
         description: "JSON array of affected app names"
         required: true
         type: string
+      is-dependabot:
+        description: "Whether the PR was authored by Dependabot (stable across re-runs, unlike github.actor)"
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
 
 permissions:
@@ -18,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     # Dependabot lockfile bumps don't mark deployable apps as affected; run the
     # full build anyway so the bump's blast radius is actually exercised.
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' || contains(fromJSON(inputs.affected-apps), 'backend')
+    if: github.event_name == 'workflow_dispatch' || inputs.is-dependabot || contains(fromJSON(inputs.affected-apps), 'backend')
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/docker-build-check
@@ -31,7 +36,7 @@ jobs:
   database:
     name: Docker Build (Database Migrations)
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' || contains(fromJSON(inputs.affected-apps), '@repo/database')
+    if: github.event_name == 'workflow_dispatch' || inputs.is-dependabot || contains(fromJSON(inputs.affected-apps), '@repo/database')
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/docker-build-check
@@ -43,7 +48,7 @@ jobs:
   macro-sandbox:
     name: Docker Build (Macro Sandbox - ${{ matrix.language }})
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' || contains(fromJSON(inputs.affected-apps), 'macro-sandbox')
+    if: github.event_name == 'workflow_dispatch' || inputs.is-dependabot || contains(fromJSON(inputs.affected-apps), 'macro-sandbox')
     strategy:
       fail-fast: false
       matrix:
@@ -61,7 +66,7 @@ jobs:
   web-opennext:
     name: OpenNext Build (Web)
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' || contains(fromJSON(inputs.affected-apps), 'web')
+    if: github.event_name == 'workflow_dispatch' || inputs.is-dependabot || contains(fromJSON(inputs.affected-apps), 'web')
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/opennext-build
@@ -72,7 +77,7 @@ jobs:
   mobile:
     name: Expo Prebuild Check (Mobile)
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' || contains(fromJSON(inputs.affected-apps), 'mobile')
+    if: github.event_name == 'workflow_dispatch' || inputs.is-dependabot || contains(fromJSON(inputs.affected-apps), 'mobile')
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-nodejs-pnpm


### PR DESCRIPTION
## What

Add `github.actor == 'dependabot[bot]'` to the build-job `if:` gates in `production-checks.yml` (backend, database, macro-sandbox, web-opennext, mobile), and loosen the `production_checks` caller gate in `pr.yml` so the reusable workflow is invoked for Dependabot even when no app is flagged affected.

## Why

Dependabot bumps are lockfile-only changes, so `detect-affected-packages` marks no deployable app as affected. The Docker/OpenNext/Expo build jobs were therefore `skipped` on every Dependabot PR, leaving dependency bumps without a real build check. This runs the full builds so a bump's blast radius is actually exercised before merge.

## Notes

- These jobs are **not** required status checks, so a flaky build on a Dependabot PR will not block the merge (only `Build, Lint, & Test`, `Validate PR title`, and CodeQL gate merges).
- The web OpenNext build gets no `POSTHOG_KEY` on Dependabot runs (Actions secrets aren't exposed to Dependabot); the `opennext-build` action tolerates an empty key, so the build still succeeds.
- Takes effect on new/rebased Dependabot PRs, since `pull_request` runs use the workflow from the PR head.
- Unrelated: the current "waiting for Analyze (javascript-typescript)" merge block on open PRs is a stale required-check name in the branch ruleset (CodeQL moved to default setup, which emits `CodeQL`); that is fixed separately in repo settings, not here.