### PR TITLE
fix(api): stop one bad row from 500ing workbooks, members and user-search endpoints

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { Logger, Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 import { APP_GUARD } from "@nestjs/core";
 import { ScheduleModule } from "@nestjs/schedule";
@@ -29,6 +29,8 @@ import { SearchModule } from "./search/search.module";
 import { UserModule } from "./users/user.module";
 import { WorkbookModule } from "./workbooks/workbook.module";
 
+const orpcLogger = new Logger("ORPC");
+
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -52,6 +54,32 @@ import { WorkbookModule } from "./workbooks/workbook.module";
     ScheduleModule.forRoot(),
     BetterAuthModule.forRoot({ auth }),
     ORPCModule.forRoot({
+      // ORPCErrors are serialized straight to the response by oRPC (the rethrow
+      // plugin below only forwards non-oRPC errors to Nest), so without this
+      // interceptor 5xx errors raised inside the oRPC pipeline — most notably
+      // output-validation failures — would never reach the logs.
+      interceptors: [
+        async (options): Promise<unknown> => {
+          try {
+            return await options.next();
+          } catch (error) {
+            if (error instanceof ORPCError && error.status >= 500) {
+              // nestjs-pino attaches the request (method + url) to this line already.
+              const cause: unknown = error.cause;
+              let issues: unknown;
+              if (typeof cause === "object" && cause !== null && "issues" in cause) {
+                issues = (cause as Record<string, unknown>).issues;
+              }
+              orpcLogger.error({
+                msg: error.message,
+                code: String(error.code),
+                ...(issues !== undefined ? { issues } : {}),
+              });
+            }
+            throw error;
+          }
+        },
+      ],
       plugins: [new RethrowHandlerPlugin({ filter: (error) => !(error instanceof ORPCError) })],
     }),
     AnalyticsModule,

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -19,6 +19,7 @@ import emailConfig from "./common/config/email.config";
 import mailchimpConfig from "./common/config/mailchimp.config";
 import { DatabaseModule } from "./common/database/database.module";
 import { AnalyticsModule } from "./common/modules/analytics/analytics.module";
+import { createOrpcErrorLoggingInterceptor } from "./common/utils/orpc-error-logging";
 import { ExperimentModule } from "./experiments/experiment.module";
 import { HealthModule } from "./health/health.module";
 import { IotModule } from "./iot/iot.module";
@@ -54,32 +55,7 @@ const orpcLogger = new Logger("ORPC");
     ScheduleModule.forRoot(),
     BetterAuthModule.forRoot({ auth }),
     ORPCModule.forRoot({
-      // ORPCErrors are serialized straight to the response by oRPC (the rethrow
-      // plugin below only forwards non-oRPC errors to Nest), so without this
-      // interceptor 5xx errors raised inside the oRPC pipeline — most notably
-      // output-validation failures — would never reach the logs.
-      interceptors: [
-        async (options): Promise<unknown> => {
-          try {
-            return await options.next();
-          } catch (error) {
-            if (error instanceof ORPCError && error.status >= 500) {
-              // nestjs-pino attaches the request (method + url) to this line already.
-              const cause: unknown = error.cause;
-              let issues: unknown;
-              if (typeof cause === "object" && cause !== null && "issues" in cause) {
-                issues = (cause as Record<string, unknown>).issues;
-              }
-              orpcLogger.error({
-                msg: error.message,
-                code: String(error.code),
-                ...(issues !== undefined ? { issues } : {}),
-              });
-            }
-            throw error;
-          }
-        },
-      ],
+      interceptors: [createOrpcErrorLoggingInterceptor(orpcLogger)],
       plugins: [new RethrowHandlerPlugin({ filter: (error) => !(error instanceof ORPCError) })],
     }),
     AnalyticsModule,

--- a/apps/backend/src/common/utils/orpc-error-logging.spec.ts
+++ b/apps/backend/src/common/utils/orpc-error-logging.spec.ts
@@ -1,0 +1,70 @@
+import type { Logger } from "@nestjs/common";
+import { ORPCError } from "@orpc/nest";
+import { describe, expect, it, vi } from "vitest";
+
+import { createOrpcErrorLoggingInterceptor } from "./orpc-error-logging";
+
+function makeLogger() {
+  const error = vi.fn();
+  return { logger: { error } as unknown as Logger, error };
+}
+
+describe("createOrpcErrorLoggingInterceptor", () => {
+  it("passes through the handler result untouched", async () => {
+    const { logger, error: logError } = makeLogger();
+    const interceptor = createOrpcErrorLoggingInterceptor(logger);
+
+    const result = await interceptor({ next: () => Promise.resolve(["row"]) });
+
+    expect(result).toEqual(["row"]);
+    expect(logError).not.toHaveBeenCalled();
+  });
+
+  it("logs a 5xx ORPCError with the validation issues from its cause, then rethrows", async () => {
+    const { logger, error: logError } = makeLogger();
+    const interceptor = createOrpcErrorLoggingInterceptor(logger);
+    const issues = [{ code: "unrecognized_keys", path: ["cells", 0, "payload"] }];
+    const error = new ORPCError("INTERNAL_SERVER_ERROR", {
+      message: "Output validation failed",
+      cause: { issues },
+    });
+
+    await expect(interceptor({ next: () => Promise.reject(error) })).rejects.toBe(error);
+
+    expect(logError).toHaveBeenCalledWith({
+      msg: "Output validation failed",
+      code: "INTERNAL_SERVER_ERROR",
+      issues,
+    });
+  });
+
+  it("logs a 5xx ORPCError without issues when the cause has none", async () => {
+    const { logger, error: logError } = makeLogger();
+    const interceptor = createOrpcErrorLoggingInterceptor(logger);
+    const error = new ORPCError("INTERNAL_SERVER_ERROR", { message: "boom" });
+
+    await expect(interceptor({ next: () => Promise.reject(error) })).rejects.toBe(error);
+
+    expect(logError).toHaveBeenCalledWith({ msg: "boom", code: "INTERNAL_SERVER_ERROR" });
+  });
+
+  it("rethrows 4xx ORPCErrors without logging (handlers already log their own failures)", async () => {
+    const { logger, error: logError } = makeLogger();
+    const interceptor = createOrpcErrorLoggingInterceptor(logger);
+    const error = new ORPCError("NOT_FOUND", { status: 404, message: "missing" });
+
+    await expect(interceptor({ next: () => Promise.reject(error) })).rejects.toBe(error);
+
+    expect(logError).not.toHaveBeenCalled();
+  });
+
+  it("rethrows non-ORPC errors without logging (the rethrow plugin hands them to Nest)", async () => {
+    const { logger, error: logError } = makeLogger();
+    const interceptor = createOrpcErrorLoggingInterceptor(logger);
+    const error = new TypeError("unrelated");
+
+    await expect(interceptor({ next: () => Promise.reject(error) })).rejects.toBe(error);
+
+    expect(logError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/common/utils/orpc-error-logging.ts
+++ b/apps/backend/src/common/utils/orpc-error-logging.ts
@@ -1,0 +1,31 @@
+import type { Logger } from "@nestjs/common";
+import { ORPCError } from "@orpc/nest";
+
+/**
+ * oRPC client interceptor that logs 5xx ORPCErrors. ORPCErrors are serialized
+ * straight to the response by oRPC (the rethrow plugin only forwards non-oRPC
+ * errors to Nest), so without this, server errors raised inside the pipeline —
+ * most notably output-validation failures — never reach the logs. nestjs-pino
+ * attaches the request (method + url) to each line.
+ */
+export function createOrpcErrorLoggingInterceptor(logger: Logger) {
+  return async (options: { next: (this: void) => Promise<unknown> }): Promise<unknown> => {
+    try {
+      return await options.next();
+    } catch (error) {
+      if (error instanceof ORPCError && error.status >= 500) {
+        const cause: unknown = error.cause;
+        let issues: unknown;
+        if (typeof cause === "object" && cause !== null && "issues" in cause) {
+          issues = (cause as Record<string, unknown>).issues;
+        }
+        logger.error({
+          msg: error.message,
+          code: String(error.code),
+          ...(issues !== undefined ? { issues } : {}),
+        });
+      }
+      throw error;
+    }
+  };
+}

--- a/apps/backend/src/workbooks/application/use-cases/list-workbooks/list-workbooks.ts
+++ b/apps/backend/src/workbooks/application/use-cases/list-workbooks/list-workbooks.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from "@nestjs/common";
 
 import { Result } from "../../../../common/utils/fp-utils";
-import { WorkbookDto } from "../../../core/models/workbook.model";
+import { WorkbookListItemDto } from "../../../core/models/workbook.model";
 import { WorkbookRepository, WorkbookFilter } from "../../../core/repositories/workbook.repository";
 
 @Injectable()
@@ -10,7 +10,7 @@ export class ListWorkbooksUseCase {
 
   constructor(private readonly workbookRepository: WorkbookRepository) {}
 
-  async execute(filter?: WorkbookFilter): Promise<Result<WorkbookDto[]>> {
+  async execute(filter?: WorkbookFilter): Promise<Result<WorkbookListItemDto[]>> {
     this.logger.log({
       msg: "Listing workbooks",
       operation: "listWorkbooks",

--- a/apps/backend/src/workbooks/core/models/workbook.model.ts
+++ b/apps/backend/src/workbooks/core/models/workbook.model.ts
@@ -30,6 +30,14 @@ export const selectWorkbookSchema = createSelectSchema(workbooks)
     experimentCount: z.number().int().nonnegative().optional(),
   });
 
+// List rows carry no `cells`: they dominate the payload and per-cell validation of
+// every row would let one legacy workbook 500 the whole collection endpoint.
+// `cellTypeCounts` is the SQL-computed projection the list UI needs instead.
+export const selectWorkbookListItemSchema = selectWorkbookSchema.omit({ cells: true }).extend({
+  cellTypeCounts: z.record(z.string(), z.number()).optional(),
+});
+
 export type CreateWorkbookDto = z.infer<typeof createWorkbookSchema>;
 export type UpdateWorkbookDto = z.infer<typeof updateWorkbookSchema>;
 export type WorkbookDto = z.infer<typeof selectWorkbookSchema>;
+export type WorkbookListItemDto = z.infer<typeof selectWorkbookListItemSchema>;

--- a/apps/backend/src/workbooks/core/repositories/workbook.repository.ts
+++ b/apps/backend/src/workbooks/core/repositories/workbook.repository.ts
@@ -28,7 +28,12 @@ import {
   getAnonymizedFirstName,
   getAnonymizedLastName,
 } from "../../../common/utils/profile-anonymization";
-import { CreateWorkbookDto, UpdateWorkbookDto, WorkbookDto } from "../models/workbook.model";
+import {
+  CreateWorkbookDto,
+  UpdateWorkbookDto,
+  WorkbookDto,
+  WorkbookListItemDto,
+} from "../models/workbook.model";
 
 export interface WorkbookFilter {
   search?: string;
@@ -39,12 +44,35 @@ export interface WorkbookFilter {
 // All workbook columns except the internal full-text `search_vector` (never returned to clients).
 const { searchVector: _workbookSearchVector, ...workbookColumns } = getTableColumns(workbooks);
 
+// List queries additionally drop `cells`: the list contract doesn't expose them and
+// they are by far the heaviest column.
+const { cells: _workbookCells, ...workbookListColumns } = workbookColumns;
+
 // Number of experiments currently referencing a workbook. A correlated subquery
 // keeps findAll/findById single-query (no N+1).
 function experimentCountSql() {
   return sql<number>`(select count(*)::int from ${experiments} where ${experiments.workbookId} = ${workbooks.id})`.mapWith(
     Number,
   );
+}
+
+// Cells grouped by raw `type` for list badges. Computed in SQL on purpose: it works
+// for rows whose cells no longer parse under the current contract, which is exactly
+// when the list must keep rendering.
+function cellTypeCountsSql() {
+  return sql<Record<string, number>>`(
+    select case when jsonb_typeof(${workbooks.cells}) = 'array'
+      then coalesce((
+        select jsonb_object_agg(t.cell_type, t.cnt)
+        from (
+          select coalesce(cell->>'type', 'unknown') as cell_type, count(*)::int as cnt
+          from jsonb_array_elements(${workbooks.cells}) as cell
+          group by 1
+        ) t
+      ), '{}'::jsonb)
+      else '{}'::jsonb
+    end
+  )`;
 }
 
 // Set of protocol/macro ids referenced by the workbook's cells.
@@ -84,14 +112,15 @@ export class WorkbookRepository {
     });
   }
 
-  async findAll(filter?: WorkbookFilter, limit?: number): Promise<Result<WorkbookDto[]>> {
+  async findAll(filter?: WorkbookFilter, limit?: number): Promise<Result<WorkbookListItemDto[]>> {
     return tryCatch(async () => {
       let query = this.database
         .select({
-          workbooks: workbookColumns,
+          workbooks: workbookListColumns,
           firstName: getAnonymizedFirstName(),
           lastName: getAnonymizedLastName(),
           experimentCount: experimentCountSql(),
+          cellTypeCounts: cellTypeCountsSql(),
         })
         .from(workbooks)
         .innerJoin(profiles, eq(workbooks.createdBy, profiles.userId))
@@ -191,11 +220,12 @@ export class WorkbookRepository {
 
       const results = await query;
       return results.map((result) => {
-        const augmented = result.workbooks as WorkbookDto;
+        const augmented = result.workbooks as WorkbookListItemDto;
         const firstName = result.firstName;
         const lastName = result.lastName;
         augmented.createdByName = firstName && lastName ? `${firstName} ${lastName}` : undefined;
         augmented.experimentCount = result.experimentCount;
+        augmented.cellTypeCounts = result.cellTypeCounts;
         return augmented;
       });
     });

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -85,8 +85,7 @@
                         "email": {
                           "anyOf": [
                             {
-                              "type": "string",
-                              "format": "email"
+                              "type": "string"
                             },
                             {
                               "type": "null"
@@ -3509,8 +3508,7 @@
                           "email": {
                             "anyOf": [
                               {
-                                "type": "string",
-                                "format": "email"
+                                "type": "string"
                               },
                               {
                                 "type": "null"
@@ -3646,8 +3644,7 @@
                           "email": {
                             "anyOf": [
                               {
-                                "type": "string",
-                                "format": "email"
+                                "type": "string"
                               },
                               {
                                 "type": "null"
@@ -3818,8 +3815,7 @@
                         "email": {
                           "anyOf": [
                             {
-                              "type": "string",
-                              "format": "email"
+                              "type": "string"
                             },
                             {
                               "type": "null"
@@ -11696,8 +11692,7 @@
                         "email": {
                           "anyOf": [
                             {
-                              "type": "string",
-                              "format": "email"
+                              "type": "string"
                             },
                             {
                               "type": "null"
@@ -11838,8 +11833,7 @@
                           "email": {
                             "anyOf": [
                               {
-                                "type": "string",
-                                "format": "email"
+                                "type": "string"
                               },
                               {
                                 "type": "null"
@@ -11981,8 +11975,7 @@
                         "email": {
                           "anyOf": [
                             {
-                              "type": "string",
-                              "format": "email"
+                              "type": "string"
                             },
                             {
                               "type": "null"
@@ -12133,8 +12126,7 @@
                         "email": {
                           "anyOf": [
                             {
-                              "type": "string",
-                              "format": "email"
+                              "type": "string"
                             },
                             {
                               "type": "null"
@@ -12285,8 +12277,7 @@
                         "email": {
                           "anyOf": [
                             {
-                              "type": "string",
-                              "format": "email"
+                              "type": "string"
                             },
                             {
                               "type": "null"
@@ -16068,8 +16059,7 @@
                       "email": {
                         "anyOf": [
                           {
-                            "type": "string",
-                            "format": "email"
+                            "type": "string"
                           },
                           {
                             "type": "null"
@@ -16143,8 +16133,7 @@
                     "email": {
                       "anyOf": [
                         {
-                          "type": "string",
-                          "format": "email"
+                          "type": "string"
                         },
                         {
                           "type": "null"
@@ -17059,468 +17048,6 @@
                           }
                         ]
                       },
-                      "cells": {
-                        "type": "array",
-                        "items": {
-                          "anyOf": [
-                            {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "minLength": 1
-                                },
-                                "isCollapsed": {
-                                  "default": false,
-                                  "type": "boolean"
-                                },
-                                "type": {
-                                  "const": "protocol"
-                                },
-                                "payload": {
-                                  "type": "object",
-                                  "properties": {
-                                    "protocolId": {
-                                      "type": "string",
-                                      "format": "uuid"
-                                    },
-                                    "version": {
-                                      "type": "integer",
-                                      "minimum": 0
-                                    },
-                                    "name": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "protocolId",
-                                    "version"
-                                  ],
-                                  "additionalProperties": false
-                                }
-                              },
-                              "required": [
-                                "id",
-                                "type",
-                                "payload"
-                              ]
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "minLength": 1
-                                },
-                                "isCollapsed": {
-                                  "default": false,
-                                  "type": "boolean"
-                                },
-                                "type": {
-                                  "const": "command"
-                                },
-                                "payload": {
-                                  "type": "object",
-                                  "properties": {
-                                    "format": {
-                                      "enum": [
-                                        "string",
-                                        "json",
-                                        "yaml"
-                                      ],
-                                      "type": "string"
-                                    },
-                                    "content": {
-                                      "type": "string",
-                                      "minLength": 1
-                                    },
-                                    "name": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "format",
-                                    "content"
-                                  ],
-                                  "additionalProperties": false
-                                }
-                              },
-                              "required": [
-                                "id",
-                                "type",
-                                "payload"
-                              ]
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "minLength": 1
-                                },
-                                "isCollapsed": {
-                                  "default": false,
-                                  "type": "boolean"
-                                },
-                                "type": {
-                                  "const": "macro"
-                                },
-                                "payload": {
-                                  "type": "object",
-                                  "properties": {
-                                    "macroId": {
-                                      "type": "string",
-                                      "format": "uuid"
-                                    },
-                                    "language": {
-                                      "enum": [
-                                        "python",
-                                        "r",
-                                        "javascript"
-                                      ],
-                                      "type": "string"
-                                    },
-                                    "name": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "macroId",
-                                    "language"
-                                  ],
-                                  "additionalProperties": false
-                                }
-                              },
-                              "required": [
-                                "id",
-                                "type",
-                                "payload"
-                              ]
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "minLength": 1
-                                },
-                                "isCollapsed": {
-                                  "default": false,
-                                  "type": "boolean"
-                                },
-                                "type": {
-                                  "const": "question"
-                                },
-                                "name": {
-                                  "type": "string",
-                                  "minLength": 1,
-                                  "maxLength": 64
-                                },
-                                "question": {
-                                  "anyOf": [
-                                    {
-                                      "type": "object",
-                                      "properties": {
-                                        "kind": {
-                                          "const": "yes_no"
-                                        },
-                                        "text": {
-                                          "type": "string",
-                                          "maxLength": 64
-                                        },
-                                        "required": {
-                                          "default": false,
-                                          "type": "boolean"
-                                        }
-                                      },
-                                      "required": [
-                                        "kind",
-                                        "text"
-                                      ],
-                                      "additionalProperties": false
-                                    },
-                                    {
-                                      "type": "object",
-                                      "properties": {
-                                        "kind": {
-                                          "const": "open_ended"
-                                        },
-                                        "text": {
-                                          "type": "string",
-                                          "maxLength": 64
-                                        },
-                                        "required": {
-                                          "default": false,
-                                          "type": "boolean"
-                                        }
-                                      },
-                                      "required": [
-                                        "kind",
-                                        "text"
-                                      ],
-                                      "additionalProperties": false
-                                    },
-                                    {
-                                      "type": "object",
-                                      "properties": {
-                                        "kind": {
-                                          "const": "multi_choice"
-                                        },
-                                        "text": {
-                                          "type": "string",
-                                          "maxLength": 64
-                                        },
-                                        "options": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string",
-                                            "minLength": 1,
-                                            "maxLength": 64
-                                          },
-                                          "minItems": 1
-                                        },
-                                        "required": {
-                                          "default": false,
-                                          "type": "boolean"
-                                        }
-                                      },
-                                      "required": [
-                                        "kind",
-                                        "text",
-                                        "options"
-                                      ],
-                                      "additionalProperties": false
-                                    },
-                                    {
-                                      "type": "object",
-                                      "properties": {
-                                        "kind": {
-                                          "const": "number"
-                                        },
-                                        "text": {
-                                          "type": "string",
-                                          "maxLength": 64
-                                        },
-                                        "required": {
-                                          "default": false,
-                                          "type": "boolean"
-                                        }
-                                      },
-                                      "required": [
-                                        "kind",
-                                        "text"
-                                      ],
-                                      "additionalProperties": false
-                                    }
-                                  ]
-                                },
-                                "answer": {
-                                  "type": "string"
-                                },
-                                "isAnswered": {
-                                  "default": false,
-                                  "type": "boolean"
-                                }
-                              },
-                              "required": [
-                                "id",
-                                "type",
-                                "name",
-                                "question"
-                              ]
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "minLength": 1
-                                },
-                                "isCollapsed": {
-                                  "default": false,
-                                  "type": "boolean"
-                                },
-                                "type": {
-                                  "const": "branch"
-                                },
-                                "paths": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "id": {
-                                        "type": "string",
-                                        "minLength": 1
-                                      },
-                                      "label": {
-                                        "type": "string",
-                                        "maxLength": 64
-                                      },
-                                      "color": {
-                                        "type": "string"
-                                      },
-                                      "conditions": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "object",
-                                          "properties": {
-                                            "id": {
-                                              "type": "string",
-                                              "minLength": 1
-                                            },
-                                            "sourceCellId": {
-                                              "type": "string"
-                                            },
-                                            "field": {
-                                              "type": "string"
-                                            },
-                                            "operator": {
-                                              "enum": [
-                                                "eq",
-                                                "neq",
-                                                "gt",
-                                                "lt",
-                                                "gte",
-                                                "lte"
-                                              ],
-                                              "type": "string"
-                                            },
-                                            "value": {
-                                              "type": "string"
-                                            }
-                                          },
-                                          "required": [
-                                            "id",
-                                            "sourceCellId",
-                                            "field",
-                                            "operator",
-                                            "value"
-                                          ]
-                                        }
-                                      },
-                                      "gotoCellId": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": [
-                                      "id",
-                                      "label",
-                                      "color",
-                                      "conditions"
-                                    ]
-                                  },
-                                  "minItems": 1
-                                },
-                                "defaultPathId": {
-                                  "type": "string"
-                                },
-                                "evaluatedPathId": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "id",
-                                "type",
-                                "paths"
-                              ]
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "minLength": 1
-                                },
-                                "isCollapsed": {
-                                  "default": false,
-                                  "type": "boolean"
-                                },
-                                "type": {
-                                  "const": "output"
-                                },
-                                "producedBy": {
-                                  "type": "string",
-                                  "minLength": 1
-                                },
-                                "data": {},
-                                "executionTime": {
-                                  "type": "number",
-                                  "minimum": 0
-                                },
-                                "messages": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                },
-                                "deviceResults": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "deviceId": {
-                                        "type": "string"
-                                      },
-                                      "deviceLabel": {
-                                        "type": "string"
-                                      },
-                                      "family": {
-                                        "enum": [
-                                          "multispeq",
-                                          "ambyte",
-                                          "minipar",
-                                          "generic",
-                                          "ambit"
-                                        ],
-                                        "type": "string"
-                                      },
-                                      "deviceName": {
-                                        "type": "string"
-                                      },
-                                      "data": {},
-                                      "error": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": [
-                                      "deviceId"
-                                    ]
-                                  }
-                                }
-                              },
-                              "required": [
-                                "id",
-                                "type",
-                                "producedBy"
-                              ]
-                            },
-                            {
-                              "type": "object",
-                              "properties": {
-                                "id": {
-                                  "type": "string",
-                                  "minLength": 1
-                                },
-                                "isCollapsed": {
-                                  "default": false,
-                                  "type": "boolean"
-                                },
-                                "type": {
-                                  "const": "markdown"
-                                },
-                                "content": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "id",
-                                "type",
-                                "content"
-                              ]
-                            }
-                          ]
-                        }
-                      },
                       "metadata": {
                         "type": "object",
                         "additionalProperties": {}
@@ -17575,13 +17102,19 @@
                       "experimentCount": {
                         "type": "integer",
                         "minimum": 0
+                      },
+                      "cellTypeCounts": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "integer",
+                          "minimum": 0
+                        }
                       }
                     },
                     "required": [
                       "id",
                       "name",
                       "description",
-                      "cells",
                       "metadata",
                       "organizationId",
                       "visibility",

--- a/apps/web/components/experiment-overview/experiment-linked-workbook.tsx
+++ b/apps/web/components/experiment-overview/experiment-linked-workbook.tsx
@@ -54,7 +54,8 @@ export function ExperimentLinkedWorkbook({
 
   if (!workbook) return null;
 
-  const hasCells = getWorkbookCellSummary(workbook.cells).length > 0;
+  const cellSummary = getWorkbookCellSummary(workbook.cells);
+  const hasCells = cellSummary.length > 0;
   const plainDescription = workbook.description ? stripHtml(workbook.description) : "";
 
   return (
@@ -97,7 +98,7 @@ export function ExperimentLinkedWorkbook({
           )}
 
           {hasCells ? (
-            <WorkbookCellSummary cells={workbook.cells} className="mt-3" />
+            <WorkbookCellSummary counts={Object.fromEntries(cellSummary)} className="mt-3" />
           ) : (
             <p className="text-muted-foreground mt-3 text-sm italic">{t("workbooks.noCells")}</p>
           )}

--- a/apps/web/components/workbook-list.test.tsx
+++ b/apps/web/components/workbook-list.test.tsx
@@ -90,6 +90,8 @@ describe("WorkbookList row actions", () => {
   });
 
   it("duplicates a workbook from the row menu", async () => {
+    // List rows carry no cells, so duplication first fetches the full workbook.
+    server.mount(contract.workbooks.getWorkbook, { status: 200, body: unused });
     const spy = server.mount(contract.workbooks.createWorkbook, {
       status: 201,
       body: makeWorkbook({ id: "99999999-9999-9999-9999-999999999999", name: "Copy of Source WB" }),
@@ -107,6 +109,7 @@ describe("WorkbookList row actions", () => {
   });
 
   it("shows an error toast when duplicate fails", async () => {
+    server.mount(contract.workbooks.getWorkbook, { status: 200, body: unused });
     server.mount(contract.workbooks.createWorkbook, { status: 500 });
     const user = userEvent.setup();
     render(<WorkbookList workbooks={[unused]} />);

--- a/apps/web/components/workbook-list.test.tsx
+++ b/apps/web/components/workbook-list.test.tsx
@@ -108,6 +108,23 @@ describe("WorkbookList row actions", () => {
     expect(spy.body).toMatchObject({ name: "Fork of Source WB" });
   });
 
+  it("shows an error toast when fetching the source workbook fails", async () => {
+    server.mount(contract.workbooks.getWorkbook, { status: 500 });
+    const spy = server.mount(contract.workbooks.createWorkbook, { status: 201 });
+    const user = userEvent.setup();
+    render(<WorkbookList workbooks={[unused]} />);
+
+    const row = screen.getByText("Source WB").closest("tr");
+    if (!row) throw new Error("row not found");
+    await user.click(within(row).getByLabelText("workbooks.actions.more"));
+    await user.click(await screen.findByRole("menuitem", { name: "workbooks.actions.fork" }));
+
+    await waitFor(() =>
+      expect(toast).toHaveBeenCalledWith(expect.objectContaining({ variant: "destructive" })),
+    );
+    expect(spy.called).toBe(false);
+  });
+
   it("shows an error toast when duplicate fails", async () => {
     server.mount(contract.workbooks.getWorkbook, { status: 200, body: unused });
     server.mount(contract.workbooks.createWorkbook, { status: 500 });

--- a/apps/web/components/workbook-list.tsx
+++ b/apps/web/components/workbook-list.tsx
@@ -5,7 +5,9 @@ import { WorkbookCellSummary } from "@/components/workbook/workbook-cell-summary
 import { useLocale } from "@/hooks/useLocale";
 import { useWorkbookCreate } from "@/hooks/workbook/useWorkbookCreate/useWorkbookCreate";
 import { useWorkbookDelete } from "@/hooks/workbook/useWorkbookDelete/useWorkbookDelete";
+import { orpc } from "@/lib/orpc";
 import { formatDate } from "@/util/date";
+import { useQueryClient } from "@tanstack/react-query";
 import { GitFork, Loader2, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -13,7 +15,7 @@ import { useFeatureFlagEnabled } from "posthog-js/react";
 import { useMemo, useState } from "react";
 
 import { FEATURE_FLAGS } from "@repo/analytics";
-import type { Workbook } from "@repo/api/domains/workbook/workbook.schema";
+import type { WorkbookListItem } from "@repo/api/domains/workbook/workbook.schema";
 import { useTranslation } from "@repo/i18n";
 import {
   AlertDialog,
@@ -46,7 +48,7 @@ import { toast } from "@repo/ui/hooks/use-toast";
 import { cn } from "@repo/ui/lib/utils";
 
 interface WorkbookListProps {
-  workbooks: Workbook[] | undefined;
+  workbooks: WorkbookListItem[] | undefined;
   isLoading?: boolean;
   showEmptyHelp?: boolean;
 }
@@ -144,12 +146,13 @@ function SkeletonRow() {
   );
 }
 
-function WorkbookTableRow({ workbook }: { workbook: Workbook }) {
+function WorkbookTableRow({ workbook }: { workbook: WorkbookListItem }) {
   const { t } = useTranslation("workbook");
   const { t: tCommon } = useTranslation("common");
   const locale = useLocale();
   const router = useRouter();
   const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const queryClient = useQueryClient();
 
   const { mutate: deleteWorkbook, isPending: isDeleting } = useWorkbookDelete();
   const { mutate: createWorkbook, isPending: isDuplicating } = useWorkbookCreate({
@@ -168,12 +171,22 @@ function WorkbookTableRow({ workbook }: { workbook: Workbook }) {
     );
   };
 
-  const handleDuplicate = () => {
+  // List rows don't carry cells, so duplication first fetches the full workbook.
+  const handleDuplicate = async () => {
+    let cells;
+    try {
+      ({ cells } = await queryClient.fetchQuery(
+        orpc.workbooks.getWorkbook.queryOptions({ input: { id: workbook.id } }),
+      ));
+    } catch {
+      toast({ title: t("workbooks.createError"), variant: "destructive" });
+      return;
+    }
     createWorkbook(
       {
         name: t("workbooks.duplicateName", { name: workbook.name }),
         description: workbook.description ?? undefined,
-        cells: workbook.cells,
+        cells,
         metadata: workbook.metadata,
         forkedFrom: workbook.id,
       },
@@ -213,7 +226,7 @@ function WorkbookTableRow({ workbook }: { workbook: Workbook }) {
           >
             {workbook.name}
           </Link>
-          <WorkbookCellSummary cells={workbook.cells} className="mt-1.5" />
+          <WorkbookCellSummary counts={workbook.cellTypeCounts ?? {}} className="mt-1.5" />
         </TableCell>
         <TableCell className={cn("px-6 py-3 text-[13px]", TEXT_MUTED)}>
           {usedBy > 0 ? (
@@ -261,7 +274,7 @@ function WorkbookTableRow({ workbook }: { workbook: Workbook }) {
                   disabled={isDuplicating}
                   onSelect={(e) => {
                     e.preventDefault();
-                    handleDuplicate();
+                    void handleDuplicate();
                   }}
                 >
                   <GitFork className="mr-2 size-4" />

--- a/apps/web/components/workbook/workbook-cell-summary.tsx
+++ b/apps/web/components/workbook/workbook-cell-summary.tsx
@@ -16,6 +16,8 @@ const cellIcons: Record<string, ReactNode> = {
   markdown: <FileText className="h-3 w-3" />,
 };
 
+const cellTypeOrder = Object.keys(cellIcons);
+
 /** Count cells by type, ignoring runtime-only output cells. */
 export function getWorkbookCellSummary(cells: WorkbookCell[]): [string, number][] {
   const counts: Record<string, number> = {};
@@ -26,32 +28,34 @@ export function getWorkbookCellSummary(cells: WorkbookCell[]): [string, number][
   return Object.entries(counts);
 }
 
-/** Pill badges summarizing a workbook's cells by type. */
+/**
+ * Pill badges summarizing a workbook's cells by type. Takes per-type counts (list
+ * responses ship `cellTypeCounts` instead of full cells); types without an icon —
+ * runtime-only output cells and unknown legacy types — are skipped.
+ */
 export function WorkbookCellSummary({
-  cells,
+  counts,
   className,
 }: {
-  cells: WorkbookCell[];
+  counts: Record<string, number>;
   className?: string;
 }) {
   const { t } = useTranslation("workbook");
-  const summary = getWorkbookCellSummary(cells);
+  const summary = Object.entries(counts)
+    .filter(([type]) => type in cellIcons)
+    .sort(([a], [b]) => cellTypeOrder.indexOf(a) - cellTypeOrder.indexOf(b));
   if (summary.length === 0) return null;
   return (
     <div className={cn("flex flex-wrap gap-1.5", className)}>
-      {summary.map(([type, count]) => {
-        const icon = cellIcons[type];
-        if (!icon) return null;
-        return (
-          <span
-            key={type}
-            className="bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium"
-          >
-            {icon}
-            {t(`workbooks.cellSummary.${type}`, { count })}
-          </span>
-        );
-      })}
+      {summary.map(([type, count]) => (
+        <span
+          key={type}
+          className="bg-muted text-muted-foreground inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium"
+        >
+          {cellIcons[type]}
+          {t(`workbooks.cellSummary.${type}`, { count })}
+        </span>
+      ))}
     </div>
   );
 }

--- a/packages/api/src/domains/experiment/experiment.schema.ts
+++ b/packages/api/src/domains/experiment/experiment.schema.ts
@@ -333,7 +333,9 @@ export const zCreateExperimentBodyBase = z.object({
         role: zExperimentMemberRole.optional(),
         firstName: z.string().optional(),
         lastName: z.string().optional(),
-        email: z.string().email().nullable().optional(),
+        // Another user's stored email passed through from the picker; format-validating
+        // it here would reject experiment creation over data the caller can't fix.
+        email: z.string().nullable().optional(),
         avatarUrl: z.string().nullable().optional(),
       }),
     )

--- a/packages/api/src/domains/experiment/join-requests/experiment-join-requests.schema.spec.ts
+++ b/packages/api/src/domains/experiment/join-requests/experiment-join-requests.schema.spec.ts
@@ -54,9 +54,9 @@ describe("zExperimentJoinRequest", () => {
     expect(zExperimentJoinRequest.parse(decided)).toEqual(decided);
   });
 
-  it("rejects a malformed email", () => {
-    const bad = { ...request, user: { ...request.user, email: "nope" } };
-    expect(() => zExperimentJoinRequest.parse(bad)).toThrow();
+  it("accepts a stored non-email value (ORCID signups have placeholder emails)", () => {
+    const orcid = { ...request, user: { ...request.user, email: "0000-0002-1825-0097" } };
+    expect(zExperimentJoinRequest.parse(orcid).user.email).toBe("0000-0002-1825-0097");
   });
 
   it("accepts a list of requests", () => {

--- a/packages/api/src/domains/experiment/join-requests/experiment-join-requests.schema.ts
+++ b/packages/api/src/domains/experiment/join-requests/experiment-join-requests.schema.ts
@@ -14,7 +14,8 @@ export const zExperimentJoinRequest = z.object({
     id: z.string().uuid(),
     firstName: z.string(),
     lastName: z.string(),
-    email: z.string().email().nullable(),
+    // Stored value returned as-is; format-validating on output can 500 the list.
+    email: z.string().nullable(),
     avatarUrl: z.string().nullable(),
   }),
   message: z.string().nullable(),

--- a/packages/api/src/domains/experiment/members/experiment-members.schema.spec.ts
+++ b/packages/api/src/domains/experiment/members/experiment-members.schema.spec.ts
@@ -38,9 +38,9 @@ describe("zExperimentMember", () => {
     expect(zExperimentMember.parse(nulled)).toEqual(nulled);
   });
 
-  it("rejects a malformed email", () => {
-    const bad = { ...member, user: { ...member.user, email: "not-an-email" } };
-    expect(() => zExperimentMember.parse(bad)).toThrow();
+  it("accepts a stored non-email value (ORCID signups have placeholder emails)", () => {
+    const orcid = { ...member, user: { ...member.user, email: "0000-0002-1825-0097" } };
+    expect(zExperimentMember.parse(orcid).user.email).toBe("0000-0002-1825-0097");
   });
 
   it("rejects an unknown role", () => {

--- a/packages/api/src/domains/experiment/members/experiment-members.schema.ts
+++ b/packages/api/src/domains/experiment/members/experiment-members.schema.ts
@@ -7,7 +7,9 @@ export const zExperimentMember = z.object({
     id: z.string().uuid(),
     firstName: z.string(),
     lastName: z.string(),
-    email: z.string().email().nullable(),
+    // Stored value returned as-is: format-validating on output would 500 the whole
+    // member list whenever one account's email doesn't match zod's email regex.
+    email: z.string().nullable(),
     avatarUrl: z.string().nullable(),
   }),
   role: zExperimentMemberRole,

--- a/packages/api/src/domains/user/user.schema.spec.ts
+++ b/packages/api/src/domains/user/user.schema.spec.ts
@@ -54,18 +54,18 @@ describe("User Schema", () => {
       expect(() => zUser.parse(invalidUser)).toThrow();
     });
 
-    it("should reject invalid email format", () => {
-      const invalidUser = {
+    it("accepts a stored non-email value (ORCID signups have placeholder emails)", () => {
+      const orcidUser = {
         id: "123e4567-e89b-12d3-a456-426614174000",
         name: "John Doe",
-        email: "invalid-email",
+        email: "0000-0002-1825-0097",
         emailVerified: false,
         image: null,
         createdAt: "2024-01-15T10:00:00Z",
         registered: true,
       };
 
-      expect(() => zUser.parse(invalidUser)).toThrow();
+      expect(zUser.parse(orcidUser).email).toBe("0000-0002-1825-0097");
     });
   });
 

--- a/packages/api/src/domains/user/user.schema.ts
+++ b/packages/api/src/domains/user/user.schema.ts
@@ -5,7 +5,8 @@ import { zExperimentMemberRole, zExperimentStatus } from "../experiment/experime
 export const zUser = z.object({
   id: z.string().uuid(),
   name: z.string().nullable(),
-  email: z.string().email().nullable(),
+  // Stored value returned as-is; format-validating on output can 500 the endpoint.
+  email: z.string().nullable(),
   emailVerified: z.boolean(),
   image: z.string().nullable(),
   createdAt: z.string().datetime(),
@@ -53,7 +54,8 @@ export const zUserProfile = z.object({
   lastName: z.string(),
   bio: z.string().nullable(),
   activated: z.boolean().nullable(),
-  email: z.string().email().nullable(),
+  // Stored value returned as-is; format-validating on output can 500 user search.
+  email: z.string().nullable(),
   avatarUrl: z.string().nullable().optional(),
 });
 

--- a/packages/api/src/domains/workbook/workbook-cells.schema.spec.ts
+++ b/packages/api/src/domains/workbook/workbook-cells.schema.spec.ts
@@ -10,6 +10,7 @@ import {
   zMarkdownCell,
   zWorkbookCell,
   zWorkbookCellArray,
+  zWorkbookCellArrayInput,
 } from "./workbook-cells.schema";
 
 const uuidA = "11111111-1111-1111-1111-111111111111";
@@ -213,7 +214,10 @@ describe("Workbook Cells Schema", () => {
           question: { kind: "open_ended", text: "B?" },
         },
       ];
-      expect(() => zWorkbookCellArray.parse(cells)).toThrow(/must be unique/i);
+      expect(() => zWorkbookCellArrayInput.parse(cells)).toThrow(/must be unique/i);
+      // The plain (output) array tolerates them: rows persisted before the rule
+      // existed must still serialize on read.
+      expect(zWorkbookCellArray.parse(cells)).toHaveLength(2);
     });
   });
 

--- a/packages/api/src/domains/workbook/workbook-cells.schema.ts
+++ b/packages/api/src/domains/workbook/workbook-cells.schema.ts
@@ -128,7 +128,13 @@ export const zWorkbookCell = z.union([
   zMarkdownCell,
 ]);
 
-export const zWorkbookCellArray = z.array(zWorkbookCell).superRefine((cells, ctx) => {
+// Plain cell array for OUTPUT schemas. Read paths must accept whatever is persisted:
+// rows written before a rule was added (or under an older contract) still have to
+// serialize, otherwise oRPC output validation turns one legacy row into a 500.
+export const zWorkbookCellArray = z.array(zWorkbookCell);
+
+// Input-side variant with cross-cell rules; use wherever clients submit cells.
+export const zWorkbookCellArrayInput = zWorkbookCellArray.superRefine((cells, ctx) => {
   // Canonicalised duplicate names collide as column keys in `questions_data` and lose answers. Mirrors zFlowGraph.
   const seen = new Map<string, number>();
   cells.forEach((cell, index) => {

--- a/packages/api/src/domains/workbook/workbook.schema.ts
+++ b/packages/api/src/domains/workbook/workbook.schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { zWorkbookCellArray } from "./workbook-cells.schema";
+import { zWorkbookCellArray, zWorkbookCellArrayInput } from "./workbook-cells.schema";
 
 export const zWorkbook = z.object({
   id: z.string().uuid(),
@@ -19,7 +19,15 @@ export const zWorkbook = z.object({
   experimentCount: z.number().int().nonnegative().optional(),
 });
 
-export const zWorkbookList = z.array(zWorkbook);
+// List rows omit `cells`: they dominate the payload (output cells embed run data)
+// and one legacy row failing cell validation must not 500 the whole collection.
+// `cellTypeCounts` is the cheap projection list badges need, computed in SQL so it
+// works regardless of whether the stored cells still parse under the current contract.
+export const zWorkbookListItem = zWorkbook.omit({ cells: true }).extend({
+  cellTypeCounts: z.record(z.string(), z.number().int().nonnegative()).optional(),
+});
+
+export const zWorkbookList = z.array(zWorkbookListItem);
 
 export const zWorkbookFilterQuery = z.object({
   search: z.string().optional(),
@@ -37,7 +45,7 @@ export const zCreateWorkbookRequestBody = z.object({
     .min(1, "Name is required")
     .max(255, "Name must be at most 255 characters"),
   description: z.string().optional(),
-  cells: zWorkbookCellArray.optional(),
+  cells: zWorkbookCellArrayInput.optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
   // Set when duplicating an existing workbook, to record its lineage.
   forkedFrom: z.string().uuid().optional(),
@@ -54,7 +62,7 @@ export const zUpdateWorkbookRequestBody = z.object({
     .max(255, "Name must be at most 255 characters")
     .optional(),
   description: z.string().optional(),
-  cells: zWorkbookCellArray.optional(),
+  cells: zWorkbookCellArrayInput.optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
@@ -64,6 +72,7 @@ export const zWorkbookErrorResponse = z.object({
 });
 
 export type Workbook = z.infer<typeof zWorkbook>;
+export type WorkbookListItem = z.infer<typeof zWorkbookListItem>;
 export type WorkbookList = z.infer<typeof zWorkbookList>;
 export type WorkbookFilterQuery = z.infer<typeof zWorkbookFilterQuery>;
 export type WorkbookIdPathParam = z.infer<typeof zWorkbookIdPathParam>;


### PR DESCRIPTION
## Summary

Prod ALB logs show persistent 500s on `GET /api/v1/workbooks`, `GET /api/v1/experiments/:id/members` and `GET /api/v1/users/search`. Root cause (reproduced locally against main): **oRPC validates handler output against the contract schema, and one stored row that no longer matches turns the entire response into `500 "Output validation failed"`** — silently, because `ORPCError`s bypass Nest and were never logged.

Two data classes trigger it:

- **ORCID signups** store an ORCID id (not an email) in `users.email`; `z.string().email()` on output schemas rejects it, 500ing every member list and user search that includes such a user.
- **Legacy workbook rows** whose cells predate newer contract rules (strict payloads, duplicate-question-name refinement) fail per-cell validation, 500ing the whole workbook list for everyone.

## Changes

- **Output schemas return stored emails as-is** (experiment members, user search, getUser, join requests, experiment-create member passthrough). Email format validation stays on write-side inputs, where the caller can actually fix it.
- **Workbook list items no longer carry `cells`** — the heaviest column (output cells embed run data). The list badges get a SQL-computed `cellTypeCounts` record instead, which works even for rows whose cells no longer parse. Duplicate-from-list now fetches the full workbook first.
- **Duplicate-question-name refinement moved to an input-only cell-array variant** (`zWorkbookCellArrayInput`) so pre-rule rows still serialize on read.
- **New ORPC interceptor logs every 5xx** raised inside the oRPC pipeline with the exact zod issues (e.g. `unrecognized_keys: protocolName at cells[0].payload`), so future output-validation failures are diagnosable from backend logs instead of ALB guesswork.

## Verification

Seeded a local DB with an ORCID-email experiment member and a workbook containing legacy cells (strict-payload violation + duplicate canonical question names), then hit all three endpoints with a forged session:

| Endpoint | main | this branch |
|---|---|---|
| `GET /api/v1/workbooks` | 500 `Output validation failed` | 200, no `cells`, correct `cellTypeCounts` |
| `GET /api/v1/experiments/:id/members` | 500 | 200, ORCID id passed through |
| `GET /api/v1/users/search?query=orcid` | 500 | 200 |

A workbook with genuinely invalid cells still 500s on its own **detail** endpoint (contained by design) — but now logs the exact failing field under `context: "ORPC"`.

Tests: 1,860 green across `packages/api`, backend (workbooks/users/members suites) and web (workbook list/summary/hooks). Typecheck and lint clean relative to main.

## Follow-ups (not in this PR)

- After deploy, watch backend logs for `context: "ORPC"` errors to identify specific bad workbook rows for migration.
- Real pagination for `GET /workbooks` — a good perf improvement, but not the cause of these 500s.
