### PR TITLE
chore(infra): enable ALB access logs for the backend load balancer

### DIFF
--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -67,6 +67,9 @@ module "logs_bucket" {
   # Configure for logging purposes
   enable_versioning = false
 
+  # Lets the backend ALB's enable_access_logs actually deliver to this bucket.
+  elb_log_delivery_prefixes = ["backend-alb-logs"]
+
   tags = {
     Environment = var.environment
     Project     = "open-jii"
@@ -1651,7 +1654,7 @@ module "backend_alb" {
   cloudfront_header_value = var.api_cloudfront_header_value
 
   # Enable access logs for better security and troubleshooting
-  enable_access_logs = false
+  enable_access_logs = true
   access_logs_bucket = module.logs_bucket.bucket_id
 
   tags = {

--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -40,6 +40,9 @@ module "logs_bucket" {
   # Configure for logging purposes
   enable_versioning = false
 
+  # Lets the backend ALB's enable_access_logs actually deliver to this bucket.
+  elb_log_delivery_prefixes = ["backend-alb-logs"]
+
   tags = {
     Environment = "prod"
     Project     = "open-jii"
@@ -1609,7 +1612,7 @@ module "backend_alb" {
   cloudfront_header_value = var.api_cloudfront_header_value
 
   # Enable access logs for better security and troubleshooting
-  enable_access_logs = false
+  enable_access_logs = true
   access_logs_bucket = module.logs_bucket.bucket_id
 
   tags = {

--- a/infrastructure/modules/s3/README.md
+++ b/infrastructure/modules/s3/README.md
@@ -165,6 +165,7 @@ For even higher security requirements:
 | `tags`                        | Tags to apply to all resources                             | `map(string)` | `{}`    |  ❌ No   |
 | `cloudfront_distribution_arn` | Optional: ARN of CloudFront distribution for bucket access | `string`      | `null`  |  ❌ No   |
 | `custom_policy_json`          | Optional: A custom bucket policy JSON document             | `string`      | `null`  |  ❌ No   |
+| `elb_log_delivery_prefixes`   | Optional: key prefixes (one per ELB) to grant ELB log-delivery write access | `list(string)` | `[]`  |  ❌ No   |
 
 ## 📤 Outputs
 

--- a/infrastructure/modules/s3/README.md
+++ b/infrastructure/modules/s3/README.md
@@ -158,14 +158,14 @@ For even higher security requirements:
 
 ## 🔑 Inputs
 
-| Name                          | Description                                                | Type          | Default | Required |
-| ----------------------------- | ---------------------------------------------------------- | ------------- | ------- | :------: |
-| `bucket_name`                 | The name of the S3 bucket to create                        | `string`      | n/a     |  ✅ Yes  |
-| `enable_versioning`           | Enable versioning on the S3 bucket                         | `bool`        | `true`  |  ❌ No   |
-| `tags`                        | Tags to apply to all resources                             | `map(string)` | `{}`    |  ❌ No   |
-| `cloudfront_distribution_arn` | Optional: ARN of CloudFront distribution for bucket access | `string`      | `null`  |  ❌ No   |
-| `custom_policy_json`          | Optional: A custom bucket policy JSON document             | `string`      | `null`  |  ❌ No   |
-| `elb_log_delivery_prefixes`   | Optional: key prefixes (one per ELB) to grant ELB log-delivery write access | `list(string)` | `[]`  |  ❌ No   |
+| Name                          | Description                                                                 | Type           | Default | Required |
+| ----------------------------- | --------------------------------------------------------------------------- | -------------- | ------- | :------: |
+| `bucket_name`                 | The name of the S3 bucket to create                                         | `string`       | n/a     |  ✅ Yes  |
+| `enable_versioning`           | Enable versioning on the S3 bucket                                          | `bool`         | `true`  |  ❌ No   |
+| `tags`                        | Tags to apply to all resources                                              | `map(string)`  | `{}`    |  ❌ No   |
+| `cloudfront_distribution_arn` | Optional: ARN of CloudFront distribution for bucket access                  | `string`       | `null`  |  ❌ No   |
+| `custom_policy_json`          | Optional: A custom bucket policy JSON document                              | `string`       | `null`  |  ❌ No   |
+| `elb_log_delivery_prefixes`   | Optional: key prefixes (one per ELB) to grant ELB log-delivery write access | `list(string)` | `[]`    |  ❌ No   |
 
 ## 📤 Outputs
 

--- a/infrastructure/modules/s3/main.tf
+++ b/infrastructure/modules/s3/main.tf
@@ -78,6 +78,28 @@ resource "aws_s3_bucket_policy" "custom_policy" {
   policy = var.custom_policy_json
 }
 
+# Grants the ELB log-delivery service write access so an ALB with
+# access_logs.enabled = true can actually deliver to this bucket.
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket_policy" "elb_log_delivery" {
+  count  = length(var.elb_log_delivery_prefixes) > 0 ? 1 : 0
+  bucket = aws_s3_bucket.bucket.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      for prefix in var.elb_log_delivery_prefixes : {
+        Sid       = "AllowELBLogDelivery${replace(prefix, "/[^a-zA-Z0-9]/", "")}"
+        Effect    = "Allow"
+        Principal = { Service = "logdelivery.elasticloadbalancing.amazonaws.com" }
+        Action    = "s3:PutObject"
+        Resource  = "${aws_s3_bucket.bucket.arn}/${prefix}/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
+      }
+    ]
+  })
+}
+
 # ──────────────────────────────────────────────────────────────────────────────
 # Cross-Region Replication — only created when enable_crr = true
 # Continuously replicates all objects to a DR region bucket.

--- a/infrastructure/modules/s3/variables.tf
+++ b/infrastructure/modules/s3/variables.tf
@@ -33,6 +33,12 @@ variable "custom_policy_json" {
   default     = null
 }
 
+variable "elb_log_delivery_prefixes" {
+  description = "Optional: S3 key prefixes (one per ELB) to grant the ELB log-delivery service write access under. Empty list skips the policy."
+  type        = list(string)
+  default     = []
+}
+
 variable "enable_crr" {
   description = "Enable Cross-Region Replication to a DR region bucket"
   type        = bool


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description
Turns on access logging for the backend ALB in prod and dev (both were
`false`), and adds the S3 bucket policy the ELB log-delivery service
needs to actually write to it — without it, enabling the flag alone
fails at apply time.


Why: chased intermittent 5xx spikes on the backend ALB that left no
trace in app-level logs. 

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #
- Related to #
