### PR TITLE
feat(workbook): proper branching with Go to and author-time validation

### DIFF
--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/evaluate-and-route.test.ts
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/evaluate-and-route.test.ts
@@ -157,6 +157,39 @@ beforeEach(() => {
 });
 
 describe("evaluateAndRoute", () => {
+  it("routes a forward conditionless default Go to and records a Back return", () => {
+    flowState.cells = [branch("b1", [path("goto", [], "target")], "goto")];
+    flowState.flowNodes = [branchFlowNode("b1"), plainFlowNode("skipped"), plainFlowNode("target")];
+    flowState.currentFlowStep = 0;
+
+    evaluateAndRoute(branchFlowNode("b1"));
+
+    expect(mockSetCurrentFlowStep).toHaveBeenCalledWith(2);
+    expect(mockRecordBranchJump).toHaveBeenCalledWith(2);
+  });
+
+  it("routes a backward conditionless default Go to without recording a Back return", () => {
+    flowState.cells = [qCell("target"), branch("b1", [path("goto", [], "target")], "goto")];
+    flowState.flowNodes = [plainFlowNode("target"), branchFlowNode("b1")];
+    flowState.currentFlowStep = 1;
+
+    evaluateAndRoute(branchFlowNode("b1"));
+
+    expect(mockSetCurrentFlowStep).toHaveBeenCalledWith(0);
+    expect(mockRecordBranchJump).not.toHaveBeenCalled();
+  });
+
+  it("falls through for a conditionless default Go to that targets itself", () => {
+    flowState.cells = [branch("b1", [path("goto", [], "b1")], "goto")];
+    flowState.flowNodes = [branchFlowNode("b1"), plainFlowNode("next")];
+    flowState.currentFlowStep = 0;
+
+    evaluateAndRoute(branchFlowNode("b1"));
+
+    expect(mockSetCurrentFlowStep).toHaveBeenCalledWith(1);
+    expect(mockRecordBranchJump).toHaveBeenCalledWith(1);
+  });
+
   it("jumps to the matched path's gotoCellId target (simple branch)", () => {
     mockGetAnswer.mockImplementation((_c, id) => (id === "q1" ? "yes" : undefined));
     flowState.cells = [

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/evaluate-and-route.test.ts
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/evaluate-and-route.test.ts
@@ -190,6 +190,24 @@ describe("evaluateAndRoute", () => {
     expect(mockRecordBranchJump).toHaveBeenCalledWith(1);
   });
 
+  it("fails closed when duplicate path ids make the default ambiguous", () => {
+    flowState.cells = [
+      branch("b1", [path("duplicate", [], "first"), path("duplicate", [], "second")], "duplicate"),
+    ];
+    flowState.flowNodes = [
+      branchFlowNode("b1"),
+      plainFlowNode("next"),
+      plainFlowNode("first"),
+      plainFlowNode("second"),
+    ];
+    flowState.currentFlowStep = 0;
+
+    evaluateAndRoute(branchFlowNode("b1"));
+
+    expect(mockSetLastMatchedPath).toHaveBeenCalledWith(undefined);
+    expect(mockSetCurrentFlowStep).toHaveBeenCalledWith(1);
+  });
+
   it("jumps to the matched path's gotoCellId target (simple branch)", () => {
     mockGetAnswer.mockImplementation((_c, id) => (id === "q1" ? "yes" : undefined));
     flowState.cells = [

--- a/apps/web/components/flow-editor/flow-editor.tsx
+++ b/apps/web/components/flow-editor/flow-editor.tsx
@@ -35,6 +35,7 @@ import type { NodeType } from "../react-flow/node-config";
 import { ALL_NODE_TYPES, getStyledEdges, nodeTypeColorMap } from "../react-flow/node-config";
 import { FlowContextProvider, BaseNodeWrapper, ensureOneStartNode } from "../react-flow/node-utils";
 import { ExperimentSidePanel } from "../side-panel-flow/side-panel-flow";
+import { resolveBranchPathColor } from "../workbook/branch-path-colors";
 import { autoLayout } from "./auto-layout";
 import { BackEdge } from "./back-edge";
 import { FlowMapper } from "./flow-mapper";
@@ -265,8 +266,11 @@ export const FlowEditor = forwardRef<FlowEditorHandle, FlowEditorProps>(
       const paths =
         (node.data as { stepSpecification?: { paths?: { id: string; color: string }[] } })
           .stepSpecification?.paths ?? [];
-      for (const path of paths) {
-        branchPathColors.set(`${node.id}:${path.id}`, path.color);
+      for (const [pathIndex, path] of paths.entries()) {
+        branchPathColors.set(
+          `${node.id}:${path.id}`,
+          resolveBranchPathColor(path.color, pathIndex),
+        );
       }
     }
 

--- a/apps/web/components/flow-editor/flow-editor.tsx
+++ b/apps/web/components/flow-editor/flow-editor.tsx
@@ -21,6 +21,7 @@ import type {
   ExperimentFlow,
   ExperimentUpsertFlowBody,
 } from "@repo/api/domains/experiment/flows/experiment-flows.schema";
+import { resolveBranchPathById } from "@repo/api/transforms/evaluate-branch";
 import { Button } from "@repo/ui/components/button";
 import { Card, CardContent } from "@repo/ui/components/card";
 import { cn } from "@repo/ui/lib/utils";
@@ -267,7 +268,13 @@ export const FlowEditor = forwardRef<FlowEditorHandle, FlowEditorProps>(
         (node.data as { stepSpecification?: { paths?: { id: string; color: string }[] } })
           .stepSpecification?.paths ?? [];
       for (const path of paths) {
-        branchPathColors.set(`${node.id}:${path.id}`, resolveBranchPathColor(path.color, path.id));
+        const resolvedPath = resolveBranchPathById(paths, path.id);
+        if (resolvedPath.status === "resolved") {
+          branchPathColors.set(
+            `${node.id}:${path.id}`,
+            resolveBranchPathColor(resolvedPath.path.color, resolvedPath.path.id),
+          );
+        }
       }
     }
 

--- a/apps/web/components/flow-editor/flow-editor.tsx
+++ b/apps/web/components/flow-editor/flow-editor.tsx
@@ -266,11 +266,8 @@ export const FlowEditor = forwardRef<FlowEditorHandle, FlowEditorProps>(
       const paths =
         (node.data as { stepSpecification?: { paths?: { id: string; color: string }[] } })
           .stepSpecification?.paths ?? [];
-      for (const [pathIndex, path] of paths.entries()) {
-        branchPathColors.set(
-          `${node.id}:${path.id}`,
-          resolveBranchPathColor(path.color, pathIndex),
-        );
+      for (const path of paths) {
+        branchPathColors.set(`${node.id}:${path.id}`, resolveBranchPathColor(path.color, path.id));
       }
     }
 

--- a/apps/web/components/react-flow/__tests__/branch-node.test.tsx
+++ b/apps/web/components/react-flow/__tests__/branch-node.test.tsx
@@ -82,6 +82,27 @@ describe("BranchNode", () => {
     expect(screen.getByText(/default/i)).toBeInTheDocument();
   });
 
+  it("leaves an ambiguous duplicate default unmarked", () => {
+    const duplicatePaths = [
+      { id: "duplicate", label: "First", color: "#10B981" },
+      { id: "duplicate", label: "Second", color: "#EF4444" },
+    ];
+    render(
+      <BranchNode
+        nodes={[node]}
+        onNodeDelete={() => null}
+        {...node}
+        {...baseProps}
+        data={{
+          title: "Broken branch",
+          stepSpecification: { paths: duplicatePaths, defaultPathId: "duplicate" },
+        }}
+      />,
+    );
+
+    expect(screen.queryByText(/^default$/i)).not.toBeInTheDocument();
+  });
+
   it("shows a placeholder when no paths are configured", () => {
     render(
       <BranchNode

--- a/apps/web/components/react-flow/branch-node.tsx
+++ b/apps/web/components/react-flow/branch-node.tsx
@@ -5,6 +5,7 @@ import React from "react";
 
 import { cn } from "@repo/ui/lib/utils";
 
+import { resolveBranchPathColor } from "../workbook/branch-path-colors";
 import { nodeTypeColorMap } from "./node-config";
 
 interface BranchPathSummary {
@@ -149,7 +150,7 @@ export function BranchNode(props: BranchNodeProps) {
                   >
                     <div
                       className="h-2 w-2 shrink-0 rounded-full"
-                      style={{ backgroundColor: path.color || accent }}
+                      style={{ backgroundColor: resolveBranchPathColor(path.color, idx) }}
                     />
                     <span
                       className="truncate text-[12.5px] font-medium text-slate-700"
@@ -175,7 +176,7 @@ export function BranchNode(props: BranchNodeProps) {
                       className="!h-2.5 !w-2.5 !rounded-full !border-2 transition-colors duration-150"
                       style={{
                         backgroundColor: "#FFFFFF",
-                        borderColor: path.color || accent,
+                        borderColor: resolveBranchPathColor(path.color, idx),
                         top: "50%",
                       }}
                     />

--- a/apps/web/components/react-flow/branch-node.tsx
+++ b/apps/web/components/react-flow/branch-node.tsx
@@ -150,7 +150,7 @@ export function BranchNode(props: BranchNodeProps) {
                   >
                     <div
                       className="h-2 w-2 shrink-0 rounded-full"
-                      style={{ backgroundColor: resolveBranchPathColor(path.color, idx) }}
+                      style={{ backgroundColor: resolveBranchPathColor(path.color, path.id) }}
                     />
                     <span
                       className="truncate text-[12.5px] font-medium text-slate-700"
@@ -176,7 +176,7 @@ export function BranchNode(props: BranchNodeProps) {
                       className="!h-2.5 !w-2.5 !rounded-full !border-2 transition-colors duration-150"
                       style={{
                         backgroundColor: "#FFFFFF",
-                        borderColor: resolveBranchPathColor(path.color, idx),
+                        borderColor: resolveBranchPathColor(path.color, path.id),
                         top: "50%",
                       }}
                     />

--- a/apps/web/components/react-flow/branch-node.tsx
+++ b/apps/web/components/react-flow/branch-node.tsx
@@ -3,6 +3,7 @@ import { Handle, Position } from "@xyflow/react";
 import { GitBranch } from "lucide-react";
 import React from "react";
 
+import { resolveBranchDefaultPath } from "@repo/api/transforms/evaluate-branch";
 import { cn } from "@repo/ui/lib/utils";
 
 import { resolveBranchPathColor } from "../workbook/branch-path-colors";
@@ -34,6 +35,9 @@ export function BranchNode(props: BranchNodeProps) {
   const title = data.title ?? "Branch";
   const paths = data.stepSpecification?.paths ?? [];
   const defaultPathId = data.stepSpecification?.defaultPathId;
+  const defaultPathResolution = resolveBranchDefaultPath({ paths, defaultPathId });
+  const defaultPath =
+    defaultPathResolution.status === "resolved" ? defaultPathResolution.path : undefined;
   const accent = nodeTypeColorMap.BRANCH.accent;
   const isActive = nodeProps.selected || nodeProps.dragging;
 
@@ -141,10 +145,10 @@ export function BranchNode(props: BranchNodeProps) {
           ) : (
             <div className="py-1.5">
               {paths.map((path, idx) => {
-                const isDefault = defaultPathId === path.id;
+                const isDefault = path === defaultPath;
                 return (
                   <div
-                    key={path.id}
+                    key={`${path.id}:${idx}`}
                     className="relative flex items-center gap-2 px-3 pl-4 pr-5 transition-colors hover:bg-slate-50"
                     style={{ height: PATH_ROW_HEIGHT }}
                   >

--- a/apps/web/components/workbook/add-cell-button.test.tsx
+++ b/apps/web/components/workbook/add-cell-button.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, userEvent } from "@/test/test-utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+import type { BranchCell } from "@repo/api/domains/workbook/workbook-cells.schema";
+
 import { AddCellButton } from "./add-cell-button";
 
 vi.mock("./macro-picker", () => ({
@@ -25,6 +27,7 @@ describe("AddCellButton", () => {
     expect(screen.getByText("Macro")).toBeInTheDocument();
     expect(screen.getByText("Question")).toBeInTheDocument();
     expect(screen.getByText("Branch")).toBeInTheDocument();
+    expect(screen.getByText("Go to")).toBeInTheDocument();
   });
 
   it("hides branch when showBranch is false", () => {
@@ -52,6 +55,20 @@ describe("AddCellButton", () => {
     render(<AddCellButton onAdd={onAdd} variant="bottom" />);
     await user.click(screen.getByText("Branch"));
     expect(onAdd).toHaveBeenCalledWith("branch");
+  });
+
+  it("creates a structurally valid Go to cell", async () => {
+    const user = userEvent.setup();
+    const onAddCell = vi.fn();
+    render(<AddCellButton onAdd={onAdd} onAddCell={onAddCell} variant="bottom" />);
+
+    await user.click(screen.getByText("Go to"));
+
+    const cell = onAddCell.mock.calls[0][0] as BranchCell;
+    expect(cell).toMatchObject({ type: "branch", defaultPathId: cell.paths[0].id });
+    expect(cell.paths).toHaveLength(1);
+    expect(cell.paths[0].conditions).toEqual([]);
+    expect(cell.paths[0].color).not.toBe("");
   });
 
   it("shows empty state when showEmptyState is true", () => {

--- a/apps/web/components/workbook/add-cell-button.tsx
+++ b/apps/web/components/workbook/add-cell-button.tsx
@@ -6,6 +6,7 @@ import {
   FileText,
   GitBranch,
   HelpCircle,
+  Milestone,
   Microscope,
   Terminal,
 } from "lucide-react";
@@ -21,6 +22,7 @@ import {
 } from "@repo/ui/components/tooltip";
 import { cn } from "@repo/ui/lib/utils";
 
+import { nextBranchPathColor } from "./branch-path-colors";
 import { MacroPicker } from "./macro-picker";
 import { ProtocolPicker } from "./protocol-picker";
 import { QuestionPicker } from "./question-picker";
@@ -43,6 +45,7 @@ const cellOptions: {
   label: string;
   icon: typeof FileText;
   color: string;
+  kind?: "goto";
 }[] = [
   { type: "markdown", label: "Markdown", icon: FileText, color: "#6F8596" },
   { type: "protocol", label: "Protocol", icon: Microscope, color: "#2D3142" },
@@ -50,7 +53,26 @@ const cellOptions: {
   { type: "command", label: "Command", icon: Terminal, color: "#119DA4" },
   { type: "question", label: "Question", icon: HelpCircle, color: "#C58AAE" },
   { type: "branch", label: "Branch", icon: GitBranch, color: "#F29D38" },
+  { type: "branch", label: "Go to", icon: Milestone, color: "#F29D38", kind: "goto" },
 ];
+
+export function createGotoCell(): WorkbookCell {
+  const pathId = crypto.randomUUID();
+  return {
+    id: crypto.randomUUID(),
+    type: "branch",
+    isCollapsed: false,
+    paths: [
+      {
+        id: pathId,
+        label: "Go to",
+        color: nextBranchPathColor([]),
+        conditions: [],
+      },
+    ],
+    defaultPathId: pathId,
+  };
+}
 
 export function AddCellButton({
   onAdd,
@@ -64,10 +86,18 @@ export function AddCellButton({
 }: AddCellButtonProps) {
   const options = showBranch ? cellOptions : cellOptions.filter((o) => o.type !== "branch");
 
-  const handleClick = (type: CellType) => {
+  const handleClick = (option: (typeof cellOptions)[number]) => {
+    if (option.kind === "goto" && onAddCell) {
+      onAddCell(createGotoCell());
+      return;
+    }
     // protocol/macro/question are picker-driven; their popovers fire onAddCell.
-    if (onAddCell && (type === "protocol" || type === "macro" || type === "question")) return;
-    onAdd(type);
+    if (
+      onAddCell &&
+      (option.type === "protocol" || option.type === "macro" || option.type === "question")
+    )
+      return;
+    onAdd(option.type);
   };
 
   const wrapWithPicker = (type: CellType, key: string, button: React.ReactNode) => {
@@ -122,7 +152,7 @@ export function AddCellButton({
               <button
                 key={opt.label}
                 className="inline-flex h-[38px] items-center justify-center gap-1 rounded-lg bg-[#EDF2F6] px-4 text-[13px] font-semibold leading-[18px] text-[#011111] transition-colors hover:bg-[#E5EBF0]"
-                onClick={() => handleClick(opt.type)}
+                onClick={() => handleClick(opt)}
               >
                 <opt.icon className="size-4" style={{ color: opt.color }} />
                 {opt.label}
@@ -153,7 +183,7 @@ export function AddCellButton({
                       variant="ghost"
                       size="sm"
                       className="h-7 w-7 rounded-full p-0 hover:bg-[#EDF2F6]"
-                      onClick={() => handleClick(opt.type)}
+                      onClick={() => handleClick(opt)}
                     >
                       <opt.icon className="h-3.5 w-3.5" style={{ color: opt.color }} />
                     </Button>

--- a/apps/web/components/workbook/branch-path-colors.test.ts
+++ b/apps/web/components/workbook/branch-path-colors.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BRANCH_PATH_COLORS,
+  nextBranchPathColor,
+  resolveBranchPathColor,
+} from "./branch-path-colors";
+
+describe("branch path colors", () => {
+  it("chooses a distinct unassigned accent when possible", () => {
+    expect(nextBranchPathColor([BRANCH_PATH_COLORS[0], BRANCH_PATH_COLORS[1]])).toBe(
+      BRANCH_PATH_COLORS[2],
+    );
+  });
+
+  it("cycles the accent palette once every color is assigned", () => {
+    expect(nextBranchPathColor([...BRANCH_PATH_COLORS])).toBe(BRANCH_PATH_COLORS[0]);
+  });
+
+  it("renders legacy empty colors with a deterministic accent without rewriting them", () => {
+    expect(resolveBranchPathColor("", 1)).toBe(BRANCH_PATH_COLORS[1]);
+    expect(resolveBranchPathColor("#abcdef", 1)).toBe("#abcdef");
+  });
+});

--- a/apps/web/components/workbook/branch-path-colors.test.ts
+++ b/apps/web/components/workbook/branch-path-colors.test.ts
@@ -8,17 +8,30 @@ import {
 
 describe("branch path colors", () => {
   it("chooses a distinct unassigned accent when possible", () => {
-    expect(nextBranchPathColor([BRANCH_PATH_COLORS[0], BRANCH_PATH_COLORS[1]])).toBe(
-      BRANCH_PATH_COLORS[2],
-    );
+    expect(
+      nextBranchPathColor([
+        { id: "a", color: BRANCH_PATH_COLORS[0] },
+        { id: "b", color: BRANCH_PATH_COLORS[1] },
+      ]),
+    ).toBe(BRANCH_PATH_COLORS[2]);
   });
 
   it("cycles the accent palette once every color is assigned", () => {
-    expect(nextBranchPathColor([...BRANCH_PATH_COLORS])).toBe(BRANCH_PATH_COLORS[0]);
+    expect(
+      nextBranchPathColor(BRANCH_PATH_COLORS.map((color, index) => ({ id: `${index}`, color }))),
+    ).toBe(BRANCH_PATH_COLORS[0]);
   });
 
-  it("renders legacy empty colors with a deterministic accent without rewriting them", () => {
-    expect(resolveBranchPathColor("", 1)).toBe(BRANCH_PATH_COLORS[1]);
-    expect(resolveBranchPathColor("#abcdef", 1)).toBe("#abcdef");
+  it("keeps a legacy path's fallback color stable across reordering", () => {
+    const color = resolveBranchPathColor("", "legacy-path");
+    expect(color).toBe(resolveBranchPathColor("", "legacy-path"));
+    expect(resolveBranchPathColor("#abcdef", "legacy-path")).toBe("#abcdef");
+  });
+
+  it("does not reuse a legacy path's effective fallback when adding a path", () => {
+    const legacyPath = { id: "legacy-path", color: "" };
+    expect(nextBranchPathColor([legacyPath])).not.toBe(
+      resolveBranchPathColor(legacyPath.color, legacyPath.id),
+    );
   });
 });

--- a/apps/web/components/workbook/branch-path-colors.ts
+++ b/apps/web/components/workbook/branch-path-colors.ts
@@ -1,0 +1,26 @@
+/**
+ * Workbook cell accents, reused so branch paths stay visually aligned with the
+ * rest of the editor while remaining distinct within one branch.
+ */
+export const BRANCH_PATH_COLORS = [
+  "#005E5E",
+  "#6C5CE7",
+  "#119DA4",
+  "#C58AAE",
+  "#6F8596",
+  "#D08A3C",
+] as const;
+
+export function nextBranchPathColor(existingColors: string[]): string {
+  const assigned = new Set(existingColors.filter(Boolean).map((color) => color.toLowerCase()));
+  return (
+    BRANCH_PATH_COLORS.find((color) => !assigned.has(color.toLowerCase())) ??
+    BRANCH_PATH_COLORS[existingColors.length % BRANCH_PATH_COLORS.length]
+  );
+}
+
+export function resolveBranchPathColor(color: string | undefined, pathIndex: number): string {
+  const assignedColor = color?.trim();
+  if (assignedColor) return assignedColor;
+  return BRANCH_PATH_COLORS[pathIndex % BRANCH_PATH_COLORS.length];
+}

--- a/apps/web/components/workbook/branch-path-colors.ts
+++ b/apps/web/components/workbook/branch-path-colors.ts
@@ -11,16 +11,32 @@ export const BRANCH_PATH_COLORS = [
   "#D08A3C",
 ] as const;
 
-export function nextBranchPathColor(existingColors: string[]): string {
-  const assigned = new Set(existingColors.filter(Boolean).map((color) => color.toLowerCase()));
+interface BranchPathColorSource {
+  id: string;
+  color?: string;
+}
+
+function pathColorIndex(pathId: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < pathId.length; index++) {
+    hash ^= pathId.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0) % BRANCH_PATH_COLORS.length;
+}
+
+export function nextBranchPathColor(existingPaths: BranchPathColorSource[]): string {
+  const assigned = new Set(
+    existingPaths.map((path) => resolveBranchPathColor(path.color, path.id).toLowerCase()),
+  );
   return (
     BRANCH_PATH_COLORS.find((color) => !assigned.has(color.toLowerCase())) ??
-    BRANCH_PATH_COLORS[existingColors.length % BRANCH_PATH_COLORS.length]
+    BRANCH_PATH_COLORS[existingPaths.length % BRANCH_PATH_COLORS.length]
   );
 }
 
-export function resolveBranchPathColor(color: string | undefined, pathIndex: number): string {
+export function resolveBranchPathColor(color: string | undefined, pathId: string): string {
   const assignedColor = color?.trim();
   if (assignedColor) return assignedColor;
-  return BRANCH_PATH_COLORS[pathIndex % BRANCH_PATH_COLORS.length];
+  return BRANCH_PATH_COLORS[pathColorIndex(pathId)];
 }

--- a/apps/web/components/workbook/cells/branch-cell.test.tsx
+++ b/apps/web/components/workbook/cells/branch-cell.test.tsx
@@ -327,6 +327,28 @@ describe("BranchCellComponent", () => {
     expect(screen.getByText("ACTIVE")).toBeInTheDocument();
   });
 
+  it("leaves an ambiguous duplicate evaluated path unmarked", () => {
+    renderBranch({
+      paths: [
+        {
+          id: "duplicate",
+          label: "First",
+          color: "",
+          conditions: [{ id: "c1", sourceCellId: "", field: "", operator: "eq", value: "" }],
+        },
+        {
+          id: "duplicate",
+          label: "Second",
+          color: "",
+          conditions: [{ id: "c2", sourceCellId: "", field: "", operator: "eq", value: "" }],
+        },
+      ],
+      evaluatedPathId: "duplicate",
+    });
+
+    expect(screen.queryByText("ACTIVE")).not.toBeInTheDocument();
+  });
+
   it("renders a conditionless default path as a compact Go to card", async () => {
     const user = userEvent.setup();
     const { onUpdate } = renderBranch({

--- a/apps/web/components/workbook/cells/branch-cell.test.tsx
+++ b/apps/web/components/workbook/cells/branch-cell.test.tsx
@@ -207,4 +207,73 @@ describe("BranchCellComponent", () => {
     renderBranch({ evaluatedPathId: "path-1" });
     expect(screen.getByText("ACTIVE")).toBeInTheDocument();
   });
+
+  it("renders a conditionless default path as a compact Go to card", async () => {
+    const user = userEvent.setup();
+    const { onUpdate } = renderBranch({
+      paths: [
+        {
+          id: "goto-path",
+          label: "Go to",
+          color: "#005E5E",
+          conditions: [],
+          gotoCellId: questionCell.id,
+        },
+      ],
+      defaultPathId: "goto-path",
+    });
+
+    expect(screen.getByText("Go to")).toBeInTheDocument();
+    expect(screen.queryByText("If")).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Go to target" })).toHaveTextContent(
+      "Q: How are you?",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Convert to branch" }));
+    const updated = onUpdate.mock.calls[0][0] as BranchCell;
+    expect(updated.paths[0].gotoCellId).toBe(questionCell.id);
+    expect(updated.paths[0].conditions).toHaveLength(1);
+  });
+
+  it("turns a one-path branch back into Go to without losing its target", async () => {
+    const user = userEvent.setup();
+    const { onUpdate } = renderBranch({
+      paths: [
+        {
+          id: "path-1",
+          label: "Path 1",
+          color: "#005E5E",
+          conditions: [{ id: "cond-1", sourceCellId: "", field: "", operator: "eq", value: "" }],
+          gotoCellId: questionCell.id,
+        },
+      ],
+      defaultPathId: "path-1",
+    });
+
+    await user.click(screen.getByRole("button", { name: "Remove condition" }));
+
+    const updated = onUpdate.mock.calls[0][0] as BranchCell;
+    expect(updated.defaultPathId).toBe("path-1");
+    expect(updated.paths[0].gotoCellId).toBe(questionCell.id);
+    expect(updated.paths[0].conditions).toEqual([]);
+  });
+
+  it("keeps a missing Go to target visible so it can be repaired", async () => {
+    const user = userEvent.setup();
+    renderBranch({
+      paths: [
+        {
+          id: "goto-path",
+          label: "Go to",
+          color: "#005E5E",
+          conditions: [],
+          gotoCellId: "deleted-cell",
+        },
+      ],
+      defaultPathId: "goto-path",
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "Go to target" }));
+    expect(screen.getByRole("option", { name: "Missing cell (deleted-cell)" })).toBeInTheDocument();
+  });
 });

--- a/apps/web/components/workbook/cells/branch-cell.test.tsx
+++ b/apps/web/components/workbook/cells/branch-cell.test.tsx
@@ -376,6 +376,27 @@ describe("BranchCellComponent", () => {
     expect(updated.paths[0].conditions).toHaveLength(1);
   });
 
+  it("keeps a new Go to compact while prompting for its target", () => {
+    renderBranch({
+      paths: [
+        {
+          id: "goto-path",
+          label: "Go to",
+          color: "#005E5E",
+          conditions: [],
+        },
+      ],
+      defaultPathId: "goto-path",
+    });
+
+    expect(screen.getByText("Go to")).toBeInTheDocument();
+    expect(screen.queryByText("If")).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Go to target" })).toHaveTextContent(
+      "Choose target cell...",
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent("Go to target is missing");
+  });
+
   it("turns a one-path branch back into Go to without losing its target", async () => {
     const user = userEvent.setup();
     const { onUpdate } = renderBranch({

--- a/apps/web/components/workbook/cells/branch-cell.test.tsx
+++ b/apps/web/components/workbook/cells/branch-cell.test.tsx
@@ -82,6 +82,32 @@ describe("BranchCellComponent", () => {
     expect(alert).toHaveTextContent("no value specified");
   });
 
+  it("presents intentional default-less fall-through as a warning, not an error", () => {
+    renderBranch({
+      paths: [
+        {
+          id: "path-1",
+          label: "Path 1",
+          color: "",
+          conditions: [
+            {
+              id: "cond-1",
+              sourceCellId: questionCell.id,
+              field: "answer",
+              operator: "eq",
+              value: "yes",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "workbooks.problems.issue.branchNoDefault",
+    );
+  });
+
   it("lets the user rename a path inline", async () => {
     const user = userEvent.setup();
     const { onUpdate } = renderBranch();
@@ -92,6 +118,63 @@ describe("BranchCellComponent", () => {
     const lastCall = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0] as BranchCell;
     expect(lastCall.paths[0].label).toContain("Path 1");
     expect(onUpdate).toHaveBeenCalled();
+  });
+
+  it("updates only the selected path when duplicate ids are being repaired", async () => {
+    const user = userEvent.setup();
+    const duplicatePaths: BranchCell["paths"] = [
+      {
+        id: "duplicate",
+        label: "First",
+        color: "",
+        conditions: [{ id: "c1", sourceCellId: "", field: "", operator: "eq", value: "" }],
+      },
+      {
+        id: "duplicate",
+        label: "Second",
+        color: "",
+        conditions: [{ id: "c2", sourceCellId: "", field: "", operator: "eq", value: "" }],
+      },
+    ];
+    const { onUpdate } = renderBranch({
+      paths: duplicatePaths,
+      defaultPathId: "duplicate",
+    });
+
+    await user.type(screen.getByDisplayValue("Second"), "!");
+
+    const updated = onUpdate.mock.calls.at(-1)?.[0] as BranchCell;
+    expect(updated.paths[0].label).toBe("First");
+    expect(updated.paths[1].label).toContain("Second");
+    expect(updated.paths[1].label).toContain("!");
+  });
+
+  it("removes only the selected duplicate path and preserves the now-resolved default", async () => {
+    const user = userEvent.setup();
+    const { onUpdate } = renderBranch({
+      paths: [
+        {
+          id: "duplicate",
+          label: "First",
+          color: "",
+          conditions: [{ id: "c1", sourceCellId: "", field: "", operator: "eq", value: "" }],
+        },
+        {
+          id: "duplicate",
+          label: "Second",
+          color: "",
+          conditions: [{ id: "c2", sourceCellId: "", field: "", operator: "eq", value: "" }],
+        },
+      ],
+      defaultPathId: "duplicate",
+    });
+
+    await user.click(screen.getByRole("button", { name: "Remove Second" }));
+
+    const updated = onUpdate.mock.calls[0][0] as BranchCell;
+    expect(updated.paths).toHaveLength(1);
+    expect(updated.paths[0].label).toBe("First");
+    expect(updated.defaultPathId).toBe("duplicate");
   });
 
   it("lets the user type a value into the condition row", async () => {
@@ -143,6 +226,33 @@ describe("BranchCellComponent", () => {
     await user.click(screen.getByRole("combobox", { name: "Otherwise path" }));
 
     expect(screen.getByRole("option", { name: "Missing path (deleted-path)" })).toBeInTheDocument();
+  });
+
+  it("preserves an ambiguous Otherwise path without collapsing duplicate options", async () => {
+    const user = userEvent.setup();
+    renderBranch({
+      paths: [
+        {
+          id: "duplicate",
+          label: "First",
+          color: "",
+          conditions: [{ id: "c1", sourceCellId: "", field: "", operator: "eq", value: "" }],
+        },
+        {
+          id: "duplicate",
+          label: "Second",
+          color: "",
+          conditions: [{ id: "c2", sourceCellId: "", field: "", operator: "eq", value: "" }],
+        },
+      ],
+      defaultPathId: "duplicate",
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "Otherwise path" }));
+
+    expect(screen.getByRole("option", { name: "Ambiguous path (duplicate)" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "First" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Second" })).toBeInTheDocument();
   });
 
   it("adds a condition when the user clicks '+ condition'", async () => {

--- a/apps/web/components/workbook/cells/branch-cell.test.tsx
+++ b/apps/web/components/workbook/cells/branch-cell.test.tsx
@@ -106,6 +106,34 @@ describe("BranchCellComponent", () => {
     expect(updated.paths).toHaveLength(2);
     expect(updated.paths[1].label).toBe("Path 2");
     expect(updated.paths[1].conditions).toHaveLength(1);
+    expect(updated.paths[1].color).toMatch(/^#[0-9A-F]{6}$/i);
+    expect(updated.paths[1].color).not.toBe(updated.paths[0].color);
+  });
+
+  it("sets and clears the Otherwise path", async () => {
+    const user = userEvent.setup();
+    const { onUpdate } = renderBranch();
+
+    await user.click(screen.getByRole("combobox", { name: "Otherwise path" }));
+    await user.click(screen.getByRole("option", { name: "Path 1" }));
+    expect(onUpdate.mock.calls[0][0]).toHaveProperty("defaultPathId", "path-1");
+
+    const { onUpdate: onClear } = renderBranch({ defaultPathId: "path-1" });
+    const clearTrigger = screen.getAllByRole("combobox", { name: "Otherwise path" }).at(-1);
+    expect(clearTrigger).toBeDefined();
+    if (!clearTrigger) throw new Error("Otherwise trigger not found");
+    await user.click(clearTrigger);
+    await user.click(screen.getByRole("option", { name: "No default (fall through)" }));
+    expect(onClear.mock.calls[0][0]).toHaveProperty("defaultPathId", undefined);
+  });
+
+  it("preserves a missing Otherwise path as a repairable option", async () => {
+    const user = userEvent.setup();
+    renderBranch({ defaultPathId: "deleted-path" });
+
+    await user.click(screen.getByRole("combobox", { name: "Otherwise path" }));
+
+    expect(screen.getByRole("option", { name: "Missing path (deleted-path)" })).toBeInTheDocument();
   });
 
   it("adds a condition when the user clicks '+ condition'", async () => {
@@ -130,9 +158,7 @@ describe("BranchCellComponent", () => {
       />,
     );
 
-    // The condition row renders the source-cell select first.
-    const [sourceTrigger] = screen.getAllByRole("combobox");
-    await user.click(sourceTrigger);
+    await user.click(screen.getByRole("combobox", { name: "Source cell" }));
 
     expect(await screen.findByText("Command (battery)")).toBeInTheDocument();
   });

--- a/apps/web/components/workbook/cells/branch-cell.test.tsx
+++ b/apps/web/components/workbook/cells/branch-cell.test.tsx
@@ -73,6 +73,15 @@ describe("BranchCellComponent", () => {
     expect(screen.getByText("If")).toBeInTheDocument();
   });
 
+  it("shows branch configuration errors inline before a run", () => {
+    renderBranch();
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("no source cell selected");
+    expect(alert).toHaveTextContent("no field selected");
+    expect(alert).toHaveTextContent("no value specified");
+  });
+
   it("lets the user rename a path inline", async () => {
     const user = userEvent.setup();
     const { onUpdate } = renderBranch();
@@ -275,5 +284,39 @@ describe("BranchCellComponent", () => {
 
     await user.click(screen.getByRole("combobox", { name: "Go to target" }));
     expect(screen.getByRole("option", { name: "Missing cell (deleted-cell)" })).toBeInTheDocument();
+  });
+
+  it("keeps missing condition sources and branch targets visible for repair", async () => {
+    const user = userEvent.setup();
+    renderBranch({
+      paths: [
+        {
+          id: "path-1",
+          label: "Broken",
+          color: "#005E5E",
+          conditions: [
+            {
+              id: "cond-1",
+              sourceCellId: "deleted-source",
+              field: "answer",
+              operator: "eq",
+              value: "yes",
+            },
+          ],
+          gotoCellId: "deleted-target",
+        },
+      ],
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "Source cell" }));
+    expect(
+      screen.getByRole("option", { name: "Missing cell (deleted-source)" }),
+    ).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+
+    await user.click(screen.getByRole("combobox", { name: /jump to cell/i }));
+    expect(
+      screen.getByRole("option", { name: "Missing cell (deleted-target)" }),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/components/workbook/cells/branch-cell.tsx
+++ b/apps/web/components/workbook/cells/branch-cell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowRight, ChevronRight, GitBranch, Plus, Route, X } from "lucide-react";
+import { AlertCircle, ArrowRight, ChevronRight, GitBranch, Plus, Route, X } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 
 import type {
@@ -10,7 +10,11 @@ import type {
   WorkbookCell,
 } from "@repo/api/domains/workbook/workbook-cells.schema";
 import { DEVICE_CONTEXT_FIELDS, DEVICE_CONTEXT_KEY } from "@repo/api/transforms/device-context";
-import { isGotoBranchCell } from "@repo/api/transforms/evaluate-branch";
+import {
+  isGotoBranchCell,
+  validateBranchCell,
+  validateDeviceBranch,
+} from "@repo/api/transforms/evaluate-branch";
 import { Button } from "@repo/ui/components/button";
 import {
   Collapsible,
@@ -94,6 +98,26 @@ export function BranchCellComponent({
     () => (allCells ?? []).filter((c) => c.id !== cell.id && c.type !== "output"),
     [allCells, cell.id],
   );
+
+  const validationErrors = useMemo(
+    () => [...validateBranchCell(cell), ...validateDeviceBranch(cell, allCells ?? [])],
+    [allCells, cell],
+  );
+
+  const validationNotice =
+    validationErrors.length > 0 ? (
+      <div
+        role="alert"
+        className="border-destructive/30 bg-destructive/5 text-destructive flex gap-2 rounded-md border px-3 py-2 text-xs"
+      >
+        <AlertCircle className="mt-0.5 size-3.5 shrink-0" />
+        <ul className="space-y-0.5">
+          {validationErrors.map((error) => (
+            <li key={error}>{error}</li>
+          ))}
+        </ul>
+      </div>
+    ) : null;
 
   const getFieldsForSource = useCallback(
     (sourceCellId: string): string[] => {
@@ -277,52 +301,55 @@ export function BranchCellComponent({
         readOnly={readOnly}
         onRun={() => onRun?.()}
       >
-        <div className="flex items-center gap-2">
-          <ArrowRight className="text-muted-foreground size-4 shrink-0" />
-          <Select
-            value={path.gotoCellId ?? undefined}
-            onValueChange={(gotoCellId) => handleUpdatePath(path.id, { gotoCellId })}
-            disabled={readOnly}
-          >
-            <SelectTrigger aria-label="Go to target" className="h-8 flex-1 text-xs">
-              <SelectValue placeholder="Choose target cell..." />
-            </SelectTrigger>
-            <SelectContent>
-              {path.gotoCellId && !targetExists && (
-                <SelectItem value={path.gotoCellId} className="text-xs">
-                  Missing cell ({path.gotoCellId})
-                </SelectItem>
-              )}
-              {jumpTargets.map((target) => (
-                <SelectItem key={target.id} value={target.id} className="text-xs">
-                  {getCellLabel(target)}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          {!readOnly && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="h-8 shrink-0 text-xs"
-              onClick={() =>
-                handleUpdatePath(path.id, {
-                  conditions: [
-                    {
-                      id: crypto.randomUUID(),
-                      sourceCellId: "",
-                      field: "",
-                      operator: "eq",
-                      value: "",
-                    },
-                  ],
-                })
-              }
+        <div className="space-y-2">
+          {validationNotice}
+          <div className="flex items-center gap-2">
+            <ArrowRight className="text-muted-foreground size-4 shrink-0" />
+            <Select
+              value={path.gotoCellId ?? undefined}
+              onValueChange={(gotoCellId) => handleUpdatePath(path.id, { gotoCellId })}
+              disabled={readOnly}
             >
-              Convert to branch
-            </Button>
-          )}
+              <SelectTrigger aria-label="Go to target" className="h-8 flex-1 text-xs">
+                <SelectValue placeholder="Choose target cell..." />
+              </SelectTrigger>
+              <SelectContent>
+                {path.gotoCellId && !targetExists && (
+                  <SelectItem value={path.gotoCellId} className="text-xs">
+                    Missing cell ({path.gotoCellId})
+                  </SelectItem>
+                )}
+                {jumpTargets.map((target) => (
+                  <SelectItem key={target.id} value={target.id} className="text-xs">
+                    {getCellLabel(target)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {!readOnly && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-8 shrink-0 text-xs"
+                onClick={() =>
+                  handleUpdatePath(path.id, {
+                    conditions: [
+                      {
+                        id: crypto.randomUUID(),
+                        sourceCellId: "",
+                        field: "",
+                        operator: "eq",
+                        value: "",
+                      },
+                    ],
+                  })
+                }
+              >
+                Convert to branch
+              </Button>
+            )}
+          </div>
         </div>
       </CellWrapper>
     );
@@ -332,6 +359,9 @@ export function BranchCellComponent({
     const fields = getFieldsForSource(cond.sourceCellId);
     const sourceCell = (allCells ?? []).find((c) => c.id === cond.sourceCellId);
     const isQuestionSource = sourceCell?.type === "question";
+    const sourceExists =
+      cond.sourceCellId === DEVICE_CONTEXT_KEY ||
+      sourceCells.some((c) => c.id === cond.sourceCellId);
 
     return (
       <div key={cond.id} className="group/cond flex items-center gap-1.5">
@@ -348,6 +378,11 @@ export function BranchCellComponent({
             <SelectValue placeholder="source..." />
           </SelectTrigger>
           <SelectContent>
+            {cond.sourceCellId && !sourceExists && (
+              <SelectItem value={cond.sourceCellId} className="text-xs">
+                Missing cell ({cond.sourceCellId})
+              </SelectItem>
+            )}
             <SelectItem value={DEVICE_CONTEXT_KEY} className="text-xs font-medium">
               Connected device
             </SelectItem>
@@ -435,6 +470,7 @@ export function BranchCellComponent({
   const renderPath = (path: BranchPath) => {
     const isExpanded = expandedPaths[path.id] ?? true;
     const isEvaluated = cell.evaluatedPathId === path.id;
+    const targetExists = jumpTargets.some((target) => target.id === path.gotoCellId);
 
     return (
       <div key={path.id} className="relative">
@@ -510,10 +546,15 @@ export function BranchCellComponent({
                     onValueChange={(v) => handleUpdatePath(path.id, { gotoCellId: v })}
                     disabled={readOnly}
                   >
-                    <SelectTrigger className="h-7 text-xs">
+                    <SelectTrigger aria-label="Jump to cell" className="h-7 text-xs">
                       <SelectValue placeholder="Jump to cell..." />
                     </SelectTrigger>
                     <SelectContent>
+                      {path.gotoCellId && !targetExists && (
+                        <SelectItem value={path.gotoCellId} className="text-xs">
+                          Missing cell ({path.gotoCellId})
+                        </SelectItem>
+                      )}
                       {jumpTargets.map((t) => (
                         <SelectItem key={t.id} value={t.id} className="text-xs">
                           {getCellLabel(t)}
@@ -549,6 +590,7 @@ export function BranchCellComponent({
       onRun={() => onRun?.()}
     >
       <div className="space-y-2">
+        {validationNotice}
         <div className="border-border/60 bg-muted/20 flex items-center gap-2 rounded-md border px-2.5 py-2">
           <span className="text-muted-foreground shrink-0 text-xs font-semibold">Otherwise</span>
           <Select

--- a/apps/web/components/workbook/cells/branch-cell.tsx
+++ b/apps/web/components/workbook/cells/branch-cell.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { AlertCircle, ArrowRight, ChevronRight, GitBranch, Plus, Route, X } from "lucide-react";
+import {
+  AlertCircle,
+  AlertTriangle,
+  ArrowRight,
+  ChevronRight,
+  GitBranch,
+  Plus,
+  Route,
+  X,
+} from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 
 import type {
@@ -12,9 +21,11 @@ import type {
 import { DEVICE_CONTEXT_FIELDS, DEVICE_CONTEXT_KEY } from "@repo/api/transforms/device-context";
 import {
   isGotoBranchCell,
+  resolveBranchDefaultPath,
   validateBranchCell,
   validateDeviceBranch,
 } from "@repo/api/transforms/evaluate-branch";
+import { useTranslation } from "@repo/i18n";
 import { Button } from "@repo/ui/components/button";
 import {
   Collapsible,
@@ -48,6 +59,8 @@ interface BranchCellProps {
 type BranchOperator = BranchCondition["operator"];
 
 const NO_DEFAULT_PATH = "__no_default_path__";
+const INVALID_DEFAULT_PATH = "__invalid_default_path__";
+const pathOptionValue = (pathIndex: number) => `path:${pathIndex}`;
 
 const operatorLabels: Record<BranchOperator, string> = {
   eq: "=",
@@ -68,6 +81,7 @@ export function BranchCellComponent({
   executionError,
   readOnly,
 }: BranchCellProps) {
+  const { t } = useTranslation("workbook");
   const cell = useMemo(
     () => (Array.isArray(rawCell.paths) ? rawCell : { ...rawCell, paths: [] as BranchPath[] }),
     [rawCell],
@@ -75,8 +89,8 @@ export function BranchCellComponent({
 
   const [expandedPaths, setExpandedPaths] = useState<Record<string, boolean>>(() => {
     const initial: Record<string, boolean> = {};
-    cell.paths.forEach((p) => {
-      initial[p.id] = true;
+    cell.paths.forEach((p, index) => {
+      initial[`${p.id}:${index}`] = true;
     });
     return initial;
   });
@@ -99,8 +113,15 @@ export function BranchCellComponent({
     [allCells, cell.id],
   );
 
+  const defaultPathResolution = useMemo(() => resolveBranchDefaultPath(cell), [cell]);
+  const defaultPath =
+    defaultPathResolution.status === "resolved" ? defaultPathResolution.path : undefined;
+
   const validationErrors = useMemo(
-    () => [...validateBranchCell(cell), ...validateDeviceBranch(cell, allCells ?? [])],
+    () => [
+      ...validateBranchCell(cell, { requireDefault: false }),
+      ...validateDeviceBranch(cell, allCells ?? []),
+    ],
     [allCells, cell],
   );
 
@@ -116,6 +137,17 @@ export function BranchCellComponent({
             <li key={error}>{error}</li>
           ))}
         </ul>
+      </div>
+    ) : null;
+
+  const defaultWarning =
+    cell.paths.length > 0 && defaultPathResolution.status !== "resolved" ? (
+      <div
+        role="status"
+        className="flex gap-2 rounded-md border border-amber-300/50 bg-amber-50 px-3 py-2 text-xs text-amber-800"
+      >
+        <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+        <span>{t("workbooks.problems.issue.branchNoDefault")}</span>
       </div>
     ) : null;
 
@@ -196,35 +228,38 @@ export function BranchCellComponent({
   }, [cell, onUpdate]);
 
   const handleRemovePath = useCallback(
-    (pathId: string) => {
+    (pathIndex: number) => {
+      const removedPath = cell.paths[pathIndex];
       onUpdate({
         ...cell,
-        paths: cell.paths.filter((p) => p.id !== pathId),
-        defaultPathId: cell.defaultPathId === pathId ? undefined : cell.defaultPathId,
+        paths: cell.paths.filter((_, index) => index !== pathIndex),
+        defaultPathId: removedPath === defaultPath ? undefined : cell.defaultPathId,
       });
     },
-    [cell, onUpdate],
+    [cell, defaultPath, onUpdate],
   );
 
   const handleUpdatePath = useCallback(
-    (pathId: string, updates: Partial<BranchPath>) => {
+    (pathIndex: number, updates: Partial<BranchPath>) => {
       onUpdate({
         ...cell,
-        paths: cell.paths.map((p) => (p.id === pathId ? { ...p, ...updates } : p)),
+        paths: cell.paths.map((path, index) =>
+          index === pathIndex ? { ...path, ...updates } : path,
+        ),
       });
     },
     [cell, onUpdate],
   );
 
   const handleConditionUpdate = useCallback(
-    (pathId: string, condId: string, field: keyof BranchCondition, value: string) => {
+    (pathIndex: number, condId: string, field: keyof BranchCondition, value: string) => {
       onUpdate({
         ...cell,
-        paths: cell.paths.map((p) =>
-          p.id === pathId
+        paths: cell.paths.map((path, index) =>
+          index === pathIndex
             ? {
-                ...p,
-                conditions: p.conditions.map((c) => {
+                ...path,
+                conditions: path.conditions.map((c) => {
                   if (c.id !== condId) return c;
                   const updated = { ...c, [field]: value };
                   if (field === "sourceCellId") {
@@ -243,7 +278,7 @@ export function BranchCellComponent({
                   return updated;
                 }),
               }
-            : p,
+            : path,
         ),
       });
     },
@@ -251,7 +286,7 @@ export function BranchCellComponent({
   );
 
   const handleAddCondition = useCallback(
-    (pathId: string) => {
+    (pathIndex: number) => {
       const newCond: BranchCondition = {
         id: crypto.randomUUID(),
         sourceCellId: "",
@@ -261,8 +296,8 @@ export function BranchCellComponent({
       };
       onUpdate({
         ...cell,
-        paths: cell.paths.map((p) =>
-          p.id === pathId ? { ...p, conditions: [...p.conditions, newCond] } : p,
+        paths: cell.paths.map((path, index) =>
+          index === pathIndex ? { ...path, conditions: [...path.conditions, newCond] } : path,
         ),
       });
     },
@@ -270,19 +305,21 @@ export function BranchCellComponent({
   );
 
   const handleRemoveCondition = useCallback(
-    (pathId: string, condId: string) => {
+    (pathIndex: number, condId: string) => {
       onUpdate({
         ...cell,
-        paths: cell.paths.map((p) =>
-          p.id === pathId ? { ...p, conditions: p.conditions.filter((c) => c.id !== condId) } : p,
+        paths: cell.paths.map((path, index) =>
+          index === pathIndex
+            ? { ...path, conditions: path.conditions.filter((c) => c.id !== condId) }
+            : path,
         ),
       });
     },
     [cell, onUpdate],
   );
 
-  const togglePathExpanded = (pathId: string) => {
-    setExpandedPaths((prev) => ({ ...prev, [pathId]: !prev[pathId] }));
+  const togglePathExpanded = (pathKey: string) => {
+    setExpandedPaths((prev) => ({ ...prev, [pathKey]: !prev[pathKey] }));
   };
 
   if (isGotoBranchCell(cell)) {
@@ -308,7 +345,7 @@ export function BranchCellComponent({
             <ArrowRight className="text-muted-foreground size-4 shrink-0" />
             <Select
               value={path.gotoCellId ?? undefined}
-              onValueChange={(gotoCellId) => handleUpdatePath(path.id, { gotoCellId })}
+              onValueChange={(gotoCellId) => handleUpdatePath(0, { gotoCellId })}
               disabled={readOnly}
             >
               <SelectTrigger aria-label="Go to target" className="h-8 flex-1 text-xs">
@@ -334,7 +371,7 @@ export function BranchCellComponent({
                 size="sm"
                 className="h-8 shrink-0 text-xs"
                 onClick={() =>
-                  handleUpdatePath(path.id, {
+                  handleUpdatePath(0, {
                     conditions: [
                       {
                         id: crypto.randomUUID(),
@@ -356,7 +393,12 @@ export function BranchCellComponent({
     );
   }
 
-  const renderCondition = (path: BranchPath, cond: BranchCondition, index: number) => {
+  const renderCondition = (
+    path: BranchPath,
+    pathIndex: number,
+    cond: BranchCondition,
+    conditionIndex: number,
+  ) => {
     const fields = getFieldsForSource(cond.sourceCellId);
     const sourceCell = (allCells ?? []).find((c) => c.id === cond.sourceCellId);
     const isQuestionSource = sourceCell?.type === "question";
@@ -367,12 +409,12 @@ export function BranchCellComponent({
     return (
       <div key={cond.id} className="group/cond flex items-center gap-1.5">
         <span className="w-7 shrink-0 text-right text-xs font-semibold uppercase text-orange-600/80 dark:text-orange-400/80">
-          {index === 0 ? "If" : "And"}
+          {conditionIndex === 0 ? "If" : "And"}
         </span>
 
         <Select
           value={cond.sourceCellId || undefined}
-          onValueChange={(v) => handleConditionUpdate(path.id, cond.id, "sourceCellId", v)}
+          onValueChange={(v) => handleConditionUpdate(pathIndex, cond.id, "sourceCellId", v)}
           disabled={readOnly}
         >
           <SelectTrigger aria-label="Source cell" className="h-7 min-w-[100px] flex-1 text-xs">
@@ -402,7 +444,7 @@ export function BranchCellComponent({
         ) : fields.length > 0 ? (
           <Select
             value={cond.field || undefined}
-            onValueChange={(v) => handleConditionUpdate(path.id, cond.id, "field", v)}
+            onValueChange={(v) => handleConditionUpdate(pathIndex, cond.id, "field", v)}
             disabled={readOnly}
           >
             <SelectTrigger className="h-7 min-w-[80px] flex-1 text-xs">
@@ -419,7 +461,7 @@ export function BranchCellComponent({
         ) : (
           <Input
             value={cond.field}
-            onChange={(e) => handleConditionUpdate(path.id, cond.id, "field", e.target.value)}
+            onChange={(e) => handleConditionUpdate(pathIndex, cond.id, "field", e.target.value)}
             placeholder="field"
             className="h-7 min-w-[80px] flex-1 border-dashed bg-transparent text-xs"
             disabled={readOnly}
@@ -428,7 +470,7 @@ export function BranchCellComponent({
 
         <Select
           value={cond.operator}
-          onValueChange={(v) => handleConditionUpdate(path.id, cond.id, "operator", v)}
+          onValueChange={(v) => handleConditionUpdate(pathIndex, cond.id, "operator", v)}
           disabled={readOnly}
         >
           <SelectTrigger className="h-7 w-16 text-xs">
@@ -445,19 +487,19 @@ export function BranchCellComponent({
 
         <Input
           value={cond.value}
-          onChange={(e) => handleConditionUpdate(path.id, cond.id, "value", e.target.value)}
+          onChange={(e) => handleConditionUpdate(pathIndex, cond.id, "value", e.target.value)}
           placeholder="value"
           className="h-7 min-w-[60px] flex-1 border-dashed bg-transparent text-xs"
           disabled={readOnly}
         />
 
-        {!readOnly && (path.conditions.length > 1 || path.id === cell.defaultPathId) ? (
+        {!readOnly && (path.conditions.length > 1 || path === defaultPath) ? (
           <Button
             variant="ghost"
             size="sm"
             aria-label="Remove condition"
             className="text-muted-foreground hover:text-destructive h-6 w-6 shrink-0 p-0 opacity-0 transition-opacity group-hover/cond:opacity-100"
-            onClick={() => handleRemoveCondition(path.id, cond.id)}
+            onClick={() => handleRemoveCondition(pathIndex, cond.id)}
           >
             <X className="h-3 w-3" />
           </Button>
@@ -468,14 +510,15 @@ export function BranchCellComponent({
     );
   };
 
-  const renderPath = (path: BranchPath) => {
-    const isExpanded = expandedPaths[path.id] ?? true;
+  const renderPath = (path: BranchPath, pathIndex: number) => {
+    const pathKey = `${path.id}:${pathIndex}`;
+    const isExpanded = expandedPaths[pathKey] ?? true;
     const isEvaluated = cell.evaluatedPathId === path.id;
     const targetExists = jumpTargets.some((target) => target.id === path.gotoCellId);
 
     return (
-      <div key={path.id} className="relative">
-        <Collapsible open={isExpanded} onOpenChange={() => togglePathExpanded(path.id)}>
+      <div className="relative">
+        <Collapsible open={isExpanded} onOpenChange={() => togglePathExpanded(pathKey)}>
           <div className="flex items-center gap-1">
             <CollapsibleTrigger asChild>
               <button
@@ -487,7 +530,7 @@ export function BranchCellComponent({
 
                 <Input
                   value={path.label}
-                  onChange={(e) => handleUpdatePath(path.id, { label: e.target.value })}
+                  onChange={(e) => handleUpdatePath(pathIndex, { label: e.target.value })}
                   onClick={(e) => e.stopPropagation()}
                   className="hover:border-border focus:border-border h-6 flex-1 border-transparent bg-transparent px-1.5 text-sm font-medium"
                   disabled={readOnly}
@@ -511,8 +554,9 @@ export function BranchCellComponent({
               <Button
                 variant="ghost"
                 size="sm"
+                aria-label={`Remove ${path.label || `Path ${pathIndex + 1}`}`}
                 className="text-muted-foreground hover:text-destructive h-6 w-6 p-0 opacity-0 transition-opacity group-hover/path:opacity-100"
-                onClick={() => handleRemovePath(path.id)}
+                onClick={() => handleRemovePath(pathIndex)}
               >
                 <X className="size-3.5" />
               </Button>
@@ -523,13 +567,15 @@ export function BranchCellComponent({
             <div className="border-border/60 ml-6 border-l pl-4 pt-2">
               <div className="border-border/60 overflow-hidden rounded-md border bg-orange-50/30 dark:bg-orange-950/10">
                 <div className="space-y-1.5 p-2.5">
-                  {path.conditions.map((cond, index) => renderCondition(path, cond, index))}
+                  {path.conditions.map((cond, conditionIndex) =>
+                    renderCondition(path, pathIndex, cond, conditionIndex),
+                  )}
                   {!readOnly && (
                     <div className="pl-[34px]">
                       <button
                         type="button"
                         className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs"
-                        onClick={() => handleAddCondition(path.id)}
+                        onClick={() => handleAddCondition(pathIndex)}
                       >
                         <Plus className="size-3" /> condition
                       </button>
@@ -544,7 +590,7 @@ export function BranchCellComponent({
                   <ArrowRight className="text-muted-foreground size-3 shrink-0" />
                   <Select
                     value={path.gotoCellId ?? undefined}
-                    onValueChange={(v) => handleUpdatePath(path.id, { gotoCellId: v })}
+                    onValueChange={(v) => handleUpdatePath(pathIndex, { gotoCellId: v })}
                     disabled={readOnly}
                   >
                     <SelectTrigger aria-label="Jump to cell" className="h-7 text-xs">
@@ -592,16 +638,25 @@ export function BranchCellComponent({
     >
       <div className="space-y-2">
         {validationNotice}
+        {defaultWarning}
         <div className="border-border/60 bg-muted/20 flex items-center gap-2 rounded-md border px-2.5 py-2">
           <span className="text-muted-foreground shrink-0 text-xs font-semibold">Otherwise</span>
           <Select
-            value={cell.defaultPathId ?? NO_DEFAULT_PATH}
-            onValueChange={(value) =>
+            value={
+              defaultPath
+                ? pathOptionValue(cell.paths.indexOf(defaultPath))
+                : cell.defaultPathId
+                  ? INVALID_DEFAULT_PATH
+                  : NO_DEFAULT_PATH
+            }
+            onValueChange={(value) => {
+              if (value === INVALID_DEFAULT_PATH) return;
+              const pathIndex = Number(value.slice("path:".length));
               onUpdate({
                 ...cell,
-                defaultPathId: value === NO_DEFAULT_PATH ? undefined : value,
-              })
-            }
+                defaultPathId: value === NO_DEFAULT_PATH ? undefined : cell.paths[pathIndex]?.id,
+              });
+            }}
             disabled={readOnly}
           >
             <SelectTrigger aria-label="Otherwise path" className="h-7 text-xs">
@@ -611,13 +666,18 @@ export function BranchCellComponent({
               <SelectItem value={NO_DEFAULT_PATH} className="text-xs">
                 No default (fall through)
               </SelectItem>
-              {cell.defaultPathId && !cell.paths.some((path) => path.id === cell.defaultPathId) && (
-                <SelectItem value={cell.defaultPathId} className="text-xs">
-                  Missing path ({cell.defaultPathId})
+              {cell.defaultPathId && defaultPathResolution.status !== "resolved" && (
+                <SelectItem value={INVALID_DEFAULT_PATH} className="text-xs">
+                  {defaultPathResolution.status === "ambiguous" ? "Ambiguous" : "Missing"} path (
+                  {cell.defaultPathId})
                 </SelectItem>
               )}
               {cell.paths.map((path, index) => (
-                <SelectItem key={path.id} value={path.id} className="text-xs">
+                <SelectItem
+                  key={`${path.id}:${index}`}
+                  value={pathOptionValue(index)}
+                  className="text-xs"
+                >
                   {path.label || `Path ${index + 1}`}
                 </SelectItem>
               ))}
@@ -626,9 +686,9 @@ export function BranchCellComponent({
         </div>
 
         <div className="space-y-1">
-          {cell.paths.map((path) => (
-            <div key={path.id} className="group/path">
-              {renderPath(path)}
+          {cell.paths.map((path, index) => (
+            <div key={`${path.id}:${index}`} className="group/path">
+              {renderPath(path, index)}
             </div>
           ))}
 

--- a/apps/web/components/workbook/cells/branch-cell.tsx
+++ b/apps/web/components/workbook/cells/branch-cell.tsx
@@ -22,6 +22,7 @@ import { DEVICE_CONTEXT_FIELDS, DEVICE_CONTEXT_KEY } from "@repo/api/transforms/
 import {
   isGotoBranchCell,
   resolveBranchDefaultPath,
+  resolveBranchEvaluatedPath,
   validateBranchCell,
   validateDeviceBranch,
 } from "@repo/api/transforms/evaluate-branch";
@@ -116,6 +117,9 @@ export function BranchCellComponent({
   const defaultPathResolution = useMemo(() => resolveBranchDefaultPath(cell), [cell]);
   const defaultPath =
     defaultPathResolution.status === "resolved" ? defaultPathResolution.path : undefined;
+  const evaluatedPathResolution = useMemo(() => resolveBranchEvaluatedPath(cell), [cell]);
+  const evaluatedPath =
+    evaluatedPathResolution.status === "resolved" ? evaluatedPathResolution.path : undefined;
 
   const validationErrors = useMemo(
     () => [
@@ -513,7 +517,7 @@ export function BranchCellComponent({
   const renderPath = (path: BranchPath, pathIndex: number) => {
     const pathKey = `${path.id}:${pathIndex}`;
     const isExpanded = expandedPaths[pathKey] ?? true;
-    const isEvaluated = cell.evaluatedPathId === path.id;
+    const isEvaluated = path === evaluatedPath;
     const targetExists = jumpTargets.some((target) => target.id === path.gotoCellId);
 
     return (

--- a/apps/web/components/workbook/cells/branch-cell.tsx
+++ b/apps/web/components/workbook/cells/branch-cell.tsx
@@ -25,6 +25,7 @@ import {
   SelectValue,
 } from "@repo/ui/components/select";
 
+import { nextBranchPathColor } from "../branch-path-colors";
 import { CellWrapper } from "../cell-wrapper";
 
 interface BranchCellProps {
@@ -40,6 +41,8 @@ interface BranchCellProps {
 }
 
 type BranchOperator = BranchCondition["operator"];
+
+const NO_DEFAULT_PATH = "__no_default_path__";
 
 const operatorLabels: Record<BranchOperator, string> = {
   eq: "=",
@@ -151,7 +154,7 @@ export function BranchCellComponent({
     const newPath: BranchPath = {
       id: crypto.randomUUID(),
       label: `Path ${cell.paths.length + 1}`,
-      color: "",
+      color: nextBranchPathColor(cell.paths.map((path) => path.color)),
       conditions: [
         {
           id: crypto.randomUUID(),
@@ -168,7 +171,11 @@ export function BranchCellComponent({
 
   const handleRemovePath = useCallback(
     (pathId: string) => {
-      onUpdate({ ...cell, paths: cell.paths.filter((p) => p.id !== pathId) });
+      onUpdate({
+        ...cell,
+        paths: cell.paths.filter((p) => p.id !== pathId),
+        defaultPathId: cell.defaultPathId === pathId ? undefined : cell.defaultPathId,
+      });
     },
     [cell, onUpdate],
   );
@@ -268,7 +275,7 @@ export function BranchCellComponent({
           onValueChange={(v) => handleConditionUpdate(path.id, cond.id, "sourceCellId", v)}
           disabled={readOnly}
         >
-          <SelectTrigger className="h-7 min-w-[100px] flex-1 text-xs">
+          <SelectTrigger aria-label="Source cell" className="h-7 min-w-[100px] flex-1 text-xs">
             <SelectValue placeholder="source..." />
           </SelectTrigger>
           <SelectContent>
@@ -471,23 +478,58 @@ export function BranchCellComponent({
       }
       onRun={() => onRun?.()}
     >
-      <div className="space-y-1">
-        {cell.paths.map((path) => (
-          <div key={path.id} className="group/path">
-            {renderPath(path)}
-          </div>
-        ))}
-
-        {!readOnly && (
-          <button
-            type="button"
-            className="text-muted-foreground hover:bg-muted/50 hover:text-foreground flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs transition-colors"
-            onClick={handleAddPath}
+      <div className="space-y-2">
+        <div className="border-border/60 bg-muted/20 flex items-center gap-2 rounded-md border px-2.5 py-2">
+          <span className="text-muted-foreground shrink-0 text-xs font-semibold">Otherwise</span>
+          <Select
+            value={cell.defaultPathId ?? NO_DEFAULT_PATH}
+            onValueChange={(value) =>
+              onUpdate({
+                ...cell,
+                defaultPathId: value === NO_DEFAULT_PATH ? undefined : value,
+              })
+            }
+            disabled={readOnly}
           >
-            <Plus className="size-3.5" />
-            Add path
-          </button>
-        )}
+            <SelectTrigger aria-label="Otherwise path" className="h-7 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NO_DEFAULT_PATH} className="text-xs">
+                No default (fall through)
+              </SelectItem>
+              {cell.defaultPathId && !cell.paths.some((path) => path.id === cell.defaultPathId) && (
+                <SelectItem value={cell.defaultPathId} className="text-xs">
+                  Missing path ({cell.defaultPathId})
+                </SelectItem>
+              )}
+              {cell.paths.map((path, index) => (
+                <SelectItem key={path.id} value={path.id} className="text-xs">
+                  {path.label || `Path ${index + 1}`}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1">
+          {cell.paths.map((path) => (
+            <div key={path.id} className="group/path">
+              {renderPath(path)}
+            </div>
+          ))}
+
+          {!readOnly && (
+            <button
+              type="button"
+              className="text-muted-foreground hover:bg-muted/50 hover:text-foreground flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs transition-colors"
+              onClick={handleAddPath}
+            >
+              <Plus className="size-3.5" />
+              Add path
+            </button>
+          )}
+        </div>
       </div>
     </CellWrapper>
   );

--- a/apps/web/components/workbook/cells/branch-cell.tsx
+++ b/apps/web/components/workbook/cells/branch-cell.tsx
@@ -176,10 +176,11 @@ export function BranchCellComponent({
   }, []);
 
   const handleAddPath = useCallback(() => {
+    const pathId = crypto.randomUUID();
     const newPath: BranchPath = {
-      id: crypto.randomUUID(),
+      id: pathId,
       label: `Path ${cell.paths.length + 1}`,
-      color: nextBranchPathColor(cell.paths.map((path) => path.color)),
+      color: nextBranchPathColor(cell.paths),
       conditions: [
         {
           id: crypto.randomUUID(),

--- a/apps/web/components/workbook/cells/branch-cell.tsx
+++ b/apps/web/components/workbook/cells/branch-cell.tsx
@@ -10,6 +10,7 @@ import type {
   WorkbookCell,
 } from "@repo/api/domains/workbook/workbook-cells.schema";
 import { DEVICE_CONTEXT_FIELDS, DEVICE_CONTEXT_KEY } from "@repo/api/transforms/device-context";
+import { isGotoBranchCell } from "@repo/api/transforms/evaluate-branch";
 import { Button } from "@repo/ui/components/button";
 import {
   Collapsible,
@@ -259,6 +260,74 @@ export function BranchCellComponent({
     setExpandedPaths((prev) => ({ ...prev, [pathId]: !prev[pathId] }));
   };
 
+  if (isGotoBranchCell(cell)) {
+    const path = cell.paths[0];
+    const targetExists = jumpTargets.some((target) => target.id === path.gotoCellId);
+
+    return (
+      <CellWrapper
+        icon={<ArrowRight className="h-3.5 w-3.5" />}
+        label="Go to"
+        accentColor="#F29D38"
+        isCollapsed={cell.isCollapsed}
+        onToggleCollapse={(collapsed) => onUpdate({ ...cell, isCollapsed: collapsed })}
+        onDelete={onDelete}
+        executionStatus={executionStatus}
+        executionError={executionError}
+        readOnly={readOnly}
+        onRun={() => onRun?.()}
+      >
+        <div className="flex items-center gap-2">
+          <ArrowRight className="text-muted-foreground size-4 shrink-0" />
+          <Select
+            value={path.gotoCellId ?? undefined}
+            onValueChange={(gotoCellId) => handleUpdatePath(path.id, { gotoCellId })}
+            disabled={readOnly}
+          >
+            <SelectTrigger aria-label="Go to target" className="h-8 flex-1 text-xs">
+              <SelectValue placeholder="Choose target cell..." />
+            </SelectTrigger>
+            <SelectContent>
+              {path.gotoCellId && !targetExists && (
+                <SelectItem value={path.gotoCellId} className="text-xs">
+                  Missing cell ({path.gotoCellId})
+                </SelectItem>
+              )}
+              {jumpTargets.map((target) => (
+                <SelectItem key={target.id} value={target.id} className="text-xs">
+                  {getCellLabel(target)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {!readOnly && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 shrink-0 text-xs"
+              onClick={() =>
+                handleUpdatePath(path.id, {
+                  conditions: [
+                    {
+                      id: crypto.randomUUID(),
+                      sourceCellId: "",
+                      field: "",
+                      operator: "eq",
+                      value: "",
+                    },
+                  ],
+                })
+              }
+            >
+              Convert to branch
+            </Button>
+          )}
+        </div>
+      </CellWrapper>
+    );
+  }
+
   const renderCondition = (path: BranchPath, cond: BranchCondition, index: number) => {
     const fields = getFieldsForSource(cond.sourceCellId);
     const sourceCell = (allCells ?? []).find((c) => c.id === cond.sourceCellId);
@@ -346,10 +415,11 @@ export function BranchCellComponent({
           disabled={readOnly}
         />
 
-        {!readOnly && path.conditions.length > 1 ? (
+        {!readOnly && (path.conditions.length > 1 || path.id === cell.defaultPathId) ? (
           <Button
             variant="ghost"
             size="sm"
+            aria-label="Remove condition"
             className="text-muted-foreground hover:text-destructive h-6 w-6 shrink-0 p-0 opacity-0 transition-opacity group-hover/cond:opacity-100"
             onClick={() => handleRemoveCondition(path.id, cond.id)}
           >

--- a/apps/web/components/workbook/cells/branch-cell.tsx
+++ b/apps/web/components/workbook/cells/branch-cell.tsx
@@ -137,8 +137,8 @@ export function BranchCellComponent({
       >
         <AlertCircle className="mt-0.5 size-3.5 shrink-0" />
         <ul className="space-y-0.5">
-          {validationErrors.map((error) => (
-            <li key={error}>{error}</li>
+          {validationErrors.map((error, index) => (
+            <li key={`${index}:${error}`}>{error}</li>
           ))}
         </ul>
       </div>
@@ -227,7 +227,8 @@ export function BranchCellComponent({
         },
       ],
     };
-    setExpandedPaths((prev) => ({ ...prev, [newPath.id]: true }));
+    const newPathKey = `${newPath.id}:${cell.paths.length}`;
+    setExpandedPaths((prev) => ({ ...prev, [newPathKey]: true }));
     onUpdate({ ...cell, paths: [...cell.paths, newPath] });
   }, [cell, onUpdate]);
 

--- a/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.tsx
+++ b/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.tsx
@@ -56,6 +56,16 @@ function issueMessage(
       return t("flow.upgradeDiff.issue.macroWithoutInput", { label });
     case "mixed-sensor-families":
       return t("flow.upgradeDiff.issue.mixedFamilies", { detail: issue.detail ?? "" });
+    case "unreachable-cell":
+      return t("flow.upgradeDiff.issue.unreachableCell", {
+        label: issue.cellLabel ?? issue.cellId,
+      });
+    case "backward-goto-loop":
+      return t("flow.upgradeDiff.issue.backwardGotoLoop", { ref: issue.ref ?? "" });
+    case "branch-no-default":
+      return t("flow.upgradeDiff.issue.branchNoDefault");
+    case "path-duplicate-conditions":
+      return t("flow.upgradeDiff.issue.duplicatePathConditions", { detail: issue.detail ?? "" });
   }
 }
 

--- a/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.tsx
+++ b/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.tsx
@@ -64,6 +64,8 @@ function issueMessage(
       return t("flow.upgradeDiff.issue.backwardGotoLoop", { ref: issue.ref ?? "" });
     case "branch-no-default":
       return t("flow.upgradeDiff.issue.branchNoDefault");
+    case "duplicate-branch-path-id":
+      return t("flow.upgradeDiff.issue.duplicateBranchPathId", { ref: issue.ref ?? "" });
     case "path-duplicate-conditions":
       return t("flow.upgradeDiff.issue.duplicatePathConditions", { detail: issue.detail ?? "" });
   }

--- a/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.tsx
+++ b/apps/web/components/workbook/upgrade/workbook-upgrade-dialog.tsx
@@ -60,6 +60,8 @@ function issueMessage(
       return t("flow.upgradeDiff.issue.unreachableCell", {
         label: issue.cellLabel ?? issue.cellId,
       });
+    case "goto-missing-target":
+      return t("flow.upgradeDiff.issue.gotoMissingTarget");
     case "backward-goto-loop":
       return t("flow.upgradeDiff.issue.backwardGotoLoop", { ref: issue.ref ?? "" });
     case "branch-no-default":

--- a/apps/web/components/workbook/workbook-editor.test.tsx
+++ b/apps/web/components/workbook/workbook-editor.test.tsx
@@ -130,6 +130,21 @@ describe("WorkbookEditor — empty state", () => {
     expect(next[0].type).toBe("markdown");
   });
 
+  it("adds a conditionless default Go to cell from the empty state", async () => {
+    const user = userEvent.setup();
+    const { onCellsChange } = renderEditor();
+
+    await user.click(screen.getByRole("button", { name: "Go to" }));
+
+    const next = onCellsChange.mock.calls[0][0] as WorkbookCell[];
+    expect(next).toHaveLength(1);
+    const goto = next[0];
+    if (goto.type !== "branch") throw new Error("expected Go to branch shape");
+    expect(goto.paths).toHaveLength(1);
+    expect(goto.paths[0].conditions).toEqual([]);
+    expect(goto.defaultPathId).toBe(goto.paths[0].id);
+  });
+
   it("adds a question cell when the user names it through the question picker", async () => {
     const user = userEvent.setup();
     const { onCellsChange } = renderEditor();

--- a/apps/web/components/workbook/workbook-editor.tsx
+++ b/apps/web/components/workbook/workbook-editor.tsx
@@ -28,6 +28,7 @@ import type { EntitySnapshots } from "@repo/api/domains/workbook/workbook-versio
 import { cn } from "@repo/ui/lib/utils";
 
 import { AddCellButton } from "./add-cell-button";
+import { nextBranchPathColor } from "./branch-path-colors";
 import { CellRenderer } from "./cell-renderer";
 import { WorkbookHeader } from "./workbook-header";
 import { WorkbookSidebar } from "./workbook-sidebar";
@@ -105,7 +106,7 @@ export function createDefaultCell(
           {
             id: crypto.randomUUID(),
             label: "Path 1",
-            color: "",
+            color: nextBranchPathColor([]),
             conditions: [
               { id: crypto.randomUUID(), sourceCellId: "", field: "", operator: "eq", value: "" },
             ],

--- a/apps/web/components/workbook/workbook-editor.tsx
+++ b/apps/web/components/workbook/workbook-editor.tsx
@@ -363,6 +363,13 @@ export function WorkbookEditor({
   );
 
   const groups = useMemo(() => buildCellGroups(cells), [cells]);
+  const validationContext = useMemo(
+    () =>
+      entitySnapshots
+        ? { protocols: entitySnapshots.protocols, macros: entitySnapshots.macros }
+        : undefined,
+    [entitySnapshots],
+  );
   const sortableIds = useMemo(
     () => groups.filter((g) => g.source.type !== "output").map((g) => g.id),
     [groups],
@@ -608,6 +615,7 @@ export function WorkbookEditor({
             onReorder={readOnly ? undefined : handleReorder}
             collapsed={sidebarCollapsed}
             onToggleCollapsed={() => setSidebarCollapsed((v) => !v)}
+            validationContext={validationContext}
           />
         </div>
       </div>

--- a/apps/web/components/workbook/workbook-sidebar.test.tsx
+++ b/apps/web/components/workbook/workbook-sidebar.test.tsx
@@ -161,4 +161,28 @@ describe("WorkbookSidebar", () => {
     render(<WorkbookSidebar cells={[markdownCell]} onCellClick={onCellClick} />);
     expect(screen.getByRole("region", { name: "Problems" })).toHaveTextContent("No problems found");
   });
+
+  it("lists an unreachable cell warning and selects the unreachable cell", async () => {
+    const user = userEvent.setup();
+    const goto = createBranchCell({
+      id: "goto",
+      paths: [
+        {
+          id: "goto-path",
+          label: "Go to",
+          color: "#005E5E",
+          conditions: [],
+          gotoCellId: "target",
+        },
+      ],
+      defaultPathId: "goto-path",
+    });
+    const orphan = createMarkdownCell({ id: "orphan", content: "Skipped" });
+    const target = createMarkdownCell({ id: "target", content: "Target" });
+    render(<WorkbookSidebar cells={[goto, orphan, target]} onCellClick={onCellClick} />);
+
+    expect(screen.getByText("orphan is unreachable")).toBeInTheDocument();
+    await user.click(screen.getByText("orphan is unreachable"));
+    expect(onCellClick).toHaveBeenCalledWith("orphan");
+  });
 });

--- a/apps/web/components/workbook/workbook-sidebar.test.tsx
+++ b/apps/web/components/workbook/workbook-sidebar.test.tsx
@@ -194,6 +194,7 @@ describe("WorkbookSidebar", () => {
   it("provides EN, NL, and DE Problems translations for every structural branch issue", () => {
     const issueKeys = [
       "unreachableCell",
+      "gotoMissingTarget",
       "backwardGotoLoop",
       "branchNoDefault",
       "duplicateBranchPathId",

--- a/apps/web/components/workbook/workbook-sidebar.test.tsx
+++ b/apps/web/components/workbook/workbook-sidebar.test.tsx
@@ -9,6 +9,9 @@ import { render, screen, userEvent } from "@/test/test-utils";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import type { WorkbookCell } from "@repo/api/domains/workbook/workbook-cells.schema";
+import deWorkbook from "@repo/i18n/locales/de-DE/workbook.json";
+import enWorkbook from "@repo/i18n/locales/en-US/workbook.json";
+import nlWorkbook from "@repo/i18n/locales/nl-NL/workbook.json";
 
 import { WorkbookSidebar } from "./workbook-sidebar";
 
@@ -150,16 +153,18 @@ describe("WorkbookSidebar", () => {
     });
     render(<WorkbookSidebar cells={[questionCell, branch]} onCellClick={onCellClick} />);
 
-    expect(screen.getByRole("region", { name: "Problems" })).toHaveTextContent(
-      "Jump target deleted-target is missing",
+    expect(screen.getByRole("region", { name: "workbooks.problems.title" })).toHaveTextContent(
+      "workbooks.problems.issue.danglingBranchGoto",
     );
-    await user.click(screen.getByText("Jump target deleted-target is missing"));
+    await user.click(screen.getByText("workbooks.problems.issue.danglingBranchGoto"));
     expect(onCellClick).toHaveBeenCalledWith("branch-1");
   });
 
   it("shows an empty Problems state for a structurally valid workbook", () => {
     render(<WorkbookSidebar cells={[markdownCell]} onCellClick={onCellClick} />);
-    expect(screen.getByRole("region", { name: "Problems" })).toHaveTextContent("No problems found");
+    expect(screen.getByRole("region", { name: "workbooks.problems.title" })).toHaveTextContent(
+      "workbooks.problems.none",
+    );
   });
 
   it("lists an unreachable cell warning and selects the unreachable cell", async () => {
@@ -181,8 +186,26 @@ describe("WorkbookSidebar", () => {
     const target = createMarkdownCell({ id: "target", content: "Target" });
     render(<WorkbookSidebar cells={[goto, orphan, target]} onCellClick={onCellClick} />);
 
-    expect(screen.getByText("orphan is unreachable")).toBeInTheDocument();
-    await user.click(screen.getByText("orphan is unreachable"));
+    expect(screen.getByText("workbooks.problems.issue.unreachableCell")).toBeInTheDocument();
+    await user.click(screen.getByText("workbooks.problems.issue.unreachableCell"));
     expect(onCellClick).toHaveBeenCalledWith("orphan");
+  });
+
+  it("provides EN, NL, and DE Problems translations for every structural branch issue", () => {
+    const issueKeys = [
+      "unreachableCell",
+      "backwardGotoLoop",
+      "branchNoDefault",
+      "duplicateBranchPathId",
+      "duplicatePathConditions",
+    ] as const;
+
+    for (const locale of [enWorkbook, nlWorkbook, deWorkbook]) {
+      expect(locale.workbooks.problems.title).toBeTruthy();
+      expect(locale.workbooks.problems.none).toBeTruthy();
+      for (const key of issueKeys) {
+        expect(locale.workbooks.problems.issue[key]).toBeTruthy();
+      }
+    }
   });
 });

--- a/apps/web/components/workbook/workbook-sidebar.test.tsx
+++ b/apps/web/components/workbook/workbook-sidebar.test.tsx
@@ -1,4 +1,5 @@
 import {
+  createBranchCell,
   createCommandCell,
   createMarkdownCell,
   createProtocolCell,
@@ -123,5 +124,41 @@ describe("WorkbookSidebar", () => {
       .getAllByRole("button")
       .filter((el) => el.getAttribute("aria-roledescription") === "sortable");
     expect(sortable).toHaveLength(0);
+  });
+
+  it("lists dangling branch references in Problems and selects the branch", async () => {
+    const user = userEvent.setup();
+    const branch = createBranchCell({
+      id: "branch-1",
+      paths: [
+        {
+          id: "path-1",
+          label: "Broken",
+          color: "#005E5E",
+          conditions: [
+            {
+              id: "cond-1",
+              sourceCellId: questionCell.id,
+              field: "answer",
+              operator: "eq",
+              value: "yes",
+            },
+          ],
+          gotoCellId: "deleted-target",
+        },
+      ],
+    });
+    render(<WorkbookSidebar cells={[questionCell, branch]} onCellClick={onCellClick} />);
+
+    expect(screen.getByRole("region", { name: "Problems" })).toHaveTextContent(
+      "Jump target deleted-target is missing",
+    );
+    await user.click(screen.getByText("Jump target deleted-target is missing"));
+    expect(onCellClick).toHaveBeenCalledWith("branch-1");
+  });
+
+  it("shows an empty Problems state for a structurally valid workbook", () => {
+    render(<WorkbookSidebar cells={[markdownCell]} onCellClick={onCellClick} />);
+    expect(screen.getByRole("region", { name: "Problems" })).toHaveTextContent("No problems found");
   });
 });

--- a/apps/web/components/workbook/workbook-sidebar.tsx
+++ b/apps/web/components/workbook/workbook-sidebar.tsx
@@ -20,6 +20,8 @@ import { CSS } from "@dnd-kit/utilities";
 import type { LucideIcon } from "lucide-react";
 import {
   Asterisk,
+  AlertCircle,
+  AlertTriangle,
   Code,
   FileText,
   GitBranch,
@@ -29,10 +31,15 @@ import {
   Microscope,
   PanelRightClose,
 } from "lucide-react";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { stripHtml } from "~/util/strip-html";
 
 import type { WorkbookCell } from "@repo/api/domains/workbook/workbook-cells.schema";
+import { validateWorkbook } from "@repo/api/transforms/validate-workbook";
+import type {
+  WorkbookIssue,
+  WorkbookValidationContext,
+} from "@repo/api/transforms/validate-workbook";
 import { useTranslation } from "@repo/i18n";
 import { cn } from "@repo/ui/lib/utils";
 
@@ -111,6 +118,34 @@ interface WorkbookSidebarProps {
   onReorder?: (activeId: string, overId: string) => void;
   collapsed?: boolean;
   onToggleCollapsed?: () => void;
+  validationContext?: WorkbookValidationContext;
+}
+
+function optimisticValidationContext(cells: WorkbookCell[]): WorkbookValidationContext {
+  const protocols: WorkbookValidationContext["protocols"] = {};
+  const macros: WorkbookValidationContext["macros"] = {};
+  for (const cell of cells) {
+    if (cell.type === "protocol") protocols[cell.payload.protocolId] = {};
+    if (cell.type === "macro") macros[cell.payload.macroId] = {};
+  }
+  return { protocols, macros };
+}
+
+export function workbookIssueMessage(issue: WorkbookIssue): string {
+  switch (issue.code) {
+    case "missing-protocol":
+      return `Protocol ${issue.ref ?? "reference"} is missing`;
+    case "missing-macro":
+      return `Macro ${issue.ref ?? "reference"} is missing`;
+    case "dangling-branch-source":
+      return `Branch source ${issue.ref ?? "reference"} is missing`;
+    case "dangling-branch-goto":
+      return `Jump target ${issue.ref ?? "reference"} is missing`;
+    case "mixed-sensor-families":
+      return `Workbook mixes sensor families${issue.detail ? `: ${issue.detail}` : ""}`;
+    case "macro-without-input":
+      return "Macro has no upstream measurement";
+  }
 }
 
 interface SidebarRowProps {
@@ -223,6 +258,7 @@ export function WorkbookSidebar({
   onReorder,
   collapsed,
   onToggleCollapsed,
+  validationContext,
 }: WorkbookSidebarProps) {
   const { t } = useTranslation("workbook");
 
@@ -238,6 +274,11 @@ export function WorkbookSidebar({
   const requiredCount = visibleCells.filter(
     (cell) => cell.type === "question" && cell.question.required,
   ).length;
+
+  const validation = useMemo(
+    () => validateWorkbook(cells, validationContext ?? optimisticValidationContext(cells)),
+    [cells, validationContext],
+  );
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
@@ -288,7 +329,9 @@ export function WorkbookSidebar({
       {/* Cell list */}
       <div
         className="mt-4 flex flex-col gap-2 overflow-y-auto"
-        style={{ maxHeight: "calc(100vh - 200px)" }}
+        style={{
+          maxHeight: validation.issues.length > 0 ? "calc(100vh - 380px)" : "calc(100vh - 260px)",
+        }}
       >
         <DndContext
           sensors={sensors}
@@ -311,6 +354,41 @@ export function WorkbookSidebar({
           </SortableContext>
         </DndContext>
       </div>
+
+      <section className="mt-5 border-t border-[#EDF2F6] pt-4" aria-label="Problems">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-[13px] font-semibold text-[#011111]">Problems</span>
+          <span className="rounded-full bg-[#EDF2F6] px-2 py-0.5 text-[11px] text-[#68737B]">
+            {validation.issues.length}
+          </span>
+        </div>
+        {validation.issues.length === 0 ? (
+          <p className="text-xs text-[#68737B]">No problems found</p>
+        ) : (
+          <div className="flex max-h-48 flex-col gap-1 overflow-y-auto">
+            {validation.issues.map((issue, index) => {
+              const Icon = issue.level === "error" ? AlertCircle : AlertTriangle;
+              return (
+                <button
+                  key={`${issue.code}:${issue.cellId ?? "workbook"}:${issue.ref ?? index}`}
+                  type="button"
+                  className="flex items-start gap-2 rounded-md px-2 py-1.5 text-left text-xs hover:bg-[#F6F8FA] disabled:cursor-default"
+                  onClick={() => issue.cellId && onCellClick?.(issue.cellId)}
+                  disabled={!issue.cellId}
+                >
+                  <Icon
+                    className={cn(
+                      "mt-0.5 size-3.5 shrink-0",
+                      issue.level === "error" ? "text-red-600" : "text-amber-600",
+                    )}
+                  />
+                  <span className="text-[#374151]">{workbookIssueMessage(issue)}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </section>
     </div>
   );
 }

--- a/apps/web/components/workbook/workbook-sidebar.tsx
+++ b/apps/web/components/workbook/workbook-sidebar.tsx
@@ -131,28 +131,37 @@ function optimisticValidationContext(cells: WorkbookCell[]): WorkbookValidationC
   return { protocols, macros };
 }
 
-export function workbookIssueMessage(issue: WorkbookIssue): string {
+export function workbookIssueMessage(
+  t: (key: string, opts?: Record<string, unknown>) => string,
+  issue: WorkbookIssue,
+): string {
   switch (issue.code) {
     case "missing-protocol":
-      return `Protocol ${issue.ref ?? "reference"} is missing`;
+      return t("workbooks.problems.issue.missingProtocol", { ref: issue.ref ?? "" });
     case "missing-macro":
-      return `Macro ${issue.ref ?? "reference"} is missing`;
+      return t("workbooks.problems.issue.missingMacro", { ref: issue.ref ?? "" });
     case "dangling-branch-source":
-      return `Branch source ${issue.ref ?? "reference"} is missing`;
+      return t("workbooks.problems.issue.danglingBranchSource", { ref: issue.ref ?? "" });
     case "dangling-branch-goto":
-      return `Jump target ${issue.ref ?? "reference"} is missing`;
+      return t("workbooks.problems.issue.danglingBranchGoto", { ref: issue.ref ?? "" });
     case "mixed-sensor-families":
-      return `Workbook mixes sensor families${issue.detail ? `: ${issue.detail}` : ""}`;
+      return t("workbooks.problems.issue.mixedSensorFamilies", { detail: issue.detail ?? "" });
     case "macro-without-input":
-      return "Macro has no upstream measurement";
+      return t("workbooks.problems.issue.macroWithoutInput");
     case "unreachable-cell":
-      return `${issue.cellLabel ?? issue.cellId ?? "Cell"} is unreachable`;
+      return t("workbooks.problems.issue.unreachableCell", {
+        label: issue.cellLabel ?? issue.cellId ?? "",
+      });
     case "backward-goto-loop":
-      return `Go to loops backward to ${issue.ref ?? "an earlier cell"}`;
+      return t("workbooks.problems.issue.backwardGotoLoop", { ref: issue.ref ?? "" });
     case "branch-no-default":
-      return "Branch has no Otherwise path and may fall through";
+      return t("workbooks.problems.issue.branchNoDefault");
+    case "duplicate-branch-path-id":
+      return t("workbooks.problems.issue.duplicateBranchPathId", { ref: issue.ref ?? "" });
     case "path-duplicate-conditions":
-      return `Duplicate path conditions${issue.detail ? `: ${issue.detail}` : ""}`;
+      return t("workbooks.problems.issue.duplicatePathConditions", {
+        detail: issue.detail ?? "",
+      });
   }
 }
 
@@ -363,15 +372,20 @@ export function WorkbookSidebar({
         </DndContext>
       </div>
 
-      <section className="mt-5 border-t border-[#EDF2F6] pt-4" aria-label="Problems">
+      <section
+        className="mt-5 border-t border-[#EDF2F6] pt-4"
+        aria-label={t("workbooks.problems.title")}
+      >
         <div className="mb-2 flex items-center justify-between">
-          <span className="text-[13px] font-semibold text-[#011111]">Problems</span>
+          <span className="text-[13px] font-semibold text-[#011111]">
+            {t("workbooks.problems.title")}
+          </span>
           <span className="rounded-full bg-[#EDF2F6] px-2 py-0.5 text-[11px] text-[#68737B]">
             {validation.issues.length}
           </span>
         </div>
         {validation.issues.length === 0 ? (
-          <p className="text-xs text-[#68737B]">No problems found</p>
+          <p className="text-xs text-[#68737B]">{t("workbooks.problems.none")}</p>
         ) : (
           <div className="flex max-h-48 flex-col gap-1 overflow-y-auto">
             {validation.issues.map((issue, index) => {
@@ -390,7 +404,7 @@ export function WorkbookSidebar({
                       issue.level === "error" ? "text-red-600" : "text-amber-600",
                     )}
                   />
-                  <span className="text-[#374151]">{workbookIssueMessage(issue)}</span>
+                  <span className="text-[#374151]">{workbookIssueMessage(t, issue)}</span>
                 </button>
               );
             })}

--- a/apps/web/components/workbook/workbook-sidebar.tsx
+++ b/apps/web/components/workbook/workbook-sidebar.tsx
@@ -152,6 +152,8 @@ export function workbookIssueMessage(
       return t("workbooks.problems.issue.unreachableCell", {
         label: issue.cellLabel ?? issue.cellId ?? "",
       });
+    case "goto-missing-target":
+      return t("workbooks.problems.issue.gotoMissingTarget");
     case "backward-goto-loop":
       return t("workbooks.problems.issue.backwardGotoLoop", { ref: issue.ref ?? "" });
     case "branch-no-default":

--- a/apps/web/components/workbook/workbook-sidebar.tsx
+++ b/apps/web/components/workbook/workbook-sidebar.tsx
@@ -145,6 +145,14 @@ export function workbookIssueMessage(issue: WorkbookIssue): string {
       return `Workbook mixes sensor families${issue.detail ? `: ${issue.detail}` : ""}`;
     case "macro-without-input":
       return "Macro has no upstream measurement";
+    case "unreachable-cell":
+      return `${issue.cellLabel ?? issue.cellId ?? "Cell"} is unreachable`;
+    case "backward-goto-loop":
+      return `Go to loops backward to ${issue.ref ?? "an earlier cell"}`;
+    case "branch-no-default":
+      return "Branch has no Otherwise path and may fall through";
+    case "path-duplicate-conditions":
+      return `Duplicate path conditions${issue.detail ? `: ${issue.detail}` : ""}`;
   }
 }
 

--- a/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.test.ts
+++ b/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.test.ts
@@ -1030,6 +1030,63 @@ describe("useWorkbookExecution", () => {
   });
 
   describe("runCell - branch", () => {
+    it("runs a conditionless default Go to and routes to its target", async () => {
+      const target = createQuestionCell({ id: "target" });
+      const goto = createBranchCell({
+        id: "goto",
+        paths: [
+          {
+            id: "goto-path",
+            label: "Go to",
+            color: "#22c55e",
+            conditions: [],
+            gotoCellId: target.id,
+          },
+        ],
+        defaultPathId: "goto-path",
+      });
+      const onPrompt = vi.fn().mockResolvedValue("arrived");
+      const { result, onCellsChange } = renderExecution([goto, target], {
+        onPromptQuestion: onPrompt,
+      });
+
+      await act(() => result.current.runCell(goto.id));
+
+      expect(onPrompt).toHaveBeenCalledWith(target);
+      const updated = onCellsChange.mock.calls.at(-1)?.[0] as WorkbookCell[];
+      expect(updated.find((cell) => cell.id === goto.id)).toHaveProperty(
+        "evaluatedPathId",
+        "goto-path",
+      );
+      expect(findOutput(updated, goto.id)?.messages).toEqual([expect.stringContaining("Go to")]);
+    });
+
+    it("falls through for a Go to that targets itself", async () => {
+      const goto = createBranchCell({
+        id: "goto",
+        paths: [
+          {
+            id: "goto-path",
+            label: "Go to",
+            color: "#22c55e",
+            conditions: [],
+            gotoCellId: "goto",
+          },
+        ],
+        defaultPathId: "goto-path",
+      });
+      const { result, onCellsChange } = renderExecution([goto]);
+
+      await act(() => result.current.runCell(goto.id));
+
+      expect(onCellsChange).toHaveBeenCalledTimes(1);
+      const updated = onCellsChange.mock.calls[0][0] as WorkbookCell[];
+      expect(updated.find((cell) => cell.id === goto.id)).toHaveProperty(
+        "evaluatedPathId",
+        "goto-path",
+      );
+    });
+
     it("evaluates branch and records matched path", async () => {
       const q = createQuestionCell({
         id: "q-1",

--- a/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.test.ts
+++ b/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.test.ts
@@ -86,6 +86,30 @@ function findOutput(cells: WorkbookCell[], producedBy?: string) {
   return output;
 }
 
+function staleDuplicateBranch(firstTargetId: string, secondTargetId: string) {
+  return createBranchCell({
+    id: "duplicate-branch",
+    paths: [
+      {
+        id: "duplicate-path",
+        label: "First duplicate",
+        color: "#22c55e",
+        conditions: [],
+        gotoCellId: firstTargetId,
+      },
+      {
+        id: "duplicate-path",
+        label: "Second duplicate",
+        color: "#0ea5e9",
+        conditions: [],
+        gotoCellId: secondTargetId,
+      },
+    ],
+    defaultPathId: "duplicate-path",
+    evaluatedPathId: "duplicate-path",
+  });
+}
+
 describe("useWorkbookExecution", () => {
   beforeEach(() => {
     mockConnections = [];
@@ -1030,6 +1054,25 @@ describe("useWorkbookExecution", () => {
   });
 
   describe("runCell - branch", () => {
+    it("clears a stale ambiguous evaluated path and runs neither duplicate target", async () => {
+      const first = createQuestionCell({ id: "first-target" });
+      const second = createQuestionCell({ id: "second-target" });
+      const branch = staleDuplicateBranch(first.id, second.id);
+      const onPrompt = vi.fn().mockResolvedValue("should not run");
+      const { result, onCellsChange } = renderExecution([branch, first, second], {
+        onPromptQuestion: onPrompt,
+      });
+
+      await act(() => result.current.runCell(branch.id));
+
+      expect(onPrompt).not.toHaveBeenCalled();
+      const updated = onCellsChange.mock.calls.at(-1)?.[0] as WorkbookCell[];
+      expect(updated.find((cell) => cell.id === branch.id)).not.toHaveProperty("evaluatedPathId");
+      expect(findOutput(updated, branch.id)?.messages).toEqual(
+        expect.arrayContaining([expect.stringContaining("duplicated")]),
+      );
+    });
+
     it("runs a conditionless default Go to and routes to its target", async () => {
       const target = createQuestionCell({ id: "target" });
       const goto = createBranchCell({
@@ -1164,6 +1207,7 @@ describe("useWorkbookExecution", () => {
           },
         ],
         defaultPathId: "path-default",
+        evaluatedPathId: "path-default",
       });
 
       const { result, onCellsChange } = renderExecution([proto, output, branch]);
@@ -1342,7 +1386,7 @@ describe("useWorkbookExecution", () => {
         "Ambit B (ambit): no measurement resolved this round",
       );
       const branchCell = updated.find((c) => c.id === branch.id);
-      expect(branchCell).toHaveProperty("evaluatedPathId", undefined);
+      expect(branchCell).not.toHaveProperty("evaluatedPathId");
     });
 
     it("runAll skips a dispatched target exactly once (no double run)", async () => {
@@ -1382,7 +1426,10 @@ describe("useWorkbookExecution", () => {
     it("errors a device-scoped branch when no device is connected", async () => {
       setMockConnected(false);
       const proto = createProtocolCell({ id: "proto-ms" });
-      const branch = deviceBranch({ multispeq: "proto-ms", other: "proto-ms" });
+      const branch = {
+        ...deviceBranch({ multispeq: "proto-ms", other: "proto-ms" }),
+        evaluatedPathId: "path-multispeq",
+      };
 
       const { result, onCellsChange } = renderExecution([branch, proto]);
       await act(() => result.current.runCell(branch.id));
@@ -1390,6 +1437,7 @@ describe("useWorkbookExecution", () => {
       const updated = onCellsChange.mock.calls[0][0] as WorkbookCell[];
       const branchOutput = findOutput(updated, branch.id);
       expect(branchOutput?.messages?.join("\n")).toContain("No device connected");
+      expect(updated.find((cell) => cell.id === branch.id)).not.toHaveProperty("evaluatedPathId");
     });
 
     it("rejects a device-scoped branch whose path lacks a measurement target", async () => {
@@ -1453,6 +1501,26 @@ describe("useWorkbookExecution", () => {
   });
 
   describe("runAll", () => {
+    it("does not jump backward from a stale ambiguous evaluated path after a config error", async () => {
+      const first = createQuestionCell({ id: "first-target" });
+      const second = createQuestionCell({ id: "second-target" });
+      const branch = staleDuplicateBranch(first.id, second.id);
+      const onPrompt = vi.fn().mockResolvedValue("answered");
+      const { result, onCellsChange } = renderExecution([first, second, branch], {
+        onPromptQuestion: onPrompt,
+      });
+
+      await act(() => result.current.runAll());
+
+      expect(onPrompt).toHaveBeenCalledTimes(2);
+      expect(onPrompt.mock.calls.map(([cell]) => (cell as QuestionCell).id)).toEqual([
+        first.id,
+        second.id,
+      ]);
+      const updated = onCellsChange.mock.calls.at(-1)?.[0] as WorkbookCell[];
+      expect(updated.find((cell) => cell.id === branch.id)).not.toHaveProperty("evaluatedPathId");
+    });
+
     it("skips output and markdown cells", async () => {
       const q = createQuestionCell();
       const output = createOutputCell({ producedBy: q.id });

--- a/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.ts
+++ b/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.ts
@@ -758,11 +758,14 @@ export function useWorkbookExecution({
 
   // Returns the jump index into `currentCells`, or -1 if no jump.
   const resolveBranchJump = (branchCellId: string, currentCells: WorkbookCell[]): number => {
-    const branch = currentCells.find((c) => c.id === branchCellId);
-    if (branch?.type !== "branch" || !branch.evaluatedPathId) return -1;
+    const branchIndex = currentCells.findIndex((c) => c.id === branchCellId);
+    if (branchIndex === -1) return -1;
+    const branch = currentCells[branchIndex];
+    if (branch.type !== "branch" || !branch.evaluatedPathId) return -1;
     const matchedPath = branch.paths.find((p) => p.id === branch.evaluatedPathId);
     if (!matchedPath?.gotoCellId) return -1;
-    return currentCells.findIndex((c) => c.id === matchedPath.gotoCellId);
+    const targetIndex = currentCells.findIndex((c) => c.id === matchedPath.gotoCellId);
+    return targetIndex === branchIndex ? -1 : targetIndex;
   };
 
   const runCell = useCallback(

--- a/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.ts
+++ b/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.ts
@@ -18,6 +18,7 @@ import { parseApiError } from "~/util/apiError";
 import type { SensorFamily } from "@repo/api/domains/protocol/protocol.schema";
 import type {
   BranchCell,
+  BranchPath,
   CommandCell,
   MacroCell,
   OutputCell,
@@ -36,6 +37,7 @@ import { presentDevice } from "@repo/api/transforms/device-presentation";
 import {
   evaluateBranch,
   isDeviceScopedBranch,
+  resolveBranchEvaluatedPath,
   validateBranchCell,
   validateDeviceBranch,
 } from "@repo/api/transforms/evaluate-branch";
@@ -101,6 +103,15 @@ function insertOutputAfterCell(
   const updated = [...filtered];
   updated.splice(idx + 1, 0, outputCell);
   return updated;
+}
+
+function clearBranchEvaluation(cells: WorkbookCell[], branchCellId: string): WorkbookCell[] {
+  return cells.map((cell) => {
+    if (cell.id !== branchCellId || cell.type !== "branch") return cell;
+    const cleared = { ...cell };
+    delete cleared.evaluatedPathId;
+    return cleared;
+  });
 }
 
 function makeOutputCell(
@@ -593,13 +604,13 @@ export function useWorkbookExecution({
       if (connections.length === 0) {
         setCellState(cell.id, { status: "error", error: "No device connected" });
         return insertOutputAfterCell(
-          currentCells,
+          clearBranchEvaluation(currentCells, cell.id),
           cell.id,
           makeErrorOutputCell(cell.id, "No device connected - connect devices to dispatch"),
         );
       }
 
-      const groups = new Map<string, IotDeviceConnection[]>();
+      const groups = new Map<BranchPath, IotDeviceConnection[]>();
       const skipped: IotDeviceConnection[] = [];
       connections.forEach((connection, index) => {
         const path = evaluateBranch(cell, currentCells, {
@@ -610,9 +621,9 @@ export function useWorkbookExecution({
           ? currentCells.find((c) => c.id === path.gotoCellId)
           : undefined;
         if (path && target && (target.type === "protocol" || target.type === "command")) {
-          const group = groups.get(path.id);
+          const group = groups.get(path);
           if (group) group.push(connection);
-          else groups.set(path.id, [connection]);
+          else groups.set(path, [connection]);
         } else {
           skipped.push(connection);
         }
@@ -621,7 +632,7 @@ export function useWorkbookExecution({
       let updated = currentCells;
       const messages: string[] = [];
       for (const path of cell.paths) {
-        const group = groups.get(path.id);
+        const group = groups.get(path);
         if (!group || group.length === 0 || !path.gotoCellId) continue;
         const target = updated.find((c) => c.id === path.gotoCellId);
         if (!target) continue;
@@ -645,7 +656,7 @@ export function useWorkbookExecution({
         makeOutputCell(cell.id, undefined, 0, messages),
       );
       // A dispatcher matches several paths at once; no single ACTIVE path.
-      return updated.map((c) => (c.id === cell.id ? { ...cell, evaluatedPathId: undefined } : c));
+      return clearBranchEvaluation(updated, cell.id);
     },
     [setCellState, runProtocolCell, runCommandCell],
   );
@@ -665,7 +676,7 @@ export function useWorkbookExecution({
       if (configErrors.length > 0) {
         setCellState(cell.id, { status: "error", error: configErrors.join("; ") });
         return insertOutputAfterCell(
-          currentCells,
+          clearBranchEvaluation(currentCells, cell.id),
           cell.id,
           makeOutputCell(cell.id, undefined, 0, configErrors),
         );
@@ -678,7 +689,7 @@ export function useWorkbookExecution({
           if (!isOutputDataNormalizationError(err)) throw err;
           setCellState(cell.id, { status: "error", error: err.message });
           return insertOutputAfterCell(
-            currentCells,
+            clearBranchEvaluation(currentCells, cell.id),
             cell.id,
             makeErrorOutputCell(cell.id, err.message),
           );
@@ -692,7 +703,7 @@ export function useWorkbookExecution({
         if (!isOutputDataNormalizationError(err)) throw err;
         setCellState(cell.id, { status: "error", error: err.message });
         return insertOutputAfterCell(
-          currentCells,
+          clearBranchEvaluation(currentCells, cell.id),
           cell.id,
           makeErrorOutputCell(cell.id, err.message),
         );
@@ -709,8 +720,9 @@ export function useWorkbookExecution({
         cell.id,
         makeOutputCell(cell.id, undefined, 0, messages),
       );
+      if (!matchedPath) return clearBranchEvaluation(updated, cell.id);
       return updated.map((c) =>
-        c.id === cell.id ? { ...cell, evaluatedPathId: matchedPath?.id } : c,
+        c.id === cell.id ? { ...cell, evaluatedPathId: matchedPath.id } : c,
       );
     },
     [setCellState, runDeviceDispatchBranch],
@@ -761,10 +773,10 @@ export function useWorkbookExecution({
     const branchIndex = currentCells.findIndex((c) => c.id === branchCellId);
     if (branchIndex === -1) return -1;
     const branch = currentCells[branchIndex];
-    if (branch.type !== "branch" || !branch.evaluatedPathId) return -1;
-    const matchedPath = branch.paths.find((p) => p.id === branch.evaluatedPathId);
-    if (!matchedPath?.gotoCellId) return -1;
-    const targetIndex = currentCells.findIndex((c) => c.id === matchedPath.gotoCellId);
+    if (branch.type !== "branch") return -1;
+    const matchedPath = resolveBranchEvaluatedPath(branch);
+    if (matchedPath.status !== "resolved" || !matchedPath.path.gotoCellId) return -1;
+    const targetIndex = currentCells.findIndex((c) => c.id === matchedPath.path.gotoCellId);
     return targetIndex === branchIndex ? -1 : targetIndex;
   };
 

--- a/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.ts
+++ b/apps/web/hooks/workbook/useWorkbookExecution/useWorkbookExecution.ts
@@ -659,7 +659,7 @@ export function useWorkbookExecution({
       setCellState(cell.id, { status: "running" });
 
       const configErrors = [
-        ...validateBranchCell(cell),
+        ...validateBranchCell(cell, { requireDefault: false }),
         ...validateDeviceBranch(cell, currentCells),
       ];
       if (configErrors.length > 0) {

--- a/packages/api/src/transforms/evaluate-branch.spec.ts
+++ b/packages/api/src/transforms/evaluate-branch.spec.ts
@@ -9,6 +9,8 @@ import {
   isGotoBranchCell,
   isDeviceScopedBranch,
   resolveBranchDefaultPath,
+  resolveBranchEvaluatedPath,
+  resolveBranchPathById,
   resolveConditionValue,
   validateBranchCell,
   validateDeviceBranch,
@@ -426,6 +428,13 @@ describe("evaluateBranch", () => {
     expect(resolveBranchDefaultPath({ paths: [path], defaultPathId: path.id })).toEqual({
       status: "resolved",
       path,
+    });
+    expect(resolveBranchEvaluatedPath({ paths: [path], evaluatedPathId: path.id })).toEqual({
+      status: "resolved",
+      path,
+    });
+    expect(resolveBranchPathById([path, { ...path }], path.id)).toEqual({
+      status: "ambiguous",
     });
   });
 

--- a/packages/api/src/transforms/evaluate-branch.spec.ts
+++ b/packages/api/src/transforms/evaluate-branch.spec.ts
@@ -478,7 +478,7 @@ describe("validateBranchCell", () => {
       paths: [{ id: "p1", label: "Path 1", color: "", conditions: [] }],
     });
     const errors = validateBranchCell(cell);
-    expect(errors).toEqual(["Path 1: no conditions defined"]);
+    expect(errors).toEqual(["Branch Otherwise path is missing", "Path 1: no conditions defined"]);
   });
 
   it("allows a conditionless path only when it is the default", () => {
@@ -490,7 +490,39 @@ describe("validateBranchCell", () => {
 
     expect(validateBranchCell(goto)).toEqual([]);
     expect(validateBranchCell({ ...goto, defaultPathId: undefined })).toEqual([
+      "Branch Otherwise path is missing",
       "Go to: no conditions defined",
+    ]);
+  });
+
+  it("rejects a dangling Otherwise path", () => {
+    const cell = makeBranchCell({
+      id: "b1",
+      paths: [{ id: "p1", label: "Go to", color: "", conditions: [], gotoCellId: "target" }],
+      defaultPathId: "missing",
+    });
+
+    expect(validateBranchCell(cell)).toEqual([
+      "Branch Otherwise path is missing",
+      "Go to: no conditions defined",
+    ]);
+  });
+
+  it("rejects duplicate path ids without treating either as the default", () => {
+    const cell = makeBranchCell({
+      id: "b1",
+      paths: [
+        { id: "same", label: "First", color: "", conditions: [], gotoCellId: "target" },
+        { id: "same", label: "Second", color: "", conditions: [], gotoCellId: "other" },
+      ],
+      defaultPathId: "same",
+    });
+
+    expect(validateBranchCell(cell)).toEqual([
+      "Branch path id same is duplicated",
+      "Branch Otherwise path is ambiguous",
+      "First: no conditions defined",
+      "Second: no conditions defined",
     ]);
   });
 
@@ -513,6 +545,7 @@ describe("validateBranchCell", () => {
   it("returns error for missing source cell", () => {
     const cell = makeBranchCell({
       id: "b1",
+      defaultPathId: "p1",
       paths: [
         {
           id: "p1",
@@ -529,6 +562,7 @@ describe("validateBranchCell", () => {
   it("returns error for missing field", () => {
     const cell = makeBranchCell({
       id: "b1",
+      defaultPathId: "p1",
       paths: [
         {
           id: "p1",
@@ -545,6 +579,7 @@ describe("validateBranchCell", () => {
   it("returns error for missing value", () => {
     const cell = makeBranchCell({
       id: "b1",
+      defaultPathId: "p1",
       paths: [
         {
           id: "p1",
@@ -561,6 +596,7 @@ describe("validateBranchCell", () => {
   it("allows value of '0'", () => {
     const cell = makeBranchCell({
       id: "b1",
+      defaultPathId: "p1",
       paths: [
         {
           id: "p1",
@@ -577,6 +613,7 @@ describe("validateBranchCell", () => {
   it("returns multiple errors for multiple bad conditions", () => {
     const cell = makeBranchCell({
       id: "b1",
+      defaultPathId: "p1",
       paths: [
         {
           id: "p1",
@@ -600,6 +637,7 @@ describe("validateBranchCell", () => {
   it("returns no errors for fully configured cell", () => {
     const cell = makeBranchCell({
       id: "b1",
+      defaultPathId: "p1",
       paths: [
         {
           id: "p1",
@@ -618,6 +656,7 @@ describe("validateBranchCell", () => {
   it("uses 'Unnamed path' when label is empty", () => {
     const cell = makeBranchCell({
       id: "b1",
+      defaultPathId: "p1",
       paths: [
         {
           id: "p1",

--- a/packages/api/src/transforms/evaluate-branch.spec.ts
+++ b/packages/api/src/transforms/evaluate-branch.spec.ts
@@ -499,7 +499,7 @@ describe("validateBranchCell", () => {
         ...goto,
         paths: [{ ...goto.paths[0], gotoCellId: undefined }],
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(isGotoBranchCell({ ...goto, defaultPathId: undefined })).toBe(false);
     expect(
       isGotoBranchCell({
@@ -535,6 +535,12 @@ describe("validateBranchCell", () => {
     });
 
     expect(validateBranchCell(goto)).toEqual([]);
+    expect(
+      validateBranchCell({
+        ...goto,
+        paths: [{ ...goto.paths[0], gotoCellId: undefined }],
+      }),
+    ).toEqual(["Go to target is missing"]);
     expect(validateBranchCell({ ...goto, defaultPathId: undefined })).toEqual([
       "Branch Otherwise path is missing",
       "Go to: no conditions defined",

--- a/packages/api/src/transforms/evaluate-branch.spec.ts
+++ b/packages/api/src/transforms/evaluate-branch.spec.ts
@@ -494,6 +494,12 @@ describe("validateBranchCell", () => {
     });
 
     expect(isGotoBranchCell(goto)).toBe(true);
+    expect(
+      isGotoBranchCell({
+        ...goto,
+        paths: [{ ...goto.paths[0], gotoCellId: undefined }],
+      }),
+    ).toBe(false);
     expect(isGotoBranchCell({ ...goto, defaultPathId: undefined })).toBe(false);
     expect(
       isGotoBranchCell({

--- a/packages/api/src/transforms/evaluate-branch.spec.ts
+++ b/packages/api/src/transforms/evaluate-branch.spec.ts
@@ -6,6 +6,7 @@ import type { BranchCell, WorkbookCell } from "../domains/workbook/workbook-cell
 import {
   evaluateBranch,
   evaluatePathConditions,
+  isGotoBranchCell,
   isDeviceScopedBranch,
   resolveConditionValue,
   validateBranchCell,
@@ -445,6 +446,26 @@ describe("evaluateBranch", () => {
 });
 
 describe("validateBranchCell", () => {
+  it("detects Go to cells structurally", () => {
+    const goto = makeBranchCell({
+      id: "b1",
+      paths: [{ id: "p1", label: "Go to", color: "", conditions: [], gotoCellId: "target" }],
+      defaultPathId: "p1",
+    });
+
+    expect(isGotoBranchCell(goto)).toBe(true);
+    expect(isGotoBranchCell({ ...goto, defaultPathId: undefined })).toBe(false);
+    expect(
+      isGotoBranchCell({
+        ...goto,
+        paths: [
+          ...goto.paths,
+          { id: "p2", label: "Other", color: "", conditions: [], gotoCellId: "target" },
+        ],
+      }),
+    ).toBe(false);
+  });
+
   it("returns error when branch has no paths", () => {
     const cell = makeBranchCell({ id: "b1", paths: [] });
     const errors = validateBranchCell(cell);

--- a/packages/api/src/transforms/evaluate-branch.spec.ts
+++ b/packages/api/src/transforms/evaluate-branch.spec.ts
@@ -460,6 +460,35 @@ describe("validateBranchCell", () => {
     expect(errors).toEqual(["Path 1: no conditions defined"]);
   });
 
+  it("allows a conditionless path only when it is the default", () => {
+    const goto = makeBranchCell({
+      id: "b1",
+      paths: [{ id: "p1", label: "Go to", color: "", conditions: [], gotoCellId: "target" }],
+      defaultPathId: "p1",
+    });
+
+    expect(validateBranchCell(goto)).toEqual([]);
+    expect(validateBranchCell({ ...goto, defaultPathId: undefined })).toEqual([
+      "Go to: no conditions defined",
+    ]);
+  });
+
+  it("documents the conditionless-path error produced by an old web client", () => {
+    const goto = makeBranchCell({
+      id: "b1",
+      paths: [{ id: "p1", label: "Go to", color: "", conditions: [], gotoCellId: "target" }],
+      defaultPathId: "p1",
+    });
+    const legacyWebErrors = goto.paths.flatMap((path) =>
+      path.conditions.length === 0
+        ? [`${path.label || "Unnamed path"}: no conditions defined`]
+        : [],
+    );
+
+    expect(legacyWebErrors).toEqual(["Go to: no conditions defined"]);
+    expect(validateBranchCell(goto)).toEqual([]);
+  });
+
   it("returns error for missing source cell", () => {
     const cell = makeBranchCell({
       id: "b1",

--- a/packages/api/src/transforms/evaluate-branch.spec.ts
+++ b/packages/api/src/transforms/evaluate-branch.spec.ts
@@ -8,6 +8,7 @@ import {
   evaluatePathConditions,
   isGotoBranchCell,
   isDeviceScopedBranch,
+  resolveBranchDefaultPath,
   resolveConditionValue,
   validateBranchCell,
   validateDeviceBranch,
@@ -396,6 +397,36 @@ describe("evaluateBranch", () => {
 
     const result = evaluateBranch(branch, cells);
     expect(result?.id).toBe("pathDefault");
+  });
+
+  it("fails closed when the default path id is ambiguous", () => {
+    const duplicate = {
+      id: "duplicate",
+      label: "Default",
+      color: "",
+      conditions: [],
+    };
+    const branch = makeBranchCell({
+      id: "b1",
+      defaultPathId: duplicate.id,
+      paths: [duplicate, { ...duplicate, label: "Also default" }],
+    });
+
+    expect(resolveBranchDefaultPath(branch)).toEqual({ status: "ambiguous" });
+    expect(evaluateBranch(branch, cells)).toBeUndefined();
+  });
+
+  it("distinguishes absent and uniquely resolved default paths", () => {
+    const path = { id: "only", label: "Only", color: "", conditions: [] };
+
+    expect(resolveBranchDefaultPath({ paths: [path] })).toEqual({ status: "absent" });
+    expect(resolveBranchDefaultPath({ paths: [path], defaultPathId: "missing" })).toEqual({
+      status: "absent",
+    });
+    expect(resolveBranchDefaultPath({ paths: [path], defaultPathId: path.id })).toEqual({
+      status: "resolved",
+      path,
+    });
   });
 
   it("returns undefined when no path matches and no default", () => {

--- a/packages/api/src/transforms/evaluate-branch.ts
+++ b/packages/api/src/transforms/evaluate-branch.ts
@@ -56,6 +56,7 @@ export function isGotoBranchCell(cell: BranchCell): boolean {
   return (
     cell.paths.length === 1 &&
     cell.paths[0].conditions.length === 0 &&
+    Boolean(cell.paths[0].gotoCellId) &&
     defaultPath.status === "resolved" &&
     defaultPath.path === cell.paths[0]
   );

--- a/packages/api/src/transforms/evaluate-branch.ts
+++ b/packages/api/src/transforms/evaluate-branch.ts
@@ -19,6 +19,15 @@ export interface BranchRuntimeContext {
   deviceId?: string;
 }
 
+/** A schema-compatible unconditional jump authored as a one-path branch. */
+export function isGotoBranchCell(cell: BranchCell): boolean {
+  return (
+    cell.paths.length === 1 &&
+    cell.paths[0].conditions.length === 0 &&
+    cell.defaultPathId === cell.paths[0].id
+  );
+}
+
 /** True when any condition of the branch reads the reserved `$device` source. */
 export function isDeviceScopedBranch(cell: BranchCell): boolean {
   return cell.paths.some((path) =>

--- a/packages/api/src/transforms/evaluate-branch.ts
+++ b/packages/api/src/transforms/evaluate-branch.ts
@@ -19,21 +19,35 @@ export interface BranchRuntimeContext {
   deviceId?: string;
 }
 
-export type BranchDefaultPathResolution<T extends { id: string }> =
+export type BranchPathResolution<T extends { id: string }> =
   | { status: "resolved"; path: T }
   | { status: "absent" }
   | { status: "ambiguous" };
 
-/** Resolve a default only when its id identifies exactly one path. */
-export function resolveBranchDefaultPath<T extends { id: string }>(cell: {
-  paths: readonly T[];
-  defaultPathId?: string;
-}): BranchDefaultPathResolution<T> {
-  if (!cell.defaultPathId) return { status: "absent" };
-  const matches = cell.paths.filter((path) => path.id === cell.defaultPathId);
+/** Resolve an id only when it identifies exactly one path. */
+export function resolveBranchPathById<T extends { id: string }>(
+  paths: readonly T[],
+  pathId?: string,
+): BranchPathResolution<T> {
+  if (!pathId) return { status: "absent" };
+  const matches = paths.filter((path) => path.id === pathId);
   if (matches.length === 0) return { status: "absent" };
   if (matches.length > 1) return { status: "ambiguous" };
   return { status: "resolved", path: matches[0] };
+}
+
+export function resolveBranchDefaultPath<T extends { id: string }>(cell: {
+  paths: readonly T[];
+  defaultPathId?: string;
+}): BranchPathResolution<T> {
+  return resolveBranchPathById(cell.paths, cell.defaultPathId);
+}
+
+export function resolveBranchEvaluatedPath<T extends { id: string }>(cell: {
+  paths: readonly T[];
+  evaluatedPathId?: string;
+}): BranchPathResolution<T> {
+  return resolveBranchPathById(cell.paths, cell.evaluatedPathId);
 }
 
 /** A schema-compatible unconditional jump authored as a one-path branch. */

--- a/packages/api/src/transforms/evaluate-branch.ts
+++ b/packages/api/src/transforms/evaluate-branch.ts
@@ -19,12 +19,31 @@ export interface BranchRuntimeContext {
   deviceId?: string;
 }
 
+export type BranchDefaultPathResolution<T extends { id: string }> =
+  | { status: "resolved"; path: T }
+  | { status: "absent" }
+  | { status: "ambiguous" };
+
+/** Resolve a default only when its id identifies exactly one path. */
+export function resolveBranchDefaultPath<T extends { id: string }>(cell: {
+  paths: readonly T[];
+  defaultPathId?: string;
+}): BranchDefaultPathResolution<T> {
+  if (!cell.defaultPathId) return { status: "absent" };
+  const matches = cell.paths.filter((path) => path.id === cell.defaultPathId);
+  if (matches.length === 0) return { status: "absent" };
+  if (matches.length > 1) return { status: "ambiguous" };
+  return { status: "resolved", path: matches[0] };
+}
+
 /** A schema-compatible unconditional jump authored as a one-path branch. */
 export function isGotoBranchCell(cell: BranchCell): boolean {
+  const defaultPath = resolveBranchDefaultPath(cell);
   return (
     cell.paths.length === 1 &&
     cell.paths[0].conditions.length === 0 &&
-    cell.defaultPathId === cell.paths[0].id
+    defaultPath.status === "resolved" &&
+    defaultPath.path === cell.paths[0]
   );
 }
 
@@ -81,15 +100,16 @@ export function validateBranchCell(
     if (count > 1) errors.push(`Branch path id ${pathId} is duplicated`);
   }
 
-  const defaultPaths = cell.defaultPathId
-    ? cell.paths.filter((path) => path.id === cell.defaultPathId)
-    : [];
-  if (options.requireDefault !== false && defaultPaths.length === 0) {
-    errors.push("Branch Otherwise path is missing");
-  } else if (defaultPaths.length > 1) {
-    errors.push("Branch Otherwise path is ambiguous");
+  const defaultPathResolution = resolveBranchDefaultPath(cell);
+  if (options.requireDefault !== false) {
+    if (defaultPathResolution.status === "absent") {
+      errors.push("Branch Otherwise path is missing");
+    } else if (defaultPathResolution.status === "ambiguous") {
+      errors.push("Branch Otherwise path is ambiguous");
+    }
   }
-  const defaultPath = defaultPaths.length === 1 ? defaultPaths[0] : undefined;
+  const defaultPath =
+    defaultPathResolution.status === "resolved" ? defaultPathResolution.path : undefined;
 
   for (const path of cell.paths) {
     const label = path.label || "Unnamed path";
@@ -199,9 +219,6 @@ export function evaluateBranch(
     }
   }
 
-  if (cell.defaultPathId) {
-    return cell.paths.find((p) => p.id === cell.defaultPathId);
-  }
-
-  return undefined;
+  const defaultPath = resolveBranchDefaultPath(cell);
+  return defaultPath.status === "resolved" ? defaultPath.path : undefined;
 }

--- a/packages/api/src/transforms/evaluate-branch.ts
+++ b/packages/api/src/transforms/evaluate-branch.ts
@@ -56,7 +56,6 @@ export function isGotoBranchCell(cell: BranchCell): boolean {
   return (
     cell.paths.length === 1 &&
     cell.paths[0].conditions.length === 0 &&
-    Boolean(cell.paths[0].gotoCellId) &&
     defaultPath.status === "resolved" &&
     defaultPath.path === cell.paths[0]
   );
@@ -125,6 +124,10 @@ export function validateBranchCell(
   }
   const defaultPath =
     defaultPathResolution.status === "resolved" ? defaultPathResolution.path : undefined;
+
+  if (isGotoBranchCell(cell) && !cell.paths[0].gotoCellId) {
+    errors.push("Go to target is missing");
+  }
 
   for (const path of cell.paths) {
     const label = path.label || "Unnamed path";

--- a/packages/api/src/transforms/evaluate-branch.ts
+++ b/packages/api/src/transforms/evaluate-branch.ts
@@ -57,7 +57,15 @@ export function validateDeviceBranch(cell: BranchCell, cells: WorkbookCell[]): s
   return errors;
 }
 
-export function validateBranchCell(cell: BranchCell): string[] {
+/**
+ * Validates an authored branch. Runtime callers may preserve the historical
+ * conditioned-branch fall-through by disabling the author-only default check;
+ * conditionless paths still require one uniquely resolved default either way.
+ */
+export function validateBranchCell(
+  cell: BranchCell,
+  options: { requireDefault?: boolean } = {},
+): string[] {
   const errors: string[] = [];
 
   if (cell.paths.length === 0) {
@@ -65,10 +73,28 @@ export function validateBranchCell(cell: BranchCell): string[] {
     return errors;
   }
 
+  const pathCounts = new Map<string, number>();
+  for (const path of cell.paths) {
+    pathCounts.set(path.id, (pathCounts.get(path.id) ?? 0) + 1);
+  }
+  for (const [pathId, count] of pathCounts) {
+    if (count > 1) errors.push(`Branch path id ${pathId} is duplicated`);
+  }
+
+  const defaultPaths = cell.defaultPathId
+    ? cell.paths.filter((path) => path.id === cell.defaultPathId)
+    : [];
+  if (options.requireDefault !== false && defaultPaths.length === 0) {
+    errors.push("Branch Otherwise path is missing");
+  } else if (defaultPaths.length > 1) {
+    errors.push("Branch Otherwise path is ambiguous");
+  }
+  const defaultPath = defaultPaths.length === 1 ? defaultPaths[0] : undefined;
+
   for (const path of cell.paths) {
     const label = path.label || "Unnamed path";
 
-    if (path.conditions.length === 0 && path.id !== cell.defaultPathId) {
+    if (path.conditions.length === 0 && path !== defaultPath) {
       errors.push(`${label}: no conditions defined`);
       continue;
     }

--- a/packages/api/src/transforms/evaluate-branch.ts
+++ b/packages/api/src/transforms/evaluate-branch.ts
@@ -59,7 +59,7 @@ export function validateBranchCell(cell: BranchCell): string[] {
   for (const path of cell.paths) {
     const label = path.label || "Unnamed path";
 
-    if (path.conditions.length === 0) {
+    if (path.conditions.length === 0 && path.id !== cell.defaultPathId) {
       errors.push(`${label}: no conditions defined`);
       continue;
     }

--- a/packages/api/src/transforms/validate-workbook.spec.ts
+++ b/packages/api/src/transforms/validate-workbook.spec.ts
@@ -40,6 +40,23 @@ const branchCell = (id: string, sourceCellId: string, gotoCellId?: string): Work
       gotoCellId,
     },
   ],
+  defaultPathId: "path-1",
+});
+
+const gotoCell = (id: string, gotoCellId: string): WorkbookCell => ({
+  id,
+  type: "branch",
+  isCollapsed: false,
+  paths: [
+    {
+      id: `${id}-path`,
+      label: "Go to",
+      color: "#005E5E",
+      conditions: [],
+      gotoCellId,
+    },
+  ],
+  defaultPathId: `${id}-path`,
 });
 
 const ctx = (
@@ -148,5 +165,145 @@ describe("validateWorkbook", () => {
         detail: "ambyte, multispeq",
       }),
     );
+  });
+
+  it("warns for a cell orphaned by a forward Go to and clears when a path reaches it", () => {
+    const orphaned = [gotoCell("goto", "target"), questionCell("orphan"), questionCell("target")];
+    expect(validateWorkbook(orphaned, ctx({})).issues).toContainEqual(
+      expect.objectContaining({ code: "unreachable-cell", cellId: "orphan" }),
+    );
+
+    const branch = orphaned[0];
+    if (branch.type !== "branch") throw new Error("expected branch");
+    const repaired: WorkbookCell[] = [
+      {
+        ...branch,
+        paths: [
+          {
+            id: "orphan-path",
+            label: "Orphan",
+            color: "#005E5E",
+            conditions: [
+              {
+                id: "condition",
+                sourceCellId: "target",
+                field: "answer",
+                operator: "eq",
+                value: "yes",
+              },
+            ],
+            gotoCellId: "orphan",
+          },
+          ...branch.paths,
+        ],
+      },
+      ...orphaned.slice(1),
+    ];
+    expect(
+      validateWorkbook(repaired, ctx({})).issues.filter(
+        (issue) => issue.code === "unreachable-cell" && issue.cellId === "orphan",
+      ),
+    ).toEqual([]);
+  });
+
+  it("warns for a backward Go to without blocking validation", () => {
+    const result = validateWorkbook([questionCell("target"), gotoCell("goto", "target")], ctx({}));
+
+    expect(result.ok).toBe(true);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({ code: "backward-goto-loop", cellId: "goto", ref: "target" }),
+    );
+  });
+
+  it("warns when a branch has no default", () => {
+    const branch = branchCell("branch", "source");
+    if (branch.type !== "branch") throw new Error("expected branch");
+    const result = validateWorkbook(
+      [questionCell("source"), { ...branch, defaultPathId: undefined }],
+      ctx({}),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({ code: "branch-no-default", cellId: "branch" }),
+    );
+  });
+
+  it("warns when a later path has structurally identical conditions", () => {
+    const branch = branchCell("branch", "source");
+    if (branch.type !== "branch") throw new Error("expected branch");
+    const duplicate = {
+      ...branch.paths[0],
+      id: "path-2",
+      label: "Duplicate",
+      conditions: branch.paths[0].conditions.map((condition) => ({
+        ...condition,
+        id: "different-condition-id",
+      })),
+    };
+    const result = validateWorkbook(
+      [questionCell("source"), { ...branch, paths: [...branch.paths, duplicate] }],
+      ctx({}),
+    );
+
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        code: "path-duplicate-conditions",
+        cellId: "branch",
+        ref: "path-2",
+      }),
+    );
+  });
+
+  it("treats a device-scoped branch as a dispatcher with a fall-through edge", () => {
+    const deviceBranch: WorkbookCell = {
+      id: "dispatch",
+      type: "branch",
+      isCollapsed: false,
+      paths: [
+        {
+          id: "multispeq",
+          label: "MultispeQ",
+          color: "#005E5E",
+          conditions: [
+            {
+              id: "device-condition",
+              sourceCellId: "$device",
+              field: "family",
+              operator: "eq",
+              value: "multispeq",
+            },
+          ],
+          gotoCellId: "measurement",
+        },
+        {
+          id: "fallback",
+          label: "Fallback",
+          color: "#6C5CE7",
+          conditions: [],
+          gotoCellId: "command",
+        },
+      ],
+      defaultPathId: "fallback",
+    };
+    const afterDispatch: WorkbookCell = {
+      id: "after-dispatch",
+      type: "markdown",
+      isCollapsed: false,
+      content: "All device groups were dispatched",
+    };
+    const measurement = protocolCell("measurement", "protocol");
+    const command: WorkbookCell = {
+      id: "command",
+      type: "command",
+      isCollapsed: false,
+      payload: { format: "string", content: "battery" },
+    };
+    const result = validateWorkbook(
+      [deviceBranch, afterDispatch, measurement, command],
+      ctx({ protocol: { family: "multispeq" } }),
+    );
+
+    expect(result.issues.filter((issue) => issue.code === "unreachable-cell")).toEqual([]);
   });
 });

--- a/packages/api/src/transforms/validate-workbook.spec.ts
+++ b/packages/api/src/transforms/validate-workbook.spec.ts
@@ -43,7 +43,7 @@ const branchCell = (id: string, sourceCellId: string, gotoCellId?: string): Work
   defaultPathId: "path-1",
 });
 
-const gotoCell = (id: string, gotoCellId: string): WorkbookCell => ({
+const gotoCell = (id: string, gotoCellId?: string): WorkbookCell => ({
   id,
   type: "branch",
   isCollapsed: false,
@@ -212,6 +212,19 @@ describe("validateWorkbook", () => {
     expect(result.ok).toBe(true);
     expect(result.issues).toContainEqual(
       expect.objectContaining({ code: "backward-goto-loop", cellId: "goto", ref: "target" }),
+    );
+  });
+
+  it("blocks a Go to until its target is selected", () => {
+    const result = validateWorkbook([gotoCell("goto")], ctx({}));
+
+    expect(result.ok).toBe(false);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        code: "goto-missing-target",
+        cellId: "goto",
+      }),
     );
   });
 

--- a/packages/api/src/transforms/validate-workbook.spec.ts
+++ b/packages/api/src/transforms/validate-workbook.spec.ts
@@ -107,6 +107,12 @@ describe("validateWorkbook", () => {
     expect(result.issues).toEqual([]);
   });
 
+  it("does not treat the reserved device context as a dangling cell source", () => {
+    const cells = [branchCell("b1", "$device")];
+    const result = validateWorkbook(cells, ctx({}));
+    expect(result.issues).toEqual([]);
+  });
+
   it("warns (not errors) when a macro has no upstream measurement", () => {
     const cells = [macroCell("m1", "mac-1"), protocolCell("p1", "prot-1")];
     const result = validateWorkbook(

--- a/packages/api/src/transforms/validate-workbook.spec.ts
+++ b/packages/api/src/transforms/validate-workbook.spec.ts
@@ -215,6 +215,21 @@ describe("validateWorkbook", () => {
     );
   });
 
+  it("keeps fall-through reachable for self, dangling, and backward Go to targets", () => {
+    const cases: WorkbookCell[][] = [
+      [gotoCell("goto", "goto"), questionCell("after")],
+      [gotoCell("goto", "missing"), questionCell("after")],
+      [questionCell("target"), gotoCell("goto", "target"), questionCell("after")],
+    ];
+
+    for (const cells of cases) {
+      const issues = validateWorkbook(cells, ctx({})).issues;
+      expect(
+        issues.filter((issue) => issue.code === "unreachable-cell" && issue.cellId === "after"),
+      ).toEqual([]);
+    }
+  });
+
   it("warns when a branch has no default", () => {
     const branch = branchCell("branch", "source");
     if (branch.type !== "branch") throw new Error("expected branch");
@@ -226,6 +241,37 @@ describe("validateWorkbook", () => {
     expect(result.ok).toBe(true);
     expect(result.issues).toContainEqual(
       expect.objectContaining({ code: "branch-no-default", cellId: "branch" }),
+    );
+  });
+
+  it("warns when Otherwise is dangling or ambiguous", () => {
+    const branch = branchCell("branch", "source");
+    if (branch.type !== "branch") throw new Error("expected branch");
+    const duplicatePath = { ...branch.paths[0], label: "Duplicate" };
+
+    const dangling = validateWorkbook(
+      [questionCell("source"), { ...branch, defaultPathId: "missing" }],
+      ctx({}),
+    );
+    expect(dangling.issues).toContainEqual(
+      expect.objectContaining({ code: "branch-no-default", cellId: "branch" }),
+    );
+
+    const ambiguous = validateWorkbook(
+      [questionCell("source"), { ...branch, paths: [...branch.paths, duplicatePath] }],
+      ctx({}),
+    );
+    expect(ambiguous.ok).toBe(false);
+    expect(ambiguous.issues).toContainEqual(
+      expect.objectContaining({ code: "branch-no-default", cellId: "branch" }),
+    );
+    expect(ambiguous.issues).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        code: "duplicate-branch-path-id",
+        cellId: "branch",
+        ref: "path-1",
+      }),
     );
   });
 
@@ -241,6 +287,30 @@ describe("validateWorkbook", () => {
         id: "different-condition-id",
       })),
     };
+    const result = validateWorkbook(
+      [questionCell("source"), { ...branch, paths: [...branch.paths, duplicate] }],
+      ctx({}),
+    );
+
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        code: "path-duplicate-conditions",
+        cellId: "branch",
+        ref: "path-2",
+      }),
+    );
+  });
+
+  it("deduplicates repeated conditions before comparing paths", () => {
+    const branch = branchCell("branch", "source");
+    if (branch.type !== "branch") throw new Error("expected branch");
+    const condition = branch.paths[0].conditions[0];
+    const duplicate = {
+      ...branch.paths[0],
+      id: "path-2",
+      conditions: [condition, { ...condition, id: "repeated-condition" }],
+    };
+
     const result = validateWorkbook(
       [questionCell("source"), { ...branch, paths: [...branch.paths, duplicate] }],
       ctx({}),

--- a/packages/api/src/transforms/validate-workbook.ts
+++ b/packages/api/src/transforms/validate-workbook.ts
@@ -17,6 +17,7 @@ export type WorkbookIssueCode =
   | "mixed-sensor-families"
   | "macro-without-input"
   | "unreachable-cell"
+  | "goto-missing-target"
   | "backward-goto-loop"
   | "branch-no-default"
   | "duplicate-branch-path-id"
@@ -164,6 +165,14 @@ function structuralBranchIssues(cells: WorkbookCell[]): WorkbookIssue[] {
 
     if (isGotoBranchCell(cell)) {
       const targetId = cell.paths[0].gotoCellId;
+      if (!targetId) {
+        issues.push({
+          level: "error",
+          code: "goto-missing-target",
+          cellId: cell.id,
+          cellLabel: cellLabelOf(cell),
+        });
+      }
       const targetIndex = targetId ? indexById.get(targetId) : undefined;
       if (targetIndex !== undefined && targetIndex < index) {
         issues.push({

--- a/packages/api/src/transforms/validate-workbook.ts
+++ b/packages/api/src/transforms/validate-workbook.ts
@@ -1,6 +1,7 @@
 import type { SensorFamily } from "../domains/protocol/protocol.schema";
 import type { WorkbookCell } from "../domains/workbook/workbook-cells.schema";
 import { DEVICE_CONTEXT_KEY } from "./device-context";
+import { isDeviceScopedBranch, isGotoBranchCell } from "./evaluate-branch";
 
 export type WorkbookIssueLevel = "error" | "warning";
 
@@ -10,7 +11,11 @@ export type WorkbookIssueCode =
   | "dangling-branch-source"
   | "dangling-branch-goto"
   | "mixed-sensor-families"
-  | "macro-without-input";
+  | "macro-without-input"
+  | "unreachable-cell"
+  | "backward-goto-loop"
+  | "branch-no-default"
+  | "path-duplicate-conditions";
 
 export interface WorkbookIssue {
   level: WorkbookIssueLevel;
@@ -48,6 +53,119 @@ function cellLabelOf(cell: WorkbookCell): string | undefined {
     default:
       return undefined;
   }
+}
+
+function duplicateConditionKey(
+  cell: Extract<WorkbookCell, { type: "branch" }>,
+): Map<string, string> {
+  const firstPathByConditions = new Map<string, string>();
+  const duplicates = new Map<string, string>();
+  for (const path of cell.paths) {
+    if (path.conditions.length === 0) continue;
+    const key = path.conditions
+      .map(({ sourceCellId, field, operator, value }) =>
+        JSON.stringify({ sourceCellId, field, operator, value }),
+      )
+      .sort()
+      .join("|");
+    const firstPathId = firstPathByConditions.get(key);
+    if (firstPathId) duplicates.set(path.id, firstPathId);
+    else firstPathByConditions.set(key, path.id);
+  }
+  return duplicates;
+}
+
+function structuralBranchIssues(cells: WorkbookCell[]): WorkbookIssue[] {
+  const issues: WorkbookIssue[] = [];
+  const indexById = new Map(cells.map((cell, index) => [cell.id, index]));
+  const reachableIndexes = new Set<number>();
+  const pending = cells.length > 0 ? [0] : [];
+  let pendingIndex = 0;
+
+  const enqueue = (index: number | undefined) => {
+    if (index === undefined || index < 0 || index >= cells.length || reachableIndexes.has(index)) {
+      return;
+    }
+    pending.push(index);
+  };
+
+  while (pendingIndex < pending.length) {
+    const index = pending[pendingIndex++];
+    if (reachableIndexes.has(index)) continue;
+    reachableIndexes.add(index);
+    const cell = cells[index];
+
+    if (cell.type !== "branch") {
+      enqueue(index + 1);
+      continue;
+    }
+
+    for (const path of cell.paths) {
+      if (path.gotoCellId) enqueue(indexById.get(path.gotoCellId));
+    }
+
+    const defaultPath = cell.defaultPathId
+      ? cell.paths.find((path) => path.id === cell.defaultPathId)
+      : undefined;
+    const canFallThrough =
+      isDeviceScopedBranch(cell) ||
+      !defaultPath?.gotoCellId ||
+      cell.paths.some((path) => !path.gotoCellId);
+    if (canFallThrough) enqueue(index + 1);
+  }
+
+  for (const [index, cell] of cells.entries()) {
+    if (cell.type !== "output" && !reachableIndexes.has(index)) {
+      issues.push({
+        level: "warning",
+        code: "unreachable-cell",
+        cellId: cell.id,
+        cellLabel: cellLabelOf(cell),
+      });
+    }
+
+    if (cell.type !== "branch") continue;
+
+    if (!cell.defaultPathId) {
+      issues.push({
+        level: "warning",
+        code: "branch-no-default",
+        cellId: cell.id,
+        cellLabel: cellLabelOf(cell),
+      });
+    }
+
+    if (isGotoBranchCell(cell)) {
+      const targetId = cell.paths[0].gotoCellId;
+      const targetIndex = targetId ? indexById.get(targetId) : undefined;
+      if (targetIndex !== undefined && targetIndex < index) {
+        issues.push({
+          level: "warning",
+          code: "backward-goto-loop",
+          cellId: cell.id,
+          cellLabel: cellLabelOf(cell),
+          ref: targetId,
+        });
+      }
+    }
+
+    const duplicateConditions = duplicateConditionKey(cell);
+    for (const [pathId, firstPathId] of duplicateConditions) {
+      const path = cell.paths.find((candidate) => candidate.id === pathId);
+      let duplicateLabel = pathId;
+      if (path?.label.trim()) duplicateLabel = path.label.trim();
+      issues.push({
+        level: "warning",
+        code: "path-duplicate-conditions",
+        cellId: cell.id,
+        cellLabel: cellLabelOf(cell),
+        ref: pathId,
+        detail: `${duplicateLabel} duplicates ${firstPathId}`,
+      });
+    }
+  }
+
+  return issues;
 }
 
 /**
@@ -151,6 +269,8 @@ export function validateWorkbook(
       detail: [...families].sort().join(", "),
     });
   }
+
+  issues.push(...structuralBranchIssues(cells));
 
   return { issues, ok: !issues.some((i) => i.level === "error") };
 }

--- a/packages/api/src/transforms/validate-workbook.ts
+++ b/packages/api/src/transforms/validate-workbook.ts
@@ -1,7 +1,11 @@
 import type { SensorFamily } from "../domains/protocol/protocol.schema";
 import type { WorkbookCell } from "../domains/workbook/workbook-cells.schema";
 import { DEVICE_CONTEXT_KEY } from "./device-context";
-import { isDeviceScopedBranch, isGotoBranchCell } from "./evaluate-branch";
+import {
+  isDeviceScopedBranch,
+  isGotoBranchCell,
+  resolveBranchDefaultPath,
+} from "./evaluate-branch";
 
 export type WorkbookIssueLevel = "error" | "warning";
 
@@ -108,10 +112,9 @@ function structuralBranchIssues(cells: WorkbookCell[]): WorkbookIssue[] {
       if (path.gotoCellId) enqueue(indexById.get(path.gotoCellId));
     }
 
-    const defaultPaths = cell.defaultPathId
-      ? cell.paths.filter((path) => path.id === cell.defaultPathId)
-      : [];
-    const defaultPath = defaultPaths.length === 1 ? defaultPaths[0] : undefined;
+    const defaultPathResolution = resolveBranchDefaultPath(cell);
+    const defaultPath =
+      defaultPathResolution.status === "resolved" ? defaultPathResolution.path : undefined;
     const allPathsJumpStrictlyForward =
       defaultPath !== undefined &&
       cell.paths.every((path) => {
@@ -134,10 +137,7 @@ function structuralBranchIssues(cells: WorkbookCell[]): WorkbookIssue[] {
 
     if (cell.type !== "branch") continue;
 
-    const defaultPathCount = cell.defaultPathId
-      ? cell.paths.filter((path) => path.id === cell.defaultPathId).length
-      : 0;
-    if (defaultPathCount !== 1) {
+    if (resolveBranchDefaultPath(cell).status !== "resolved") {
       issues.push({
         level: "warning",
         code: "branch-no-default",

--- a/packages/api/src/transforms/validate-workbook.ts
+++ b/packages/api/src/transforms/validate-workbook.ts
@@ -1,5 +1,6 @@
 import type { SensorFamily } from "../domains/protocol/protocol.schema";
 import type { WorkbookCell } from "../domains/workbook/workbook-cells.schema";
+import { DEVICE_CONTEXT_KEY } from "./device-context";
 
 export type WorkbookIssueLevel = "error" | "warning";
 
@@ -112,7 +113,12 @@ export function validateWorkbook(
       for (const path of cell.paths) {
         for (const cond of path.conditions) {
           const key = `s:${cell.id}:${cond.sourceCellId}`;
-          if (cond.sourceCellId && !cellIds.has(cond.sourceCellId) && !seenBranchRefs.has(key)) {
+          if (
+            cond.sourceCellId &&
+            cond.sourceCellId !== DEVICE_CONTEXT_KEY &&
+            !cellIds.has(cond.sourceCellId) &&
+            !seenBranchRefs.has(key)
+          ) {
             seenBranchRefs.add(key);
             issues.push({
               level: "error",

--- a/packages/api/src/transforms/validate-workbook.ts
+++ b/packages/api/src/transforms/validate-workbook.ts
@@ -15,6 +15,7 @@ export type WorkbookIssueCode =
   | "unreachable-cell"
   | "backward-goto-loop"
   | "branch-no-default"
+  | "duplicate-branch-path-id"
   | "path-duplicate-conditions";
 
 export interface WorkbookIssue {
@@ -62,10 +63,13 @@ function duplicateConditionKey(
   const duplicates = new Map<string, string>();
   for (const path of cell.paths) {
     if (path.conditions.length === 0) continue;
-    const key = path.conditions
-      .map(({ sourceCellId, field, operator, value }) =>
-        JSON.stringify({ sourceCellId, field, operator, value }),
-      )
+    const key = [
+      ...new Set(
+        path.conditions.map(({ sourceCellId, field, operator, value }) =>
+          JSON.stringify({ sourceCellId, field, operator, value }),
+        ),
+      ),
+    ]
       .sort()
       .join("|");
     const firstPathId = firstPathByConditions.get(key);
@@ -104,13 +108,17 @@ function structuralBranchIssues(cells: WorkbookCell[]): WorkbookIssue[] {
       if (path.gotoCellId) enqueue(indexById.get(path.gotoCellId));
     }
 
-    const defaultPath = cell.defaultPathId
-      ? cell.paths.find((path) => path.id === cell.defaultPathId)
-      : undefined;
-    const canFallThrough =
-      isDeviceScopedBranch(cell) ||
-      !defaultPath?.gotoCellId ||
-      cell.paths.some((path) => !path.gotoCellId);
+    const defaultPaths = cell.defaultPathId
+      ? cell.paths.filter((path) => path.id === cell.defaultPathId)
+      : [];
+    const defaultPath = defaultPaths.length === 1 ? defaultPaths[0] : undefined;
+    const allPathsJumpStrictlyForward =
+      defaultPath !== undefined &&
+      cell.paths.every((path) => {
+        const targetIndex = path.gotoCellId ? indexById.get(path.gotoCellId) : undefined;
+        return targetIndex !== undefined && targetIndex > index;
+      });
+    const canFallThrough = isDeviceScopedBranch(cell) || !allPathsJumpStrictlyForward;
     if (canFallThrough) enqueue(index + 1);
   }
 
@@ -126,12 +134,31 @@ function structuralBranchIssues(cells: WorkbookCell[]): WorkbookIssue[] {
 
     if (cell.type !== "branch") continue;
 
-    if (!cell.defaultPathId) {
+    const defaultPathCount = cell.defaultPathId
+      ? cell.paths.filter((path) => path.id === cell.defaultPathId).length
+      : 0;
+    if (defaultPathCount !== 1) {
       issues.push({
         level: "warning",
         code: "branch-no-default",
         cellId: cell.id,
         cellLabel: cellLabelOf(cell),
+      });
+    }
+
+    const seenPathIds = new Set<string>();
+    const duplicatePathIds = new Set<string>();
+    for (const path of cell.paths) {
+      if (seenPathIds.has(path.id)) duplicatePathIds.add(path.id);
+      seenPathIds.add(path.id);
+    }
+    for (const pathId of duplicatePathIds) {
+      issues.push({
+        level: "error",
+        code: "duplicate-branch-path-id",
+        cellId: cell.id,
+        cellLabel: cellLabelOf(cell),
+        ref: pathId,
       });
     }
 

--- a/packages/api/src/transforms/validate-workbook.ts
+++ b/packages/api/src/transforms/validate-workbook.ts
@@ -62,9 +62,9 @@ function cellLabelOf(cell: WorkbookCell): string | undefined {
 
 function duplicateConditionKey(
   cell: Extract<WorkbookCell, { type: "branch" }>,
-): Map<string, string> {
+): Map<(typeof cell.paths)[number], string> {
   const firstPathByConditions = new Map<string, string>();
-  const duplicates = new Map<string, string>();
+  const duplicates = new Map<(typeof cell.paths)[number], string>();
   for (const path of cell.paths) {
     if (path.conditions.length === 0) continue;
     const key = [
@@ -77,7 +77,7 @@ function duplicateConditionKey(
       .sort()
       .join("|");
     const firstPathId = firstPathByConditions.get(key);
-    if (firstPathId) duplicates.set(path.id, firstPathId);
+    if (firstPathId) duplicates.set(path, firstPathId);
     else firstPathByConditions.set(key, path.id);
   }
   return duplicates;
@@ -177,16 +177,15 @@ function structuralBranchIssues(cells: WorkbookCell[]): WorkbookIssue[] {
     }
 
     const duplicateConditions = duplicateConditionKey(cell);
-    for (const [pathId, firstPathId] of duplicateConditions) {
-      const path = cell.paths.find((candidate) => candidate.id === pathId);
-      let duplicateLabel = pathId;
-      if (path?.label.trim()) duplicateLabel = path.label.trim();
+    for (const [path, firstPathId] of duplicateConditions) {
+      let duplicateLabel = path.id;
+      if (path.label.trim()) duplicateLabel = path.label.trim();
       issues.push({
         level: "warning",
         code: "path-duplicate-conditions",
         cellId: cell.id,
         cellLabel: cellLabelOf(cell),
-        ref: pathId,
+        ref: path.id,
         detail: `${duplicateLabel} duplicates ${firstPathId}`,
       });
     }

--- a/packages/i18n/locales/de-DE/experiments.json
+++ b/packages/i18n/locales/de-DE/experiments.json
@@ -138,6 +138,7 @@
         "macroWithoutInput": "Makro \"{{label}}\" hat keine vorangehende Messung zum Ausführen",
         "mixedFamilies": "Dieses Arbeitsbuch mischt Sensorfamilien ({{detail}}); ein Durchlauf zielt auf ein einzelnes Gerät",
         "unreachableCell": "Zelle \"{{label}}\" ist nicht erreichbar",
+        "gotoMissingTarget": "Ein Gehe zu hat keine Zielzelle",
         "backwardGotoLoop": "Ein Gehe zu springt zurück zu {{ref}}",
         "branchNoDefault": "Eine Verzweigung hat keinen eindeutigen Sonst-Pfad und kann durchfallen",
         "duplicateBranchPathId": "Eine Verzweigungspfad-ID ist doppelt vorhanden ({{ref}})",

--- a/packages/i18n/locales/de-DE/experiments.json
+++ b/packages/i18n/locales/de-DE/experiments.json
@@ -136,7 +136,11 @@
         "danglingSource": "Eine Verzweigungsbedingung verweist auf eine nicht mehr vorhandene Zelle ({{ref}})",
         "danglingGoto": "Eine Verzweigung springt zu einer nicht mehr vorhandenen Zelle ({{ref}})",
         "macroWithoutInput": "Makro \"{{label}}\" hat keine vorangehende Messung zum Ausführen",
-        "mixedFamilies": "Dieses Arbeitsbuch mischt Sensorfamilien ({{detail}}); ein Durchlauf zielt auf ein einzelnes Gerät"
+        "mixedFamilies": "Dieses Arbeitsbuch mischt Sensorfamilien ({{detail}}); ein Durchlauf zielt auf ein einzelnes Gerät",
+        "unreachableCell": "Zelle \"{{label}}\" ist nicht erreichbar",
+        "backwardGotoLoop": "Ein Gehe zu springt zurück zu {{ref}}",
+        "branchNoDefault": "Eine Verzweigung hat keinen Sonst-Pfad und kann durchfallen",
+        "duplicatePathConditions": "Ein späterer Pfad wiederholt frühere Bedingungen ({{detail}})"
       }
     }
   },

--- a/packages/i18n/locales/de-DE/experiments.json
+++ b/packages/i18n/locales/de-DE/experiments.json
@@ -139,7 +139,8 @@
         "mixedFamilies": "Dieses Arbeitsbuch mischt Sensorfamilien ({{detail}}); ein Durchlauf zielt auf ein einzelnes Gerät",
         "unreachableCell": "Zelle \"{{label}}\" ist nicht erreichbar",
         "backwardGotoLoop": "Ein Gehe zu springt zurück zu {{ref}}",
-        "branchNoDefault": "Eine Verzweigung hat keinen Sonst-Pfad und kann durchfallen",
+        "branchNoDefault": "Eine Verzweigung hat keinen eindeutigen Sonst-Pfad und kann durchfallen",
+        "duplicateBranchPathId": "Eine Verzweigungspfad-ID ist doppelt vorhanden ({{ref}})",
         "duplicatePathConditions": "Ein späterer Pfad wiederholt frühere Bedingungen ({{detail}})"
       }
     }

--- a/packages/i18n/locales/de-DE/workbook.json
+++ b/packages/i18n/locales/de-DE/workbook.json
@@ -26,6 +26,23 @@
     "allChangesSaved": "Alle Änderungen gespeichert",
     "viewWorkbook": "Arbeitsmappe anzeigen",
     "required": "Erforderlich",
+    "problems": {
+      "title": "Probleme",
+      "none": "Keine Probleme gefunden",
+      "issue": {
+        "missingProtocol": "Protokoll {{ref}} fehlt",
+        "missingMacro": "Makro {{ref}} fehlt",
+        "danglingBranchSource": "Verzweigungsquelle {{ref}} fehlt",
+        "danglingBranchGoto": "Sprungziel {{ref}} fehlt",
+        "mixedSensorFamilies": "Arbeitsmappe mischt Sensorfamilien: {{detail}}",
+        "macroWithoutInput": "Makro hat keine vorherige Messung",
+        "unreachableCell": "{{label}} ist nicht erreichbar",
+        "backwardGotoLoop": "Gehe zu springt zurück zu {{ref}}",
+        "branchNoDefault": "Verzweigung hat keinen eindeutigen Sonst-Pfad und kann durchfallen",
+        "duplicateBranchPathId": "Verzweigungspfad-ID {{ref}} ist doppelt vorhanden",
+        "duplicatePathConditions": "Doppelte Pfadbedingungen: {{detail}}"
+      }
+    },
     "outputsCleared_one": "{{count}} Ausgabe gelöscht",
     "outputsCleared_other": "{{count}} Ausgaben gelöscht",
     "createDescription": "Geben Sie Ihrer Arbeitsmappe einen Namen. Sie können ihn später ändern.",

--- a/packages/i18n/locales/de-DE/workbook.json
+++ b/packages/i18n/locales/de-DE/workbook.json
@@ -37,6 +37,7 @@
         "mixedSensorFamilies": "Arbeitsmappe mischt Sensorfamilien: {{detail}}",
         "macroWithoutInput": "Makro hat keine vorherige Messung",
         "unreachableCell": "{{label}} ist nicht erreichbar",
+        "gotoMissingTarget": "Gehe zu hat keine Zielzelle",
         "backwardGotoLoop": "Gehe zu springt zurück zu {{ref}}",
         "branchNoDefault": "Verzweigung hat keinen eindeutigen Sonst-Pfad und kann durchfallen",
         "duplicateBranchPathId": "Verzweigungspfad-ID {{ref}} ist doppelt vorhanden",

--- a/packages/i18n/locales/en-US/experiments.json
+++ b/packages/i18n/locales/en-US/experiments.json
@@ -162,7 +162,8 @@
         "mixedFamilies": "This workbook mixes sensor families ({{detail}}); one run targets a single device",
         "unreachableCell": "Cell \"{{label}}\" cannot be reached",
         "backwardGotoLoop": "A Go to loops backward to {{ref}}",
-        "branchNoDefault": "A branch has no Otherwise path and may fall through",
+        "branchNoDefault": "A branch has no unique Otherwise path and may fall through",
+        "duplicateBranchPathId": "A branch path id is duplicated ({{ref}})",
         "duplicatePathConditions": "A later path repeats earlier conditions ({{detail}})"
       }
     }

--- a/packages/i18n/locales/en-US/experiments.json
+++ b/packages/i18n/locales/en-US/experiments.json
@@ -159,7 +159,11 @@
         "danglingSource": "A branch condition points at a cell that no longer exists ({{ref}})",
         "danglingGoto": "A branch jumps to a cell that no longer exists ({{ref}})",
         "macroWithoutInput": "Macro \"{{label}}\" has no measurement before it to run on",
-        "mixedFamilies": "This workbook mixes sensor families ({{detail}}); one run targets a single device"
+        "mixedFamilies": "This workbook mixes sensor families ({{detail}}); one run targets a single device",
+        "unreachableCell": "Cell \"{{label}}\" cannot be reached",
+        "backwardGotoLoop": "A Go to loops backward to {{ref}}",
+        "branchNoDefault": "A branch has no Otherwise path and may fall through",
+        "duplicatePathConditions": "A later path repeats earlier conditions ({{detail}})"
       }
     }
   },

--- a/packages/i18n/locales/en-US/experiments.json
+++ b/packages/i18n/locales/en-US/experiments.json
@@ -161,6 +161,7 @@
         "macroWithoutInput": "Macro \"{{label}}\" has no measurement before it to run on",
         "mixedFamilies": "This workbook mixes sensor families ({{detail}}); one run targets a single device",
         "unreachableCell": "Cell \"{{label}}\" cannot be reached",
+        "gotoMissingTarget": "A Go to has no target cell",
         "backwardGotoLoop": "A Go to loops backward to {{ref}}",
         "branchNoDefault": "A branch has no unique Otherwise path and may fall through",
         "duplicateBranchPathId": "A branch path id is duplicated ({{ref}})",

--- a/packages/i18n/locales/en-US/workbook.json
+++ b/packages/i18n/locales/en-US/workbook.json
@@ -48,6 +48,7 @@
         "mixedSensorFamilies": "Workbook mixes sensor families: {{detail}}",
         "macroWithoutInput": "Macro has no upstream measurement",
         "unreachableCell": "{{label}} is unreachable",
+        "gotoMissingTarget": "Go to has no target",
         "backwardGotoLoop": "Go to loops backward to {{ref}}",
         "branchNoDefault": "Branch has no unique Otherwise path and may fall through",
         "duplicateBranchPathId": "Branch path id {{ref}} is duplicated",

--- a/packages/i18n/locales/en-US/workbook.json
+++ b/packages/i18n/locales/en-US/workbook.json
@@ -37,6 +37,23 @@
     "allChangesSaved": "All changes saved",
     "viewWorkbook": "View Workbook",
     "required": "Required",
+    "problems": {
+      "title": "Problems",
+      "none": "No problems found",
+      "issue": {
+        "missingProtocol": "Protocol {{ref}} is missing",
+        "missingMacro": "Macro {{ref}} is missing",
+        "danglingBranchSource": "Branch source {{ref}} is missing",
+        "danglingBranchGoto": "Jump target {{ref}} is missing",
+        "mixedSensorFamilies": "Workbook mixes sensor families: {{detail}}",
+        "macroWithoutInput": "Macro has no upstream measurement",
+        "unreachableCell": "{{label}} is unreachable",
+        "backwardGotoLoop": "Go to loops backward to {{ref}}",
+        "branchNoDefault": "Branch has no unique Otherwise path and may fall through",
+        "duplicateBranchPathId": "Branch path id {{ref}} is duplicated",
+        "duplicatePathConditions": "Duplicate path conditions: {{detail}}"
+      }
+    },
     "outputsCleared_one": "Cleared {{count}} output",
     "outputsCleared_other": "Cleared {{count}} outputs",
     "notUsed": "Not used",

--- a/packages/i18n/locales/nl-NL/experiments.json
+++ b/packages/i18n/locales/nl-NL/experiments.json
@@ -135,6 +135,7 @@
         "macroWithoutInput": "Macro \"{{label}}\" heeft geen voorafgaande meting om op te draaien",
         "mixedFamilies": "Dit werkboek mengt sensorfamilies ({{detail}}); een run richt zich op één apparaat",
         "unreachableCell": "Cel \"{{label}}\" is niet bereikbaar",
+        "gotoMissingTarget": "Een Ga naar heeft geen doelcel",
         "backwardGotoLoop": "Een Ga naar springt terug naar {{ref}}",
         "branchNoDefault": "Een branch heeft geen uniek Anders-pad en kan doorlopen",
         "duplicateBranchPathId": "Een branchpad-id komt dubbel voor ({{ref}})",

--- a/packages/i18n/locales/nl-NL/experiments.json
+++ b/packages/i18n/locales/nl-NL/experiments.json
@@ -136,7 +136,8 @@
         "mixedFamilies": "Dit werkboek mengt sensorfamilies ({{detail}}); een run richt zich op één apparaat",
         "unreachableCell": "Cel \"{{label}}\" is niet bereikbaar",
         "backwardGotoLoop": "Een Ga naar springt terug naar {{ref}}",
-        "branchNoDefault": "Een branch heeft geen Anders-pad en kan doorlopen",
+        "branchNoDefault": "Een branch heeft geen uniek Anders-pad en kan doorlopen",
+        "duplicateBranchPathId": "Een branchpad-id komt dubbel voor ({{ref}})",
         "duplicatePathConditions": "Een later pad herhaalt eerdere voorwaarden ({{detail}})"
       }
     }

--- a/packages/i18n/locales/nl-NL/experiments.json
+++ b/packages/i18n/locales/nl-NL/experiments.json
@@ -133,7 +133,11 @@
         "danglingSource": "Een branchvoorwaarde verwijst naar een cel die niet meer bestaat ({{ref}})",
         "danglingGoto": "Een branch springt naar een cel die niet meer bestaat ({{ref}})",
         "macroWithoutInput": "Macro \"{{label}}\" heeft geen voorafgaande meting om op te draaien",
-        "mixedFamilies": "Dit werkboek mengt sensorfamilies ({{detail}}); een run richt zich op één apparaat"
+        "mixedFamilies": "Dit werkboek mengt sensorfamilies ({{detail}}); een run richt zich op één apparaat",
+        "unreachableCell": "Cel \"{{label}}\" is niet bereikbaar",
+        "backwardGotoLoop": "Een Ga naar springt terug naar {{ref}}",
+        "branchNoDefault": "Een branch heeft geen Anders-pad en kan doorlopen",
+        "duplicatePathConditions": "Een later pad herhaalt eerdere voorwaarden ({{detail}})"
       }
     }
   },

--- a/packages/i18n/locales/nl-NL/workbook.json
+++ b/packages/i18n/locales/nl-NL/workbook.json
@@ -37,6 +37,7 @@
         "mixedSensorFamilies": "Werkboek combineert sensorfamilies: {{detail}}",
         "macroWithoutInput": "Macro heeft geen voorafgaande meting",
         "unreachableCell": "{{label}} is onbereikbaar",
+        "gotoMissingTarget": "Ga naar heeft geen doelcel",
         "backwardGotoLoop": "Ga naar springt terug naar {{ref}}",
         "branchNoDefault": "Branch heeft geen uniek Anders-pad en kan doorlopen",
         "duplicateBranchPathId": "Branchpad-id {{ref}} komt dubbel voor",

--- a/packages/i18n/locales/nl-NL/workbook.json
+++ b/packages/i18n/locales/nl-NL/workbook.json
@@ -26,6 +26,23 @@
     "allChangesSaved": "Alle wijzigingen opgeslagen",
     "viewWorkbook": "Werkboek bekijken",
     "required": "Verplicht",
+    "problems": {
+      "title": "Problemen",
+      "none": "Geen problemen gevonden",
+      "issue": {
+        "missingProtocol": "Protocol {{ref}} ontbreekt",
+        "missingMacro": "Macro {{ref}} ontbreekt",
+        "danglingBranchSource": "Branchbron {{ref}} ontbreekt",
+        "danglingBranchGoto": "Sprongdoel {{ref}} ontbreekt",
+        "mixedSensorFamilies": "Werkboek combineert sensorfamilies: {{detail}}",
+        "macroWithoutInput": "Macro heeft geen voorafgaande meting",
+        "unreachableCell": "{{label}} is onbereikbaar",
+        "backwardGotoLoop": "Ga naar springt terug naar {{ref}}",
+        "branchNoDefault": "Branch heeft geen uniek Anders-pad en kan doorlopen",
+        "duplicateBranchPathId": "Branchpad-id {{ref}} komt dubbel voor",
+        "duplicatePathConditions": "Dubbele padvoorwaarden: {{detail}}"
+      }
+    },
     "outputsCleared_one": "{{count}} uitvoer gewist",
     "outputsCleared_other": "{{count}} uitvoeren gewist",
     "createDescription": "Geef uw werkboek een naam. U kunt deze later wijzigen.",


### PR DESCRIPTION
First PR of the workbook branching-and-parallelism stack. Zero schema change, both hosts.

## What this adds

| Area | Change |
| --- | --- |
| Go to | A first-class jump cell: a branch with one conditionless path marked default, rendered as a compact `Go to → target` card with a picker and `Convert to branch`. Makes if/else arms that end cleanly expressible for the first time. |
| Otherwise | `defaultPathId` becomes authorable (it previously existed in the schema with no UI). A conditionless path is legal only as the uniquely resolved default. |
| Path colors | Paths get real colors from the workbook accent palette (previously created as `""`, so branch edges rendered grey on the canvas); legacy empty colors get a stable id-hashed fallback. |
| Author-time validation | Branch/device configuration errors render inline on the cell, plus a live **Problems** panel in the sidebar with click-to-cell: dangling jump targets, no-unique-Otherwise, unreachable cells, duplicate path conditions, backward-Go-to loop warnings. EN/NL/DE strings. |
| Identity safety | One shared resolver (`resolveBranchPathById` / default resolution returning `resolved`/`absent`/`ambiguous`) consumed by the evaluator, validator, authoring, reachability, and canvas. `evaluateBranch` fails closed on ambiguous ids; every error path clears stale `evaluatedPathId`. Mobile proves duplicate defaults fall through without needing a validator call. |

<img src="https://raw.githubusercontent.com/Jan-IngenHousz-Institute/open-jii/docs/workbook-parallel-arc/apps/docs/public/img/workbooks/wb-branch-cell.png" width="700" alt="Branch cell with Otherwise selector and colored paths" />

<img src="https://raw.githubusercontent.com/Jan-IngenHousz-Institute/open-jii/docs/workbook-parallel-arc/apps/docs/public/img/workbooks/wb-goto-cell.png" width="700" alt="Compact Go to cell" />

<img src="https://raw.githubusercontent.com/Jan-IngenHousz-Institute/open-jii/docs/workbook-parallel-arc/apps/docs/public/img/workbooks/wb-problems.png" width="320" alt="Problems panel" />

## Key mechanics

- A conditionless path still evaluates **false** in the shared evaluator; Go to routes because that path is the uniquely resolved default. Zero-condition semantics are untouched (the parallel-container work depends on this).
- Reachability treats a `$device` dispatcher as a dispatcher (every target reachable, fall-through preserved) and errs toward reachable for self/dangling/backward targets, so it never cries wolf on valid multi-device workbooks.
- One behavioral nuance on old web clients: before this PR, `validateBranchCell` rejected a conditionless default at run time, so a stale open tab errors on such a branch rather than executing it. Mobile routing needed no change.

## Verification

Four adversarial review rounds, clean at the final tip (review artifact in the Traycer epic). Post-IAM-rebase gates on Node 24: focused API 68 / web 132 / mobile 29 tests plus package typechecks and lint; earlier full-suite runs green (API 1,379; web 4,800; mobile 943).

## Merge order

Stack: this PR merges first (together with the independent run-completeness PR). The editable-canvas PR is based on this branch.
