### PR TITLE
chore(infra): grant OIDC role kinesis stream-encryption perrmision

### DIFF
--- a/infrastructure/modules/iam-oidc/main.tf
+++ b/infrastructure/modules/iam-oidc/main.tf
@@ -704,6 +704,9 @@ locals {
         "kinesis:AddTagsToStream",
         "kinesis:RemoveTagsFromStream",
         "kinesis:ListTagsForStream",
+        # Required to manage server-side (SSE-KMS) encryption on the stream.
+        "kinesis:StartStreamEncryption",
+        "kinesis:StopStreamEncryption",
       ]
       resource = "*"
     }


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description
Grants the GitHub Actions OIDC role the `kinesis:StartStreamEncryption` and `kinesis:StopStreamEncryption` permissions so OpenTofu can manage SSE-KMS encryption on Kinesis streams.

<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #
- Related to #