### PR TITLE
fix(iot): classify hello replies by device key across all families, case-insensitively

### DIFF
--- a/packages/iot/src/core/identify-device.spec.ts
+++ b/packages/iot/src/core/identify-device.spec.ts
@@ -121,6 +121,21 @@ describe("identifyDevice", () => {
     expect(identified.info.firmwareVersion).toBe("1.04");
   });
 
+  it("prefers the name key of a JSON hello and keeps it through enrichment", async () => {
+    const jsonHello = '{"device":"MiniPAR","version":"1.1","name":"Roof PAR"}';
+    const transport = createMockTransport((payload, reply) => {
+      if (payload === HELLO) reply(jsonHello);
+      if (payload === "hello\n") reply(jsonHello + "\n");
+      if (payload === "get_name\n") reply("NoName\n");
+    });
+
+    const identified = await identifyDevice(transport, { probeTimeoutMs: 50 });
+
+    expect(identified.family).toBe("minipar");
+    expect(identified.info.name).toBe("Roof PAR");
+    expect(identified.info.firmwareVersion).toBe("1.1");
+  });
+
   it("classifies the miniPAR CSV hello as minipar with the firmware column", async () => {
     const transport = createMockTransport((payload, reply) => {
       if (payload === HELLO) reply("MiniPAR,1.1,1.04");
@@ -149,6 +164,36 @@ describe("identifyDevice", () => {
     expect(identified.info.raw.helloReply).toBe("NEW Name Here Ready");
   });
 
+  it("classifies a JSON hello by its device key case-insensitively, capturing name and version", async () => {
+    const jsonHello = '{"device":"Ambit","version":"2.0","name":"Greenhouse A"}\nAmbit Ready\n';
+    const transport = createMockTransport((payload, reply) => {
+      if (payload === HELLO || payload === "hello\n") reply(jsonHello);
+    });
+
+    const identified = await identifyDevice(transport, { probeTimeoutMs: 50 });
+
+    expect(identified.family).toBe("ambit");
+    expect(identified.connector).toBeInstanceOf(AmbitDriver);
+    expect(identified.info.name).toBe("Greenhouse A");
+    expect(identified.info.firmwareVersion).toBe("2.0");
+  });
+
+  it("keeps a self-declared unknown device (CO2Dot) off the AmbitDriver and on the raw fallback", async () => {
+    const transport = createMockTransport((payload, reply) => {
+      if (payload === HELLO)
+        reply('{"device":"CO2Dot","version":"0.4","name":"Bench CO2"}\nCO2Dot Ready\n');
+    });
+
+    const identified = await identifyDevice(transport, { probeTimeoutMs: 30 });
+
+    expect(identified.family).toBe("generic");
+    expect(identified.connector).toBeInstanceOf(GenericCommandConnector);
+    expect(identified.info.name).toBe("Bench CO2");
+    expect(identified.info.firmwareVersion).toBe("0.4");
+    // The Ready line alone must not classify it as ambit; INFO was still tried.
+    expect(transport.sent).toContain(INFO);
+  });
+
   it("falls through to the INFO probe and picks the generic driver", async () => {
     const transport = createMockTransport(infoReply(GENERIC_INFO));
 
@@ -166,8 +211,8 @@ describe("identifyDevice", () => {
     expect(transport.sent.filter((p) => p === INFO)).toHaveLength(2);
   });
 
-  it("maps INFO device_type ambit onto the ambit family", async () => {
-    const answerInfo = infoReply({ ...GENERIC_INFO, device_type: "ambit" });
+  it("maps INFO device_type onto the family case-insensitively", async () => {
+    const answerInfo = infoReply({ ...GENERIC_INFO, device_type: "Ambit" });
     const transport = createMockTransport((payload, reply) => {
       answerInfo(payload, reply);
       if (payload === "hello\n") reply("NEW WeatherBox Ready\n");

--- a/packages/iot/src/core/identify-device.ts
+++ b/packages/iot/src/core/identify-device.ts
@@ -13,7 +13,7 @@ import type { ITransportAdapter } from "../transport/interface";
 import type { Logger } from "../utils/logger/logger";
 import { defaultLogger } from "../utils/logger/logger";
 import type { DeviceIdentity, SensorFamily } from "./families";
-import { isSensorFamily } from "./families";
+import { isSensorFamily, SENSOR_FAMILIES } from "./families";
 
 export interface IdentifyDeviceOptions {
   /** Per-probe reply timeout in ms (default 2000). */
@@ -89,42 +89,71 @@ function createProbeSession(transport: ITransportAdapter) {
   };
 }
 
+interface JsonHello {
+  family: SensorFamily | null;
+  name?: string;
+  firmwareVersion?: string;
+}
+
+/**
+ * JSON hello line carrying a string `device` key, lowercase-matched against
+ * the known families (family null when unrecognized, first recognized line
+ * wins). Every JSON hello carries `version`; some carry a persisted `name`.
+ */
+function parseJsonHello(text: string): JsonHello | null {
+  let unknown: JsonHello | null = null;
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue; // not JSON, keep scanning
+    }
+    if (parsed === null || typeof parsed !== "object") continue;
+    const record = parsed as Record<string, unknown>;
+    if (typeof record.device !== "string") continue;
+    const device = record.device.toLowerCase();
+    const hello: JsonHello = {
+      family: SENSOR_FAMILIES.find((candidate) => device.includes(candidate)) ?? null,
+      name:
+        typeof record.name === "string" && record.name.trim() !== ""
+          ? record.name.trim()
+          : record.device,
+      firmwareVersion: typeof record.version === "string" ? record.version : undefined,
+    };
+    if (hello.family) return hello;
+    unknown ??= hello;
+  }
+  return unknown;
+}
+
 /**
  * Classify a hello reply against the known firmware signatures, weakest
- * signature last:
- *  - miniPAR: `{"device":"MiniPAR","version":"1.1"}` (JSON mode) or
- *    `MiniPAR,1.1,1.04` (line mode)
+ * signature last. All matching is lowercase-normalized:
+ *  - JSON hello (e.g. `{"device":"MiniPAR","version":"1.1"}`): the `device`
+ *    key names the family
+ *  - miniPAR line mode: `MiniPAR,1.1,1.04`
  *  - MultispeQ: `MultispeQ Ready`, older firmware `Instrument Ready`
  *  - Ambit: any other `<name> Ready` line (firmware prints a hardcoded
- *    `NEW Name Here Ready`; never trust the name, only the sentinel)
+ *    `NEW Name Here Ready`; never trust the name, only the sentinel), skipped
+ *    when a JSON line self-declared an unrecognized device (e.g. CO2Dot):
+ *    that must fall through rather than be handed to the AmbitDriver
  */
 function classifyHelloReply(reply: string): DeviceIdentity | null {
   const text = reply.trim();
   if (!text) return null;
   const raw = { helloReply: text };
 
-  for (const line of text.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed.startsWith("{")) continue;
-    try {
-      const parsed: unknown = JSON.parse(trimmed);
-      if (
-        parsed !== null &&
-        typeof parsed === "object" &&
-        typeof (parsed as Record<string, unknown>).device === "string" &&
-        /minipar/i.test((parsed as Record<string, unknown>).device as string)
-      ) {
-        const version = (parsed as Record<string, unknown>).version;
-        return {
-          family: "minipar",
-          name: (parsed as Record<string, unknown>).device as string,
-          firmwareVersion: typeof version === "string" ? version : undefined,
-          raw,
-        };
-      }
-    } catch {
-      // not JSON, keep scanning
-    }
+  const jsonHello = parseJsonHello(text);
+  if (jsonHello?.family) {
+    return {
+      family: jsonHello.family,
+      name: jsonHello.name,
+      firmwareVersion: jsonHello.firmwareVersion,
+      raw,
+    };
   }
 
   const csvMatch = /^minipar\s*,\s*(?<version>[^,\s]+)\s*(?:,\s*(?<firmware>[^,\s]+))?/im.exec(
@@ -142,6 +171,9 @@ function classifyHelloReply(reply: string): DeviceIdentity | null {
   if (/multispeq/i.test(text) || /instrument\s+ready/i.test(text)) {
     return { family: "multispeq", raw };
   }
+
+  // A self-declared unknown device outranks the weak Ready sentinel.
+  if (jsonHello) return null;
 
   const readyMatch = /^(.*?)\s*\bready\b\s*$/im.exec(text);
   if (readyMatch) {
@@ -223,6 +255,7 @@ export async function identifyDevice(
 
   let probeIdentity: DeviceIdentity | undefined;
   let connector: IDeviceDriver | undefined;
+  let helloReply = "";
 
   // Probe 1: every known console firmware answers "hello" with a signature.
   for (let attempt = 0; attempt <= helloRetries; attempt++) {
@@ -231,6 +264,7 @@ export async function identifyDevice(
       isComplete: (buffer) => buffer.includes("\n") || classifyHelloReply(buffer) !== null,
     });
     if (reply.trim() === "") continue;
+    helloReply = reply.trim();
     const classified = classifyHelloReply(reply);
     if (classified) {
       log.debug("identify: hello probe matched", { family: classified.family });
@@ -252,7 +286,9 @@ export async function identifyDevice(
         parsed.data !== null && typeof parsed.data === "object"
           ? (parsed.data as Record<string, unknown>)
           : {};
-      const family: SensorFamily = isSensorFamily(data.device_type) ? data.device_type : "generic";
+      const deviceType =
+        typeof data.device_type === "string" ? data.device_type.toLowerCase() : data.device_type;
+      const family: SensorFamily = isSensorFamily(deviceType) ? deviceType : "generic";
       log.debug("identify: INFO probe matched", { family });
       probeIdentity = {
         family,
@@ -266,10 +302,23 @@ export async function identifyDevice(
     }
   }
 
-  // Both probes silent: last-resort verbatim connector.
+  // Nothing classified: last-resort verbatim connector, keeping any identity
+  // an unrecognized device self-declared over hello.
   if (!connector || !probeIdentity) {
-    log.debug("identify: probes silent, falling back to raw command connector");
-    probeIdentity = { family: "generic", raw: {} };
+    const selfDeclared = parseJsonHello(helloReply);
+    log.debug(
+      selfDeclared
+        ? "identify: unrecognized hello device key, raw connector with self-declared identity"
+        : "identify: probes silent, falling back to raw command connector",
+    );
+    probeIdentity = selfDeclared
+      ? {
+          family: "generic",
+          name: selfDeclared.name,
+          firmwareVersion: selfDeclared.firmwareVersion,
+          raw: { helloReply },
+        }
+      : { family: "generic", raw: {} };
     connector = new GenericCommandConnector(undefined, options?.logger);
   }
 

--- a/packages/iot/src/driver/minipar/driver.ts
+++ b/packages/iot/src/driver/minipar/driver.ts
@@ -192,7 +192,11 @@ export class MiniParDriver extends DeviceDriver<MiniParStreamEvents> {
     } else {
       try {
         const parsed = JSON.parse(text) as Record<string, unknown>;
-        if (typeof parsed.device === "string") name = parsed.device;
+        if (typeof parsed.name === "string" && parsed.name.trim() !== "") {
+          name = parsed.name.trim();
+        } else if (typeof parsed.device === "string") {
+          name = parsed.device;
+        }
         if (typeof parsed.version === "string") firmwareVersion = parsed.version;
       } catch {
         // unrecognized hello; identity stays minimal


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [x] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

The identify handshake (`identifyDevice` hello probe) only used the `device` key of a JSON hello reply to detect MiniPAR; MultispeQ and Ambit were matched purely on text sentinels, and the INFO probe compared `device_type` case-sensitively, so a device reporting `"Ambit"` or `"MultispeQ"` silently fell through to the generic driver.

JSON hello replies carry `device` and `version`, and some carry a persisted `name`. The classifier now uses these keys generically for every family, with all matching lowercase-normalized:

- the `device` key is lowercased and matched against every known sensor family, not just minipar
- `version` is captured as `firmwareVersion` for all families, and a non-empty `name` key is used as the device name (falling back to the `device` value)
- INFO probe `device_type` is lowercased before the family check
- `MiniParDriver.getDeviceIdentity` prefers the `name` key over `device` so a probe-captured name is not clobbered during identity enrichment

Unknown self-declared devices (e.g. a CO2Dot, which is not a known sensor family yet) are also handled safely now:

- a JSON hello declaring an unrecognized `device` no longer falls through to the weak `<x> Ready` sentinel, which previously would have misclassified it as ambit and handed it the AmbitDriver
- it still gets the INFO probe chance, and if that is silent it connects through the raw `GenericCommandConnector` carrying its self-declared name and firmware version instead of an empty identity

Text sentinels (`MultispeQ Ready` / `Instrument Ready` / bare `<x> Ready` for Ambit) are unchanged, including never trusting the hardcoded name Ambit prints before `Ready`.

## Related Issues

- Follow-up on the multi-device identify handshake from #1791

## Testing Instructions

- [x] `pnpm vitest run` in `packages/iot`: 329/329 pass
- [x] `pnpm lint` and `pnpm tsc --noEmit` in `packages/iot`: clean

## Changes Made

- `packages/iot/src/core/identify-device.ts`: extracted `parseJsonHello`, generalized JSON hello classification to all families with lowercase matching, suppressed the Ready sentinel for self-declared unknown devices, lowercased INFO `device_type`, and preserved self-declared identity in the raw fallback
- `packages/iot/src/driver/minipar/driver.ts`: prefer the `name` key over `device` when parsing the hello reply in `getDeviceIdentity`
- `packages/iot/src/core/identify-device.spec.ts`: new cases for JSON hello name/version capture (MiniPAR and Ambit), case-insensitive `device_type`, and the unknown-device (CO2Dot) fallback

## Checklist

- [x] I have added/updated tests for my changes
- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have tested these changes locally
- [x] My changes generate no new warnings
- [x] I have reviewed my own code

## Screenshots/Recordings

N/A

## Additional Notes

Making CO2Dot a first-class family still requires the hand-synced trio (pg `sensor_family` enum migration, `zSensorFamily` in `@repo/api`, `SENSOR_FAMILIES` in `@repo/iot`) plus a driver and dispatch/UI support, and is blocked on knowing its actual console contract. This PR only guarantees it identifies gracefully as generic in the meantime.
