### PR TITLE
fix(mobile): show full device MAC in nearby scan list

### DIFF
--- a/apps/mobile/src/features/connection/components/device-sheet/nearby-device-row.tsx
+++ b/apps/mobile/src/features/connection/components/device-sheet/nearby-device-row.tsx
@@ -41,8 +41,10 @@ export function NearbyDeviceRow({ device, isConnecting, onConnect, isLast }: Nea
 
   const presentation = presentMobileDevice(device);
   const title = mobileDevicePrimaryLabel(presentation, t("identity.unknownDevice"));
+  // Omit the "Measurement device" role label here: before the identity
+  // handshake completes the role is only assumed, and dropping it keeps the
+  // device's identifier (often a full MAC) fully visible instead of truncated.
   const subParts = mobileDeviceSecondaryParts(presentation, {
-    measurementDevice: t("identity.measurementDevice"),
     identifier: (id) => t("identity.identifier", { id }),
   });
   if (sigKey) subParts.push(t("deviceList.signal", { strength: t(`deviceList.${sigKey}`) }));

--- a/apps/mobile/src/features/connection/services/mobile-device-presentation.test.ts
+++ b/apps/mobile/src/features/connection/services/mobile-device-presentation.test.ts
@@ -55,6 +55,14 @@ describe("presentMobileDevice", () => {
     ]);
   });
 
+  it("omits the role label when no measurement-device label is provided", () => {
+    const presentation = presentMobileDevice(device, identity({}));
+
+    expect(mobileDeviceSecondaryParts(presentation, { identifier: labels.identifier })).toEqual([
+      "ID AA:BB:CC:DD:EE:FF",
+    ]);
+  });
+
   it("does not fabricate MultispeQ while identity is unavailable or failed", () => {
     const presentation = presentMobileDevice(device);
 

--- a/apps/mobile/src/features/connection/services/mobile-device-presentation.ts
+++ b/apps/mobile/src/features/connection/services/mobile-device-presentation.ts
@@ -57,7 +57,13 @@ export function mobileDeviceAttributedLabel(
 }
 
 interface SecondaryLabels {
-  measurementDevice: string;
+  /**
+   * Role label for the measurement-device role. Omit it to suppress the role
+   * line entirely — pre-identity surfaces (the nearby scan list) shouldn't
+   * assert a role that hasn't been confirmed, and dropping it keeps the
+   * identifier fully visible instead of pushed off-screen.
+   */
+  measurementDevice?: string;
   identifier: (id: string) => string;
 }
 
@@ -75,7 +81,9 @@ export function mobileDeviceSecondaryParts(
   ) {
     parts.push(presentation.productName);
   }
-  if (presentation.roles.includes("measurement-device")) parts.push(labels.measurementDevice);
+  if (labels.measurementDevice && presentation.roles.includes("measurement-device")) {
+    parts.push(labels.measurementDevice);
+  }
   if (presentation.id) parts.push(labels.identifier(presentation.id));
   return parts;
 }


### PR DESCRIPTION
## Problem

In the mobile app's device drawer, the **Nearby devices** section truncated each device's MAC address on most phones. The MAC (rendered as the row's identifier) was being pushed off-screen by a redundant **"Measurement device"** label placed ahead of it in the subtitle.

That label came from `presentMobileDevice`, which assumes the `measurement-device` role for *every* device **before** the identity handshake completes. So the label was always shown, added nothing (you can't actually confirm a device is a MultispeQ — or read its battery — until you connect), and stole the horizontal space the identifier needed.

## Change

- `mobileDeviceSecondaryParts`: the `measurementDevice` role label is now **optional** — omit it to suppress the role line entirely.
- `NearbyDeviceRow`: stop passing the role label, so the device identifier (often a full MAC) is shown in full.
- The **connected-device row** and **home card** — where the device is already connected/known — are unchanged and keep the label.

## Tests

- Added a case in `mobile-device-presentation.test.ts` covering the omitted-label path.
- `vitest` (presentation service, connected-device row, home card), `tsc --noEmit`, and `eslint` all pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)