### PR TITLE
fix(backend): normalize completed export metadata before ORPC output validation

### DIFF
--- a/apps/backend/src/experiments/core/repositories/experiment-data-exports.repository.spec.ts
+++ b/apps/backend/src/experiments/core/repositories/experiment-data-exports.repository.spec.ts
@@ -164,6 +164,115 @@ describe("ExperimentDataExportsRepository", () => {
       expect(result.value[0].exportId).toBeNull();
       expect(result.value[1].status).toBe("completed");
       expect(result.value[1].exportId).toBe("completed-export-1");
+      expect(result.value[1].rowCount).toBe(1000);
+      expect(result.value[1].fileSize).toBe(50000);
+      expect(result.value[1].jobRunId).toBe(111);
+    });
+
+    it("should normalize raw Databricks numeric and timestamp cells", async () => {
+      const exportId = faker.string.uuid();
+      const mockSchemaData = {
+        columns: [
+          { name: "export_id", type_name: "string", type_text: "string", position: 0 },
+          { name: "experiment_id", type_name: "string", type_text: "string", position: 1 },
+          { name: "table_name", type_name: "string", type_text: "string", position: 2 },
+          { name: "format", type_name: "string", type_text: "string", position: 3 },
+          { name: "status", type_name: "string", type_text: "string", position: 4 },
+          { name: "file_path", type_name: "string", type_text: "string", position: 5 },
+          { name: "row_count", type_name: "bigint", type_text: "bigint", position: 6 },
+          { name: "file_size", type_name: "bigint", type_text: "bigint", position: 7 },
+          { name: "created_by", type_name: "string", type_text: "string", position: 8 },
+          { name: "created_at", type_name: "timestamp", type_text: "timestamp", position: 9 },
+          { name: "completed_at", type_name: "timestamp", type_text: "timestamp", position: 10 },
+          { name: "job_run_id", type_name: "bigint", type_text: "bigint", position: 11 },
+        ],
+        rows: [
+          [
+            exportId,
+            experimentId,
+            tableName,
+            "parquet",
+            "completed",
+            "/path/to/file.parquet",
+            "2500",
+            "1048576",
+            faker.string.uuid(),
+            "2026-07-18 09:55:01.123456",
+            "2026-07-18 09:59:55.892636",
+            "987654",
+          ],
+        ],
+        totalRows: 1,
+        truncated: false,
+      };
+
+      vi.spyOn(databricksPort, "getExportMetadata").mockResolvedValue(success(mockSchemaData));
+      vi.spyOn(databricksPort, "getActiveExports").mockResolvedValue(success([]));
+      vi.spyOn(databricksPort, "getFailedExports").mockResolvedValue(success([]));
+
+      const result = await repository.listExports({ experimentId, tableName });
+
+      assertSuccess(result);
+      expect(result.value[0]).toMatchObject({
+        exportId,
+        rowCount: 2500,
+        fileSize: 1048576,
+        createdAt: "2026-07-18T09:55:01.123456Z",
+        completedAt: "2026-07-18T09:59:55.892636Z",
+        jobRunId: 987654,
+      });
+    });
+
+    it("should map empty and invalid nullable integers to null", async () => {
+      const mockSchemaData = {
+        columns: [
+          { name: "export_id", type_name: "string", type_text: "string", position: 0 },
+          { name: "experiment_id", type_name: "string", type_text: "string", position: 1 },
+          { name: "table_name", type_name: "string", type_text: "string", position: 2 },
+          { name: "format", type_name: "string", type_text: "string", position: 3 },
+          { name: "status", type_name: "string", type_text: "string", position: 4 },
+          { name: "file_path", type_name: "string", type_text: "string", position: 5 },
+          { name: "row_count", type_name: "bigint", type_text: "bigint", position: 6 },
+          { name: "file_size", type_name: "bigint", type_text: "bigint", position: 7 },
+          { name: "created_by", type_name: "string", type_text: "string", position: 8 },
+          { name: "created_at", type_name: "timestamp", type_text: "timestamp", position: 9 },
+          { name: "completed_at", type_name: "timestamp", type_text: "timestamp", position: 10 },
+          { name: "job_run_id", type_name: "bigint", type_text: "bigint", position: 11 },
+        ],
+        rows: [
+          [
+            faker.string.uuid(),
+            experimentId,
+            tableName,
+            "csv",
+            "completed",
+            null,
+            "",
+            "12MB",
+            faker.string.uuid(),
+            "2026-07-18 09:55:01",
+            null,
+            null,
+          ],
+        ],
+        totalRows: 1,
+        truncated: false,
+      };
+
+      vi.spyOn(databricksPort, "getExportMetadata").mockResolvedValue(success(mockSchemaData));
+      vi.spyOn(databricksPort, "getActiveExports").mockResolvedValue(success([]));
+      vi.spyOn(databricksPort, "getFailedExports").mockResolvedValue(success([]));
+
+      const result = await repository.listExports({ experimentId, tableName });
+
+      assertSuccess(result);
+      expect(result.value[0]).toMatchObject({
+        filePath: null,
+        rowCount: null,
+        fileSize: null,
+        completedAt: null,
+        jobRunId: null,
+      });
     });
 
     it("should return only completed exports when getActiveExports fails", async () => {

--- a/apps/backend/src/experiments/core/repositories/experiment-data-exports.repository.ts
+++ b/apps/backend/src/experiments/core/repositories/experiment-data-exports.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable, Inject, Logger } from "@nestjs/common";
 import { Readable } from "stream";
 
+import type { SchemaData } from "../../../common/modules/databricks/services/sql/sql.types";
 import { Result, success } from "../../../common/utils/fp-utils";
 import type { ExportMetadata } from "../models/experiment-data-exports.model";
 import { DATABRICKS_PORT } from "../ports/databricks.port";
@@ -88,33 +89,7 @@ export class ExperimentDataExportsRepository {
       return completedResult;
     }
 
-    // Map database columns (snake_case) to domain model (camelCase)
-    const columnMapping: Record<string, string> = {
-      export_id: "exportId",
-      experiment_id: "experimentId",
-      table_name: "tableName",
-      format: "format",
-      status: "status",
-      file_path: "filePath",
-      row_count: "rowCount",
-      file_size: "fileSize",
-      created_by: "createdBy",
-      created_at: "createdAt",
-      completed_at: "completedAt",
-      job_run_id: "jobRunId",
-    };
-
-    const schemaData = completedResult.value;
-    const completedExports: ExportMetadata[] = schemaData.rows.map((row) => {
-      const exportRecord: Record<string, any> = {};
-      schemaData.columns.forEach((col, index) => {
-        const mappedKey = columnMapping[col.name];
-        if (mappedKey) {
-          exportRecord[mappedKey] = row[index];
-        }
-      });
-      return exportRecord as ExportMetadata;
-    });
+    const completedExports = this.mapCompletedRows(completedResult.value);
 
     // Get active exports from job runs
     const activeResult = await this.databricksPort.getActiveExports(experimentId, tableName);
@@ -172,6 +147,89 @@ export class ExperimentDataExportsRepository {
     });
 
     return success(allExports);
+  }
+
+  private mapCompletedRows(schemaData: SchemaData): ExportMetadata[] {
+    const idx = (name: string): number =>
+      schemaData.columns.findIndex((column) => column.name === name);
+    const exportIdIdx = idx("export_id");
+    const experimentIdIdx = idx("experiment_id");
+    const tableNameIdx = idx("table_name");
+    const formatIdx = idx("format");
+    const statusIdx = idx("status");
+    const filePathIdx = idx("file_path");
+    const rowCountIdx = idx("row_count");
+    const fileSizeIdx = idx("file_size");
+    const createdByIdx = idx("created_by");
+    const createdAtIdx = idx("created_at");
+    const completedAtIdx = idx("completed_at");
+    const jobRunIdIdx = idx("job_run_id");
+
+    const emptyToNull = (value: string | null | undefined): string | null => {
+      const normalized = value?.trim();
+      if (!normalized) {
+        return null;
+      }
+      return normalized;
+    };
+
+    const normalizeTimestamp = (value: string | null | undefined): string | null => {
+      const normalized = emptyToNull(value);
+      if (!normalized) {
+        return null;
+      }
+
+      // Databricks SQL timestamps have no offset. Treat export metadata as UTC
+      // so the conversion is deterministic and satisfies the API contract.
+      if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)?$/.test(normalized)) {
+        return `${normalized.replace(" ", "T")}Z`;
+      }
+
+      return normalized;
+    };
+
+    const parseIntegerOrNull = (
+      value: string | null | undefined,
+      field: "row_count" | "file_size" | "job_run_id",
+      exportId: string | null,
+    ): number | null => {
+      const normalized = emptyToNull(value);
+      if (!normalized) {
+        return null;
+      }
+
+      const parsed = Number(normalized);
+      if (/^-?\d+$/.test(normalized) && Number.isSafeInteger(parsed)) {
+        return parsed;
+      }
+
+      this.logger.warn({
+        msg: "Ignoring invalid integer in completed export metadata",
+        operation: "mapCompletedRows",
+        exportId,
+        field,
+      });
+      return null;
+    };
+
+    return schemaData.rows.map((row) => {
+      const exportId = emptyToNull(row[exportIdIdx]);
+
+      return {
+        exportId,
+        experimentId: row[experimentIdIdx] ?? "",
+        tableName: row[tableNameIdx] ?? "",
+        format: (row[formatIdx] ?? "") as ExportMetadata["format"],
+        status: (row[statusIdx] ?? "") as ExportMetadata["status"],
+        filePath: emptyToNull(row[filePathIdx]),
+        rowCount: parseIntegerOrNull(row[rowCountIdx], "row_count", exportId),
+        fileSize: parseIntegerOrNull(row[fileSizeIdx], "file_size", exportId),
+        createdBy: row[createdByIdx] ?? "",
+        createdAt: normalizeTimestamp(row[createdAtIdx]) ?? "",
+        completedAt: normalizeTimestamp(row[completedAtIdx]),
+        jobRunId: parseIntegerOrNull(row[jobRunIdIdx], "job_run_id", exportId),
+      };
+    });
   }
 
   /**

--- a/apps/backend/src/experiments/presentation/experiment-data-exports.controller.spec.ts
+++ b/apps/backend/src/experiments/presentation/experiment-data-exports.controller.spec.ts
@@ -94,11 +94,11 @@ describe("ExperimentDataExportsController", () => {
         format: "csv" as const,
         status: "completed" as const,
         filePath: "/path/to/file.csv",
-        rowCount: 500,
-        fileSize: 25000,
+        rowCount: 2500,
+        fileSize: 1048576,
         createdBy: testUserId,
-        createdAt: "2026-01-01T00:00:00Z",
-        completedAt: "2026-01-01T00:05:00Z",
+        createdAt: "2026-07-18T09:55:01.123456Z",
+        completedAt: "2026-07-18T09:59:55.892636Z",
       };
 
       vi.spyOn(listExportsUseCase, "execute").mockResolvedValue(


### PR DESCRIPTION
## Problem

Opening the data-export modal failed (ORPC output validation error / 500) for any table with **completed** export history. Databricks returns the metadata cells as `string | null`:

- `row_count` / `file_size` arrive as numeric **strings** (e.g. `"62"`, `"6325"`)
- timestamps arrive **timezone-less**, space-separated with microseconds (e.g. `2026-07-18 09:59:55.892636`)

The strict `ExperimentExportRecord` contract expects `z.number().int()` and `z.string().datetime()`, so serialization rejected these rows.

## Fix

Normalize completed rows at the **repository boundary** (`ExperimentDataExportsRepository.mapCompletedRows`), keeping the API contract strict (no coercion in the schema):

- Numeric strings → nullable safe integers; non-numeric / out-of-range values are logged and returned as `null` rather than emitting `NaN` or a misleading value.
- Space-separated Databricks timestamps → `Z`-suffixed ISO strings. Timezone-less export metadata is interpreted as **UTC** (deterministic; the export task writes timezone-less timestamps).
- Empty/whitespace nullable cells map consistently to `null`.

Active and failed export paths already emit ISO timestamps via `new Date(...).toISOString()` and are untouched.

### Side effect
`jobRunId` is now parsed to a real `number`, so the `Set<number>` run-id dedup in `getFailedExports` actually matches (previously a raw string was added to the set, so the dedup silently never hit).

## Scope
- Normalization + regression coverage only. No contract relaxation, no Databricks schema migration, no export-generation or modal-UX changes, no existing-metadata cleanup.

## Tests
- Repository spec: proves numeric + timestamp normalization from raw Databricks-shaped rows, and that empty/invalid nullable integers map to `null`.
- Controller spec: proves the normalized response (microsecond ISO timestamps) passes ORPC output validation and strips internal fields (`jobRunId`).
