### PR TITLE
feat(iot): drop protocolId from the ingest topic, keep the legacy shape as a transitional channel

### DIFF
--- a/apps/data/src/pipelines/centrum/silver/clean_data.py
+++ b/apps/data/src/pipelines/centrum/silver/clean_data.py
@@ -70,10 +70,16 @@ def clean_data():
         )
         .withColumn("output", F.col("parsed_data.output"))
         .withColumn("user_id", F.col("parsed_data.user_id"))
-        # Which protocol produced the row; topic = experiment/data_ingest/v1/<experiment>/<protocol>/...
+        # Which protocol produced the row. Only the legacy 8-segment topic
+        # (.../{sensorId}/{protocolId}) carries it, as its trailing segment; the
+        # lean 7-segment shape has no protocol in the topic. The previous
+        # extraction read segment 4, which is the sensor family, not a protocol.
         .withColumn(
             "protocol_id",
-            F.expr(r"nullif(regexp_extract(parsed_data.topic, 'experiment/data_ingest/v1/[^/]+/([^/]+)', 1), '')")
+            F.expr(
+                r"CASE WHEN size(split(parsed_data.topic, '/')) = 8 "
+                r"THEN element_at(split(parsed_data.topic, '/'), 8) ELSE NULL END"
+            )
         )
         # Null on single-device uploads; rows of one multi-device workbook
         # run share it and can be joined back on it.

--- a/apps/docs/content/developers/design-decisions/mqtt-topic-proposal.mdx
+++ b/apps/docs/content/developers/design-decisions/mqtt-topic-proposal.mdx
@@ -6,6 +6,8 @@ description: "Historical proposal for the standardized experiment data-ingestion
 {/* verified: code@12a361a74966 2026-07-19 */}
 
 > Historical record: the proposal text below is preserved without changing its substance. The topic is represented in the current `asyncapi.yaml`; use the [MQTT API reference](/api/mqtt) for the live contract.
+>
+> Superseded in part: the trailing `<protocolId>` segment was removed from the ingest topic. It carried no routing or policy value, and protocol attribution now travels in the message payload. The original 8-segment shape remains temporarily as a transitional channel for fielded mobile builds.
 
 ## Overview
 

--- a/apps/docs/content/developers/design-decisions/mqtt-topic-proposal.mdx
+++ b/apps/docs/content/developers/design-decisions/mqtt-topic-proposal.mdx
@@ -7,7 +7,7 @@ description: "Historical proposal for the standardized experiment data-ingestion
 
 > Historical record: the proposal text below is preserved without changing its substance. The topic is represented in the current `asyncapi.yaml`; use the [MQTT API reference](/api/mqtt) for the live contract.
 >
-> Superseded in part: the trailing `<protocolId>` segment was removed from the ingest topic. It carried no routing or policy value, and protocol attribution now travels in the message payload. The original 8-segment shape remains temporarily as a transitional channel for fielded mobile builds.
+> Superseded in part: the trailing `<protocolId>` segment was removed from the ingest topic. It carried no routing or policy value; the lean shape carries no protocol attribution in the topic and the pipeline records a null protocol_id for it. The original 8-segment shape remains temporarily as a transitional channel for fielded mobile builds.
 
 ## Overview
 

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -69,13 +69,6 @@
                           "type": "string",
                           "format": "uuid"
                         },
-                        "role": {
-                          "enum": [
-                            "admin",
-                            "member"
-                          ],
-                          "type": "string"
-                        },
                         "firstName": {
                           "type": "string"
                         },
@@ -107,7 +100,7 @@
                         "userId"
                       ]
                     },
-                    "description": "Optional array of member objects with userId and role"
+                    "description": "Optional collaborators to seed: each listed user receives a contributing grant on the new experiment. Higher tiers are handed out through the sharing endpoints."
                   },
                   "locations": {
                     "type": "array",
@@ -1007,18 +1000,10 @@
                     "type": "string",
                     "description": "Updated experiment status"
                   },
-                  "visibility": {
-                    "enum": [
-                      "private",
-                      "public"
-                    ],
-                    "type": "string",
-                    "description": "Updated visibility setting"
-                  },
                   "embargoUntil": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Updated embargo end date and time (ISO datetime string, will be stored as UTC in database)"
+                    "description": "Updated embargo end date and time (ISO datetime string, will be stored as UTC in database). Only editable while the experiment is still private."
                   },
                   "anonymizeContributors": {
                     "type": "boolean",
@@ -1618,12 +1603,108 @@
                     },
                     "isAdmin": {
                       "type": "boolean"
+                    },
+                    "capabilities": {
+                      "type": "object",
+                      "properties": {
+                        "canContribute": {
+                          "type": "boolean"
+                        },
+                        "canUpdate": {
+                          "type": "boolean"
+                        },
+                        "canManage": {
+                          "type": "boolean"
+                        },
+                        "canShare": {
+                          "type": "boolean"
+                        },
+                        "canLeave": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "canContribute",
+                        "canUpdate",
+                        "canManage",
+                        "canShare",
+                        "canLeave"
+                      ]
                     }
                   },
                   "required": [
                     "experiment",
                     "hasAccess",
-                    "isAdmin"
+                    "isAdmin",
+                    "capabilities"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/experiments/{id}/visibility": {
+      "patch": {
+        "operationId": "experiments.setVisibility",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the experiment"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "visibility": {
+                    "enum": [
+                      "private",
+                      "public"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "visibility"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "visibility": {
+                      "enum": [
+                        "private",
+                        "public"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "visibility"
                   ]
                 }
               }
@@ -3467,9 +3548,9 @@
         }
       }
     },
-    "/api/v1/experiments/{id}/members": {
+    "/api/v1/experiments/{id}/contributors": {
       "get": {
-        "operationId": "experiments.listExperimentMembers",
+        "operationId": "experiments.listExperimentContributors",
         "parameters": [
           {
             "name": "id",
@@ -3492,604 +3573,34 @@
                   "items": {
                     "type": "object",
                     "properties": {
-                      "user": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "firstName": {
-                            "type": "string"
-                          },
-                          "lastName": {
-                            "type": "string"
-                          },
-                          "email": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "avatarUrl": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "firstName",
-                          "lastName",
-                          "email",
-                          "avatarUrl"
-                        ]
+                      "userId": {
+                        "type": "string",
+                        "minLength": 1
                       },
-                      "role": {
-                        "enum": [
-                          "admin",
-                          "member"
-                        ],
+                      "firstName": {
                         "type": "string"
                       },
-                      "joinedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "experimentId": {
-                        "type": "string",
-                        "format": "uuid"
-                      }
-                    },
-                    "required": [
-                      "user",
-                      "role",
-                      "joinedAt"
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/experiments/{id}/members/batch": {
-      "post": {
-        "operationId": "experiments.addExperimentMembers",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the experiment"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "members": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "userId": {
-                          "type": "string",
-                          "format": "uuid",
-                          "description": "ID of the user to add as a member"
-                        },
-                        "role": {
-                          "default": "member",
-                          "enum": [
-                            "admin",
-                            "member"
-                          ],
-                          "type": "string",
-                          "description": "ExperimentRole to assign to the new member"
-                        }
-                      },
-                      "required": [
-                        "userId"
-                      ]
-                    }
-                  }
-                },
-                "required": [
-                  "members"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "user": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "firstName": {
-                            "type": "string"
-                          },
-                          "lastName": {
-                            "type": "string"
-                          },
-                          "email": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "avatarUrl": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "firstName",
-                          "lastName",
-                          "email",
-                          "avatarUrl"
-                        ]
-                      },
-                      "role": {
-                        "enum": [
-                          "admin",
-                          "member"
-                        ],
+                      "lastName": {
                         "type": "string"
                       },
-                      "joinedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "experimentId": {
-                        "type": "string",
-                        "format": "uuid"
+                      "avatarUrl": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     },
                     "required": [
-                      "user",
-                      "role",
-                      "joinedAt"
+                      "userId",
+                      "firstName",
+                      "lastName",
+                      "avatarUrl"
                     ]
                   }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/experiments/{id}/members/{memberId}": {
-      "delete": {
-        "operationId": "experiments.removeExperimentMember",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the experiment"
-            }
-          },
-          {
-            "name": "memberId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the member"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "anyOf": [
-                    {
-                      "not": {}
-                    },
-                    {
-                      "not": {}
-                    }
-                  ]
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "operationId": "experiments.updateExperimentMemberRole",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the experiment"
-            }
-          },
-          {
-            "name": "memberId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the member"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "role": {
-                    "enum": [
-                      "admin",
-                      "member"
-                    ],
-                    "type": "string",
-                    "description": "New role to assign to the member"
-                  }
-                },
-                "required": [
-                  "role"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "user": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        "firstName": {
-                          "type": "string"
-                        },
-                        "lastName": {
-                          "type": "string"
-                        },
-                        "email": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        },
-                        "avatarUrl": {
-                          "anyOf": [
-                            {
-                              "type": "string"
-                            },
-                            {
-                              "type": "null"
-                            }
-                          ]
-                        }
-                      },
-                      "required": [
-                        "id",
-                        "firstName",
-                        "lastName",
-                        "email",
-                        "avatarUrl"
-                      ]
-                    },
-                    "role": {
-                      "enum": [
-                        "admin",
-                        "member"
-                      ],
-                      "type": "string"
-                    },
-                    "joinedAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "experimentId": {
-                      "type": "string",
-                      "format": "uuid"
-                    }
-                  },
-                  "required": [
-                    "user",
-                    "role",
-                    "joinedAt"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/experiments/transfer-admin": {
-      "post": {
-        "operationId": "experiments.transferExperimentAdmin",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "transfers": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "experimentId": {
-                          "type": "string",
-                          "format": "uuid",
-                          "description": "Experiment to transfer admin rights on"
-                        },
-                        "targetUserId": {
-                          "type": "string",
-                          "format": "uuid",
-                          "description": "User to make an admin of the experiment"
-                        }
-                      },
-                      "required": [
-                        "experimentId",
-                        "targetUserId"
-                      ]
-                    },
-                    "minItems": 1,
-                    "description": "Per-experiment admin assignments"
-                  }
-                },
-                "required": [
-                  "transfers"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "results": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "experimentId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "success": {
-                            "type": "boolean"
-                          },
-                          "error": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "experimentId",
-                          "success"
-                        ]
-                      }
-                    }
-                  },
-                  "required": [
-                    "results"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/experiments/{id}/devices": {
-      "get": {
-        "operationId": "experiments.listExperimentDevices",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the experiment"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "device": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "thingName": {
-                            "type": "string"
-                          },
-                          "serialNumber": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "deviceType": {
-                            "enum": [
-                              "multispeq",
-                              "ambyte",
-                              "minipar",
-                              "generic",
-                              "ambit"
-                            ],
-                            "type": "string"
-                          },
-                          "status": {
-                            "enum": [
-                              "pending",
-                              "active",
-                              "rotating",
-                              "revoked"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "thingName",
-                          "serialNumber",
-                          "name",
-                          "deviceType",
-                          "status"
-                        ]
-                      },
-                      "addedBy": {
-                        "type": "string",
-                        "format": "uuid"
-                      },
-                      "addedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                      }
-                    },
-                    "required": [
-                      "device",
-                      "addedBy",
-                      "addedAt"
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/experiments/{id}/devices/{deviceId}": {
-      "delete": {
-        "operationId": "experiments.removeExperimentDevice",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the experiment"
-            }
-          },
-          {
-            "name": "deviceId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the device"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "anyOf": [
-                    {
-                      "not": {}
-                    },
-                    {
-                      "not": {}
-                    }
-                  ]
                 }
               }
             }
@@ -13650,6 +13161,33 @@
                     "updatedAt": {
                       "type": "string",
                       "format": "date-time"
+                    },
+                    "capabilities": {
+                      "type": "object",
+                      "properties": {
+                        "canContribute": {
+                          "type": "boolean"
+                        },
+                        "canUpdate": {
+                          "type": "boolean"
+                        },
+                        "canManage": {
+                          "type": "boolean"
+                        },
+                        "canShare": {
+                          "type": "boolean"
+                        },
+                        "canLeave": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "canContribute",
+                        "canUpdate",
+                        "canManage",
+                        "canShare",
+                        "canLeave"
+                      ]
                     }
                   },
                   "required": [
@@ -13666,7 +13204,8 @@
                     "organizationId",
                     "visibility",
                     "createdAt",
-                    "updatedAt"
+                    "updatedAt",
+                    "capabilities"
                   ]
                 }
               }
@@ -13952,314 +13491,6 @@
         }
       }
     },
-    "/api/v1/devices/{deviceId}/onboard": {
-      "post": {
-        "operationId": "iot.onboardDevice",
-        "parameters": [
-          {
-            "name": "deviceId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the device"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "experimentIds": {
-                    "default": [],
-                    "type": "array",
-                    "items": {
-                      "type": "string",
-                      "format": "uuid"
-                    },
-                    "maxItems": 100,
-                    "description": "Experiments to bind the device to. An empty list re-issues the config."
-                  },
-                  "includeWorkbook": {
-                    "default": true,
-                    "type": "boolean",
-                    "description": "When false, the config carries only the connection and topic contract."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "thingName": {
-                      "type": "string"
-                    },
-                    "deviceType": {
-                      "enum": [
-                        "multispeq",
-                        "ambyte",
-                        "minipar",
-                        "generic",
-                        "ambit"
-                      ],
-                      "type": "string"
-                    },
-                    "endpoint": {
-                      "type": "string",
-                      "description": "MQTT broker host (AWS IoT ATS data endpoint)"
-                    },
-                    "experiments": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "experimentId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "experimentName": {
-                            "type": "string"
-                          },
-                          "topicPrefix": {
-                            "type": "string",
-                            "description": "Ingest topic prefix (experiment/data_ingest/v1/{experimentId}/{sensorType}); the device appends /{sensorVersion}/{sensorId}/{protocolId} per measurement."
-                          },
-                          "workbookVersion": {
-                            "anyOf": [
-                              {
-                                "type": "integer",
-                                "minimum": 0
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ],
-                            "description": "Pinned workbook version the procedures were compiled from"
-                          },
-                          "procedures": {
-                            "type": "array",
-                            "items": {
-                              "anyOf": [
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "type": {
-                                      "const": "protocol"
-                                    },
-                                    "protocolId": {
-                                      "type": "string",
-                                      "format": "uuid"
-                                    },
-                                    "name": {
-                                      "type": "string"
-                                    },
-                                    "family": {
-                                      "enum": [
-                                        "multispeq",
-                                        "ambyte",
-                                        "minipar",
-                                        "generic",
-                                        "ambit"
-                                      ],
-                                      "type": "string"
-                                    },
-                                    "code": {
-                                      "description": "The protocol's executable code, snapshotted at workbook publish"
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "protocolId"
-                                  ]
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "type": {
-                                      "const": "command"
-                                    },
-                                    "format": {
-                                      "enum": [
-                                        "string",
-                                        "json",
-                                        "yaml"
-                                      ],
-                                      "type": "string"
-                                    },
-                                    "content": {
-                                      "type": "string"
-                                    },
-                                    "name": {
-                                      "type": "string"
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "format",
-                                    "content"
-                                  ]
-                                },
-                                {
-                                  "type": "object",
-                                  "properties": {
-                                    "type": {
-                                      "const": "question"
-                                    },
-                                    "id": {
-                                      "type": "string",
-                                      "description": "Workbook cell id; delivery-time answers key on it"
-                                    },
-                                    "name": {
-                                      "type": "string",
-                                      "description": "Canonical column key the pipeline uses for this question"
-                                    },
-                                    "kind": {
-                                      "enum": [
-                                        "yes_no",
-                                        "open_ended",
-                                        "multi_choice",
-                                        "number"
-                                      ],
-                                      "type": "string"
-                                    },
-                                    "text": {
-                                      "type": "string"
-                                    },
-                                    "options": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    "required": {
-                                      "type": "boolean"
-                                    },
-                                    "answer": {
-                                      "anyOf": [
-                                        {
-                                          "type": "string"
-                                        },
-                                        {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          }
-                                        },
-                                        {
-                                          "type": "null"
-                                        }
-                                      ],
-                                      "description": "Prefilled at delivery; the device attaches it to every measurement"
-                                    }
-                                  },
-                                  "required": [
-                                    "type",
-                                    "id",
-                                    "name",
-                                    "kind",
-                                    "text",
-                                    "required",
-                                    "answer"
-                                  ]
-                                }
-                              ]
-                            }
-                          }
-                        },
-                        "required": [
-                          "experimentId",
-                          "experimentName",
-                          "topicPrefix",
-                          "workbookVersion",
-                          "procedures"
-                        ]
-                      }
-                    }
-                  },
-                  "required": [
-                    "thingName",
-                    "deviceType",
-                    "endpoint",
-                    "experiments"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/devices/{deviceId}/experiments": {
-      "get": {
-        "operationId": "iot.listDeviceExperiments",
-        "parameters": [
-          {
-            "name": "deviceId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the device"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "format": "uuid"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "status": {
-                        "enum": [
-                          "active",
-                          "stale",
-                          "archived",
-                          "published"
-                        ],
-                        "type": "string"
-                      },
-                      "addedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                      }
-                    },
-                    "required": [
-                      "id",
-                      "name",
-                      "status",
-                      "addedAt"
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/macros": {
       "get": {
         "operationId": "macros.listMacros",
@@ -14452,6 +13683,13 @@
                   "organizationId": {
                     "type": "string",
                     "format": "uuid"
+                  },
+                  "visibility": {
+                    "enum": [
+                      "private",
+                      "public"
+                    ],
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -14683,6 +13921,33 @@
                         "public"
                       ],
                       "type": "string"
+                    },
+                    "capabilities": {
+                      "type": "object",
+                      "properties": {
+                        "canContribute": {
+                          "type": "boolean"
+                        },
+                        "canUpdate": {
+                          "type": "boolean"
+                        },
+                        "canManage": {
+                          "type": "boolean"
+                        },
+                        "canShare": {
+                          "type": "boolean"
+                        },
+                        "canLeave": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "canContribute",
+                        "canUpdate",
+                        "canManage",
+                        "canShare",
+                        "canLeave"
+                      ]
                     }
                   },
                   "required": [
@@ -14696,7 +13961,8 @@
                     "createdAt",
                     "updatedAt",
                     "organizationId",
-                    "visibility"
+                    "visibility",
+                    "capabilities"
                   ]
                 }
               }
@@ -14895,6 +14161,73 @@
         }
       }
     },
+    "/api/v1/macros/{id}/visibility": {
+      "patch": {
+        "operationId": "macros.setVisibility",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "visibility": {
+                    "enum": [
+                      "private",
+                      "public"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "visibility"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "visibility": {
+                      "enum": [
+                        "private",
+                        "public"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "visibility"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/macros/{id}/protocols": {
       "get": {
         "operationId": "macros.listCompatibleProtocols",
@@ -14991,7 +14324,8 @@
                       "type": "string",
                       "format": "uuid"
                     },
-                    "minItems": 1
+                    "minItems": 1,
+                    "maxItems": 100
                   }
                 },
                 "required": [
@@ -15645,6 +14979,13 @@
                   "organizationId": {
                     "type": "string",
                     "format": "uuid"
+                  },
+                  "visibility": {
+                    "enum": [
+                      "private",
+                      "public"
+                    ],
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -15882,6 +15223,33 @@
                         "public"
                       ],
                       "type": "string"
+                    },
+                    "capabilities": {
+                      "type": "object",
+                      "properties": {
+                        "canContribute": {
+                          "type": "boolean"
+                        },
+                        "canUpdate": {
+                          "type": "boolean"
+                        },
+                        "canManage": {
+                          "type": "boolean"
+                        },
+                        "canShare": {
+                          "type": "boolean"
+                        },
+                        "canLeave": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "canContribute",
+                        "canUpdate",
+                        "canManage",
+                        "canShare",
+                        "canLeave"
+                      ]
                     }
                   },
                   "required": [
@@ -15895,7 +15263,8 @@
                     "createdAt",
                     "updatedAt",
                     "organizationId",
-                    "visibility"
+                    "visibility",
+                    "capabilities"
                   ]
                 }
               }
@@ -16103,6 +15472,73 @@
         }
       }
     },
+    "/api/v1/protocols/{id}/visibility": {
+      "patch": {
+        "operationId": "protocols.setVisibility",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "visibility": {
+                    "enum": [
+                      "private",
+                      "public"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "visibility"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "visibility": {
+                      "enum": [
+                        "private",
+                        "public"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "visibility"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/protocols/{id}/macros": {
       "get": {
         "operationId": "protocols.listCompatibleMacros",
@@ -16208,7 +15644,8 @@
                       "type": "string",
                       "format": "uuid"
                     },
-                    "minItems": 1
+                    "minItems": 1,
+                    "maxItems": 100
                   }
                 },
                 "required": [
@@ -16415,6 +15852,1076 @@
                           "title",
                           "subtitle",
                           "meta"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "results"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/{resourceType}/{id}/collaborators": {
+      "get": {
+        "operationId": "sharing.listGrants",
+        "parameters": [
+          {
+            "name": "resourceType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "enum": [
+                "experiment",
+                "macro",
+                "protocol",
+                "workbook",
+                "device"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the resource being shared"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "const": "owner"
+                          },
+                          "granteeType": {
+                            "const": "user"
+                          },
+                          "granteeId": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "grantee": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "enum": [
+                                  "user",
+                                  "organization"
+                                ],
+                                "type": "string"
+                              },
+                              "displayName": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "email": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "avatarUrl": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "displayName",
+                              "email",
+                              "avatarUrl"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "granteeType",
+                          "granteeId",
+                          "grantee"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "resourceType": {
+                            "enum": [
+                              "experiment",
+                              "macro",
+                              "protocol",
+                              "workbook",
+                              "device"
+                            ],
+                            "type": "string"
+                          },
+                          "resourceId": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "granteeType": {
+                            "enum": [
+                              "user",
+                              "organization"
+                            ],
+                            "type": "string"
+                          },
+                          "granteeId": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "role": {
+                            "enum": [
+                              "owner",
+                              "admin",
+                              "viewer"
+                            ],
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "createdBy": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "isOutsideCollaborator": {
+                            "type": "boolean"
+                          },
+                          "grantee": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "enum": [
+                                  "user",
+                                  "organization"
+                                ],
+                                "type": "string"
+                              },
+                              "displayName": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "email": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "avatarUrl": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "displayName",
+                              "email",
+                              "avatarUrl"
+                            ]
+                          },
+                          "kind": {
+                            "const": "grant"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "resourceType",
+                          "resourceId",
+                          "granteeType",
+                          "granteeId",
+                          "role",
+                          "createdAt",
+                          "createdBy",
+                          "isOutsideCollaborator",
+                          "grantee",
+                          "kind"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "sharing.createGrant",
+        "parameters": [
+          {
+            "name": "resourceType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "enum": [
+                "experiment",
+                "macro",
+                "protocol",
+                "workbook",
+                "device"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the resource being shared"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "granteeType": {
+                    "enum": [
+                      "user",
+                      "organization"
+                    ],
+                    "type": "string"
+                  },
+                  "granteeId": {
+                    "type": "string",
+                    "format": "uuid"
+                  },
+                  "role": {
+                    "default": "viewer",
+                    "enum": [
+                      "admin",
+                      "viewer"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "granteeType",
+                  "granteeId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "const": "owner"
+                          },
+                          "granteeType": {
+                            "const": "user"
+                          },
+                          "granteeId": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "grantee": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "enum": [
+                                  "user",
+                                  "organization"
+                                ],
+                                "type": "string"
+                              },
+                              "displayName": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "email": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "avatarUrl": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "displayName",
+                              "email",
+                              "avatarUrl"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "granteeType",
+                          "granteeId",
+                          "grantee"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "resourceType": {
+                            "enum": [
+                              "experiment",
+                              "macro",
+                              "protocol",
+                              "workbook",
+                              "device"
+                            ],
+                            "type": "string"
+                          },
+                          "resourceId": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "granteeType": {
+                            "enum": [
+                              "user",
+                              "organization"
+                            ],
+                            "type": "string"
+                          },
+                          "granteeId": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "role": {
+                            "enum": [
+                              "owner",
+                              "admin",
+                              "viewer"
+                            ],
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "createdBy": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "isOutsideCollaborator": {
+                            "type": "boolean"
+                          },
+                          "grantee": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "enum": [
+                                  "user",
+                                  "organization"
+                                ],
+                                "type": "string"
+                              },
+                              "displayName": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "email": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "avatarUrl": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "displayName",
+                              "email",
+                              "avatarUrl"
+                            ]
+                          },
+                          "kind": {
+                            "const": "grant"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "resourceType",
+                          "resourceId",
+                          "granteeType",
+                          "granteeId",
+                          "role",
+                          "createdAt",
+                          "createdBy",
+                          "isOutsideCollaborator",
+                          "grantee",
+                          "kind"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/{resourceType}/{id}/collaborators/{grantId}": {
+      "patch": {
+        "operationId": "sharing.updateGrant",
+        "parameters": [
+          {
+            "name": "resourceType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "enum": [
+                "experiment",
+                "macro",
+                "protocol",
+                "workbook",
+                "device"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the resource being shared"
+            }
+          },
+          {
+            "name": "grantId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the grant to modify"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "role": {
+                    "enum": [
+                      "admin",
+                      "viewer"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "role"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "const": "owner"
+                          },
+                          "granteeType": {
+                            "const": "user"
+                          },
+                          "granteeId": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "grantee": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "enum": [
+                                  "user",
+                                  "organization"
+                                ],
+                                "type": "string"
+                              },
+                              "displayName": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "email": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "avatarUrl": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "displayName",
+                              "email",
+                              "avatarUrl"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "granteeType",
+                          "granteeId",
+                          "grantee"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "resourceType": {
+                            "enum": [
+                              "experiment",
+                              "macro",
+                              "protocol",
+                              "workbook",
+                              "device"
+                            ],
+                            "type": "string"
+                          },
+                          "resourceId": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "granteeType": {
+                            "enum": [
+                              "user",
+                              "organization"
+                            ],
+                            "type": "string"
+                          },
+                          "granteeId": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "role": {
+                            "enum": [
+                              "owner",
+                              "admin",
+                              "viewer"
+                            ],
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "string"
+                          },
+                          "createdBy": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "isOutsideCollaborator": {
+                            "type": "boolean"
+                          },
+                          "grantee": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "enum": [
+                                  "user",
+                                  "organization"
+                                ],
+                                "type": "string"
+                              },
+                              "displayName": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "email": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "avatarUrl": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "type",
+                              "displayName",
+                              "email",
+                              "avatarUrl"
+                            ]
+                          },
+                          "kind": {
+                            "const": "grant"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "resourceType",
+                          "resourceId",
+                          "granteeType",
+                          "granteeId",
+                          "role",
+                          "createdAt",
+                          "createdBy",
+                          "isOutsideCollaborator",
+                          "grantee",
+                          "kind"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "sharing.revokeGrant",
+        "parameters": [
+          {
+            "name": "resourceType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "enum": [
+                "experiment",
+                "macro",
+                "protocol",
+                "workbook",
+                "device"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the resource being shared"
+            }
+          },
+          {
+            "name": "grantId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the grant to modify"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "not": {}
+                    },
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/{resourceType}/{id}/collaborators/me": {
+      "delete": {
+        "operationId": "sharing.leaveResource",
+        "parameters": [
+          {
+            "name": "resourceType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "enum": [
+                "experiment",
+                "macro",
+                "protocol",
+                "workbook",
+                "device"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the resource being shared"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "not": {}
+                    },
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/organizations/search": {
+      "get": {
+        "operationId": "sharing.searchGranteeOrganizations",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "Name substring to match"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "description": "Maximum number of organizations to return"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "format": "uuid"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "slug": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "name",
+                      "slug"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/collaborators/transfer-admin": {
+      "post": {
+        "operationId": "sharing.transferResourceAdmin",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "transfers": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "resourceType": {
+                          "enum": [
+                            "experiment",
+                            "macro",
+                            "protocol",
+                            "workbook",
+                            "device"
+                          ],
+                          "type": "string",
+                          "description": "Type of resource to transfer admin on"
+                        },
+                        "resourceId": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Resource to transfer admin rights on"
+                        },
+                        "targetUserId": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "User to make an admin of the resource"
+                        }
+                      },
+                      "required": [
+                        "resourceType",
+                        "resourceId",
+                        "targetUserId"
+                      ]
+                    },
+                    "minItems": 1,
+                    "description": "Per-resource admin assignments"
+                  }
+                },
+                "required": [
+                  "transfers"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "resourceType": {
+                            "enum": [
+                              "experiment",
+                              "macro",
+                              "protocol",
+                              "workbook",
+                              "device"
+                            ],
+                            "type": "string"
+                          },
+                          "resourceId": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "success": {
+                            "type": "boolean"
+                          },
+                          "error": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "resourceType",
+                          "resourceId",
+                          "success"
                         ]
                       }
                     }
@@ -16822,11 +17329,21 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "experiments": {
+                    "resources": {
                       "type": "array",
                       "items": {
                         "type": "object",
                         "properties": {
+                          "resourceType": {
+                            "enum": [
+                              "experiment",
+                              "macro",
+                              "protocol",
+                              "workbook",
+                              "device"
+                            ],
+                            "type": "string"
+                          },
                           "id": {
                             "type": "string",
                             "format": "uuid"
@@ -16835,13 +17352,20 @@
                             "type": "string"
                           },
                           "status": {
-                            "enum": [
-                              "active",
-                              "stale",
-                              "archived",
-                              "published"
-                            ],
-                            "type": "string"
+                            "anyOf": [
+                              {
+                                "enum": [
+                                  "active",
+                                  "stale",
+                                  "archived",
+                                  "published"
+                                ],
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
                           },
                           "candidates": {
                             "type": "array",
@@ -16879,6 +17403,7 @@
                           }
                         },
                         "required": [
+                          "resourceType",
                           "id",
                           "name",
                           "status",
@@ -16888,7 +17413,7 @@
                     }
                   },
                   "required": [
-                    "experiments"
+                    "resources"
                   ]
                 }
               }
@@ -17005,13 +17530,14 @@
                     "type": "string",
                     "format": "email"
                   },
-                  "role": {
-                    "default": "member",
+                  "tier": {
+                    "default": "viewer",
                     "enum": [
                       "admin",
-                      "member"
+                      "viewer"
                     ],
-                    "type": "string"
+                    "type": "string",
+                    "description": "Access tier to grant on acceptance"
                   }
                 },
                 "required": [
@@ -17057,7 +17583,11 @@
                       "type": "string",
                       "format": "email"
                     },
-                    "role": {
+                    "tier": {
+                      "enum": [
+                        "admin",
+                        "viewer"
+                      ],
                       "type": "string"
                     },
                     "status": {
@@ -17092,7 +17622,7 @@
                     "resourceType",
                     "resourceId",
                     "email",
-                    "role",
+                    "tier",
                     "status",
                     "invitedBy",
                     "createdAt",
@@ -17169,7 +17699,11 @@
                         "type": "string",
                         "format": "email"
                       },
-                      "role": {
+                      "tier": {
+                        "enum": [
+                          "admin",
+                          "viewer"
+                        ],
                         "type": "string"
                       },
                       "status": {
@@ -17204,7 +17738,7 @@
                       "resourceType",
                       "resourceId",
                       "email",
-                      "role",
+                      "tier",
                       "status",
                       "invitedBy",
                       "createdAt",
@@ -17219,124 +17753,6 @@
       }
     },
     "/api/v1/invitations/{invitationId}": {
-      "patch": {
-        "operationId": "users.updateInvitationRole",
-        "parameters": [
-          {
-            "name": "invitationId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the invitation"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "role": {
-                    "enum": [
-                      "admin",
-                      "member"
-                    ],
-                    "type": "string",
-                    "description": "New role to assign to the invitation"
-                  }
-                },
-                "required": [
-                  "role"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "format": "uuid"
-                    },
-                    "resourceType": {
-                      "enum": [
-                        "platform",
-                        "experiment"
-                      ],
-                      "type": "string"
-                    },
-                    "resourceId": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "format": "uuid"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "email": {
-                      "type": "string",
-                      "format": "email"
-                    },
-                    "role": {
-                      "type": "string"
-                    },
-                    "status": {
-                      "enum": [
-                        "pending",
-                        "accepted",
-                        "revoked"
-                      ],
-                      "type": "string"
-                    },
-                    "invitedBy": {
-                      "type": "string",
-                      "format": "uuid"
-                    },
-                    "invitedByName": {
-                      "type": "string"
-                    },
-                    "resourceName": {
-                      "type": "string"
-                    },
-                    "createdAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "updatedAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "resourceType",
-                    "resourceId",
-                    "email",
-                    "role",
-                    "status",
-                    "invitedBy",
-                    "createdAt",
-                    "updatedAt"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      },
       "delete": {
         "operationId": "users.revokeInvitation",
         "parameters": [
@@ -18072,6 +18488,13 @@
                   "organizationId": {
                     "type": "string",
                     "format": "uuid"
+                  },
+                  "visibility": {
+                    "enum": [
+                      "private",
+                      "public"
+                    ],
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -19198,6 +19621,33 @@
                     "experimentCount": {
                       "type": "integer",
                       "minimum": 0
+                    },
+                    "capabilities": {
+                      "type": "object",
+                      "properties": {
+                        "canContribute": {
+                          "type": "boolean"
+                        },
+                        "canUpdate": {
+                          "type": "boolean"
+                        },
+                        "canManage": {
+                          "type": "boolean"
+                        },
+                        "canShare": {
+                          "type": "boolean"
+                        },
+                        "canLeave": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "canContribute",
+                        "canUpdate",
+                        "canManage",
+                        "canShare",
+                        "canLeave"
+                      ]
                     }
                   },
                   "required": [
@@ -19210,7 +19660,8 @@
                     "visibility",
                     "createdBy",
                     "createdAt",
-                    "updatedAt"
+                    "updatedAt",
+                    "capabilities"
                   ]
                 }
               }
@@ -20304,6 +20755,73 @@
                     {
                       "not": {}
                     }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workbooks/{id}/visibility": {
+      "patch": {
+        "operationId": "workbooks.setVisibility",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "visibility": {
+                    "enum": [
+                      "private",
+                      "public"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "visibility"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "visibility": {
+                      "enum": [
+                        "private",
+                        "public"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "visibility"
                   ]
                 }
               }

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -69,6 +69,13 @@
                           "type": "string",
                           "format": "uuid"
                         },
+                        "role": {
+                          "enum": [
+                            "admin",
+                            "member"
+                          ],
+                          "type": "string"
+                        },
                         "firstName": {
                           "type": "string"
                         },
@@ -100,7 +107,7 @@
                         "userId"
                       ]
                     },
-                    "description": "Optional collaborators to seed: each listed user receives a contributing grant on the new experiment. Higher tiers are handed out through the sharing endpoints."
+                    "description": "Optional array of member objects with userId and role"
                   },
                   "locations": {
                     "type": "array",
@@ -1000,10 +1007,18 @@
                     "type": "string",
                     "description": "Updated experiment status"
                   },
+                  "visibility": {
+                    "enum": [
+                      "private",
+                      "public"
+                    ],
+                    "type": "string",
+                    "description": "Updated visibility setting"
+                  },
                   "embargoUntil": {
                     "type": "string",
                     "format": "date-time",
-                    "description": "Updated embargo end date and time (ISO datetime string, will be stored as UTC in database). Only editable while the experiment is still private."
+                    "description": "Updated embargo end date and time (ISO datetime string, will be stored as UTC in database)"
                   },
                   "anonymizeContributors": {
                     "type": "boolean",
@@ -1603,108 +1618,12 @@
                     },
                     "isAdmin": {
                       "type": "boolean"
-                    },
-                    "capabilities": {
-                      "type": "object",
-                      "properties": {
-                        "canContribute": {
-                          "type": "boolean"
-                        },
-                        "canUpdate": {
-                          "type": "boolean"
-                        },
-                        "canManage": {
-                          "type": "boolean"
-                        },
-                        "canShare": {
-                          "type": "boolean"
-                        },
-                        "canLeave": {
-                          "type": "boolean"
-                        }
-                      },
-                      "required": [
-                        "canContribute",
-                        "canUpdate",
-                        "canManage",
-                        "canShare",
-                        "canLeave"
-                      ]
                     }
                   },
                   "required": [
                     "experiment",
                     "hasAccess",
-                    "isAdmin",
-                    "capabilities"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/experiments/{id}/visibility": {
-      "patch": {
-        "operationId": "experiments.setVisibility",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the experiment"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "visibility": {
-                    "enum": [
-                      "private",
-                      "public"
-                    ],
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "visibility"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "format": "uuid"
-                    },
-                    "visibility": {
-                      "enum": [
-                        "private",
-                        "public"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "visibility"
+                    "isAdmin"
                   ]
                 }
               }
@@ -3548,9 +3467,9 @@
         }
       }
     },
-    "/api/v1/experiments/{id}/contributors": {
+    "/api/v1/experiments/{id}/members": {
       "get": {
-        "operationId": "experiments.listExperimentContributors",
+        "operationId": "experiments.listExperimentMembers",
         "parameters": [
           {
             "name": "id",
@@ -3573,34 +3492,604 @@
                   "items": {
                     "type": "object",
                     "properties": {
-                      "userId": {
-                        "type": "string",
-                        "minLength": 1
-                      },
-                      "firstName": {
-                        "type": "string"
-                      },
-                      "lastName": {
-                        "type": "string"
-                      },
-                      "avatarUrl": {
-                        "anyOf": [
-                          {
+                      "user": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "firstName": {
                             "type": "string"
                           },
-                          {
-                            "type": "null"
+                          "lastName": {
+                            "type": "string"
+                          },
+                          "email": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "avatarUrl": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
                           }
+                        },
+                        "required": [
+                          "id",
+                          "firstName",
+                          "lastName",
+                          "email",
+                          "avatarUrl"
                         ]
+                      },
+                      "role": {
+                        "enum": [
+                          "admin",
+                          "member"
+                        ],
+                        "type": "string"
+                      },
+                      "joinedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "experimentId": {
+                        "type": "string",
+                        "format": "uuid"
                       }
                     },
                     "required": [
-                      "userId",
-                      "firstName",
-                      "lastName",
-                      "avatarUrl"
+                      "user",
+                      "role",
+                      "joinedAt"
                     ]
                   }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/experiments/{id}/members/batch": {
+      "post": {
+        "operationId": "experiments.addExperimentMembers",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the experiment"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "members": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "userId": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "ID of the user to add as a member"
+                        },
+                        "role": {
+                          "default": "member",
+                          "enum": [
+                            "admin",
+                            "member"
+                          ],
+                          "type": "string",
+                          "description": "ExperimentRole to assign to the new member"
+                        }
+                      },
+                      "required": [
+                        "userId"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "members"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "user": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "firstName": {
+                            "type": "string"
+                          },
+                          "lastName": {
+                            "type": "string"
+                          },
+                          "email": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "avatarUrl": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "firstName",
+                          "lastName",
+                          "email",
+                          "avatarUrl"
+                        ]
+                      },
+                      "role": {
+                        "enum": [
+                          "admin",
+                          "member"
+                        ],
+                        "type": "string"
+                      },
+                      "joinedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "experimentId": {
+                        "type": "string",
+                        "format": "uuid"
+                      }
+                    },
+                    "required": [
+                      "user",
+                      "role",
+                      "joinedAt"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/experiments/{id}/members/{memberId}": {
+      "delete": {
+        "operationId": "experiments.removeExperimentMember",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the experiment"
+            }
+          },
+          {
+            "name": "memberId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the member"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "not": {}
+                    },
+                    {
+                      "not": {}
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "experiments.updateExperimentMemberRole",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the experiment"
+            }
+          },
+          {
+            "name": "memberId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the member"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "role": {
+                    "enum": [
+                      "admin",
+                      "member"
+                    ],
+                    "type": "string",
+                    "description": "New role to assign to the member"
+                  }
+                },
+                "required": [
+                  "role"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        "firstName": {
+                          "type": "string"
+                        },
+                        "lastName": {
+                          "type": "string"
+                        },
+                        "email": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "avatarUrl": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "firstName",
+                        "lastName",
+                        "email",
+                        "avatarUrl"
+                      ]
+                    },
+                    "role": {
+                      "enum": [
+                        "admin",
+                        "member"
+                      ],
+                      "type": "string"
+                    },
+                    "joinedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "experimentId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  },
+                  "required": [
+                    "user",
+                    "role",
+                    "joinedAt"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/experiments/transfer-admin": {
+      "post": {
+        "operationId": "experiments.transferExperimentAdmin",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "transfers": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "experimentId": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "Experiment to transfer admin rights on"
+                        },
+                        "targetUserId": {
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "User to make an admin of the experiment"
+                        }
+                      },
+                      "required": [
+                        "experimentId",
+                        "targetUserId"
+                      ]
+                    },
+                    "minItems": 1,
+                    "description": "Per-experiment admin assignments"
+                  }
+                },
+                "required": [
+                  "transfers"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "experimentId": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "success": {
+                            "type": "boolean"
+                          },
+                          "error": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "experimentId",
+                          "success"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "results"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/experiments/{id}/devices": {
+      "get": {
+        "operationId": "experiments.listExperimentDevices",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the experiment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "device": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "thingName": {
+                            "type": "string"
+                          },
+                          "serialNumber": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "deviceType": {
+                            "enum": [
+                              "multispeq",
+                              "ambyte",
+                              "minipar",
+                              "generic",
+                              "ambit"
+                            ],
+                            "type": "string"
+                          },
+                          "status": {
+                            "enum": [
+                              "pending",
+                              "active",
+                              "rotating",
+                              "revoked"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "thingName",
+                          "serialNumber",
+                          "name",
+                          "deviceType",
+                          "status"
+                        ]
+                      },
+                      "addedBy": {
+                        "type": "string",
+                        "format": "uuid"
+                      },
+                      "addedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                      }
+                    },
+                    "required": [
+                      "device",
+                      "addedBy",
+                      "addedAt"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/experiments/{id}/devices/{deviceId}": {
+      "delete": {
+        "operationId": "experiments.removeExperimentDevice",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the experiment"
+            }
+          },
+          {
+            "name": "deviceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the device"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "not": {}
+                    },
+                    {
+                      "not": {}
+                    }
+                  ]
                 }
               }
             }
@@ -13161,33 +13650,6 @@
                     "updatedAt": {
                       "type": "string",
                       "format": "date-time"
-                    },
-                    "capabilities": {
-                      "type": "object",
-                      "properties": {
-                        "canContribute": {
-                          "type": "boolean"
-                        },
-                        "canUpdate": {
-                          "type": "boolean"
-                        },
-                        "canManage": {
-                          "type": "boolean"
-                        },
-                        "canShare": {
-                          "type": "boolean"
-                        },
-                        "canLeave": {
-                          "type": "boolean"
-                        }
-                      },
-                      "required": [
-                        "canContribute",
-                        "canUpdate",
-                        "canManage",
-                        "canShare",
-                        "canLeave"
-                      ]
                     }
                   },
                   "required": [
@@ -13204,8 +13666,7 @@
                     "organizationId",
                     "visibility",
                     "createdAt",
-                    "updatedAt",
-                    "capabilities"
+                    "updatedAt"
                   ]
                 }
               }
@@ -13491,6 +13952,314 @@
         }
       }
     },
+    "/api/v1/devices/{deviceId}/onboard": {
+      "post": {
+        "operationId": "iot.onboardDevice",
+        "parameters": [
+          {
+            "name": "deviceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the device"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "experimentIds": {
+                    "default": [],
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "maxItems": 100,
+                    "description": "Experiments to bind the device to. An empty list re-issues the config."
+                  },
+                  "includeWorkbook": {
+                    "default": true,
+                    "type": "boolean",
+                    "description": "When false, the config carries only the connection and topic contract."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "thingName": {
+                      "type": "string"
+                    },
+                    "deviceType": {
+                      "enum": [
+                        "multispeq",
+                        "ambyte",
+                        "minipar",
+                        "generic",
+                        "ambit"
+                      ],
+                      "type": "string"
+                    },
+                    "endpoint": {
+                      "type": "string",
+                      "description": "MQTT broker host (AWS IoT ATS data endpoint)"
+                    },
+                    "experiments": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "experimentId": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "experimentName": {
+                            "type": "string"
+                          },
+                          "topicPrefix": {
+                            "type": "string",
+                            "description": "Ingest topic prefix (experiment/data_ingest/v1/{experimentId}/{sensorType}); the device appends /{sensorVersion}/{sensorId}/{protocolId} per measurement."
+                          },
+                          "workbookVersion": {
+                            "anyOf": [
+                              {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "description": "Pinned workbook version the procedures were compiled from"
+                          },
+                          "procedures": {
+                            "type": "array",
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "const": "protocol"
+                                    },
+                                    "protocolId": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "family": {
+                                      "enum": [
+                                        "multispeq",
+                                        "ambyte",
+                                        "minipar",
+                                        "generic",
+                                        "ambit"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "code": {
+                                      "description": "The protocol's executable code, snapshotted at workbook publish"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "protocolId"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "const": "command"
+                                    },
+                                    "format": {
+                                      "enum": [
+                                        "string",
+                                        "json",
+                                        "yaml"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "content": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "format",
+                                    "content"
+                                  ]
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "const": "question"
+                                    },
+                                    "id": {
+                                      "type": "string",
+                                      "description": "Workbook cell id; delivery-time answers key on it"
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "description": "Canonical column key the pipeline uses for this question"
+                                    },
+                                    "kind": {
+                                      "enum": [
+                                        "yes_no",
+                                        "open_ended",
+                                        "multi_choice",
+                                        "number"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "options": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": {
+                                      "type": "boolean"
+                                    },
+                                    "answer": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ],
+                                      "description": "Prefilled at delivery; the device attaches it to every measurement"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "id",
+                                    "name",
+                                    "kind",
+                                    "text",
+                                    "required",
+                                    "answer"
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "experimentId",
+                          "experimentName",
+                          "topicPrefix",
+                          "workbookVersion",
+                          "procedures"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "thingName",
+                    "deviceType",
+                    "endpoint",
+                    "experiments"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/devices/{deviceId}/experiments": {
+      "get": {
+        "operationId": "iot.listDeviceExperiments",
+        "parameters": [
+          {
+            "name": "deviceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the device"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "format": "uuid"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "enum": [
+                          "active",
+                          "stale",
+                          "archived",
+                          "published"
+                        ],
+                        "type": "string"
+                      },
+                      "addedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "name",
+                      "status",
+                      "addedAt"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/macros": {
       "get": {
         "operationId": "macros.listMacros",
@@ -13683,13 +14452,6 @@
                   "organizationId": {
                     "type": "string",
                     "format": "uuid"
-                  },
-                  "visibility": {
-                    "enum": [
-                      "private",
-                      "public"
-                    ],
-                    "type": "string"
                   }
                 },
                 "required": [
@@ -13921,33 +14683,6 @@
                         "public"
                       ],
                       "type": "string"
-                    },
-                    "capabilities": {
-                      "type": "object",
-                      "properties": {
-                        "canContribute": {
-                          "type": "boolean"
-                        },
-                        "canUpdate": {
-                          "type": "boolean"
-                        },
-                        "canManage": {
-                          "type": "boolean"
-                        },
-                        "canShare": {
-                          "type": "boolean"
-                        },
-                        "canLeave": {
-                          "type": "boolean"
-                        }
-                      },
-                      "required": [
-                        "canContribute",
-                        "canUpdate",
-                        "canManage",
-                        "canShare",
-                        "canLeave"
-                      ]
                     }
                   },
                   "required": [
@@ -13961,8 +14696,7 @@
                     "createdAt",
                     "updatedAt",
                     "organizationId",
-                    "visibility",
-                    "capabilities"
+                    "visibility"
                   ]
                 }
               }
@@ -14161,73 +14895,6 @@
         }
       }
     },
-    "/api/v1/macros/{id}/visibility": {
-      "patch": {
-        "operationId": "macros.setVisibility",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "visibility": {
-                    "enum": [
-                      "private",
-                      "public"
-                    ],
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "visibility"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "format": "uuid"
-                    },
-                    "visibility": {
-                      "enum": [
-                        "private",
-                        "public"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "visibility"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/macros/{id}/protocols": {
       "get": {
         "operationId": "macros.listCompatibleProtocols",
@@ -14324,8 +14991,7 @@
                       "type": "string",
                       "format": "uuid"
                     },
-                    "minItems": 1,
-                    "maxItems": 100
+                    "minItems": 1
                   }
                 },
                 "required": [
@@ -14979,13 +15645,6 @@
                   "organizationId": {
                     "type": "string",
                     "format": "uuid"
-                  },
-                  "visibility": {
-                    "enum": [
-                      "private",
-                      "public"
-                    ],
-                    "type": "string"
                   }
                 },
                 "required": [
@@ -15223,33 +15882,6 @@
                         "public"
                       ],
                       "type": "string"
-                    },
-                    "capabilities": {
-                      "type": "object",
-                      "properties": {
-                        "canContribute": {
-                          "type": "boolean"
-                        },
-                        "canUpdate": {
-                          "type": "boolean"
-                        },
-                        "canManage": {
-                          "type": "boolean"
-                        },
-                        "canShare": {
-                          "type": "boolean"
-                        },
-                        "canLeave": {
-                          "type": "boolean"
-                        }
-                      },
-                      "required": [
-                        "canContribute",
-                        "canUpdate",
-                        "canManage",
-                        "canShare",
-                        "canLeave"
-                      ]
                     }
                   },
                   "required": [
@@ -15263,8 +15895,7 @@
                     "createdAt",
                     "updatedAt",
                     "organizationId",
-                    "visibility",
-                    "capabilities"
+                    "visibility"
                   ]
                 }
               }
@@ -15472,73 +16103,6 @@
         }
       }
     },
-    "/api/v1/protocols/{id}/visibility": {
-      "patch": {
-        "operationId": "protocols.setVisibility",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "visibility": {
-                    "enum": [
-                      "private",
-                      "public"
-                    ],
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "visibility"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "format": "uuid"
-                    },
-                    "visibility": {
-                      "enum": [
-                        "private",
-                        "public"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "visibility"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/protocols/{id}/macros": {
       "get": {
         "operationId": "protocols.listCompatibleMacros",
@@ -15644,8 +16208,7 @@
                       "type": "string",
                       "format": "uuid"
                     },
-                    "minItems": 1,
-                    "maxItems": 100
+                    "minItems": 1
                   }
                 },
                 "required": [
@@ -15852,1076 +16415,6 @@
                           "title",
                           "subtitle",
                           "meta"
-                        ]
-                      }
-                    }
-                  },
-                  "required": [
-                    "results"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/{resourceType}/{id}/collaborators": {
-      "get": {
-        "operationId": "sharing.listGrants",
-        "parameters": [
-          {
-            "name": "resourceType",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "enum": [
-                "experiment",
-                "macro",
-                "protocol",
-                "workbook",
-                "device"
-              ],
-              "type": "string"
-            }
-          },
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the resource being shared"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "anyOf": [
-                      {
-                        "type": "object",
-                        "properties": {
-                          "kind": {
-                            "const": "owner"
-                          },
-                          "granteeType": {
-                            "const": "user"
-                          },
-                          "granteeId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "grantee": {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "enum": [
-                                  "user",
-                                  "organization"
-                                ],
-                                "type": "string"
-                              },
-                              "displayName": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              },
-                              "email": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              },
-                              "avatarUrl": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "displayName",
-                              "email",
-                              "avatarUrl"
-                            ]
-                          }
-                        },
-                        "required": [
-                          "kind",
-                          "granteeType",
-                          "granteeId",
-                          "grantee"
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "resourceType": {
-                            "enum": [
-                              "experiment",
-                              "macro",
-                              "protocol",
-                              "workbook",
-                              "device"
-                            ],
-                            "type": "string"
-                          },
-                          "resourceId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "granteeType": {
-                            "enum": [
-                              "user",
-                              "organization"
-                            ],
-                            "type": "string"
-                          },
-                          "granteeId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "role": {
-                            "enum": [
-                              "owner",
-                              "admin",
-                              "viewer"
-                            ],
-                            "type": "string"
-                          },
-                          "createdAt": {
-                            "type": "string"
-                          },
-                          "createdBy": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "isOutsideCollaborator": {
-                            "type": "boolean"
-                          },
-                          "grantee": {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "enum": [
-                                  "user",
-                                  "organization"
-                                ],
-                                "type": "string"
-                              },
-                              "displayName": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              },
-                              "email": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              },
-                              "avatarUrl": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "displayName",
-                              "email",
-                              "avatarUrl"
-                            ]
-                          },
-                          "kind": {
-                            "const": "grant"
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "resourceType",
-                          "resourceId",
-                          "granteeType",
-                          "granteeId",
-                          "role",
-                          "createdAt",
-                          "createdBy",
-                          "isOutsideCollaborator",
-                          "grantee",
-                          "kind"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "operationId": "sharing.createGrant",
-        "parameters": [
-          {
-            "name": "resourceType",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "enum": [
-                "experiment",
-                "macro",
-                "protocol",
-                "workbook",
-                "device"
-              ],
-              "type": "string"
-            }
-          },
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the resource being shared"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "granteeType": {
-                    "enum": [
-                      "user",
-                      "organization"
-                    ],
-                    "type": "string"
-                  },
-                  "granteeId": {
-                    "type": "string",
-                    "format": "uuid"
-                  },
-                  "role": {
-                    "default": "viewer",
-                    "enum": [
-                      "admin",
-                      "viewer"
-                    ],
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "granteeType",
-                  "granteeId"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "anyOf": [
-                      {
-                        "type": "object",
-                        "properties": {
-                          "kind": {
-                            "const": "owner"
-                          },
-                          "granteeType": {
-                            "const": "user"
-                          },
-                          "granteeId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "grantee": {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "enum": [
-                                  "user",
-                                  "organization"
-                                ],
-                                "type": "string"
-                              },
-                              "displayName": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              },
-                              "email": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              },
-                              "avatarUrl": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "displayName",
-                              "email",
-                              "avatarUrl"
-                            ]
-                          }
-                        },
-                        "required": [
-                          "kind",
-                          "granteeType",
-                          "granteeId",
-                          "grantee"
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "resourceType": {
-                            "enum": [
-                              "experiment",
-                              "macro",
-                              "protocol",
-                              "workbook",
-                              "device"
-                            ],
-                            "type": "string"
-                          },
-                          "resourceId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "granteeType": {
-                            "enum": [
-                              "user",
-                              "organization"
-                            ],
-                            "type": "string"
-                          },
-                          "granteeId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "role": {
-                            "enum": [
-                              "owner",
-                              "admin",
-                              "viewer"
-                            ],
-                            "type": "string"
-                          },
-                          "createdAt": {
-                            "type": "string"
-                          },
-                          "createdBy": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "isOutsideCollaborator": {
-                            "type": "boolean"
-                          },
-                          "grantee": {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "enum": [
-                                  "user",
-                                  "organization"
-                                ],
-                                "type": "string"
-                              },
-                              "displayName": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              },
-                              "email": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              },
-                              "avatarUrl": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "displayName",
-                              "email",
-                              "avatarUrl"
-                            ]
-                          },
-                          "kind": {
-                            "const": "grant"
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "resourceType",
-                          "resourceId",
-                          "granteeType",
-                          "granteeId",
-                          "role",
-                          "createdAt",
-                          "createdBy",
-                          "isOutsideCollaborator",
-                          "grantee",
-                          "kind"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/{resourceType}/{id}/collaborators/{grantId}": {
-      "patch": {
-        "operationId": "sharing.updateGrant",
-        "parameters": [
-          {
-            "name": "resourceType",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "enum": [
-                "experiment",
-                "macro",
-                "protocol",
-                "workbook",
-                "device"
-              ],
-              "type": "string"
-            }
-          },
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the resource being shared"
-            }
-          },
-          {
-            "name": "grantId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the grant to modify"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "role": {
-                    "enum": [
-                      "admin",
-                      "viewer"
-                    ],
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "role"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "anyOf": [
-                      {
-                        "type": "object",
-                        "properties": {
-                          "kind": {
-                            "const": "owner"
-                          },
-                          "granteeType": {
-                            "const": "user"
-                          },
-                          "granteeId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "grantee": {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "enum": [
-                                  "user",
-                                  "organization"
-                                ],
-                                "type": "string"
-                              },
-                              "displayName": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              },
-                              "email": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              },
-                              "avatarUrl": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "displayName",
-                              "email",
-                              "avatarUrl"
-                            ]
-                          }
-                        },
-                        "required": [
-                          "kind",
-                          "granteeType",
-                          "granteeId",
-                          "grantee"
-                        ]
-                      },
-                      {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "resourceType": {
-                            "enum": [
-                              "experiment",
-                              "macro",
-                              "protocol",
-                              "workbook",
-                              "device"
-                            ],
-                            "type": "string"
-                          },
-                          "resourceId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "granteeType": {
-                            "enum": [
-                              "user",
-                              "organization"
-                            ],
-                            "type": "string"
-                          },
-                          "granteeId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "role": {
-                            "enum": [
-                              "owner",
-                              "admin",
-                              "viewer"
-                            ],
-                            "type": "string"
-                          },
-                          "createdAt": {
-                            "type": "string"
-                          },
-                          "createdBy": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "isOutsideCollaborator": {
-                            "type": "boolean"
-                          },
-                          "grantee": {
-                            "type": "object",
-                            "properties": {
-                              "type": {
-                                "enum": [
-                                  "user",
-                                  "organization"
-                                ],
-                                "type": "string"
-                              },
-                              "displayName": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              },
-                              "email": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              },
-                              "avatarUrl": {
-                                "anyOf": [
-                                  {
-                                    "type": "string"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              }
-                            },
-                            "required": [
-                              "type",
-                              "displayName",
-                              "email",
-                              "avatarUrl"
-                            ]
-                          },
-                          "kind": {
-                            "const": "grant"
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "resourceType",
-                          "resourceId",
-                          "granteeType",
-                          "granteeId",
-                          "role",
-                          "createdAt",
-                          "createdBy",
-                          "isOutsideCollaborator",
-                          "grantee",
-                          "kind"
-                        ]
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "operationId": "sharing.revokeGrant",
-        "parameters": [
-          {
-            "name": "resourceType",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "enum": [
-                "experiment",
-                "macro",
-                "protocol",
-                "workbook",
-                "device"
-              ],
-              "type": "string"
-            }
-          },
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the resource being shared"
-            }
-          },
-          {
-            "name": "grantId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the grant to modify"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "anyOf": [
-                    {
-                      "not": {}
-                    },
-                    {
-                      "not": {}
-                    }
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/{resourceType}/{id}/collaborators/me": {
-      "delete": {
-        "operationId": "sharing.leaveResource",
-        "parameters": [
-          {
-            "name": "resourceType",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "enum": [
-                "experiment",
-                "macro",
-                "protocol",
-                "workbook",
-                "device"
-              ],
-              "type": "string"
-            }
-          },
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "ID of the resource being shared"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "anyOf": [
-                    {
-                      "not": {}
-                    },
-                    {
-                      "not": {}
-                    }
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/organizations/search": {
-      "get": {
-        "operationId": "sharing.searchGranteeOrganizations",
-        "parameters": [
-          {
-            "name": "query",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "description": "Name substring to match"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "default": 20,
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 50,
-              "description": "Maximum number of organizations to return"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "format": "uuid"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "slug": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      }
-                    },
-                    "required": [
-                      "id",
-                      "name",
-                      "slug"
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/collaborators/transfer-admin": {
-      "post": {
-        "operationId": "sharing.transferResourceAdmin",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "transfers": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "resourceType": {
-                          "enum": [
-                            "experiment",
-                            "macro",
-                            "protocol",
-                            "workbook",
-                            "device"
-                          ],
-                          "type": "string",
-                          "description": "Type of resource to transfer admin on"
-                        },
-                        "resourceId": {
-                          "type": "string",
-                          "format": "uuid",
-                          "description": "Resource to transfer admin rights on"
-                        },
-                        "targetUserId": {
-                          "type": "string",
-                          "format": "uuid",
-                          "description": "User to make an admin of the resource"
-                        }
-                      },
-                      "required": [
-                        "resourceType",
-                        "resourceId",
-                        "targetUserId"
-                      ]
-                    },
-                    "minItems": 1,
-                    "description": "Per-resource admin assignments"
-                  }
-                },
-                "required": [
-                  "transfers"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "results": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "resourceType": {
-                            "enum": [
-                              "experiment",
-                              "macro",
-                              "protocol",
-                              "workbook",
-                              "device"
-                            ],
-                            "type": "string"
-                          },
-                          "resourceId": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "success": {
-                            "type": "boolean"
-                          },
-                          "error": {
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "resourceType",
-                          "resourceId",
-                          "success"
                         ]
                       }
                     }
@@ -17329,21 +16822,11 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "resources": {
+                    "experiments": {
                       "type": "array",
                       "items": {
                         "type": "object",
                         "properties": {
-                          "resourceType": {
-                            "enum": [
-                              "experiment",
-                              "macro",
-                              "protocol",
-                              "workbook",
-                              "device"
-                            ],
-                            "type": "string"
-                          },
                           "id": {
                             "type": "string",
                             "format": "uuid"
@@ -17352,20 +16835,13 @@
                             "type": "string"
                           },
                           "status": {
-                            "anyOf": [
-                              {
-                                "enum": [
-                                  "active",
-                                  "stale",
-                                  "archived",
-                                  "published"
-                                ],
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
+                            "enum": [
+                              "active",
+                              "stale",
+                              "archived",
+                              "published"
+                            ],
+                            "type": "string"
                           },
                           "candidates": {
                             "type": "array",
@@ -17403,7 +16879,6 @@
                           }
                         },
                         "required": [
-                          "resourceType",
                           "id",
                           "name",
                           "status",
@@ -17413,7 +16888,7 @@
                     }
                   },
                   "required": [
-                    "resources"
+                    "experiments"
                   ]
                 }
               }
@@ -17530,14 +17005,13 @@
                     "type": "string",
                     "format": "email"
                   },
-                  "tier": {
-                    "default": "viewer",
+                  "role": {
+                    "default": "member",
                     "enum": [
                       "admin",
-                      "viewer"
+                      "member"
                     ],
-                    "type": "string",
-                    "description": "Access tier to grant on acceptance"
+                    "type": "string"
                   }
                 },
                 "required": [
@@ -17583,11 +17057,7 @@
                       "type": "string",
                       "format": "email"
                     },
-                    "tier": {
-                      "enum": [
-                        "admin",
-                        "viewer"
-                      ],
+                    "role": {
                       "type": "string"
                     },
                     "status": {
@@ -17622,7 +17092,7 @@
                     "resourceType",
                     "resourceId",
                     "email",
-                    "tier",
+                    "role",
                     "status",
                     "invitedBy",
                     "createdAt",
@@ -17699,11 +17169,7 @@
                         "type": "string",
                         "format": "email"
                       },
-                      "tier": {
-                        "enum": [
-                          "admin",
-                          "viewer"
-                        ],
+                      "role": {
                         "type": "string"
                       },
                       "status": {
@@ -17738,7 +17204,7 @@
                       "resourceType",
                       "resourceId",
                       "email",
-                      "tier",
+                      "role",
                       "status",
                       "invitedBy",
                       "createdAt",
@@ -17753,6 +17219,124 @@
       }
     },
     "/api/v1/invitations/{invitationId}": {
+      "patch": {
+        "operationId": "users.updateInvitationRole",
+        "parameters": [
+          {
+            "name": "invitationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "ID of the invitation"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "role": {
+                    "enum": [
+                      "admin",
+                      "member"
+                    ],
+                    "type": "string",
+                    "description": "New role to assign to the invitation"
+                  }
+                },
+                "required": [
+                  "role"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "resourceType": {
+                      "enum": [
+                        "platform",
+                        "experiment"
+                      ],
+                      "type": "string"
+                    },
+                    "resourceId": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "uuid"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "email": {
+                      "type": "string",
+                      "format": "email"
+                    },
+                    "role": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "enum": [
+                        "pending",
+                        "accepted",
+                        "revoked"
+                      ],
+                      "type": "string"
+                    },
+                    "invitedBy": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "invitedByName": {
+                      "type": "string"
+                    },
+                    "resourceName": {
+                      "type": "string"
+                    },
+                    "createdAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "resourceType",
+                    "resourceId",
+                    "email",
+                    "role",
+                    "status",
+                    "invitedBy",
+                    "createdAt",
+                    "updatedAt"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
       "delete": {
         "operationId": "users.revokeInvitation",
         "parameters": [
@@ -18488,13 +18072,6 @@
                   "organizationId": {
                     "type": "string",
                     "format": "uuid"
-                  },
-                  "visibility": {
-                    "enum": [
-                      "private",
-                      "public"
-                    ],
-                    "type": "string"
                   }
                 },
                 "required": [
@@ -19621,33 +19198,6 @@
                     "experimentCount": {
                       "type": "integer",
                       "minimum": 0
-                    },
-                    "capabilities": {
-                      "type": "object",
-                      "properties": {
-                        "canContribute": {
-                          "type": "boolean"
-                        },
-                        "canUpdate": {
-                          "type": "boolean"
-                        },
-                        "canManage": {
-                          "type": "boolean"
-                        },
-                        "canShare": {
-                          "type": "boolean"
-                        },
-                        "canLeave": {
-                          "type": "boolean"
-                        }
-                      },
-                      "required": [
-                        "canContribute",
-                        "canUpdate",
-                        "canManage",
-                        "canShare",
-                        "canLeave"
-                      ]
                     }
                   },
                   "required": [
@@ -19660,8 +19210,7 @@
                     "visibility",
                     "createdBy",
                     "createdAt",
-                    "updatedAt",
-                    "capabilities"
+                    "updatedAt"
                   ]
                 }
               }
@@ -20755,73 +20304,6 @@
                     {
                       "not": {}
                     }
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/workbooks/{id}/visibility": {
-      "patch": {
-        "operationId": "workbooks.setVisibility",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "visibility": {
-                    "enum": [
-                      "private",
-                      "public"
-                    ],
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "visibility"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string",
-                      "format": "uuid"
-                    },
-                    "visibility": {
-                      "enum": [
-                        "private",
-                        "public"
-                      ],
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "visibility"
                   ]
                 }
               }

--- a/apps/docs/public/asyncapi.yaml
+++ b/apps/docs/public/asyncapi.yaml
@@ -79,7 +79,7 @@ channels:
         schema:
           type: string
       protocolId:
-        description: Legacy topic-carried protocol identifier; superseded by the payload protocol_id.
+        description: Legacy protocol identifier carried in the trailing topic segment; the lean topic shape omits it.
         schema:
           type: string
     subscribe:

--- a/apps/docs/public/asyncapi.yaml
+++ b/apps/docs/public/asyncapi.yaml
@@ -20,16 +20,18 @@ servers:
     description: AWS IoT Core production endpoint
 
 channels:
-  experiment/data_ingest/v1/{experimentId}/{sensorType}/{sensorVersion}/{sensorId}/{protocolId}:
+  experiment/data_ingest/v1/{experimentId}/{sensorType}/{sensorVersion}/{sensorId}:
+    x-infra-name: experiment_data_ingest_v1_lean
     description: |
-      Channel for ingesting experiment sensor data.
+      Channel for ingesting experiment sensor data. This shape carries no
+      protocol attribution in the topic; the pipeline records a null protocol_id
+      for rows ingested on it.
       The path parameters represent:
       <ul>
         <li><strong>experimentId:</strong> Unique identifier of the experiment (e.g., exp123).</li>
         <li><strong>sensorType:</strong> The type or family of sensor (e.g., MutlispeQ, Ambit...).</li>
         <li><strong>sensorVersion:</strong> Sensor firmware/hardware revision (without the 'v' prefix, e.g., 1, 2.1).</li>
         <li><strong>sensorId:</strong> Unique sensor identifier (UUID format recommended).</li>
-        <li><strong>protocolId:</strong> Unique identifier for the sampling or measurement protocol (e.g., protoA).</li>
       </ul>
     parameters:
       experimentId:
@@ -41,7 +43,36 @@ channels:
         schema:
           type: string
       sensorVersion:
-        description: Sensor firmware/hardware revision (e.g., v1, v2.1).
+        description: Sensor firmware/hardware revision (without the 'v' prefix, e.g., 1, 2.1).
+        schema:
+          type: string
+      sensorId:
+        description: Unique sensor identifier (UUID format recommended).
+        schema:
+          type: string
+    subscribe:
+      operationId: ingestExperimentData
+      summary: Ingest experiment sensor data.
+      message:
+        $ref: "#/components/messages/ExperimentDataMessage"
+
+  experiment/data_ingest/v1/{experimentId}/{sensorType}/{sensorVersion}/{sensorId}/{protocolId}:
+    description: |
+      TRANSITIONAL: the legacy ingest shape with a trailing protocolId segment,
+      published by fielded mobile builds. New publishers must use the shape
+      without protocolId. Delete this channel once the mobile fleet has rolled
+      over to a template without the protocolId segment.
+    parameters:
+      experimentId:
+        description: Unique identifier of the experiment (e.g., exp123).
+        schema:
+          type: string
+      sensorType:
+        description: The type or family of sensor (e.g., MutlispeQ, Ambit...).
+        schema:
+          type: string
+      sensorVersion:
+        description: Sensor firmware/hardware revision (without the 'v' prefix, e.g., 1, 2.1).
         schema:
           type: string
       sensorId:
@@ -49,12 +80,12 @@ channels:
         schema:
           type: string
       protocolId:
-        description: Unique identifier for the sampling or measurement protocol (e.g., protoA).
+        description: Legacy topic-carried protocol identifier; superseded by the payload protocol_id.
         schema:
           type: string
     subscribe:
-      operationId: ingestExperimentData
-      summary: Ingest experiment sensor data.
+      operationId: ingestExperimentDataLegacy
+      summary: Ingest experiment sensor data (legacy topic shape).
       message:
         $ref: "#/components/messages/ExperimentDataMessage"
 

--- a/apps/docs/public/asyncapi.yaml
+++ b/apps/docs/public/asyncapi.yaml
@@ -60,8 +60,7 @@ channels:
     description: |
       TRANSITIONAL: the legacy ingest shape with a trailing protocolId segment,
       published by fielded mobile builds. New publishers must use the shape
-      without protocolId. Delete this channel once the mobile fleet has rolled
-      over to a template without the protocolId segment.
+      without protocolId.
     parameters:
       experimentId:
         description: Unique identifier of the experiment (e.g., exp123).

--- a/asyncapi.yaml
+++ b/asyncapi.yaml
@@ -79,7 +79,7 @@ channels:
         schema:
           type: string
       protocolId:
-        description: Legacy topic-carried protocol identifier; superseded by the payload protocol_id.
+        description: Legacy protocol identifier carried in the trailing topic segment; the lean topic shape omits it.
         schema:
           type: string
     subscribe:

--- a/asyncapi.yaml
+++ b/asyncapi.yaml
@@ -23,8 +23,9 @@ channels:
   experiment/data_ingest/v1/{experimentId}/{sensorType}/{sensorVersion}/{sensorId}:
     x-infra-name: experiment_data_ingest_v1_lean
     description: |
-      Channel for ingesting experiment sensor data. Protocol attribution travels
-      in the payload (protocol_id), not the topic.
+      Channel for ingesting experiment sensor data. This shape carries no
+      protocol attribution in the topic; the pipeline records a null protocol_id
+      for rows ingested on it.
       The path parameters represent:
       <ul>
         <li><strong>experimentId:</strong> Unique identifier of the experiment (e.g., exp123).</li>
@@ -42,7 +43,7 @@ channels:
         schema:
           type: string
       sensorVersion:
-        description: Sensor firmware/hardware revision (e.g., v1, v2.1).
+        description: Sensor firmware/hardware revision (without the 'v' prefix, e.g., 1, 2.1).
         schema:
           type: string
       sensorId:
@@ -71,7 +72,7 @@ channels:
         schema:
           type: string
       sensorVersion:
-        description: Sensor firmware/hardware revision (e.g., v1, v2.1).
+        description: Sensor firmware/hardware revision (without the 'v' prefix, e.g., 1, 2.1).
         schema:
           type: string
       sensorId:

--- a/asyncapi.yaml
+++ b/asyncapi.yaml
@@ -20,16 +20,17 @@ servers:
     description: AWS IoT Core production endpoint
 
 channels:
-  experiment/data_ingest/v1/{experimentId}/{sensorType}/{sensorVersion}/{sensorId}/{protocolId}:
+  experiment/data_ingest/v1/{experimentId}/{sensorType}/{sensorVersion}/{sensorId}:
+    x-infra-name: experiment_data_ingest_v1_lean
     description: |
-      Channel for ingesting experiment sensor data.
+      Channel for ingesting experiment sensor data. Protocol attribution travels
+      in the payload (protocol_id), not the topic.
       The path parameters represent:
       <ul>
         <li><strong>experimentId:</strong> Unique identifier of the experiment (e.g., exp123).</li>
         <li><strong>sensorType:</strong> The type or family of sensor (e.g., MutlispeQ, Ambit...).</li>
         <li><strong>sensorVersion:</strong> Sensor firmware/hardware revision (without the 'v' prefix, e.g., 1, 2.1).</li>
         <li><strong>sensorId:</strong> Unique sensor identifier (UUID format recommended).</li>
-        <li><strong>protocolId:</strong> Unique identifier for the sampling or measurement protocol (e.g., protoA).</li>
       </ul>
     parameters:
       experimentId:
@@ -48,13 +49,42 @@ channels:
         description: Unique sensor identifier (UUID format recommended).
         schema:
           type: string
-      protocolId:
-        description: Unique identifier for the sampling or measurement protocol (e.g., protoA).
-        schema:
-          type: string
     subscribe:
       operationId: ingestExperimentData
       summary: Ingest experiment sensor data.
+      message:
+        $ref: "#/components/messages/ExperimentDataMessage"
+
+  experiment/data_ingest/v1/{experimentId}/{sensorType}/{sensorVersion}/{sensorId}/{protocolId}:
+    description: |
+      TRANSITIONAL: the legacy ingest shape with a trailing protocolId segment,
+      published by fielded mobile builds. New publishers must use the shape
+      without protocolId. Delete this channel once the mobile fleet has rolled
+      over to a template without the protocolId segment.
+    parameters:
+      experimentId:
+        description: Unique identifier of the experiment (e.g., exp123).
+        schema:
+          type: string
+      sensorType:
+        description: The type or family of sensor (e.g., MutlispeQ, Ambit...).
+        schema:
+          type: string
+      sensorVersion:
+        description: Sensor firmware/hardware revision (e.g., v1, v2.1).
+        schema:
+          type: string
+      sensorId:
+        description: Unique sensor identifier (UUID format recommended).
+        schema:
+          type: string
+      protocolId:
+        description: Legacy topic-carried protocol identifier; superseded by the payload protocol_id.
+        schema:
+          type: string
+    subscribe:
+      operationId: ingestExperimentDataLegacy
+      summary: Ingest experiment sensor data (legacy topic shape).
       message:
         $ref: "#/components/messages/ExperimentDataMessage"
 

--- a/asyncapi.yaml
+++ b/asyncapi.yaml
@@ -60,8 +60,7 @@ channels:
     description: |
       TRANSITIONAL: the legacy ingest shape with a trailing protocolId segment,
       published by fielded mobile builds. New publishers must use the shape
-      without protocolId. Delete this channel once the mobile fleet has rolled
-      over to a template without the protocolId segment.
+      without protocolId.
     parameters:
       experimentId:
         description: Unique identifier of the experiment (e.g., exp123).

--- a/infrastructure/modules/cognito/main.tf
+++ b/infrastructure/modules/cognito/main.tf
@@ -45,9 +45,13 @@ resource "aws_iam_policy" "unauth_iot" {
         Resource = "arn:aws:iot:${var.region}:${data.aws_caller_identity.current.account_id}:client/*"
       },
       {
-        Effect   = "Allow"
-        Action   = ["iot:Publish"]
-        Resource = "arn:aws:iot:${var.region}:${data.aws_caller_identity.current.account_id}:topic/experiment/data_ingest/v1/*/*/*/*/*"
+        Effect = "Allow"
+        Action = ["iot:Publish"]
+        # Lean (4 params) and transitional legacy (5 params) ingest topic shapes.
+        Resource = [
+          "arn:aws:iot:${var.region}:${data.aws_caller_identity.current.account_id}:topic/experiment/data_ingest/v1/*/*/*/*",
+          "arn:aws:iot:${var.region}:${data.aws_caller_identity.current.account_id}:topic/experiment/data_ingest/v1/*/*/*/*/*"
+        ]
       }
     ]
   })
@@ -101,9 +105,13 @@ resource "aws_iam_policy" "auth_iot" {
         Resource = "arn:aws:iot:${var.region}:${data.aws_caller_identity.current.account_id}:client/*"
       },
       {
-        Effect   = "Allow"
-        Action   = ["iot:Publish"]
-        Resource = "arn:aws:iot:${var.region}:${data.aws_caller_identity.current.account_id}:topic/experiment/data_ingest/v1/*/*/*/*/*"
+        Effect = "Allow"
+        Action = ["iot:Publish"]
+        # Lean (4 params) and transitional legacy (5 params) ingest topic shapes.
+        Resource = [
+          "arn:aws:iot:${var.region}:${data.aws_caller_identity.current.account_id}:topic/experiment/data_ingest/v1/*/*/*/*",
+          "arn:aws:iot:${var.region}:${data.aws_caller_identity.current.account_id}:topic/experiment/data_ingest/v1/*/*/*/*/*"
+        ]
       }
     ]
   })

--- a/infrastructure/modules/iot-core/main.tf
+++ b/infrastructure/modules/iot-core/main.tf
@@ -31,10 +31,18 @@ locals {
     contains(keys(details), "publish") ? ["iot:Subscribe"] : []
   }
 
-  # Compute a friendly name for each IoT topic rule based on the static portion of the channel.
+  # Friendly name per channel: the static topic prefix, unless the channel sets
+  # x-infra-name (needed when two channels share a prefix, e.g. the lean and
+  # legacy ingest shapes). Existing channels must never change names: policies
+  # are attached to live certificates.
+  iot_infra_names = {
+    for channel, details in local.asyncapi.channels : channel =>
+    lookup(details, "x-infra-name", replace(trim(split("/{", channel)[0], "/"), "/", "_"))
+  }
+
   iot_rule_names = {
     for channel in local.all_channels : channel =>
-    "open_jii_${var.environment}_iot_rule_${replace(trim(split("/{", channel)[0], "/"), "/", "_")}"
+    "open_jii_${var.environment}_iot_rule_${local.iot_infra_names[channel]}"
   }
 
   # Convert the channel into a topic filter by replacing any parameter segment with "+"
@@ -67,10 +75,9 @@ locals {
     if contains(keys(details), "subscribe")
   }
 
-  # Friendly name per channel, derived from the channel's static prefix.
   iot_policy_names = {
     for channel in local.all_channels : channel =>
-    "open_jii_${var.environment}_iot_policy_${replace(trim(split("/{", channel)[0], "/"), "/", "_")}"
+    "open_jii_${var.environment}_iot_policy_${local.iot_infra_names[channel]}"
   }
 }
 


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Removes the trailing `{protocolId}` segment from the MQTT ingest topic. The lean shape is now the canonical channel; the old 8-segment shape stays as a clearly marked transitional channel until the mobile fleet rolls over.

```
experiment/data_ingest/v1/{experimentId}/{sensorType}/{sensorVersion}/{sensorId}
```

### Why

- The segment carried no routing or security value: nothing subscribes per protocol, and the IoT policy renders it as a wildcard.
- Nothing consumes it downstream: gold and enriched pass the column through, no join, filter, or grouping anywhere.
- It was extracted **wrong** the whole time: the silver pipeline read segment 4 (the sensor family) and labeled it `protocol_id`, so the warehouse column contains values like `ambyte` instead of a protocol id for every MQTT row. The true id sits unparsed in the stored raw `topic` column and is backfillable.
- New procedure types (inline commands) have no protocolId, so the old contract could not even name their topic.

Protocol attribution belongs in the payload or is derivable from `workbook_version_id` (already sent). The payload schema is deliberately untouched by this PR.

### Changes

- **asyncapi.yaml**: ingest channel redefined without `{protocolId}`; the legacy 8-segment shape kept as a transitional channel (delete after mobile rollover). `x-infra-name` on the lean channel because both now share a static prefix.
- **infrastructure/modules/iot-core/main.tf**: rule and policy names honor an optional `x-infra-name` channel extension. Existing channels keep their derived names, so no live resource is renamed or replaced (policies are attached to live identities).
- **silver clean_data.py**: `protocol_id` is now taken from the legacy topic's trailing segment only (correct position), and is null on the lean shape. Fixes the wrong-segment extraction.
- **ADR** `mqtt-topic-proposal.mdx`: superseding note.

## OJD-1602