### PR TITLE
fix(infra): use managed AllViewerExceptHostHeader policy for OpenNext lambda origins

### DIFF
--- a/infrastructure/modules/opennext/opennext-cloudfront/main.tf
+++ b/infrastructure/modules/opennext/opennext-cloudfront/main.tf
@@ -233,8 +233,8 @@ resource "aws_cloudfront_distribution" "distribution" {
     cached_methods         = ["GET", "HEAD"]
     compress               = true
 
-    cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # Managed-CachingOptimized
-    origin_request_policy_id = aws_cloudfront_origin_request_policy.lambda_signed_requests.id
+    cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # Managed-CachingDisabled
+    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # Managed-AllViewerExceptHostHeader
 
     lambda_function_association {
       event_type   = "origin-request"
@@ -270,7 +270,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     compress               = true
 
     cache_policy_id          = aws_cloudfront_cache_policy.image_cache_policy.id
-    origin_request_policy_id = aws_cloudfront_origin_request_policy.lambda_signed_requests.id
+    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # Managed-AllViewerExceptHostHeader
   }
 
   # Cache behavior for PostHog ingest routes - direct passthrough to PostHog
@@ -317,7 +317,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     compress               = true
 
     cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # Managed-CachingDisabled
-    origin_request_policy_id = aws_cloudfront_origin_request_policy.lambda_signed_requests.id
+    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # Managed-AllViewerExceptHostHeader
 
     lambda_function_association {
       event_type   = "origin-request"
@@ -341,7 +341,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     compress               = true
 
     cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" # Managed-CachingDisabled
-    origin_request_policy_id = aws_cloudfront_origin_request_policy.lambda_signed_requests.id
+    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # Managed-AllViewerExceptHostHeader
 
     function_association {
       event_type   = "viewer-request"
@@ -384,43 +384,6 @@ resource "aws_cloudfront_distribution" "distribution" {
   restrictions {
     geo_restriction {
       restriction_type = "none"
-    }
-  }
-}
-
-resource "aws_cloudfront_cache_policy" "cache_policy" {
-  name = "${var.project_name}-cache-policy"
-
-  default_ttl = 0
-  max_ttl     = 31536000
-  min_ttl     = 0
-
-  parameters_in_cache_key_and_forwarded_to_origin {
-    cookies_config {
-      cookie_behavior = "all"
-    }
-
-    headers_config {
-      header_behavior = "whitelist"
-
-      headers {
-        items = [
-          "x-forwarded-host",       # Essential for routing
-          "next-action",            # Required for server actions
-          "next-router-state-tree", # Required for RSC navigation
-          "next-router-prefetch",   # Required for prefetching
-          "rsc",                    # Essential RSC marker
-          "content-type",           # Required for content negotiation
-          "x-prerender-revalidate", # Needed for revalidation
-          "referer",                # Important for auth flows
-          "x-action-redirect",      # Needed for redirects in server actions
-          "origin"                  # Required for CORS
-        ]
-      }
-    }
-
-    query_strings_config {
-      query_string_behavior = "all"
     }
   }
 }
@@ -476,7 +439,10 @@ resource "aws_cloudfront_origin_request_policy" "posthog_passthrough" {
   }
 }
 
-# Origin Request Policy for Lambda signed requests
+
+# Detached from all behaviors. CloudFront 409s deletes of a policy that any
+# deployed distribution still references, so removal ships in a follow-up
+# after this detachment has been applied to every environment.
 resource "aws_cloudfront_origin_request_policy" "lambda_signed_requests" {
   name    = "${var.project_name}-lambda-signed-requests"
   comment = "Policy to forward necessary headers and cookies for signed Lambda requests"


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

dev.openjii.org feels slow and the Network tab shows a storm of duplicate RSC prefetch requests: every prefetch is a 307 + refetch pair, repeating endlessly (see screenshot).

**Root cause**: Next.js 16 validates the `_rsc` cache-busting query param on RSC requests: the client hashes the RSC request headers (`next-router-prefetch`, `next-router-segment-prefetch`, `next-router-state-tree`, `next-url`) and the server recomputes the hash from the headers it receives, 307-redirecting on mismatch (cache poisoning protection for CDNs that ignore `Vary`).

Our custom CloudFront origin request policy whitelisted only some of those headers. `next-url` never reached the Lambda origin, so the server hash could never match the browser hash. Result: every prefetch double round trips, the router prefetch cache is never reusable, and each hit is a CloudFront miss doing a full dynamic render.

Verified against the live site: adding `Next-Router-State-Tree` to a request changes the redirect hash (header reaches origin), adding `Next-Url` does not (header stripped).

Prod is unaffected only because it runs an older Next.js release without the hash check. It would regress identically on the next production promotion without this fix.

**Why not just add the missing headers**: The whitelist sat at exactly 10 headers, the CloudFront default quota per policy (adjustable only via support case). Appending two more would fail `tofu apply`.

Instead, the lambda behaviors now use the AWS managed `AllViewerExceptHostHeader` origin request policy (`b689b0a8-53d0-40ab-baf2-68738e2966ac`), which forwards all viewer headers except `Host` (required off for OAC SigV4 to function URLs), plus all cookies and query strings. This is what AWS recommends for Lambda function URL origins and what OpenNext reference implementations do: SST hardcodes this exact policy id for the server behavior, and RJPearson94/terraform-aws-open-next defaults to it via a data source. It also future-proofs us against any new header Next.js starts hashing.

### Changes

- Point the four ServerLambda/ImageLambda behaviors (default, `/_next/image`, `api/*`, `_next/data/*`) at `Managed-AllViewerExceptHostHeader`
- Remove the now-unused `lambda_signed_requests` origin request policy
- Remove `aws_cloudfront_cache_policy.cache_policy`, which was never attached to any behavior (all behaviors use managed cache policies or `image_cache_policy`)
- Fix a mislabeled comment: the default behavior's cache policy is `Managed-CachingDisabled`, not `CachingOptimized`
