### PR TITLE
fix(infra): rename Mailchimp secret to unblock dev tofu apply

### DIFF
--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -1358,7 +1358,7 @@ module "contentful_secrets" {
 module "mailchimp_secrets" {
   source = "../../modules/secrets-manager"
 
-  name        = "openjii-mailchimp-secrets-${var.environment}"
+  name        = "openjii-newsletter-secrets-${var.environment}"
   description = "Mailchimp API secrets for the openJII backend service"
 
   # Store secrets as JSON using variables

--- a/infrastructure/env/dr/main.tf
+++ b/infrastructure/env/dr/main.tf
@@ -308,7 +308,7 @@ module "contentful_secrets" {
 module "mailchimp_secrets" {
   source = "../../modules/secrets-manager"
 
-  name        = "openjii-mailchimp-secrets-${var.environment}"
+  name        = "openjii-newsletter-secrets-${var.environment}"
   description = "Mailchimp API secrets for the openJII backend service"
 
   secret_string = jsonencode({

--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -1315,7 +1315,7 @@ module "contentful_secrets" {
 module "mailchimp_secrets" {
   source = "../../modules/secrets-manager"
 
-  name        = "openjii-mailchimp-secrets-${var.environment}"
+  name        = "openjii-newsletter-secrets-${var.environment}"
   description = "Mailchimp API secrets for the openJII backend service"
 
   # Store secrets as JSON using variables


### PR DESCRIPTION
## Problem

The last two dev deploys from `main` failed in **Deploy Infrastructure / OpenTofu Apply** ([run 29913552313](https://github.com/Jan-IngenHousz-Institute/open-jii/actions/runs/29913552313), [run 29918740321](https://github.com/Jan-IngenHousz-Institute/open-jii/actions/runs/29918740321)):

```
Error: creating Secrets Manager Secret (openjii-mailchimp-secrets-dev):
InvalidRequestException: You can't create this secret because a secret
with this name is already scheduled for deletion.
```

A secret with that exact name was deleted earlier (presumably during #1802 testing) and is sitting in the Secrets Manager recovery window (module default: 7 days), which blocks re-creating the name until the window expires.

## Fix

Rename the secret to `openjii-newsletter-secrets-<env>` in dev, dr, and prod. This stays within the existing `openjii-<thing>-secrets-<env>` convention and sidesteps the tombstoned name. The ECS task definitions and everything else reference `module.mailchimp_secrets.secret_arn`, so no other changes are needed.

Alternative would be `aws secretsmanager delete-secret --force-delete-without-recovery` on the old name, but the rename keeps the fix in code and avoids the same trap on the next delete/recreate cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)