### PR TITLE
fix(web): search workbooks server-side in the attach picker

### DIFF
--- a/apps/web/components/experiment-flow/empty-workbook-state.tsx
+++ b/apps/web/components/experiment-flow/empty-workbook-state.tsx
@@ -3,7 +3,6 @@
 import { useAttachWorkbook } from "@/hooks/experiment/useAttachWorkbook/useAttachWorkbook";
 import { useLocale } from "@/hooks/useLocale";
 import { useWorkbookCreate } from "@/hooks/workbook/useWorkbookCreate/useWorkbookCreate";
-import { useWorkbookList } from "@/hooks/workbook/useWorkbookList/useWorkbookList";
 import { BookOpen, LinkIcon, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -31,7 +30,6 @@ export function EmptyWorkbookState({
 
   const attachWorkbook = useAttachWorkbook();
   const [selectedWorkbookId, setSelectedWorkbookId] = useState("");
-  const { data: workbooks = [] } = useWorkbookList();
 
   // Create + attach + open in one step: a fresh workbook is only useful once it
   // is linked to this experiment and the user can start adding cells.
@@ -88,7 +86,6 @@ export function EmptyWorkbookState({
           <div className="flex flex-col items-center gap-4">
             <div className="flex items-center gap-2">
               <WorkbookSelect
-                workbooks={workbooks}
                 value={selectedWorkbookId || undefined}
                 onChange={(id) => setSelectedWorkbookId(id ?? "")}
                 triggerPlaceholder={t("newExperiment.workbookPlaceholder")}

--- a/apps/web/components/experiment-flow/linked-workbook-card.tsx
+++ b/apps/web/components/experiment-flow/linked-workbook-card.tsx
@@ -5,7 +5,6 @@ import { useAttachWorkbook } from "@/hooks/experiment/useAttachWorkbook/useAttac
 import { useDetachWorkbook } from "@/hooks/experiment/useDetachWorkbook/useDetachWorkbook";
 import { useUpgradeWorkbookVersion } from "@/hooks/experiment/useUpgradeWorkbookVersion/useUpgradeWorkbookVersion";
 import { useWorkbook } from "@/hooks/workbook/useWorkbook/useWorkbook";
-import { useWorkbookList } from "@/hooks/workbook/useWorkbookList/useWorkbookList";
 import { useWorkbookUpdate } from "@/hooks/workbook/useWorkbookUpdate/useWorkbookUpdate";
 import { useWorkbookVersions } from "@/hooks/workbook/useWorkbookVersions/useWorkbookVersions";
 import { orpc } from "@/lib/orpc";
@@ -110,7 +109,6 @@ export function LinkedWorkbookCard({
 
   const attachWorkbook = useAttachWorkbook();
   const [selectedWorkbookId, setSelectedWorkbookId] = useState("");
-  const { data: workbooks = [] } = useWorkbookList();
   const [isChanging, setIsChanging] = useState(false);
 
   const renameWorkbook = useWorkbookUpdate(workbookId);
@@ -419,7 +417,6 @@ export function LinkedWorkbookCard({
       {isChanging && hasAccess && (
         <div className="flex items-center gap-2 border-t px-4 py-3">
           <WorkbookSelect
-            workbooks={workbooks}
             value={selectedWorkbookId || undefined}
             onChange={(id) => setSelectedWorkbookId(id ?? "")}
             triggerPlaceholder={t("flow.selectWorkbook")}

--- a/apps/web/components/new-experiment/new-experiment-details-card.tsx
+++ b/apps/web/components/new-experiment/new-experiment-details-card.tsx
@@ -13,7 +13,6 @@ import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@repo/
 import { Input } from "@repo/ui/components/input";
 import { RichTextarea } from "@repo/ui/components/rich-textarea";
 
-import { useWorkbookList } from "../../hooks/workbook/useWorkbookList/useWorkbookList";
 import { WorkbookSelect } from "../workbook/workbook-select";
 
 interface NewExperimentDetailsCardProps {
@@ -22,8 +21,6 @@ interface NewExperimentDetailsCardProps {
 
 export function NewExperimentDetailsCard({ form }: NewExperimentDetailsCardProps) {
   const { t } = useTranslation();
-
-  const { data: workbooks = [] } = useWorkbookList();
 
   return (
     <Card>
@@ -69,7 +66,6 @@ export function NewExperimentDetailsCard({ form }: NewExperimentDetailsCardProps
             <FormItem>
               <FormLabel>{t("newExperiment.workbook")}</FormLabel>
               <WorkbookSelect
-                workbooks={workbooks}
                 value={field.value ?? undefined}
                 onChange={(id) => field.onChange(id ?? undefined)}
                 triggerPlaceholder={t("newExperiment.workbookPlaceholder")}

--- a/apps/web/components/workbook/workbook-select.test.tsx
+++ b/apps/web/components/workbook/workbook-select.test.tsx
@@ -198,6 +198,40 @@ describe("WorkbookSelect", () => {
     await waitFor(() => expect(screen.getByText("No workbooks found")).toBeInTheDocument());
   });
 
+  it("shows an error instead of the empty text when the list request fails", async () => {
+    const user = userEvent.setup();
+    server.mount(contract.workbooks.listWorkbooks, { status: 500 });
+    render(<WorkbookSelect onChange={vi.fn()} noneLabel="None" {...labels} />);
+
+    await user.click(screen.getByRole("combobox"));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent("experiments.workbookSearchFailed"),
+    );
+    // Neither the empty text nor the synthetic "none" row should suggest a settled list.
+    expect(screen.queryByText("No workbooks found")).not.toBeInTheDocument();
+    expect(screen.queryByRole("option")).not.toBeInTheDocument();
+  });
+
+  it("shows an error instead of stale results when a search fails", async () => {
+    const user = userEvent.setup();
+    mountList(() => [alpha, beta]);
+    render(<WorkbookSelect onChange={vi.fn()} {...labels} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await waitFor(() => expect(screen.getByText("Alpha Workbook")).toBeInTheDocument());
+
+    // Mounted after the successful load: the most recent handler wins, so only
+    // the search request fails.
+    server.mount(contract.workbooks.listWorkbooks, { status: 500 });
+    await user.type(screen.getByPlaceholderText("Search workbooks..."), "beta");
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent("experiments.workbookSearchFailed"),
+    );
+    expect(screen.queryByRole("option")).not.toBeInTheDocument();
+  });
+
   it("shows the empty text when the server returns no matches", async () => {
     const user = userEvent.setup();
     mountList((search) => (search ? [] : [alpha, beta]));

--- a/apps/web/components/workbook/workbook-select.test.tsx
+++ b/apps/web/components/workbook/workbook-select.test.tsx
@@ -1,12 +1,15 @@
+import { createWorkbook } from "@/test/factories";
+import type { SpyCall } from "@/test/msw/mount";
+import { server } from "@/test/msw/server";
 import { render, screen, userEvent, waitFor } from "@/test/test-utils";
 import { describe, it, expect, vi } from "vitest";
 
+import { contract } from "@repo/api/contract";
+
 import { WorkbookSelect } from "./workbook-select";
 
-const workbooks = [
-  { id: "wb-1", name: "Alpha Workbook" },
-  { id: "wb-2", name: "Beta Workbook" },
-];
+const alpha = createWorkbook({ name: "Alpha Workbook" });
+const beta = createWorkbook({ name: "Beta Workbook" });
 
 const labels = {
   triggerPlaceholder: "Select a workbook",
@@ -14,70 +17,211 @@ const labels = {
   emptyText: "No workbooks found",
 };
 
+/** Mount the list endpoint, answering each request from its `search` query param. */
+function mountList(respond: (search: string | undefined) => unknown[]) {
+  return server.mount(contract.workbooks.listWorkbooks, {
+    body: (call: SpyCall) => respond(call.query.search),
+  });
+}
+
+const optionNames = () => screen.getAllByRole("option").map((o) => o.textContent.trim());
+
 describe("WorkbookSelect", () => {
   it("shows the placeholder and lists workbooks when opened", async () => {
     const user = userEvent.setup();
-    render(<WorkbookSelect workbooks={workbooks} onChange={vi.fn()} {...labels} />);
+    mountList(() => [alpha, beta]);
+    render(<WorkbookSelect onChange={vi.fn()} {...labels} />);
 
     const trigger = screen.getByRole("combobox");
     expect(trigger).toHaveTextContent("Select a workbook");
 
     await user.click(trigger);
-    expect(screen.getByText("Alpha Workbook")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("Alpha Workbook")).toBeInTheDocument());
     expect(screen.getByText("Beta Workbook")).toBeInTheDocument();
   });
 
-  it("filters the list by name as the user types", async () => {
+  it("sends the typed search to the server", async () => {
     const user = userEvent.setup();
-    render(<WorkbookSelect workbooks={workbooks} onChange={vi.fn()} {...labels} />);
+    const spy = mountList((search) => (search ? [beta] : [alpha, beta]));
+    render(<WorkbookSelect onChange={vi.fn()} {...labels} />);
 
     await user.click(screen.getByRole("combobox"));
     await user.type(screen.getByPlaceholderText("Search workbooks..."), "beta");
 
-    await waitFor(() => {
-      expect(screen.queryByText("Alpha Workbook")).not.toBeInTheDocument();
-      expect(screen.getByText("Beta Workbook")).toBeInTheDocument();
-    });
+    await waitFor(() => expect(spy.calls.at(-1)?.query.search).toBe("beta"));
+  });
+
+  it("debounces so a burst of keystrokes is one request", async () => {
+    const user = userEvent.setup();
+    const spy = mountList(() => [alpha]);
+    render(<WorkbookSelect onChange={vi.fn()} {...labels} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await waitFor(() => expect(spy.callCount).toBe(1));
+
+    await user.type(screen.getByPlaceholderText("Search workbooks..."), "alpha");
+
+    await waitFor(() => expect(spy.calls.at(-1)?.query.search).toBe("alpha"));
+    // The initial list plus one request for the settled term, not one per keystroke.
+    expect(spy.callCount).toBe(2);
+  });
+
+  it("renders the server's results as-is, including matches the name does not explain", async () => {
+    const user = userEvent.setup();
+    // The server also matches creator and linked entity names, so a result whose own
+    // name lacks the query is legitimate and must not be filtered out again here.
+    const byCreator = createWorkbook({ name: "Sable Notebook", createdByName: "Ada Lovelace" });
+    mountList((search) => (search === "lovelace" ? [byCreator] : [alpha, beta]));
+    render(<WorkbookSelect onChange={vi.fn()} {...labels} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.type(screen.getByPlaceholderText("Search workbooks..."), "lovelace");
+
+    await waitFor(() => expect(optionNames()).toEqual(["Sable Notebook"]));
+  });
+
+  it("preserves the server's ranking", async () => {
+    const user = userEvent.setup();
+    const ranked = [
+      createWorkbook({ name: "Zulu Trial" }),
+      createWorkbook({ name: "Alpha Trial" }),
+    ];
+    mountList((search) => (search ? ranked : []));
+    render(<WorkbookSelect onChange={vi.fn()} {...labels} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.type(screen.getByPlaceholderText("Search workbooks..."), "trial");
+
+    await waitFor(() => expect(optionNames()).toEqual(["Zulu Trial", "Alpha Trial"]));
   });
 
   it("calls onChange with the workbook id when one is selected", async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
-    render(<WorkbookSelect workbooks={workbooks} onChange={onChange} {...labels} />);
+    mountList(() => [alpha, beta]);
+    render(<WorkbookSelect onChange={onChange} {...labels} />);
 
     await user.click(screen.getByRole("combobox"));
+    await waitFor(() => expect(screen.getByText("Alpha Workbook")).toBeInTheDocument());
     await user.click(screen.getByText("Alpha Workbook"));
 
-    expect(onChange).toHaveBeenCalledWith("wb-1");
+    expect(onChange).toHaveBeenCalledWith(alpha.id);
   });
 
   it("calls onChange with undefined when the none option is selected", async () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
-    render(
-      <WorkbookSelect
-        workbooks={workbooks}
-        value="wb-1"
-        onChange={onChange}
-        noneLabel="None"
-        {...labels}
-      />,
-    );
+    mountList(() => [alpha, beta]);
+    render(<WorkbookSelect value={alpha.id} onChange={onChange} noneLabel="None" {...labels} />);
 
-    expect(screen.getByRole("combobox")).toHaveTextContent("Alpha Workbook");
+    await waitFor(() => expect(screen.getByRole("combobox")).toHaveTextContent("Alpha Workbook"));
     await user.click(screen.getByRole("combobox"));
     await user.click(screen.getByText("None"));
 
     expect(onChange).toHaveBeenCalledWith(undefined);
   });
 
-  it("shows the empty text when nothing matches the search", async () => {
+  it("keeps workbooks with duplicate names selectable", async () => {
+    const onChange = vi.fn();
     const user = userEvent.setup();
-    render(<WorkbookSelect workbooks={workbooks} onChange={vi.fn()} {...labels} />);
+    const duplicates = [
+      createWorkbook({ name: "Shared Name" }),
+      createWorkbook({ name: "Shared Name" }),
+    ];
+    mountList(() => duplicates);
+    render(<WorkbookSelect onChange={onChange} {...labels} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await waitFor(() => expect(screen.getAllByRole("option")).toHaveLength(2));
+    await user.click(screen.getAllByRole("option")[1]);
+
+    expect(onChange).toHaveBeenCalledWith(duplicates[1].id);
+  });
+
+  it("keeps the trigger label when a search narrows the selection out of the list", async () => {
+    const user = userEvent.setup();
+    mountList((search) => (search ? [beta] : [alpha, beta]));
+    render(<WorkbookSelect value={alpha.id} onChange={vi.fn()} {...labels} />);
+
+    // Held onto directly: cmdk's search input is also a combobox once the list opens.
+    const trigger = screen.getByRole("combobox");
+    await waitFor(() => expect(trigger).toHaveTextContent("Alpha Workbook"));
+    await user.click(trigger);
+    await user.type(screen.getByPlaceholderText("Search workbooks..."), "beta");
+
+    await waitFor(() => expect(optionNames()).toEqual(["Beta Workbook"]));
+    expect(trigger).toHaveTextContent("Alpha Workbook");
+  });
+
+  it("drops the trigger label once a settled unfiltered list no longer has the selection", async () => {
+    const user = userEvent.setup();
+    // Stands in for the workbook being deleted elsewhere: the unfiltered list stops
+    // returning it, which is authoritative in a way a narrowed list is not.
+    let deleted = false;
+    server.mount(contract.workbooks.listWorkbooks, {
+      body: (call: SpyCall) => {
+        if (call.query.search) return [beta];
+        return deleted ? [beta] : [alpha, beta];
+      },
+    });
+    render(<WorkbookSelect value={alpha.id} onChange={vi.fn()} {...labels} />);
+
+    const trigger = screen.getByRole("combobox");
+    await waitFor(() => expect(trigger).toHaveTextContent("Alpha Workbook"));
+
+    // Round-trip through a search and back to refetch the unfiltered list.
+    await user.click(trigger);
+    const input = screen.getByPlaceholderText("Search workbooks...");
+    await user.type(input, "beta");
+    await waitFor(() => expect(optionNames()).toEqual(["Beta Workbook"]));
+    deleted = true;
+    await user.clear(input);
+
+    await waitFor(() => expect(trigger).toHaveTextContent("Select a workbook"));
+  });
+
+  it("shows a searching state instead of the empty text while results are in flight", async () => {
+    const user = userEvent.setup();
+    let release: (() => void) | undefined;
+    const unblock = new Promise((resolve) => {
+      release = () => resolve(undefined);
+    });
+    server.mount(contract.workbooks.listWorkbooks, { body: [], unblock });
+    render(<WorkbookSelect onChange={vi.fn()} {...labels} />);
+
+    await user.click(screen.getByRole("combobox"));
+
+    expect(screen.getByRole("status")).toHaveTextContent("experiments.searchingWorkbooks");
+    expect(screen.queryByText("No workbooks found")).not.toBeInTheDocument();
+
+    release?.();
+    await waitFor(() => expect(screen.getByText("No workbooks found")).toBeInTheDocument());
+  });
+
+  it("shows the empty text when the server returns no matches", async () => {
+    const user = userEvent.setup();
+    mountList((search) => (search ? [] : [alpha, beta]));
+    render(<WorkbookSelect onChange={vi.fn()} {...labels} />);
 
     await user.click(screen.getByRole("combobox"));
     await user.type(screen.getByPlaceholderText("Search workbooks..."), "zzzzz");
 
     await waitFor(() => expect(screen.getByText("No workbooks found")).toBeInTheDocument());
+  });
+
+  it("clears the search when reopened", async () => {
+    const user = userEvent.setup();
+    mountList((search) => (search ? [beta] : [alpha, beta]));
+    render(<WorkbookSelect onChange={vi.fn()} {...labels} />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.type(screen.getByPlaceholderText("Search workbooks..."), "beta");
+    await waitFor(() => expect(optionNames()).toEqual(["Beta Workbook"]));
+
+    await user.click(screen.getByText("Beta Workbook"));
+    await user.click(screen.getByRole("combobox"));
+
+    expect(screen.getByPlaceholderText("Search workbooks...")).toHaveValue("");
+    await waitFor(() => expect(optionNames()).toEqual(["Alpha Workbook", "Beta Workbook"]));
   });
 });

--- a/apps/web/components/workbook/workbook-select.tsx
+++ b/apps/web/components/workbook/workbook-select.tsx
@@ -55,7 +55,11 @@ export function WorkbookSelect({
   const { t } = useTranslation("common");
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
-  const { data: workbooks = [], isSearching } = useWorkbookList({ search });
+  const { data: workbooks = [], isSearching, error } = useWorkbookList({ search });
+
+  // Only a settled failure is shown: while a retry or the next term is in flight,
+  // the searching state below is the more truthful one.
+  const showError = !!error && !isSearching;
 
   // The "none" entry is synthetic rather than a server result, so it is matched here.
   const query = search.trim().toLowerCase();
@@ -106,33 +110,46 @@ export function WorkbookSelect({
         <Command shouldFilter={false}>
           <CommandInput placeholder={searchPlaceholder} value={search} onValueChange={setSearch} />
           <CommandList>
-            {isSearching && workbooks.length === 0 ? (
+            {showError ? (
               <div
-                role="status"
-                className="text-muted-foreground flex items-center justify-center gap-2 py-6 text-sm"
+                role="alert"
+                className="text-destructive flex items-center justify-center py-6 text-sm"
               >
-                <Loader2 className="h-4 w-4 animate-spin" />
-                {t("experiments.searchingWorkbooks")}
+                {t("experiments.workbookSearchFailed")}
               </div>
             ) : (
-              <CommandEmpty>{emptyText}</CommandEmpty>
+              <>
+                {isSearching && workbooks.length === 0 ? (
+                  <div
+                    role="status"
+                    className="text-muted-foreground flex items-center justify-center gap-2 py-6 text-sm"
+                  >
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    {t("experiments.searchingWorkbooks")}
+                  </div>
+                ) : (
+                  <CommandEmpty>{emptyText}</CommandEmpty>
+                )}
+                {/* Rows held over from the previous query are dimmed, so it is visible that
+                    they are not yet an answer to what is currently typed. */}
+                <CommandGroup className={cn(isSearching && workbooks.length > 0 && "opacity-60")}>
+                  {showNone && (
+                    <CommandItem value={NONE_VALUE} onSelect={() => handleSelect(undefined)}>
+                      <Check className={cn("h-4 w-4", !value ? "opacity-100" : "opacity-0")} />
+                      <span className="truncate">{noneLabel}</span>
+                    </CommandItem>
+                  )}
+                  {workbooks.map((wb) => (
+                    <CommandItem key={wb.id} value={wb.id} onSelect={() => handleSelect(wb.id)}>
+                      <Check
+                        className={cn("h-4 w-4", value === wb.id ? "opacity-100" : "opacity-0")}
+                      />
+                      <span className="truncate">{wb.name}</span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </>
             )}
-            {/* Rows held over from the previous query are dimmed, so it is visible that
-                they are not yet an answer to what is currently typed. */}
-            <CommandGroup className={cn(isSearching && workbooks.length > 0 && "opacity-60")}>
-              {showNone && (
-                <CommandItem value={NONE_VALUE} onSelect={() => handleSelect(undefined)}>
-                  <Check className={cn("h-4 w-4", !value ? "opacity-100" : "opacity-0")} />
-                  <span className="truncate">{noneLabel}</span>
-                </CommandItem>
-              )}
-              {workbooks.map((wb) => (
-                <CommandItem key={wb.id} value={wb.id} onSelect={() => handleSelect(wb.id)}>
-                  <Check className={cn("h-4 w-4", value === wb.id ? "opacity-100" : "opacity-0")} />
-                  <span className="truncate">{wb.name}</span>
-                </CommandItem>
-              ))}
-            </CommandGroup>
           </CommandList>
         </Command>
       </PopoverContent>

--- a/apps/web/components/workbook/workbook-select.tsx
+++ b/apps/web/components/workbook/workbook-select.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { Check, ChevronsUpDown } from "lucide-react";
-import { useState } from "react";
+import { useWorkbookList } from "@/hooks/workbook/useWorkbookList/useWorkbookList";
+import { Check, ChevronsUpDown, Loader2 } from "lucide-react";
+import { useRef, useState } from "react";
 
+import { useTranslation } from "@repo/i18n";
 import { Button } from "@repo/ui/components/button";
 import {
   Command,
@@ -15,13 +17,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@repo/ui/components/popover";
 import { cn } from "@repo/ui/lib/utils";
 
-interface WorkbookOption {
-  id: string;
-  name: string;
-}
-
 interface WorkbookSelectProps {
-  workbooks: WorkbookOption[];
   value?: string;
   onChange: (id: string | undefined) => void;
   triggerPlaceholder: string;
@@ -38,12 +34,13 @@ interface WorkbookSelectProps {
 const NONE_VALUE = "__none__";
 
 /**
- * Searchable workbook picker. Filtering is client-side over the already-loaded
- * list; the item `value` carries the name (for cmdk's fuzzy match) plus the id
- * (so duplicate names stay distinct), while selection resolves back to the id.
+ * Searchable workbook picker, backed by the server's full-text search so it matches
+ * the same things the workbooks page does (name, creator, linked entities) and keeps
+ * the server's ranking. cmdk's own filter stays off: the results are already
+ * filtered, and its fuzzy match would re-filter them against the item `value`, which
+ * carries the id so duplicate names stay distinct.
  */
 export function WorkbookSelect({
-  workbooks,
   value,
   onChange,
   triggerPlaceholder,
@@ -55,16 +52,37 @@ export function WorkbookSelect({
   triggerClassName,
   invalid,
 }: WorkbookSelectProps) {
+  const { t } = useTranslation("common");
   const [open, setOpen] = useState(false);
-  const selected = workbooks.find((wb) => wb.id === value);
+  const [search, setSearch] = useState("");
+  const { data: workbooks = [], isSearching } = useWorkbookList({ search });
+
+  // The "none" entry is synthetic rather than a server result, so it is matched here.
+  const query = search.trim().toLowerCase();
+  const showNone = !!noneLabel && (!query || noneLabel.toLowerCase().includes(query));
+
+  // A narrowed or in-flight list can omit the selected workbook, so its name is
+  // remembered to keep the trigger label stable. A settled unfiltered list is
+  // authoritative: a selection missing from that one is gone, not merely filtered out.
+  const seenNames = useRef(new Map<string, string>());
+  for (const wb of workbooks) seenNames.current.set(wb.id, wb.name);
+  const liveName = value ? workbooks.find((wb) => wb.id === value)?.name : undefined;
+  const mayOmitSelection = !!query || isSearching;
+  const selectedName =
+    liveName ?? (value && mayOmitSelection ? seenNames.current.get(value) : undefined);
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) setSearch("");
+  };
 
   const handleSelect = (id: string | undefined) => {
     onChange(id);
-    setOpen(false);
+    handleOpenChange(false);
   };
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
           id={triggerId}
@@ -76,35 +94,40 @@ export function WorkbookSelect({
           disabled={disabled}
           className={cn(
             "w-full justify-between font-normal",
-            !selected && "text-muted-foreground",
+            !selectedName && "text-muted-foreground",
             triggerClassName,
           )}
         >
-          <span className="truncate">{selected ? selected.name : triggerPlaceholder}</span>
+          <span className="truncate">{selectedName ?? triggerPlaceholder}</span>
           <ChevronsUpDown className="ml-2 h-3.5 w-3.5 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
-        <Command>
-          <CommandInput placeholder={searchPlaceholder} />
+        <Command shouldFilter={false}>
+          <CommandInput placeholder={searchPlaceholder} value={search} onValueChange={setSearch} />
           <CommandList>
-            <CommandEmpty>{emptyText}</CommandEmpty>
-            <CommandGroup>
-              {noneLabel && (
-                <CommandItem
-                  value={`${noneLabel} ${NONE_VALUE}`}
-                  onSelect={() => handleSelect(undefined)}
-                >
-                  <Check className={cn("h-4 w-4", !selected ? "opacity-100" : "opacity-0")} />
+            {isSearching && workbooks.length === 0 ? (
+              <div
+                role="status"
+                className="text-muted-foreground flex items-center justify-center gap-2 py-6 text-sm"
+              >
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {t("experiments.searchingWorkbooks")}
+              </div>
+            ) : (
+              <CommandEmpty>{emptyText}</CommandEmpty>
+            )}
+            {/* Rows held over from the previous query are dimmed, so it is visible that
+                they are not yet an answer to what is currently typed. */}
+            <CommandGroup className={cn(isSearching && workbooks.length > 0 && "opacity-60")}>
+              {showNone && (
+                <CommandItem value={NONE_VALUE} onSelect={() => handleSelect(undefined)}>
+                  <Check className={cn("h-4 w-4", !value ? "opacity-100" : "opacity-0")} />
                   <span className="truncate">{noneLabel}</span>
                 </CommandItem>
               )}
               {workbooks.map((wb) => (
-                <CommandItem
-                  key={wb.id}
-                  value={`${wb.name} ${wb.id}`}
-                  onSelect={() => handleSelect(wb.id)}
-                >
+                <CommandItem key={wb.id} value={wb.id} onSelect={() => handleSelect(wb.id)}>
                   <Check className={cn("h-4 w-4", value === wb.id ? "opacity-100" : "opacity-0")} />
                   <span className="truncate">{wb.name}</span>
                 </CommandItem>

--- a/apps/web/hooks/workbook/useWorkbookList/useWorkbookList.test.tsx
+++ b/apps/web/hooks/workbook/useWorkbookList/useWorkbookList.test.tsx
@@ -52,4 +52,66 @@ describe("useWorkbookList", () => {
       expect(result.current.error).toBeTruthy();
     });
   });
+
+  it("stops reporting searching as soon as the first response settles", async () => {
+    server.mount(contract.workbooks.listWorkbooks, { body: [] });
+
+    const { result } = renderHook(() => useWorkbookList());
+
+    // Nothing is waiting to be searched on mount, so the debounce must not hold this
+    // pending for its full window once an empty list has already come back.
+    await waitFor(() => expect(result.current.data).toEqual([]));
+    expect(result.current.isSearching).toBe(false);
+  });
+
+  it("sends the search term to the API", async () => {
+    const spy = server.mount(contract.workbooks.listWorkbooks, { body: [] });
+
+    renderHook(() => useWorkbookList({ search: "chlorophyll" }));
+
+    await waitFor(() => expect(spy.calls.at(-1)?.query.search).toBe("chlorophyll"));
+  });
+
+  it("omits an empty or whitespace-only search so the full list is returned", async () => {
+    const spy = server.mount(contract.workbooks.listWorkbooks, { body: [] });
+
+    renderHook(() => useWorkbookList({ search: "   " }));
+
+    await waitFor(() => expect(spy.called).toBe(true));
+    expect(spy.calls.every((call) => !("search" in call.query))).toBe(true);
+  });
+
+  it("debounces so intermediate terms are never requested", async () => {
+    const spy = server.mount(contract.workbooks.listWorkbooks, { body: [] });
+
+    const { rerender } = renderHook(({ search }) => useWorkbookList({ search }), {
+      initialProps: { search: "" },
+    });
+    await waitFor(() => expect(spy.called).toBe(true));
+
+    for (const search of ["c", "ch", "chl", "chlo"]) rerender({ search });
+
+    await waitFor(() => expect(spy.calls.at(-1)?.query.search).toBe("chlo"));
+    const searches = spy.calls.map((call) => ("search" in call.query ? call.query.search : null));
+    expect(searches).toEqual([null, "chlo"]);
+  });
+
+  it("keeps the previous results while the next search loads", async () => {
+    const first = createWorkbook({ name: "First" });
+    server.mount(contract.workbooks.listWorkbooks, { body: [first] });
+
+    const { result, rerender } = renderHook(({ search }) => useWorkbookList({ search }), {
+      initialProps: { search: "" },
+    });
+    await waitFor(() => expect(result.current.data).toHaveLength(1));
+
+    server.mount(contract.workbooks.listWorkbooks, { body: [], delay: 200 });
+    rerender({ search: "nothing" });
+
+    // Still the old page, flagged as searching, rather than an empty flash.
+    await waitFor(() => expect(result.current.isSearching).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+
+    await waitFor(() => expect(result.current.data).toEqual([]));
+  });
 });

--- a/apps/web/hooks/workbook/useWorkbookList/useWorkbookList.ts
+++ b/apps/web/hooks/workbook/useWorkbookList/useWorkbookList.ts
@@ -1,12 +1,34 @@
 import { orpc } from "@/lib/orpc";
 import { useQuery } from "@tanstack/react-query";
 
-export function useWorkbookList() {
-  const query = useQuery(orpc.workbooks.listWorkbooks.queryOptions({ input: {} }));
+import { useDebounce } from "../../useDebounce";
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Workbook list, optionally narrowed by the server's full-text search. The server
+ * ranks the results and also matches creator and linked experiment/protocol/macro
+ * names, so callers must render the list as-is instead of filtering it again.
+ * Previous results are kept while the next search loads; `isSearching` covers both
+ * the debounce window and the fetch.
+ */
+export function useWorkbookList({ search = "" }: { search?: string } = {}) {
+  const trimmed = search.trim();
+  const [debouncedSearch] = useDebounce(trimmed, SEARCH_DEBOUNCE_MS);
+
+  const query = useQuery(
+    orpc.workbooks.listWorkbooks.queryOptions({
+      input: { search: debouncedSearch === "" ? undefined : debouncedSearch },
+      placeholderData: (prev) => prev,
+    }),
+  );
 
   return {
     data: query.data,
     isLoading: query.isLoading,
     error: query.error,
+    // Compared against the settled term rather than `useDebounce`'s own flag, which
+    // also goes pending on mount, when nothing is waiting to be searched yet.
+    isSearching: trimmed !== debouncedSearch || query.isFetching,
   };
 }

--- a/apps/web/test/msw/mount.ts
+++ b/apps/web/test/msw/mount.ts
@@ -31,7 +31,9 @@ export type MountFn = <T extends AnyContractProcedure>(
     /**
      * JSON response body. A `(call: SpyCall) => unknown` function is called per
      * request instead, so search-style endpoints can answer per query rather than
-     * needing one handler per case.
+     * needing one handler per case. `unknown` already includes functions, so the
+     * union can't be written out — any function value is treated as a resolver,
+     * never sent as a literal body.
      */
     body?: unknown;
     /** Artificial delay in ms (or "infinite" to hang forever). */
@@ -170,12 +172,13 @@ export function createMount(server: SetupServer): MountFn {
 
       // ── Response ────────────────────────────────────────────
       const status = options.status ?? route.successStatus ?? statusForMethod(method);
+      // 204 first: a body resolver must not run for a response that carries no body.
+      if (status === 204) return new HttpResponse(null, { status });
+
       const responseBody =
         typeof options.body === "function"
           ? (options.body as (call: SpyCall) => unknown)(call)
           : options.body;
-
-      if (status === 204) return new HttpResponse(null, { status });
       if (status >= 400) return HttpResponse.json(responseBody ?? { message: "Error" }, { status });
       return HttpResponse.json(responseBody ?? null, { status });
     });

--- a/apps/web/test/msw/mount.ts
+++ b/apps/web/test/msw/mount.ts
@@ -28,7 +28,11 @@ export type MountFn = <T extends AnyContractProcedure>(
   options?: {
     /** HTTP status. Defaults to the procedure's `successStatus`. */
     status?: number;
-    /** JSON response body. */
+    /**
+     * JSON response body. A `(call: SpyCall) => unknown` function is called per
+     * request instead, so search-style endpoints can answer per query rather than
+     * needing one handler per case.
+     */
     body?: unknown;
     /** Artificial delay in ms (or "infinite" to hang forever). */
     delay?: number | "infinite";
@@ -166,10 +170,14 @@ export function createMount(server: SetupServer): MountFn {
 
       // ── Response ────────────────────────────────────────────
       const status = options.status ?? route.successStatus ?? statusForMethod(method);
+      const responseBody =
+        typeof options.body === "function"
+          ? (options.body as (call: SpyCall) => unknown)(call)
+          : options.body;
 
       if (status === 204) return new HttpResponse(null, { status });
-      if (status >= 400) return HttpResponse.json(options.body ?? { message: "Error" }, { status });
-      return HttpResponse.json(options.body ?? null, { status });
+      if (status >= 400) return HttpResponse.json(responseBody ?? { message: "Error" }, { status });
+      return HttpResponse.json(responseBody ?? null, { status });
     });
 
     server.use(handler);

--- a/packages/i18n/locales/en-US/common.json
+++ b/packages/i18n/locales/en-US/common.json
@@ -179,6 +179,7 @@
     "macroIncompatibilityWarning": "This macro has not been marked as compatible with the selected protocol.",
     "searchingMacros": "Searching macros...",
     "searchingWorkbooks": "Searching workbooks...",
+    "workbookSearchFailed": "Couldn't load workbooks. Try again.",
     "noMacrosFound": "No macros found",
     "tryDifferentSearchMacros": "Try a different search term than \"{{searchValue}}\"",
     "noMacrosAvailable": "No macros available",

--- a/packages/i18n/locales/en-US/common.json
+++ b/packages/i18n/locales/en-US/common.json
@@ -178,6 +178,7 @@
     "seeMacroDetails": "See macro details",
     "macroIncompatibilityWarning": "This macro has not been marked as compatible with the selected protocol.",
     "searchingMacros": "Searching macros...",
+    "searchingWorkbooks": "Searching workbooks...",
     "noMacrosFound": "No macros found",
     "tryDifferentSearchMacros": "Try a different search term than \"{{searchValue}}\"",
     "noMacrosAvailable": "No macros available",


### PR DESCRIPTION
Fixes OJD-1699

The attach-workbook picker's search "did not work". Root cause was a cmdk fuzzy-match
against a uuid. Fixing that exposed a second gap: the picker never used the backend's
full-text search at all, so it could not find what the workbooks page could. Both are
addressed here, plus two fixes from the review pass.

## The original defect

Each row's cmdk `value` was `` `${wb.name} ${wb.id}` `` and cmdk scored that whole
string with its default fuzzy filter. `wb.id` is a uuid, so its hex characters and
digits satisfied most query characters. Measured against the real cmdk 1.1.1 scorer:

| query | matched before | matched now |
| --- | --- | --- |
| `leaf` | Leaf Area Index, Photosynthesis Baseline, Chlorophyll Screening | Leaf Area Index |
| `2` | all 4 workbooks | Drought Trial 2 |

The intended match still ranked first, which is why this never looked broken in tests:
the old fixtures used short ids (`wb-1`), not uuids. On real data the list barely
narrowed as you typed.

## Change areas

```mermaid
flowchart LR
  subgraph before["Before"]
    C1[3 call sites] -->|"useWorkbookList()<br/>input: {} — no search"| A1[list all workbooks]
    A1 -->|workbooks prop| S1[WorkbookSelect]
    S1 --> F1["cmdk fuzzy filter<br/>over name + uuid"]
  end
  subgraph after["After"]
    C2[3 call sites] --> S2[WorkbookSelect<br/>owns search state]
    S2 -->|"useWorkbookList({ search })"| H2[debounce 300ms<br/>keepPreviousData]
    H2 -->|"?search="| A2["Postgres FTS<br/>name · creator · linked<br/>experiment/protocol/macro<br/>+ ranking"]
    A2 -->|render as-is| S2
  end
```

| Area | What changed |
| --- | --- |
| `useWorkbookList.ts` | Takes optional `search`; trims, debounces 300ms, omits the param when empty, `placeholderData: (prev) => prev`, returns `isSearching`. Modelled on the existing `useGlobalSearch`. |
| `workbook-select.tsx` | `workbooks` prop dropped; owns its query and search state. No local filtering: server order is rendered verbatim. Adds a searching state and a stale-results cue. |
| 3 call sites | Each dropped its own `useWorkbookList()` call and the `workbooks` prop. |
| `test/msw/mount.ts` | `body` may be a `(call: SpyCall) => unknown` function, answered per request. Enables search-aware tests. |
| `en-US/common.json` | `experiments.searchingWorkbooks`. |

All three attach surfaces share the one component, so all three are fixed:
experiment design empty state, linked-workbook card's "change workbook" row, and the
new-experiment form.

## Review order

1. **`workbook-select.tsx:64-72` — the name cache.** Highest subtlety. A narrowed or
   in-flight list can omit the selected workbook, which would blank the trigger label
   mid-search. Names seen are remembered, but a *settled unfiltered* list is treated as
   authoritative, so a deleted workbook still falls back to the placeholder. Check the
   `mayOmitSelection` condition covers the transition when a search is cleared.
2. **`useWorkbookList.ts:32` — `isSearching`.** Drives spinner vs. "no workbooks
   found". Getting it wrong shows a false negative or a stuck spinner.
3. **`workbook-select.tsx:106-119` — spinner vs. `CommandEmpty` branch**, and that
   `shouldFilter={false}` is still set (see Gotchas: it is load-bearing).
4. **The three call sites** — confirm nothing else relied on the caller holding the list.
5. **`mount.ts`** — shared test infra; additive and backwards compatible.

## Important decisions

| Decision | Why, and what was rejected |
| --- | --- |
| Component owns the query; `workbooks` prop removed | All three callers used the list *only* to feed this component. The alternative (thread `search`/`onSearchChange` back out to three callers) duplicates wiring three times for no gain. |
| Server results rendered verbatim, no local filter | The server also matches creator and linked entity names. Any local name filter would discard legitimate matches the user cannot explain from the name alone. |
| `placeholderData` kept, stale rows dimmed not disabled | Review flagged that held-over rows stay clickable. Dropping `placeholderData` reintroduces blank-list flicker; disabling rows blocks the common case of typing to narrow and clicking a target that is still listed. A click is deliberate, on a row the user can read. Dimming makes staleness visible; the residual edge is Enter on an auto-highlighted stale row. |
| `isSearching` derived from `trimmed !== debouncedSearch` | Not from `useDebounce`'s own `isDebounced` flag, which goes pending on mount when nothing is waiting to be searched. |
| `searchingWorkbooks` added to `en-US` only | de-DE and nl-NL lack this feature's sibling strings (`flow.searchWorkbook`, `flow.noWorkbooksFound`) entirely. Adding one key alone would be inconsistent, not more complete. |
| Component now owns one i18n string | It stopped being purely presentational when it took over the fetch. Avoids adding the same key to three different namespaces. |

## Gotchas

- **`shouldFilter={false}` is load-bearing, for two reasons now.** Originally: cmdk's
  fuzzy filter matched the uuid in the item `value`. Now also: the server already
  filtered, and cmdk would re-filter away rows that matched on creator or a linked
  entity rather than on the name.
- **The item `value` must stay the id.** Using the name would let cmdk collapse two
  workbooks that share a name.
- **cmdk's search input is also `role="combobox"`.** Once the popover is open there are
  two, so `getByRole("combobox")` becomes ambiguous. Tests hold the trigger element
  from before opening.
- **Renames are picked up, deletions are the interesting case.** The cache is rewritten
  every render for every id in the list, so a rename lands immediately. Only a
  workbook disappearing from the list needs the authority rule.
- **The cache never affected correctness of the submitted value** — `value` is owned by
  the caller in all three call sites. It only ever affected the displayed label.
- **Fetch timing shifted, favourably.** `linked-workbook-card` no longer requests the
  list on render (only when "change workbook" is clicked), and `empty-workbook-state`
  no longer requests it for users without access.

## Verification

Done:

| Check | Result |
| --- | --- |
| `workbook-select.test.tsx` | 13 tests: search reaches the server, debounce coalesces a keystroke burst into one request, server order and creator-only matches rendered as-is, trigger label stable while narrowed **and** dropped once a settled unfiltered list omits it, spinner vs. empty text, duplicate names, reset on reopen |
| `useWorkbookList.test.tsx` | 9 tests: search param sent, empty/whitespace omitted, debounce, previous results kept, searching settles on first response |
| Both review fixes | Confirmed the new tests **fail against the pre-fix code** before restoring, so they are not passing for the wrong reason |
| Full `apps/web` suite | 666 files, 4791 passed, 2 skipped |
| tsc / eslint / prettier | Clean |

Also verified in a real browser against the local stack and seeded Postgres, 17/17
checks, 0 page errors:

| Query | Returned | What it proves |
| --- | --- | --- |
| `chloro` | Chlorophyll Fluorescence Baseline | prefix/stemming match, `?search=` confirmed on the wire |
| `2` | Drought Trial 2 | the original defect is gone; this used to match every workbook |
| `participant one` | Zephyr Notebook | server-side FTS is genuinely in play. The query appears nowhere in that workbook's name, it matched on creator, so any local name filter would have discarded it |
| `photosynthesis` | Quokka Notebook | linked-experiment match, after attaching through the UI |
| `notebook` | Quokka, Zephyr | multi-match in server rank order |

Both new UI states were confirmed in-browser too: held-over rows dimmed with previous
results still visible, and the searching row on a cold open (only observable with
injected latency, so it may rarely be seen in practice).

That check is committed as `apps/web/e2e/smoke_workbook_search.py` on
`chore/web-e2e-and-agents-md`; it seeds and removes its own workbooks so it is
repeatable.
