### PR TITLE
feat(data,web): allow selecting device_id as a custom metadata merge key

### DIFF
--- a/apps/data/README.md
+++ b/apps/data/README.md
@@ -24,7 +24,7 @@ pyproject.toml                   # uv workspace root, ruff / pyright / pytest co
 
 - **uv**: Python toolchain. Install with `brew install uv` or `curl -LsSf https://astral.sh/uv/install.sh | sh`.
 - **Databricks CLI**: for `databricks bundle …` commands.
-- **Java 11+**: required by the local PySpark used in tests.
+- **Java 17 or 21**: required by the local PySpark 4 test runtime.
 
 ## Setup
 

--- a/apps/data/pyproject.toml
+++ b/apps/data/pyproject.toml
@@ -17,7 +17,7 @@ dev = [
     "chispa>=0.10",
     "pyright>=1.1.385",
     "pyarrow>=10.0",
-    "pyspark>=3.5,<4",
+    "pyspark==4.0.1",
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "responses>=0.25",

--- a/apps/data/src/lib/enrich/enrich/custom_metadata.py
+++ b/apps/data/src/lib/enrich/enrich/custom_metadata.py
@@ -8,10 +8,23 @@ MATCHABLE_MEASUREMENT_COLUMNS = ("device_id",)
 _META_RECORDS = "_meta_records"
 _QUESTIONS_DATA = "questions_data"
 
+_ORDERED_METADATA_SQL = """
+    transform(
+        array_sort(
+            collect_list(named_struct(
+                'created_at', created_at,
+                'metadata_id', metadata_id,
+                'json', to_json(metadata)
+            ))
+        ),
+        item -> parse_json(item.json)
+    )
+"""
+
 
 def _group_metadata(metadata_df):
-    """Collapse raw metadata rows into one row per experiment before joining."""
-    return metadata_df.groupBy("experiment_id").agg(F.collect_list("metadata").alias(_META_RECORDS))
+    """Collapse metadata oldest-first; later blobs take precedence when merged."""
+    return metadata_df.groupBy("experiment_id").agg(F.expr(_ORDERED_METADATA_SQL).alias(_META_RECORDS))
 
 
 def _match_value_sql(columns):
@@ -44,6 +57,7 @@ def _match_value_sql(columns):
 
 
 def _merge_sql(columns):
+    """Merge ordered blobs, with each later blob replacing repeated keys."""
     match_value = _match_value_sql(columns)
     return f"""
         aggregate(
@@ -72,7 +86,13 @@ def _merge_sql(columns):
                 WHEN acc IS NULL THEN x
                 WHEN x IS NULL THEN acc
                 ELSE parse_json(to_json(map_concat(
-                    cast(acc AS MAP<STRING, VARIANT>),
+                    map_filter(
+                        cast(acc AS MAP<STRING, VARIANT>),
+                        (k, v) -> NOT array_contains(
+                            map_keys(cast(x AS MAP<STRING, VARIANT>)),
+                            k
+                        )
+                    ),
                     cast(x AS MAP<STRING, VARIANT>)
                 )))
             END

--- a/apps/data/src/lib/enrich/enrich/custom_metadata.py
+++ b/apps/data/src/lib/enrich/enrich/custom_metadata.py
@@ -21,6 +21,20 @@ _ORDERED_METADATA_SQL = """
     )
 """
 
+# Used inside an aggregate lambda bound as (acc, x), where x is the later blob.
+_MERGE_MAPS_SQL = """
+    map_concat(
+        map_filter(
+            cast(acc AS MAP<STRING, VARIANT>),
+            (k, v) -> NOT array_contains(
+                map_keys(cast(x AS MAP<STRING, VARIANT>)),
+                k
+            )
+        ),
+        cast(x AS MAP<STRING, VARIANT>)
+    )
+"""
+
 
 def _group_metadata(metadata_df):
     """Collapse metadata oldest-first; later blobs take precedence when merged."""
@@ -85,16 +99,7 @@ def _merge_sql(columns):
             (acc, x) -> CASE
                 WHEN acc IS NULL THEN x
                 WHEN x IS NULL THEN acc
-                ELSE parse_json(to_json(map_concat(
-                    map_filter(
-                        cast(acc AS MAP<STRING, VARIANT>),
-                        (k, v) -> NOT array_contains(
-                            map_keys(cast(x AS MAP<STRING, VARIANT>)),
-                            k
-                        )
-                    ),
-                    cast(x AS MAP<STRING, VARIANT>)
-                )))
+                ELSE parse_json(to_json({_MERGE_MAPS_SQL}))
             END
         )
     """

--- a/apps/data/src/lib/enrich/enrich/custom_metadata.py
+++ b/apps/data/src/lib/enrich/enrich/custom_metadata.py
@@ -21,20 +21,6 @@ _ORDERED_METADATA_SQL = """
     )
 """
 
-# Used inside an aggregate lambda bound as (acc, x), where x is the later blob.
-_MERGE_MAPS_SQL = """
-    map_concat(
-        map_filter(
-            cast(acc AS MAP<STRING, VARIANT>),
-            (k, v) -> NOT array_contains(
-                map_keys(cast(x AS MAP<STRING, VARIANT>)),
-                k
-            )
-        ),
-        cast(x AS MAP<STRING, VARIANT>)
-    )
-"""
-
 
 def _group_metadata(metadata_df):
     """Collapse metadata oldest-first; later blobs take precedence when merged."""
@@ -99,7 +85,16 @@ def _merge_sql(columns):
             (acc, x) -> CASE
                 WHEN acc IS NULL THEN x
                 WHEN x IS NULL THEN acc
-                ELSE parse_json(to_json({_MERGE_MAPS_SQL}))
+                ELSE parse_json(to_json(map_concat(
+                    map_filter(
+                        cast(acc AS MAP<STRING, VARIANT>),
+                        (k, v) -> NOT array_contains(
+                            map_keys(cast(x AS MAP<STRING, VARIANT>)),
+                            k
+                        )
+                    ),
+                    cast(x AS MAP<STRING, VARIANT>)
+                )))
             END
         )
     """

--- a/apps/data/src/lib/enrich/enrich/custom_metadata.py
+++ b/apps/data/src/lib/enrich/enrich/custom_metadata.py
@@ -1,75 +1,102 @@
-"""Custom Metadata Enrichment
-
-Enriches measurement DataFrames with user-uploaded custom metadata.
-Groups raw metadata records per experiment before joining so the
-measurement DataFrame is never fanned-out.
-"""
+"""Enrich measurement DataFrames with user-uploaded custom metadata."""
 
 from pyspark.sql import functions as F
 
+COLUMN_MATCH_PREFIX = "column:"
+MATCHABLE_MEASUREMENT_COLUMNS = ("device_id",)
+
+_META_RECORDS = "_meta_records"
+_QUESTIONS_DATA = "questions_data"
+
 
 def _group_metadata(metadata_df):
-    """Collapse raw metadata rows into one row per experiment."""
-    return metadata_df.groupBy("experiment_id").agg(F.collect_list("metadata").alias("_meta_records"))
+    """Collapse raw metadata rows into one row per experiment before joining."""
+    return metadata_df.groupBy("experiment_id").agg(F.collect_list("metadata").alias(_META_RECORDS))
+
+
+def _match_value_sql(columns):
+    """Return SQL for the measurement value selected by a metadata blob.
+
+    Existing blobs store a question key in ``experimentQuestionId``. A value
+    prefixed with ``column:`` selects an allowlisted top-level measurement
+    column instead. Unsupported prefixed values deliberately resolve to NULL.
+    """
+    key = "variant_get(meta, '$.experimentQuestionId', 'STRING')"
+    column_cases = [
+        f"WHEN {key} = '{COLUMN_MATCH_PREFIX}{column}' THEN CAST(`{column}` AS STRING)"
+        for column in MATCHABLE_MEASUREMENT_COLUMNS
+        if column in columns
+    ]
+    question_value = (
+        f"variant_get({_QUESTIONS_DATA}, concat('$.', {key}), 'STRING')"
+        if _QUESTIONS_DATA in columns
+        else "CAST(NULL AS STRING)"
+    )
+    return "\n".join(
+        [
+            "CASE",
+            *column_cases,
+            f"WHEN {key} LIKE '{COLUMN_MATCH_PREFIX}%' THEN CAST(NULL AS STRING)",
+            f"ELSE {question_value}",
+            "END",
+        ]
+    )
+
+
+def _merge_sql(columns):
+    match_value = _match_value_sql(columns)
+    return f"""
+        aggregate(
+            transform(
+                {_META_RECORDS},
+                meta -> parse_json(to_json(map_filter(
+                    cast(
+                        try_element_at(
+                            filter(
+                                cast(variant_get(meta, '$.rows', 'VARIANT') as ARRAY<VARIANT>),
+                                r -> variant_get(
+                                         r,
+                                         concat('$.', variant_get(meta, '$.identifierColumnId', 'STRING')),
+                                         'STRING'
+                                     ) = {match_value}
+                            ),
+                            1
+                        ) AS MAP<STRING, VARIANT>
+                    ),
+                    (k, v) -> k != '_id'
+                               AND k != variant_get(meta, '$.identifierColumnId', 'STRING')
+                )))
+            ),
+            cast(null as variant),
+            (acc, x) -> CASE
+                WHEN acc IS NULL THEN x
+                WHEN x IS NULL THEN acc
+                ELSE parse_json(to_json(map_concat(
+                    cast(acc AS MAP<STRING, VARIANT>),
+                    cast(x AS MAP<STRING, VARIANT>)
+                )))
+            END
+        )
+    """
 
 
 def add_custom_metadata_column(df, metadata_df):
-    """
-    Enrich measurement rows with user-uploaded custom metadata.
+    """Add a ``custom_metadata`` VARIANT column to a measurement DataFrame."""
+    has_match_value = _QUESTIONS_DATA in df.columns or any(
+        column in df.columns for column in MATCHABLE_MEASUREMENT_COLUMNS
+    )
+    if not has_match_value:
+        return df.withColumn("custom_metadata", F.lit(None).cast("variant"))
 
-    Args:
-        df: PySpark DataFrame with 'experiment_id' and 'questions_data' columns.
-        metadata_df: Raw metadata DataFrame with 'experiment_id' and 'metadata'
-            VARIANT column (straight from the DLT mirror table).
-
-    Returns:
-        DataFrame with an additional `custom_metadata` VARIANT column.
-    """
     try:
-        grouped = _group_metadata(metadata_df)
-
-        enriched = df.join(grouped, "experiment_id", "left")
-
-        enriched = enriched.withColumn(
+        enriched = df.join(_group_metadata(metadata_df), "experiment_id", "left")
+        return enriched.withColumn(
             "custom_metadata",
             F.when(
-                F.col("_meta_records").isNotNull(),
-                F.expr(
-                    """
-                    aggregate(
-                        transform(
-                            _meta_records,
-                            meta -> parse_json(to_json(map_filter(
-                                cast(
-                                    filter(
-                                        cast(variant_get(meta, '$.rows', 'VARIANT') as ARRAY<VARIANT>),
-                                        r -> variant_get(r, concat('$.', variant_get(meta, '$.identifierColumnId', 'STRING')), 'STRING')
-                                             = variant_get(questions_data, concat('$.', variant_get(meta, '$.experimentQuestionId', 'STRING')), 'STRING')
-                                    )[0]
-                                    AS MAP<STRING, VARIANT>
-                                ),
-                                (k, v) -> k != '_id'
-                                           AND k != variant_get(meta, '$.identifierColumnId', 'STRING')
-                            )))
-                        ),
-                        cast(null as variant),
-                        (acc, x) -> CASE
-                            WHEN acc IS NULL THEN x
-                            WHEN x IS NULL THEN acc
-                            ELSE parse_json(to_json(map_concat(
-                                cast(acc AS MAP<STRING, VARIANT>),
-                                cast(x AS MAP<STRING, VARIANT>)
-                            )))
-                        END
-                    )
-                    """
-                ),
+                F.col(_META_RECORDS).isNotNull(),
+                F.expr(_merge_sql(df.columns)),
             ),
-        ).drop("_meta_records")
-
-        print("Custom metadata enrichment completed")
-        return enriched
-
-    except Exception as e:
-        print(f"Warning: Could not enrich with experiment metadata: {e!s}")
+        ).drop(_META_RECORDS)
+    except Exception as error:
+        print(f"Warning: Could not enrich with experiment metadata: {error!s}")
         return df.withColumn("custom_metadata", F.lit(None).cast("variant"))

--- a/apps/data/src/lib/enrich/enrich/question_metadata.py
+++ b/apps/data/src/lib/enrich/enrich/question_metadata.py
@@ -68,18 +68,21 @@ def add_question_columns(df, question_labels):
         # Sanitize the label for use as column name
         sanitized_label = _sanitize_column_name(label)
 
-        # Create a column for each question label by finding the matching answer
-        # Use filter + first to get the answer for the specific question label
+        # Create a column for each question label by finding the matching answer.
+        # try_element_at keeps a missing label NULL under Spark's ANSI behavior.
         # Note: We still use the original label for filtering, but sanitized for column name
         result_df = result_df.withColumn(
             sanitized_label,
             F.when(
                 F.col("questions").isNotNull() & (F.size(F.col("questions")) > 0),
                 F.expr(f"""
-                    transform(
-                        filter(questions, q -> q.question_label = '{label}'),
-                        q -> q.question_answer
-                    )[0]
+                    try_element_at(
+                        transform(
+                            filter(questions, q -> q.question_label = '{label}'),
+                            q -> q.question_answer
+                        ),
+                        1
+                    )
                 """),
             ).otherwise(F.lit(None).cast(StringType())),
         )

--- a/apps/data/src/lib/enrich/enrich/question_metadata.py
+++ b/apps/data/src/lib/enrich/enrich/question_metadata.py
@@ -50,6 +50,16 @@ def _sanitize_column_name(label):
     return sanitized
 
 
+def _answer_for_label(label):
+    return F.try_element_at(
+        F.transform(
+            F.filter(F.col("questions"), lambda question: question.question_label == F.lit(label)),
+            lambda question: question.question_answer,
+        ),
+        F.lit(1),
+    )
+
+
 def add_question_columns(df, question_labels):
     """
     Add individual question columns to a DataFrame by extracting answers
@@ -75,15 +85,7 @@ def add_question_columns(df, question_labels):
             sanitized_label,
             F.when(
                 F.col("questions").isNotNull() & (F.size(F.col("questions")) > 0),
-                F.expr(f"""
-                    try_element_at(
-                        transform(
-                            filter(questions, q -> q.question_label = '{label}'),
-                            q -> q.question_answer
-                        ),
-                        1
-                    )
-                """),
+                _answer_for_label(label),
             ).otherwise(F.lit(None).cast(StringType())),
         )
 

--- a/apps/data/tests/lib/test_custom_metadata.py
+++ b/apps/data/tests/lib/test_custom_metadata.py
@@ -1,6 +1,16 @@
 """Focused tests for custom metadata match-target SQL generation."""
 
-from enrich.custom_metadata import _match_value_sql, _merge_sql
+from enrich.custom_metadata import _ORDERED_METADATA_SQL, _match_value_sql, _merge_sql
+
+
+def test_metadata_blobs_are_ordered_by_persisted_creation_order() -> None:
+    sql = " ".join(_ORDERED_METADATA_SQL.split())
+
+    assert "array_sort( collect_list(named_struct(" in sql
+    assert "'created_at', created_at" in sql
+    assert "'metadata_id', metadata_id" in sql
+    assert "'json', to_json(metadata)" in sql
+    assert "item -> parse_json(item.json)" in sql
 
 
 def test_question_target_reads_questions_data() -> None:
@@ -37,3 +47,10 @@ def test_merge_uses_ansi_safe_first_match() -> None:
     assert "try_element_at(" in sql
     assert "filter(" in sql
     assert "column:device_id" in sql
+
+
+def test_later_blob_explicitly_replaces_repeated_keys() -> None:
+    sql = " ".join(_merge_sql(["questions_data"]).split())
+
+    assert "map_filter( cast(acc AS MAP<STRING, VARIANT>)" in sql
+    assert "map_keys(cast(x AS MAP<STRING, VARIANT>))" in sql

--- a/apps/data/tests/lib/test_custom_metadata.py
+++ b/apps/data/tests/lib/test_custom_metadata.py
@@ -67,20 +67,29 @@ def test_merge_uses_ansi_safe_first_match() -> None:
 
 
 @pytest.mark.spark
-def test_later_blob_explicitly_replaces_repeated_keys(spark) -> None:
+@pytest.mark.parametrize(
+    ("match_key", "identifier_value"),
+    [
+        ("q1", "sample-1"),
+        ("column:device_id", "device-1"),
+    ],
+)
+def test_later_blob_explicitly_replaces_repeated_keys(spark, match_key, identifier_value) -> None:
     records = spark.createDataFrame(
         [
             (
                 '{"q1":"sample-1"}',
+                "device-1",
                 [
-                    """{"identifierColumnId":"sample","experimentQuestionId":"q1","rows":[{"sample":"sample-1","shared":"old","first_only":"kept"}]}""",
-                    """{"identifierColumnId":"sample","experimentQuestionId":"q1","rows":[{"sample":"sample-1","shared":"new","second_only":"kept"}]}""",
+                    f"""{{"identifierColumnId":"sample","experimentQuestionId":"{match_key}","rows":[{{"sample":"{identifier_value}","shared":"old","first_only":"kept"}}]}}""",
+                    f"""{{"identifierColumnId":"sample","experimentQuestionId":"{match_key}","rows":[{{"sample":"{identifier_value}","shared":"new","second_only":"kept"}}]}}""",
                 ],
             )
         ],
-        "questions_json STRING, metadata_json ARRAY<STRING>",
+        "questions_json STRING, device_id STRING, metadata_json ARRAY<STRING>",
     ).select(
         F.parse_json("questions_json").alias("questions_data"),
+        "device_id",
         F.expr("transform(metadata_json, item -> parse_json(item))").alias("_meta_records"),
     )
 

--- a/apps/data/tests/lib/test_custom_metadata.py
+++ b/apps/data/tests/lib/test_custom_metadata.py
@@ -1,34 +1,27 @@
-"""Focused tests for custom metadata match-target SQL generation."""
+"""Focused tests for custom metadata match and merge behavior."""
 
-import json
 from datetime import datetime
 
 import pytest
-from enrich import custom_metadata
-from enrich.custom_metadata import _MERGE_MAPS_SQL, _ORDERED_METADATA_SQL, _match_value_sql, _merge_sql
+from enrich.custom_metadata import _group_metadata, _match_value_sql, _merge_sql
 from pyspark.sql import functions as F
 
 
 @pytest.mark.spark
-def test_metadata_blobs_are_ordered_by_persisted_creation_order(spark, monkeypatch) -> None:
-    # Apache Spark 3.5 lacks Databricks parse_json/VARIANT. Keep the ordering
-    # expression intact and stub only that conversion boundary for local tests.
-    local_sql = _ORDERED_METADATA_SQL.replace("parse_json(item.json)", "item.json")
-    monkeypatch.setattr(custom_metadata, "_ORDERED_METADATA_SQL", local_sql)
-
+def test_metadata_blobs_are_ordered_by_persisted_creation_order(spark) -> None:
     metadata = spark.createDataFrame(
         [
-            ("experiment-1", datetime(2026, 1, 2), "a", {"value": "newest"}),
-            ("experiment-1", datetime(2026, 1, 1), "b", {"value": "aaa-second"}),
-            ("experiment-1", datetime(2026, 1, 1), "a", {"value": "zzz-first"}),
-            ("experiment-2", datetime(2026, 1, 3), "a", {"value": "only"}),
+            ("experiment-1", datetime(2026, 1, 2), "a", '{"value":"newest"}'),
+            ("experiment-1", datetime(2026, 1, 1), "b", '{"value":"aaa-second"}'),
+            ("experiment-1", datetime(2026, 1, 1), "a", '{"value":"zzz-first"}'),
+            ("experiment-2", datetime(2026, 1, 3), "a", '{"value":"only"}'),
         ],
-        "experiment_id STRING, created_at TIMESTAMP, metadata_id STRING, metadata MAP<STRING, STRING>",
-    )
+        "experiment_id STRING, created_at TIMESTAMP, metadata_id STRING, metadata_json STRING",
+    ).withColumn("metadata", F.parse_json("metadata_json"))
 
     grouped = {
-        row.experiment_id: [json.loads(item)["value"] for item in row._meta_records]
-        for row in custom_metadata._group_metadata(metadata).collect()
+        row.experiment_id: [item.toPython()["value"] for item in row._meta_records]
+        for row in _group_metadata(metadata).collect()
     }
 
     assert grouped == {
@@ -75,46 +68,26 @@ def test_merge_uses_ansi_safe_first_match() -> None:
 
 @pytest.mark.spark
 def test_later_blob_explicitly_replaces_repeated_keys(spark) -> None:
-    # The merge itself is standard Spark SQL; substitute STRING only for the
-    # Databricks-only VARIANT value type used in production.
-    local_merge_sql = _MERGE_MAPS_SQL.replace("VARIANT", "STRING")
     records = spark.createDataFrame(
         [
             (
+                '{"q1":"sample-1"}',
                 [
-                    {"shared": "old", "first_only": "kept"},
-                    {"shared": "new", "second_only": "kept"},
+                    """{"identifierColumnId":"sample","experimentQuestionId":"q1","rows":[{"sample":"sample-1","shared":"old","first_only":"kept"}]}""",
+                    """{"identifierColumnId":"sample","experimentQuestionId":"q1","rows":[{"sample":"sample-1","shared":"new","second_only":"kept"}]}""",
                 ],
             )
         ],
-        "records ARRAY<MAP<STRING, STRING>>",
+        "questions_json STRING, metadata_json ARRAY<STRING>",
+    ).select(
+        F.parse_json("questions_json").alias("questions_data"),
+        F.expr("transform(metadata_json, item -> parse_json(item))").alias("_meta_records"),
     )
 
-    merged = (
-        records.select(
-            F.expr(
-                f"""
-            aggregate(
-                records,
-                cast(map() AS MAP<STRING, STRING>),
-                (acc, x) -> {local_merge_sql}
-            )
-            """
-            ).alias("metadata")
-        )
-        .first()
-        .metadata
-    )
+    merged = records.select(F.expr(_merge_sql(records.columns)).alias("metadata")).first().metadata
 
-    assert merged == {
+    assert merged.toPython() == {
         "shared": "new",
         "first_only": "kept",
         "second_only": "kept",
     }
-
-
-def test_merge_sql_uses_explicit_later_blob_precedence() -> None:
-    sql = " ".join(_merge_sql(["questions_data"]).split())
-
-    assert "map_filter( cast(acc AS MAP<STRING, VARIANT>)" in sql
-    assert "map_keys(cast(x AS MAP<STRING, VARIANT>))" in sql

--- a/apps/data/tests/lib/test_custom_metadata.py
+++ b/apps/data/tests/lib/test_custom_metadata.py
@@ -1,0 +1,39 @@
+"""Focused tests for custom metadata match-target SQL generation."""
+
+from enrich.custom_metadata import _match_value_sql, _merge_sql
+
+
+def test_question_target_reads_questions_data() -> None:
+    sql = _match_value_sql(["questions_data"])
+
+    assert "variant_get(questions_data" in sql
+    assert "CAST(`device_id` AS STRING)" not in sql
+
+
+def test_device_target_reads_existing_measurement_column() -> None:
+    sql = _match_value_sql(["questions_data", "device_id"])
+
+    assert "= 'column:device_id' THEN CAST(`device_id` AS STRING)" in sql
+    assert "variant_get(questions_data" in sql
+
+
+def test_missing_question_namespace_resolves_question_targets_to_null() -> None:
+    sql = _match_value_sql(["device_id"])
+
+    assert "ELSE CAST(NULL AS STRING)" in sql
+
+
+def test_unsupported_column_target_does_not_fall_back_to_question_data() -> None:
+    sql = _match_value_sql(["questions_data"])
+
+    prefix_guard = "LIKE 'column:%' THEN CAST(NULL AS STRING)"
+    assert prefix_guard in sql
+    assert sql.index(prefix_guard) < sql.index("ELSE variant_get(questions_data")
+
+
+def test_merge_uses_ansi_safe_first_match() -> None:
+    sql = _merge_sql(["questions_data", "device_id"])
+
+    assert "try_element_at(" in sql
+    assert "filter(" in sql
+    assert "column:device_id" in sql

--- a/apps/data/tests/lib/test_custom_metadata.py
+++ b/apps/data/tests/lib/test_custom_metadata.py
@@ -1,16 +1,40 @@
 """Focused tests for custom metadata match-target SQL generation."""
 
-from enrich.custom_metadata import _ORDERED_METADATA_SQL, _match_value_sql, _merge_sql
+import json
+from datetime import datetime
+
+import pytest
+from enrich import custom_metadata
+from enrich.custom_metadata import _MERGE_MAPS_SQL, _ORDERED_METADATA_SQL, _match_value_sql, _merge_sql
+from pyspark.sql import functions as F
 
 
-def test_metadata_blobs_are_ordered_by_persisted_creation_order() -> None:
-    sql = " ".join(_ORDERED_METADATA_SQL.split())
+@pytest.mark.spark
+def test_metadata_blobs_are_ordered_by_persisted_creation_order(spark, monkeypatch) -> None:
+    # Apache Spark 3.5 lacks Databricks parse_json/VARIANT. Keep the ordering
+    # expression intact and stub only that conversion boundary for local tests.
+    local_sql = _ORDERED_METADATA_SQL.replace("parse_json(item.json)", "item.json")
+    monkeypatch.setattr(custom_metadata, "_ORDERED_METADATA_SQL", local_sql)
 
-    assert "array_sort( collect_list(named_struct(" in sql
-    assert "'created_at', created_at" in sql
-    assert "'metadata_id', metadata_id" in sql
-    assert "'json', to_json(metadata)" in sql
-    assert "item -> parse_json(item.json)" in sql
+    metadata = spark.createDataFrame(
+        [
+            ("experiment-1", datetime(2026, 1, 2), "a", {"value": "newest"}),
+            ("experiment-1", datetime(2026, 1, 1), "b", {"value": "aaa-second"}),
+            ("experiment-1", datetime(2026, 1, 1), "a", {"value": "zzz-first"}),
+            ("experiment-2", datetime(2026, 1, 3), "a", {"value": "only"}),
+        ],
+        "experiment_id STRING, created_at TIMESTAMP, metadata_id STRING, metadata MAP<STRING, STRING>",
+    )
+
+    grouped = {
+        row.experiment_id: [json.loads(item)["value"] for item in row._meta_records]
+        for row in custom_metadata._group_metadata(metadata).collect()
+    }
+
+    assert grouped == {
+        "experiment-1": ["zzz-first", "aaa-second", "newest"],
+        "experiment-2": ["only"],
+    }
 
 
 def test_question_target_reads_questions_data() -> None:
@@ -49,7 +73,47 @@ def test_merge_uses_ansi_safe_first_match() -> None:
     assert "column:device_id" in sql
 
 
-def test_later_blob_explicitly_replaces_repeated_keys() -> None:
+@pytest.mark.spark
+def test_later_blob_explicitly_replaces_repeated_keys(spark) -> None:
+    # The merge itself is standard Spark SQL; substitute STRING only for the
+    # Databricks-only VARIANT value type used in production.
+    local_merge_sql = _MERGE_MAPS_SQL.replace("VARIANT", "STRING")
+    records = spark.createDataFrame(
+        [
+            (
+                [
+                    {"shared": "old", "first_only": "kept"},
+                    {"shared": "new", "second_only": "kept"},
+                ],
+            )
+        ],
+        "records ARRAY<MAP<STRING, STRING>>",
+    )
+
+    merged = (
+        records.select(
+            F.expr(
+                f"""
+            aggregate(
+                records,
+                cast(map() AS MAP<STRING, STRING>),
+                (acc, x) -> {local_merge_sql}
+            )
+            """
+            ).alias("metadata")
+        )
+        .first()
+        .metadata
+    )
+
+    assert merged == {
+        "shared": "new",
+        "first_only": "kept",
+        "second_only": "kept",
+    }
+
+
+def test_merge_sql_uses_explicit_later_blob_precedence() -> None:
     sql = " ".join(_merge_sql(["questions_data"]).split())
 
     assert "map_filter( cast(acc AS MAP<STRING, VARIANT>)" in sql

--- a/apps/data/tests/lib/test_question_metadata.py
+++ b/apps/data/tests/lib/test_question_metadata.py
@@ -40,6 +40,7 @@ class TestAddQuestionColumns:
                 "questions": [
                     {"question_label": "Plant Height (cm)", "question_text": "?", "question_answer": "42"},
                     {"question_label": "Leaf Color", "question_text": "?", "question_answer": "green"},
+                    {"question_label": "Farmer's name", "question_text": "?", "question_answer": "Ada"},
                 ],
             },
             {
@@ -50,11 +51,12 @@ class TestAddQuestionColumns:
             },
         ]
         df = spark.createDataFrame(rows)
-        result = add_question_columns(df, ["Plant Height (cm)", "Leaf Color"]).collect()
+        result = add_question_columns(df, ["Plant Height (cm)", "Leaf Color", "Farmer's name"]).collect()
         by_id = {r.id: r.asDict() for r in result}
 
         assert by_id["1"]["plant_height_cm"] == "42"
         assert by_id["1"]["leaf_color"] == "green"
+        assert by_id["1"]["farmer's_name"] == "Ada"
         assert by_id["2"]["plant_height_cm"] == "37"
         assert by_id["2"]["leaf_color"] is None
 

--- a/apps/data/uv.lock
+++ b/apps/data/uv.lock
@@ -411,7 +411,7 @@ dev = [
     { name = "chispa", specifier = ">=0.10" },
     { name = "pyarrow", specifier = ">=10.0" },
     { name = "pyright", specifier = ">=1.1.385" },
-    { name = "pyspark", specifier = ">=3.5,<4" },
+    { name = "pyspark", specifier = "==4.0.1" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "responses", specifier = ">=0.25" },
@@ -591,12 +591,12 @@ wheels = [
 
 [[package]]
 name = "pyspark"
-version = "3.5.8"
+version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "py4j" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/5a/3806f44eb47387e8af803508cdd6bbc0df784febf4dc010700be04a1ff89/pyspark-3.5.8.tar.gz", hash = "sha256:54cca0767b21b40e3953ad1d30f8601c53abf9cbda763653289cdcfcac52313c", size = 317817299, upload-time = "2026-01-15T11:46:14.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/40/1414582f16c1d7b051c668c2e19c62d21a18bd181d944cb24f5ddbb2423f/pyspark-4.0.1.tar.gz", hash = "sha256:9d1f22d994f60369228397e3479003ffe2dd736ba79165003246ff7bd48e2c73", size = 434204896, upload-time = "2025-09-06T07:15:57.091Z" }
 
 [[package]]
 name = "pytest"

--- a/apps/web/components/experiment-data/metadata-upload-modal/metadata-edit-view.tsx
+++ b/apps/web/components/experiment-data/metadata-upload-modal/metadata-edit-view.tsx
@@ -14,6 +14,7 @@ import {
 import { useCallback, useMemo, useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 
+import { MATCHABLE_MEASUREMENT_COLUMNS } from "@repo/api/domains/experiment/metadata/experiment-metadata.schema";
 import type { ExperimentMetadata } from "@repo/api/domains/experiment/metadata/experiment-metadata.schema";
 import { useTranslation } from "@repo/i18n/client";
 import { Button } from "@repo/ui/components/button";
@@ -23,7 +24,9 @@ import { Label } from "@repo/ui/components/label";
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@repo/ui/components/select";
@@ -47,6 +50,11 @@ interface MetadataEditViewProps {
   questionOptions: QuestionOption[];
   onBack: () => void;
 }
+
+const measurementColumnOptions = MATCHABLE_MEASUREMENT_COLUMNS.map((column) => ({
+  label: column,
+  value: `column:${column}`,
+}));
 
 export function MetadataEditView({
   experimentId,
@@ -283,21 +291,16 @@ export function MetadataEditView({
           )}
 
           <div className="grid gap-2">
-            <Label htmlFor="experiment-question">
-              {t("uploadModal.metadata.experimentQuestionLabel", {
-                defaultValue: "Identifier column from experiment question",
+            <Label htmlFor="metadata-match-target">
+              {t("uploadModal.metadata.matchTargetLabel", {
+                defaultValue: "Match target",
               })}
             </Label>
             <p className="text-muted-foreground text-xs">
-              {questionOptions.length > 0
-                ? t("uploadModal.metadata.experimentQuestionHint", {
-                    defaultValue:
-                      "Select the experiment question whose answers should match the metadata identifier column (e.g., a plot question).",
-                  })
-                : t("uploadModal.metadata.experimentQuestionNoQuestions", {
-                    defaultValue:
-                      "No questions found. Add question nodes to the experiment flow first.",
-                  })}
+              {t("uploadModal.metadata.matchTargetHint", {
+                defaultValue:
+                  "Select the experiment question or measurement column whose values should match the metadata identifier column.",
+              })}
             </p>
             <Controller
               control={control}
@@ -306,27 +309,44 @@ export function MetadataEditView({
                 <Select
                   value={field.value}
                   onValueChange={field.onChange}
-                  disabled={questionOptions.length === 0}
+                  disabled={questionOptions.length === 0 && measurementColumnOptions.length === 0}
                 >
-                  <SelectTrigger id="experiment-question">
+                  <SelectTrigger id="metadata-match-target">
                     <SelectValue
-                      placeholder={
-                        questionOptions.length === 0
-                          ? t("uploadModal.metadata.experimentQuestionNoQuestionsPlaceholder", {
-                              defaultValue: "No questions available",
-                            })
-                          : t("uploadModal.metadata.experimentQuestionPlaceholder", {
-                              defaultValue: "Select a question",
-                            })
-                      }
+                      placeholder={t("uploadModal.metadata.matchTargetPlaceholder", {
+                        defaultValue: "Select a match target",
+                      })}
                     />
                   </SelectTrigger>
                   <SelectContent>
-                    {questionOptions.map((q) => (
-                      <SelectItem key={q.id} value={q.id}>
-                        {q.name}
-                      </SelectItem>
-                    ))}
+                    {questionOptions.length > 0 && (
+                      <SelectGroup>
+                        <SelectLabel>
+                          {t("uploadModal.metadata.matchTargetQuestionsGroup", {
+                            defaultValue: "Questions",
+                          })}
+                        </SelectLabel>
+                        {questionOptions.map((question) => (
+                          <SelectItem key={question.id} value={question.id}>
+                            {question.name}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    )}
+                    {measurementColumnOptions.length > 0 && (
+                      <SelectGroup>
+                        <SelectLabel>
+                          {t("uploadModal.metadata.matchTargetMeasurementColumnsGroup", {
+                            defaultValue: "Measurement columns",
+                          })}
+                        </SelectLabel>
+                        {measurementColumnOptions.map((target) => (
+                          <SelectItem key={target.value} value={target.value}>
+                            {target.label}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    )}
                   </SelectContent>
                 </Select>
               )}

--- a/apps/web/components/experiment-data/metadata-upload-modal/steps/metadata-upload-step.test.tsx
+++ b/apps/web/components/experiment-data/metadata-upload-modal/steps/metadata-upload-step.test.tsx
@@ -48,6 +48,7 @@ vi.mock("@/components/metadata-table/utils/parse-metadata-import", () => ({
 }));
 
 let mockFlowData: unknown = null;
+let mockSelectOnValueChange: ((value: string) => void) | undefined;
 vi.mock("@/hooks/experiment/useExperimentFlow/useExperimentFlow", () => ({
   useExperimentFlow: () => ({ data: mockFlowData, isLoading: false, error: null }),
 }));
@@ -113,26 +114,33 @@ vi.mock("@repo/ui/components/select", () => ({
     children,
     onValueChange,
     value,
+    disabled,
   }: {
     children: React.ReactNode;
     onValueChange?: (v: string) => void;
     value?: string;
     disabled?: boolean;
-  }) => (
-    <div data-testid="select" data-value={value}>
-      {children}
-      {onValueChange && (
-        <button
-          data-testid="select-trigger-action"
-          onClick={() => onValueChange("test_question")}
-        />
-      )}
-    </div>
-  ),
+  }) => {
+    mockSelectOnValueChange = onValueChange;
+    return (
+      <div data-testid="select" data-value={value} data-disabled={disabled ? "true" : "false"}>
+        {children}
+      </div>
+    );
+  },
   SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
-    <div data-value={value}>{children}</div>
+    <button
+      type="button"
+      data-testid={`select-item-${value}`}
+      data-value={value}
+      onClick={() => mockSelectOnValueChange?.(value)}
+    >
+      {children}
+    </button>
   ),
+  SelectLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SelectTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
 }));
@@ -161,6 +169,7 @@ describe("MetadataUploadStep", () => {
     vi.clearAllMocks();
     mockFlowData = null;
     mockExistingMetadata = [];
+    mockSelectOnValueChange = undefined;
   });
 
   const renderStep = (props?: Partial<{ onClose: () => void }>) =>
@@ -458,7 +467,7 @@ describe("MetadataUploadStep", () => {
       fireEvent.change(nameInput, { target: { value: "Test Metadata" } });
 
       fireEvent.click(screen.getByTestId("set-identifier"));
-      fireEvent.click(screen.getByTestId("select-trigger-action"));
+      fireEvent.click(screen.getByTestId("select-item-column:device_id"));
 
       return { onClose };
     };
@@ -482,7 +491,7 @@ describe("MetadataUploadStep", () => {
               { _id: "row_1", ID: 2, Name: "Test2" },
             ],
             identifierColumnId: "ID",
-            experimentQuestionId: "test_question",
+            experimentQuestionId: "column:device_id",
           },
         });
       });
@@ -531,6 +540,36 @@ describe("MetadataUploadStep", () => {
       expect(screen.getByText("Plot Number")).toBeInTheDocument();
       expect(screen.getByText("Location ID")).toBeInTheDocument();
       expect(screen.queryByText("Temperature")).not.toBeInTheDocument();
+      expect(
+        screen.getByText("uploadModal.metadata.matchTargetQuestionsGroup"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("uploadModal.metadata.matchTargetMeasurementColumnsGroup"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("device_id")).toBeInTheDocument();
+    });
+
+    it("offers measurement columns and enables the target select with zero questions", async () => {
+      mockFlowData = { graph: { nodes: [] } };
+      mockParseClipboard.mockResolvedValue(sampleData);
+      renderStep();
+      goToEditView();
+
+      fireEvent.click(getButton("uploadModal.metadata.pasteClipboard"));
+      await screen.findByTestId("metadata-table");
+
+      expect(screen.getByTestId("select")).toHaveAttribute("data-disabled", "false");
+      expect(screen.getByText("device_id")).toBeInTheDocument();
+      expect(
+        screen.getByText("uploadModal.metadata.matchTargetMeasurementColumnsGroup"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("uploadModal.metadata.matchTargetQuestionsGroup"),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("uploadModal.metadata.matchTargetHint")).toBeInTheDocument();
+      expect(
+        screen.queryByText("uploadModal.metadata.experimentQuestionNoQuestions"),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/components/workbook/cells/protocol-cell.test.tsx
+++ b/apps/web/components/workbook/cells/protocol-cell.test.tsx
@@ -2,7 +2,7 @@ import { __resetProtocolCodeRegistry, getLiveProtocolCode } from "@/lib/protocol
 import { createProtocol, createProtocolDetail, readOnlyCapabilities } from "@/test/factories";
 import { API_URL } from "@/test/msw/mount";
 import { server } from "@/test/msw/server";
-import { act, render, screen, userEvent, waitFor } from "@/test/test-utils";
+import { render, screen, userEvent, waitFor } from "@/test/test-utils";
 import { http, HttpResponse } from "msw";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
@@ -196,7 +196,6 @@ describe("ProtocolCellComponent", () => {
   });
 
   it("debounces and persists protocol code edits when a user with update capability types valid JSON", async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
     server.mount(contract.protocols.getProtocol, {
       body: createProtocolDetail({ id: "p1", code: [{ measurement: "light" }] }),
     });
@@ -204,7 +203,7 @@ describe("ProtocolCellComponent", () => {
       body: createProtocol({ id: "p1" }),
     });
 
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const user = userEvent.setup();
     render(
       <ProtocolCellComponent cell={makeProtocolCell()} onUpdate={vi.fn()} onDelete={vi.fn()} />,
     );
@@ -212,12 +211,8 @@ describe("ProtocolCellComponent", () => {
     await waitFor(() => expect(screen.getByTestId("simulate-change")).toBeInTheDocument());
     await user.click(screen.getByTestId("simulate-change"));
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1100);
-    });
-    await waitFor(() => expect(updateSpy.called).toBe(true));
+    await waitFor(() => expect(updateSpy.called).toBe(true), { timeout: 3000 });
     expect(updateSpy.body).toEqual({ code: [{ measurement: "new", duration: 10 }] });
-    vi.useRealTimers();
   });
 
   it("notifies the host after a successful save so the experiment can re-pin", async () => {

--- a/apps/web/components/workbook/cells/protocol-cell.test.tsx
+++ b/apps/web/components/workbook/cells/protocol-cell.test.tsx
@@ -2,7 +2,7 @@ import { __resetProtocolCodeRegistry, getLiveProtocolCode } from "@/lib/protocol
 import { createProtocol, createProtocolDetail, readOnlyCapabilities } from "@/test/factories";
 import { API_URL } from "@/test/msw/mount";
 import { server } from "@/test/msw/server";
-import { render, screen, userEvent, waitFor } from "@/test/test-utils";
+import { act, render, screen, userEvent, waitFor } from "@/test/test-utils";
 import { http, HttpResponse } from "msw";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
@@ -212,7 +212,9 @@ describe("ProtocolCellComponent", () => {
     await waitFor(() => expect(screen.getByTestId("simulate-change")).toBeInTheDocument());
     await user.click(screen.getByTestId("simulate-change"));
 
-    await vi.advanceTimersByTimeAsync(1100);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1100);
+    });
     await waitFor(() => expect(updateSpy.called).toBe(true));
     expect(updateSpy.body).toEqual({ code: [{ measurement: "new", duration: 10 }] });
     vi.useRealTimers();

--- a/packages/api/src/domains/experiment/metadata/experiment-metadata.schema.spec.ts
+++ b/packages/api/src/domains/experiment/metadata/experiment-metadata.schema.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  MATCHABLE_MEASUREMENT_COLUMNS,
   makeCustomMetadataFormSchema,
   zExperimentCustomMetadataPayload,
 } from "./experiment-metadata.schema";
@@ -19,6 +20,29 @@ describe("zExperimentCustomMetadataPayload", () => {
 
   it("accepts a well-formed payload", () => {
     expect(zExperimentCustomMetadataPayload.parse(validBlob)).toEqual(validBlob);
+  });
+
+  it("accepts a supported measurement column target", () => {
+    const blob = { ...validBlob, experimentQuestionId: "column:device_id" };
+
+    expect(zExperimentCustomMetadataPayload.parse(blob)).toEqual(blob);
+    expect(MATCHABLE_MEASUREMENT_COLUMNS).toEqual(["device_id"]);
+  });
+
+  it("keeps an unprefixed device_id as a question target", () => {
+    const blob = { ...validBlob, experimentQuestionId: "device_id" };
+    expect(zExperimentCustomMetadataPayload.safeParse(blob).success).toBe(true);
+  });
+
+  it("rejects an unsupported measurement column target", () => {
+    const blob = { ...validBlob, experimentQuestionId: "column:device_name" };
+    const result = zExperimentCustomMetadataPayload.safeParse(blob);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path.join(".") === "experimentQuestionId");
+      expect(issue?.message).toContain("device_id");
+    }
   });
 
   it("rejects empty/whitespace column names", () => {

--- a/packages/api/src/domains/experiment/metadata/experiment-metadata.schema.ts
+++ b/packages/api/src/domains/experiment/metadata/experiment-metadata.schema.ts
@@ -2,6 +2,10 @@ import { z } from "zod";
 
 import { RESERVED_EXPERIMENT_COLUMN_NAMES } from "../experiment.schema";
 
+/** Measurement columns custom metadata may match against directly. */
+export const MATCHABLE_MEASUREMENT_COLUMNS = ["device_id"] as const;
+const METADATA_COLUMN_TARGET_PREFIX = "column:";
+
 function isAllowedMetadataColumnChar(c: string): boolean {
   return (c >= "a" && c <= "z") || (c >= "A" && c <= "Z") || (c >= "0" && c <= "9") || c === "_";
 }
@@ -47,6 +51,17 @@ export const zExperimentCustomMetadataPayload = z
       .max(64, "Experiment question must be 64 characters or less"),
   })
   .superRefine((blob, ctx) => {
+    if (blob.experimentQuestionId.startsWith(METADATA_COLUMN_TARGET_PREFIX)) {
+      const column = blob.experimentQuestionId.slice(METADATA_COLUMN_TARGET_PREFIX.length);
+      if (!MATCHABLE_MEASUREMENT_COLUMNS.some((allowed) => allowed === column)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["experimentQuestionId"],
+          message: `Measurement column must be one of: ${MATCHABLE_MEASUREMENT_COLUMNS.join(", ")}`,
+        });
+      }
+    }
+
     // Reserved names: would collide with system columns once `custom_metadata`
     // is flattened to top-level by an export sink that requires unique columns.
     blob.columns.forEach((col, idx) => {


### PR DESCRIPTION
Closes OJD-1694.

## Problem

Custom metadata could only match uploaded rows through an experiment-question answer. Device-direct experiments can have no questions, leaving the match-target selector empty and preventing metadata from being joined to their measurements.

For the affected Ambit/Ambyte data, device_id is the stable identifier already present on measurement rows, so it is the first explicitly supported measurement-column match target.

## What changed

- The metadata editor now groups match targets into experiment questions and allowlisted measurement columns, currently device_id.
- Measurement-column targets reuse the existing persisted field with the value column:device_id, so existing question-keyed metadata remains compatible.
- API validation accepts allowlisted column targets and rejects unsupported column names.
- Data enrichment resolves each blob against either questions_data or the selected top-level measurement column.
- Frames with neither questions_data nor an allowlisted match column return a NULL custom_metadata column without joining.
- Metadata blobs are processed in persisted created_at/metadata_id order. When blobs repeat a metadata key, the later blob wins deterministically instead of relying on Spark's duplicate-map-key behavior.
- Missing matches remain NULL with ANSI mode enabled.
- Question labels are compared through Spark literal/Column APIs, so labels containing quotes remain valid.

## Compatibility and runtime

- Existing question-keyed payloads keep their current wire shape and behavior.
- Direct column matching is intentionally limited to device_id; adding arbitrary measurement columns is not part of this change.
- The local data dependency is pinned to PySpark 4.0.1 so the executed tests use the same Spark feature generation as the current Lakeflow runtime.
- Spark tests require JDK 17 or 21.
- No Java setup, CI workflow, Turbo configuration, Databricks pipeline configuration, baselines, or one-off scripts are added.

## Validation

- Data suite: 78 passed on PySpark 4.0.1 with JDK 17.
- Ruff lint and format checks pass.
- Pyright reports 0 errors.
- Custom-metadata execution tests cover both question matching and column:device_id matching, deterministic blob ordering, later-blob precedence, missing matches, and ANSI behavior.
- API schema tests cover accepted and rejected measurement-column targets.
- Metadata upload tests cover grouped options, device_id selection, payload persistence, and experiments without questions.

## Out of scope

- Matching on arbitrary measurement columns.
- Device-registry resolution through client_id.
- Broader cleanup of the legacy uploaded-data enrichment call site and blanket fallback behavior.
