### PR TITLE
fix(mobile): pin EAS pnpm bootstrap (OJD-1681)

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -5,7 +5,7 @@
   "build": {
     "base": {
       "node": "24.18.0",
-      "corepack": true
+      "pnpm": "11.15.0"
     },
     "preview": {
       "extends": "base",


### PR DESCRIPTION
## Type of PR

- [x] Bug Fix

## Description

Corrects the EAS build-tool bootstrap from #1804. Every mobile build profile still inherits Node 24.18.0, but EAS now installs pnpm 11.15.0 directly and Corepack remains disabled.

## Root cause

The reported dependency-install logs did run under Node 20.19.4 because those builds predated the Node 24 configuration. The first post-merge SDK 57 build did consume Node 24.18.0, but failed earlier: Corepack created the pnpm executable and EAS then tried to install its image-default pnpm into the same path, producing EEXIST.

Explicitly configuring both EAS tool fields handles both failure modes:

- node: 24.18.0
- pnpm: 11.15.0
- corepack: absent (defaults false)

## Related Issues

- Closes #1803
- Related to #1804
- Linear: OJD-1681

## Validation

- [x] JSON and current EAS config/schema resolution pass
- [x] preview, internal, beta, and production resolve Node 24.18.0 and pnpm 11.15.0 with Corepack disabled
- [x] Existing channels, build types, auto-increment, and submit tracks are unchanged
- [x] Node 24.18.0 / pnpm 11.15.0 frozen workspace install passes
- [x] All GitHub PR checks pass
- [x] One Android internal EAS cloud build completed without auto-submit

## Cloud proof

Build: https://expo.dev/accounts/jan-ingenhousz-institute/projects/openjii/builds/36009761-c928-47cb-91f3-5e6cb7ad702d

- Commit: a0a8e186c745807b6fefe59005f3c0cf600de471
- Profile/channel: internal
- Android versionCode: 164
- Status: FINISHED
- Auto-submit: false; no submission record
- EAS log: Now using node v24.18.0
- EAS log: Installing pnpm@11.15.0
- EAS log: pnpm install --frozen-lockfile
- EAS log: Done in 40.2s using pnpm v11.15.0
- EAS log: BUILD SUCCESSFUL in 22m 28s
- Signed AAB artifact produced

## Scope and safety

The code diff is one line in apps/mobile/eas.json. The proof build was invoked directly without --auto-submit. No submission, EAS Update, deployment, or production build was performed.
