### PR TITLE
fix(data): tolerate invalid measurement timezones

### DIFF
--- a/apps/data/src/lib/enrich/enrich/timezone.py
+++ b/apps/data/src/lib/enrich/enrich/timezone.py
@@ -1,0 +1,124 @@
+"""Safe timezone normalization for enriched measurement views.
+
+The source ``timezone`` value is user/device supplied. Spark's
+``from_utc_timestamp`` raises for an unknown zone ID, so passing that column
+through directly lets one legacy value fail an entire materialized-view update.
+This module validates the value with Spark-native expressions first and only
+passes a canonical, known-safe value to Spark's timezone conversion.
+"""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError, available_timezones
+
+from pyspark.sql import DataFrame
+from pyspark.sql import functions as F
+
+# Historical JII provisioning used AMT as shorthand for Amsterdam. AMT is not
+# an IANA zone ID (and is ambiguous globally), so Spark/Java correctly rejects
+# it. Keep the migration deliberately narrow instead of accepting arbitrary
+# abbreviations.
+LEGACY_TIMEZONE_ALIASES = {"AMT": "Europe/Amsterdam"}
+
+_OFFSET_PATTERN = r"^([+-])(\d{2})(?::(\d{2})(?::(\d{2}))?)?$"
+_OFFSET_RE = re.compile(_OFFSET_PATTERN)
+_VALID_IANA_TIMEZONES = tuple(sorted(available_timezones() | {"UTC"}))
+
+
+def _valid_zone_offset(value: str) -> bool:
+    """Return whether *value* is a Spark-supported ``+/-HH[:mm[:ss]]`` offset."""
+    match = _OFFSET_RE.fullmatch(value)
+    if match is None:
+        return False
+    hour = int(match.group(2))
+    minute = int(match.group(3) or 0)
+    second = int(match.group(4) or 0)
+    return hour <= 18 and minute <= 59 and second <= 59 and (hour < 18 or (minute == 0 and second == 0))
+
+
+@lru_cache(maxsize=512)
+def canonical_timezone(value: str | None) -> str | None:
+    """Return a safe Spark timezone or ``None`` for missing/unknown input.
+
+    The received value is not rewritten in the measurement table; this return
+    value is an internal conversion operand. That preserves provenance while
+    preventing bad data from aborting the pipeline.
+    """
+    if value is None:
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+    candidate = LEGACY_TIMEZONE_ALIASES.get(candidate, candidate)
+    if candidate == "Z":
+        return "UTC"
+    if _valid_zone_offset(candidate):
+        return candidate
+    try:
+        ZoneInfo(candidate)
+    except (ZoneInfoNotFoundError, ValueError):
+        return None
+    return candidate
+
+
+def _valid_zone_offset_column(candidate):
+    """Spark expression matching the same bounded offset grammar as Python."""
+    matches = candidate.rlike(_OFFSET_PATTERN)
+    hour = F.regexp_extract(candidate, _OFFSET_PATTERN, 2).cast("int")
+    minute = F.coalesce(F.regexp_extract(candidate, _OFFSET_PATTERN, 3).cast("int"), F.lit(0))
+    second = F.coalesce(F.regexp_extract(candidate, _OFFSET_PATTERN, 4).cast("int"), F.lit(0))
+    return matches & (hour <= 18) & (minute <= 59) & (second <= 59) & ((hour < 18) | ((minute == 0) & (second == 0)))
+
+
+def _canonical_timezone_column(source):
+    """Return a Spark column containing only conversion-safe timezone IDs."""
+    candidate = F.trim(source)
+    return (
+        F.when(candidate == "AMT", F.lit("Europe/Amsterdam"))
+        .when(candidate == "Z", F.lit("UTC"))
+        .when(candidate.isin(*_VALID_IANA_TIMEZONES), candidate)
+        .when(_valid_zone_offset_column(candidate), candidate)
+    )
+
+
+def add_local_time_columns(
+    df: DataFrame,
+    *,
+    utc_column: str = "measurement_time_utc",
+    timezone_column: str = "timezone",
+) -> DataFrame:
+    """Add safe local-time projections and a timezone validation signal.
+
+    ``timezone`` remains byte-for-byte as received. ``timezone_valid`` is true
+    for a missing value (local time was not requested) or a recognized zone,
+    and false for a non-empty value that could not be validated. Invalid values
+    produce null derived local-time columns instead of a Spark exception.
+    """
+    effective_column = "__effective_timezone"
+    original = F.col(timezone_column)
+    effective = F.col(effective_column)
+
+    return (
+        df.withColumn(effective_column, _canonical_timezone_column(original))
+        .withColumn(
+            "timezone_valid",
+            original.isNull() | (F.length(F.trim(original)) == 0) | effective.isNotNull(),
+        )
+        .withColumn(
+            "measurement_time_local",
+            F.when(
+                effective.isNotNull(),
+                F.date_format(F.from_utc_timestamp(F.col(utc_column), effective), "yyyy-MM-dd HH:mm:ss"),
+            ),
+        )
+        .withColumn(
+            "local_time",
+            F.when(
+                effective.isNotNull(),
+                F.date_format(F.from_utc_timestamp(F.col(utc_column), effective), "HH:mm"),
+            ),
+        )
+        .drop(effective_column)
+    )

--- a/apps/data/src/lib/enrich/enrich/timezone.py
+++ b/apps/data/src/lib/enrich/enrich/timezone.py
@@ -11,8 +11,7 @@ from __future__ import annotations
 
 import re
 from functools import lru_cache
-from typing import Any, cast
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError, available_timezones
 
 from pyspark.sql import DataFrame
 from pyspark.sql import functions as F
@@ -26,6 +25,7 @@ LEGACY_TIMEZONE_ALIASES = {"AMT": "Europe/Amsterdam"}
 _OFFSET_PATTERN = r"^([+-])(\d{2})(?::(\d{2})(?::(\d{2}))?)?$"
 _OFFSET_RE = re.compile(_OFFSET_PATTERN)
 _EDGE_WHITESPACE_PATTERN = r"^[ \t\r\n]+|[ \t\r\n]+$"
+_VALID_IANA_TIMEZONES = tuple(sorted(available_timezones() | {"UTC"}))
 
 
 def _valid_zone_offset(value: str) -> bool:
@@ -78,15 +78,6 @@ def _strip_timezone_column(source):
     return F.regexp_replace(source, _EDGE_WHITESPACE_PATTERN, "")
 
 
-def _jvm_zone_ids(df: DataFrame) -> tuple[str, ...]:
-    """Read the exact region IDs accepted by this Spark JVM's timezone engine."""
-    jvm = cast(Any, df.sparkSession._jvm)
-    if jvm is None:
-        raise RuntimeError("Spark JVM is unavailable for timezone validation")
-    zone_ids = jvm.java.time.ZoneId.getAvailableZoneIds().toArray()
-    return tuple(sorted({str(zone_id) for zone_id in zone_ids} | {"UTC"}))
-
-
 def _canonical_timezone_column(source, valid_zone_ids: tuple[str, ...]):
     """Return a Spark column containing only conversion-safe timezone IDs."""
     candidate = _strip_timezone_column(source)
@@ -116,10 +107,11 @@ def add_local_time_columns(
     original = F.col(timezone_column)
     stripped = _strip_timezone_column(original)
     effective = F.col(effective_column)
-    valid_zone_ids = _jvm_zone_ids(df)
-
     return (
-        df.withColumn(effective_column, _canonical_timezone_column(original, valid_zone_ids))
+        # Databricks blocks java.time.ZoneId.getAvailableZoneIds() through its
+        # Py4J allowlist. Use Python's system IANA database, which is also what
+        # canonical_timezone() validates, and keep conversion Spark-native.
+        df.withColumn(effective_column, _canonical_timezone_column(original, _VALID_IANA_TIMEZONES))
         .withColumn(
             "timezone_valid",
             original.isNull() | (F.length(stripped) == 0) | effective.isNotNull(),

--- a/apps/data/src/lib/enrich/enrich/timezone.py
+++ b/apps/data/src/lib/enrich/enrich/timezone.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 
 import re
 from functools import lru_cache
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError, available_timezones
+from typing import Any, cast
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from pyspark.sql import DataFrame
 from pyspark.sql import functions as F
@@ -24,7 +25,7 @@ LEGACY_TIMEZONE_ALIASES = {"AMT": "Europe/Amsterdam"}
 
 _OFFSET_PATTERN = r"^([+-])(\d{2})(?::(\d{2})(?::(\d{2}))?)?$"
 _OFFSET_RE = re.compile(_OFFSET_PATTERN)
-_VALID_IANA_TIMEZONES = tuple(sorted(available_timezones() | {"UTC"}))
+_EDGE_WHITESPACE_PATTERN = r"^[ \t\r\n]+|[ \t\r\n]+$"
 
 
 def _valid_zone_offset(value: str) -> bool:
@@ -72,14 +73,29 @@ def _valid_zone_offset_column(candidate):
     return matches & (hour <= 18) & (minute <= 59) & (second <= 59) & ((hour < 18) | ((minute == 0) & (second == 0)))
 
 
-def _canonical_timezone_column(source):
+def _strip_timezone_column(source):
+    """Match Python ``str.strip`` for the ASCII whitespace seen on the wire."""
+    return F.regexp_replace(source, _EDGE_WHITESPACE_PATTERN, "")
+
+
+def _jvm_zone_ids(df: DataFrame) -> tuple[str, ...]:
+    """Read the exact region IDs accepted by this Spark JVM's timezone engine."""
+    jvm = cast(Any, df.sparkSession._jvm)
+    if jvm is None:
+        raise RuntimeError("Spark JVM is unavailable for timezone validation")
+    zone_ids = jvm.java.time.ZoneId.getAvailableZoneIds().toArray()
+    return tuple(sorted({str(zone_id) for zone_id in zone_ids} | {"UTC"}))
+
+
+def _canonical_timezone_column(source, valid_zone_ids: tuple[str, ...]):
     """Return a Spark column containing only conversion-safe timezone IDs."""
-    candidate = F.trim(source)
+    candidate = _strip_timezone_column(source)
+    canonical = F.when(candidate == "Z", F.lit("UTC")).otherwise(candidate)
+    for alias, target in sorted(LEGACY_TIMEZONE_ALIASES.items()):
+        canonical = F.when(candidate == alias, F.lit(target)).otherwise(canonical)
     return (
-        F.when(candidate == "AMT", F.lit("Europe/Amsterdam"))
-        .when(candidate == "Z", F.lit("UTC"))
-        .when(candidate.isin(*_VALID_IANA_TIMEZONES), candidate)
-        .when(_valid_zone_offset_column(candidate), candidate)
+        F.when(canonical.isin(*valid_zone_ids), canonical)
+        .when(_valid_zone_offset_column(canonical), canonical)
     )
 
 
@@ -98,13 +114,15 @@ def add_local_time_columns(
     """
     effective_column = "__effective_timezone"
     original = F.col(timezone_column)
+    stripped = _strip_timezone_column(original)
     effective = F.col(effective_column)
+    valid_zone_ids = _jvm_zone_ids(df)
 
     return (
-        df.withColumn(effective_column, _canonical_timezone_column(original))
+        df.withColumn(effective_column, _canonical_timezone_column(original, valid_zone_ids))
         .withColumn(
             "timezone_valid",
-            original.isNull() | (F.length(F.trim(original)) == 0) | effective.isNotNull(),
+            original.isNull() | (F.length(stripped) == 0) | effective.isNotNull(),
         )
         .withColumn(
             "measurement_time_local",

--- a/apps/data/src/pipelines/centrum/enriched/enriched_experiment_macro_data.py
+++ b/apps/data/src/pipelines/centrum/enriched/enriched_experiment_macro_data.py
@@ -5,10 +5,10 @@
 
 # COMMAND ----------
 import dlt
-from pyspark.sql import functions as F
 
 from enrich.annotations_metadata import add_annotation_column
 from enrich.custom_metadata import add_custom_metadata_column
+from enrich.timezone import add_local_time_columns
 from openjii.centrum import (
     ANNOTATIONS_SOURCE_TABLE,
     ENRICHED_MACRO_DATA_VIEW,
@@ -79,21 +79,9 @@ def enriched_experiment_macro_data():
             macro_data.questions_data,
             macro_data.annotations
         )
-        .withColumn(
-            "measurement_time_local",
-            F.when(
-                F.col("timezone").isNotNull(),
-                F.date_format(F.from_utc_timestamp(F.col("measurement_time_utc"), F.col("timezone")), "yyyy-MM-dd HH:mm:ss")
-            )
-        )
-        .withColumn(
-            "local_time",
-            F.when(
-                F.col("timezone").isNotNull(),
-                F.date_format(F.from_utc_timestamp(F.col("measurement_time_utc"), F.col("timezone")), "HH:mm")
-            )
-        )
     )
+
+    enriched = add_local_time_columns(enriched)
 
     enriched = add_annotation_column(enriched, annotations_source)
 

--- a/apps/data/src/pipelines/centrum/enriched/enriched_experiment_raw_data.py
+++ b/apps/data/src/pipelines/centrum/enriched/enriched_experiment_raw_data.py
@@ -5,10 +5,10 @@
 
 # COMMAND ----------
 import dlt
-from pyspark.sql import functions as F
 
 from enrich.annotations_metadata import add_annotation_column
 from enrich.custom_metadata import add_custom_metadata_column
+from enrich.timezone import add_local_time_columns
 from openjii.centrum import (
     ANNOTATIONS_SOURCE_TABLE,
     ENRICHED_RAW_DATA_VIEW,
@@ -77,21 +77,9 @@ def enriched_experiment_raw_data():
             raw_data.data,
             raw_data.processed_timestamp
         )
-        .withColumn(
-            "measurement_time_local",
-            F.when(
-                F.col("timezone").isNotNull(),
-                F.date_format(F.from_utc_timestamp(F.col("measurement_time_utc"), F.col("timezone")), "yyyy-MM-dd HH:mm:ss")
-            )
-        )
-        .withColumn(
-            "local_time",
-            F.when(
-                F.col("timezone").isNotNull(),
-                F.date_format(F.from_utc_timestamp(F.col("measurement_time_utc"), F.col("timezone")), "HH:mm")
-            )
-        )
     )
+
+    enriched = add_local_time_columns(enriched)
 
     enriched = add_annotation_column(enriched, annotations_source)
 

--- a/apps/data/tests/lib/test_timezone.py
+++ b/apps/data/tests/lib/test_timezone.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import inspect
+
+import enrich.timezone as timezone_module
 import pytest
 from enrich.timezone import add_local_time_columns, canonical_timezone
 from pyspark.sql import functions as F
@@ -27,6 +30,12 @@ from pyspark.sql import functions as F
 )
 def test_canonical_timezone(source, expected):
     assert canonical_timezone(source) == expected
+
+
+def test_timezone_validation_does_not_call_blocked_databricks_py4j_api():
+    source = inspect.getsource(timezone_module)
+    assert "jvm.java.time.ZoneId" not in source
+    assert "sparkSession._jvm" not in source
 
 
 @pytest.mark.spark

--- a/apps/data/tests/lib/test_timezone.py
+++ b/apps/data/tests/lib/test_timezone.py
@@ -13,6 +13,8 @@ from pyspark.sql import functions as F
         ("AMT", "Europe/Amsterdam"),
         ("Europe/Amsterdam", "Europe/Amsterdam"),
         ("UTC", "UTC"),
+        ("\tUTC", "UTC"),
+        (" Europe/Amsterdam ", "Europe/Amsterdam"),
         ("Z", "UTC"),
         ("+05:30", "+05:30"),
         ("-18", "-18"),
@@ -35,8 +37,11 @@ def test_add_local_time_columns_keeps_invalid_rows_and_preserves_source(spark):
             ("legacy", "AMT"),
             ("utc", "UTC"),
             ("offset", "+05:30"),
+            ("padded", " Europe/Amsterdam "),
+            ("tabbed", "\tUTC\n"),
             ("invalid", "Mars/Olympus"),
             ("missing", None),
+            ("blank", " \t\n"),
         ],
         "id string, timezone string",
     ).withColumn("measurement_time_utc", F.to_timestamp(F.lit("2026-08-06 12:00:00")))
@@ -45,14 +50,26 @@ def test_add_local_time_columns_keeps_invalid_rows_and_preserves_source(spark):
 
     assert rows["amsterdam"]["timezone"] == "Europe/Amsterdam"
     assert rows["amsterdam"]["measurement_time_local"] == "2026-08-06 14:00:00"
+    assert rows["amsterdam"]["timezone_valid"] is True
     assert rows["legacy"]["timezone"] == "AMT"
     assert rows["legacy"]["measurement_time_local"] == "2026-08-06 14:00:00"
+    assert rows["legacy"]["timezone_valid"] is True
     assert rows["utc"]["measurement_time_local"] == "2026-08-06 12:00:00"
+    assert rows["utc"]["timezone_valid"] is True
     assert rows["offset"]["measurement_time_local"] == "2026-08-06 17:30:00"
+    assert rows["offset"]["timezone_valid"] is True
+    assert rows["padded"]["timezone"] == " Europe/Amsterdam "
+    assert rows["padded"]["measurement_time_local"] == "2026-08-06 14:00:00"
+    assert rows["padded"]["timezone_valid"] is True
+    assert rows["tabbed"]["timezone"] == "\tUTC\n"
+    assert rows["tabbed"]["measurement_time_local"] == "2026-08-06 12:00:00"
+    assert rows["tabbed"]["timezone_valid"] is True
     assert rows["invalid"]["measurement_time_local"] is None
     assert rows["invalid"]["local_time"] is None
     assert rows["invalid"]["timezone_valid"] is False
     assert rows["missing"]["measurement_time_local"] is None
     assert rows["missing"]["timezone_valid"] is True
-    assert len(rows) == 6
+    assert rows["blank"]["measurement_time_local"] is None
+    assert rows["blank"]["timezone_valid"] is True
+    assert len(rows) == 9
     assert "PythonUDF" not in add_local_time_columns(source)._jdf.queryExecution().executedPlan().toString()

--- a/apps/data/tests/lib/test_timezone.py
+++ b/apps/data/tests/lib/test_timezone.py
@@ -1,0 +1,58 @@
+"""Timezone normalization tests for enriched Centrum measurements."""
+
+from __future__ import annotations
+
+import pytest
+from enrich.timezone import add_local_time_columns, canonical_timezone
+from pyspark.sql import functions as F
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("AMT", "Europe/Amsterdam"),
+        ("Europe/Amsterdam", "Europe/Amsterdam"),
+        ("UTC", "UTC"),
+        ("Z", "UTC"),
+        ("+05:30", "+05:30"),
+        ("-18", "-18"),
+        (None, None),
+        ("", None),
+        ("Mars/Olympus", None),
+        ("+18:00:01", None),
+        ("+19", None),
+    ],
+)
+def test_canonical_timezone(source, expected):
+    assert canonical_timezone(source) == expected
+
+
+@pytest.mark.spark
+def test_add_local_time_columns_keeps_invalid_rows_and_preserves_source(spark):
+    source = spark.createDataFrame(
+        [
+            ("amsterdam", "Europe/Amsterdam"),
+            ("legacy", "AMT"),
+            ("utc", "UTC"),
+            ("offset", "+05:30"),
+            ("invalid", "Mars/Olympus"),
+            ("missing", None),
+        ],
+        "id string, timezone string",
+    ).withColumn("measurement_time_utc", F.to_timestamp(F.lit("2026-08-06 12:00:00")))
+
+    rows = {row.id: row.asDict() for row in add_local_time_columns(source).collect()}
+
+    assert rows["amsterdam"]["timezone"] == "Europe/Amsterdam"
+    assert rows["amsterdam"]["measurement_time_local"] == "2026-08-06 14:00:00"
+    assert rows["legacy"]["timezone"] == "AMT"
+    assert rows["legacy"]["measurement_time_local"] == "2026-08-06 14:00:00"
+    assert rows["utc"]["measurement_time_local"] == "2026-08-06 12:00:00"
+    assert rows["offset"]["measurement_time_local"] == "2026-08-06 17:30:00"
+    assert rows["invalid"]["measurement_time_local"] is None
+    assert rows["invalid"]["local_time"] is None
+    assert rows["invalid"]["timezone_valid"] is False
+    assert rows["missing"]["measurement_time_local"] is None
+    assert rows["missing"]["timezone_valid"] is True
+    assert len(rows) == 6
+    assert "PythonUDF" not in add_local_time_columns(source)._jdf.queryExecution().executedPlan().toString()


### PR DESCRIPTION
## Summary
- centralize Spark-native timezone validation and normalization for raw and macro enriched views
- normalize legacy `AMT` to `Europe/Amsterdam` while preserving the original source field
- preserve rows with invalid/missing timezones, emit null local time, and expose `timezone_valid`
- add focused timezone tests

## DEV validation
- deployed exact commit `e5f7954d6b8baa0f494e9000794a8733113774f7` to DEV only
- validate-only update `f33c04a6-8c09-41c0-925d-06f0755f7d66` completed
- incremental update `ac2db8f3-626d-4e0e-8fea-45ac15585b8f` completed; both enriched raw and macro views completed
- DEV SQL: 12 raw `AMT` rows, 12 enriched rows, all 12 normalized with valid local time; no rows dropped
- 82 pytest tests passed; Ruff/Pyright/bundle validation passed

Production was not changed.