### PR TITLE
fix(iot): restore ambit protocol measurements over direct connection

### DIFF
--- a/apps/web/hooks/iot/useIotProtocolExecution/useIotProtocolExecution.test.ts
+++ b/apps/web/hooks/iot/useIotProtocolExecution/useIotProtocolExecution.test.ts
@@ -166,6 +166,41 @@ describe("useIotProtocolExecution", () => {
     });
   });
 
+  describe("ambit execution", () => {
+    it("sends protocol JSON directly as a single command (no command-cell rejection)", async () => {
+      const envelope = { sample: [{ protocol_id: "NaN", set: [{ s_630: [159] }] }] };
+      const mockExecute = vi.fn().mockResolvedValueOnce({ success: true, data: envelope });
+      const mockDriver: Partial<IDeviceDriver> = { execute: mockExecute };
+
+      const { result } = renderHook(() =>
+        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambit"),
+      );
+
+      const protocolCode = [{ label: "arrun,1,0,2,0,0,9,0,1,0,1" }];
+      const data = await result.current.executeProtocol(protocolCode);
+
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+      expect(mockExecute).toHaveBeenCalledWith(protocolCode);
+      expect(data).toEqual(envelope);
+    });
+
+    it("throws the device error when execution fails", async () => {
+      const mockExecute = vi.fn().mockResolvedValueOnce({
+        success: false,
+        error: { message: "Ambit rejected the protocol: json_parse" },
+      });
+      const mockDriver: Partial<IDeviceDriver> = { execute: mockExecute };
+
+      const { result } = renderHook(() =>
+        useIotProtocolExecution(mockDriver as IDeviceDriver, true, "ambit"),
+      );
+
+      await expect(result.current.executeProtocol([{ label: "arrun,1,0" }])).rejects.toThrow(
+        "Ambit rejected the protocol: json_parse",
+      );
+    });
+  });
+
   describe("generic/ambyte execution", () => {
     it("executes SET_CONFIG, RUN, GET_DATA steps in order", async () => {
       const mockExecute = vi

--- a/apps/web/hooks/iot/useIotProtocolExecution/useIotProtocolExecution.ts
+++ b/apps/web/hooks/iot/useIotProtocolExecution/useIotProtocolExecution.ts
@@ -37,18 +37,11 @@ export async function executeProtocolWithDriver(
   sensorFamily: SensorFamily,
   protocolCode: Record<string, unknown>[],
 ): Promise<unknown> {
-  if (sensorFamily === "multispeq" || sensorFamily === "minipar") {
-    // MultispeQ + MiniPAR: send the protocol JSON array directly; the device
+  if (sensorFamily === "multispeq" || sensorFamily === "minipar" || sensorFamily === "ambit") {
+    // MultispeQ + MiniPAR + Ambit: send the protocol JSON directly; the device
     // runs the measurement and replies one envelope.
     const result = await driver.execute(protocolCode);
     return parseResponseData(unwrap(result, "Protocol execution failed"));
-  }
-
-  if (sensorFamily === "ambit") {
-    // Ambit measures via its Ambyte gateway; a direct session is command/response.
-    throw new Error(
-      "Ambit devices do not run protocol cells over a direct connection. Use a command cell instead.",
-    );
   }
 
   // Generic: load config → run → retrieve data

--- a/packages/iot/src/driver/ambit/config.ts
+++ b/packages/iot/src/driver/ambit/config.ts
@@ -25,6 +25,17 @@ export const AMBIT_FRAMING = {
   SLEEP_AFTER_IDLE_MS: 20_000,
   /** `hello` replies `NEW <name> Ready`; the name is firmware-hardcoded, never trust it. */
   READY_SENTINEL: "NEW",
+  /**
+   * JSON-envelope replies end with this constant sentinel before the newline
+   * (same openjii_proto framing as MiniPAR; a fixed footer, not a checksum).
+   */
+  FRAME_FOOTER: "7A1E3AA1",
+  FOOTER_LENGTH: 8,
+  /**
+   * JSON protocol timeout: an arrun runs pulses x tick_factor/freq seconds per
+   * segment and multi-segment traces can take minutes.
+   */
+  PROTOCOL_TIMEOUT: 120_000,
 } as const;
 
 export interface AmbitDriverConfig {
@@ -32,4 +43,6 @@ export interface AmbitDriverConfig {
   timeoutMs?: number;
   /** RX quiet window in ms that completes an unframed reply (default 300). */
   quietWindowMs?: number;
+  /** JSON protocol reply timeout in ms (default 120000). */
+  protocolTimeoutMs?: number;
 }

--- a/packages/iot/src/driver/ambit/config.ts
+++ b/packages/iot/src/driver/ambit/config.ts
@@ -1,3 +1,5 @@
+import { OPENJII_FRAME_FOOTER } from "../../utils/framing/openjii-envelope";
+
 /** Ambit serial defaults (ESP32 USB-CDC console). */
 export const AMBIT_SERIAL_DEFAULTS = {
   baudRate: 115200,
@@ -29,8 +31,7 @@ export const AMBIT_FRAMING = {
    * JSON-envelope replies end with this constant sentinel before the newline
    * (same openjii_proto framing as MiniPAR; a fixed footer, not a checksum).
    */
-  FRAME_FOOTER: "7A1E3AA1",
-  FOOTER_LENGTH: 8,
+  FRAME_FOOTER: OPENJII_FRAME_FOOTER,
   /**
    * JSON protocol timeout: an arrun runs pulses x tick_factor/freq seconds per
    * segment and multi-segment traces can take minutes.

--- a/packages/iot/src/driver/ambit/driver.spec.ts
+++ b/packages/iot/src/driver/ambit/driver.spec.ts
@@ -71,14 +71,77 @@ describe("AmbitDriver", () => {
     expect(overflow).toHaveBeenCalledWith({ discardedBytes: DEFAULT_MAX_BUFFER_SIZE + 1 });
   });
 
-  it("rejects protocol JSON with a command-cell hint", async () => {
-    const transport = tableTransport({ "hello\n": HELLO_REPLY });
+  it("runs protocol JSON as one write and parses the footer-framed envelope", async () => {
+    const protocol = [{ label: "arrun,1,0,2,0,0,9,0,1,0,1" }];
+    const envelope =
+      '{"device_name":"Ambit","device_version":"1.1.4","device_battery":0,' +
+      '"device_firmware":"1.1.4","sample":[{"protocol_id":"NaN","set":[' +
+      '{"env":[{"temp_c":23.10}],"s_630":[159,164],"r_630":[4605,4604]}]}]}';
+    const transport = tableTransport({
+      "hello\n": HELLO_REPLY,
+      [`${JSON.stringify(protocol)}\n`]: [envelope.slice(0, 40), envelope.slice(40), "7A1E3AA1\n"],
+    });
     const driver = fastDriver();
     await driver.initialize(transport);
 
-    const result = await driver.execute([{ set: [] }]);
+    const result = await driver.execute<{ sample: { set: unknown[] }[] }>(protocol);
+
+    expect(result.success).toBe(true);
+    expect(result.checksum).toBe("7A1E3AA1");
+    expect(result.data?.sample[0].set).toHaveLength(1);
+    // The protocol went out as ONE write, JSON-serialized.
+    expect(transport.send).toHaveBeenCalledWith(`${JSON.stringify(protocol)}\n`);
+  });
+
+  it("re-wakes the device before a protocol write after console idle", async () => {
+    const protocol = [{ label: "arrun,1,0,2,0,0,9,0,1,0,1" }];
+    const envelope = '{"sample":[{"protocol_id":"NaN","set":[{"s_630":[1]}]}]}7A1E3AA1\n';
+    const transport = tableTransport({
+      "hello\n": HELLO_REPLY,
+      [`${JSON.stringify(protocol)}\n`]: envelope,
+    });
+    const driver = fastDriver();
+    await driver.initialize(transport);
+    vi.mocked(transport.send).mockClear();
+    vi.spyOn(Date, "now").mockReturnValue(Date.now() + 30_000);
+
+    const result = await driver.execute(protocol);
+
+    expect(result.success).toBe(true);
+    expect(vi.mocked(transport.send).mock.calls.map(([payload]) => payload)).toEqual([
+      "hello\n",
+      `${JSON.stringify(protocol)}\n`,
+    ]);
+  });
+
+  it("surfaces a footer-less top-level error reply as a protocol failure", async () => {
+    const protocol = [{ label: "arrun,1,0" }];
+    const transport = tableTransport({
+      "hello\n": HELLO_REPLY,
+      [`${JSON.stringify(protocol)}\n`]: '{"error":"json_parse","detail":"InvalidInput"}\n',
+    });
+    const driver = fastDriver();
+    await driver.initialize(transport);
+
+    const result = await driver.execute(protocol);
+
     expect(result.success).toBe(false);
-    expect(result.error?.message).toMatch(/command cell/);
+    expect(result.error?.message).toMatch(/json_parse/);
+  });
+
+  it("times out a protocol whose envelope never completes", async () => {
+    const protocol = [{ label: "arrun,1,0,2,0,0,9,0,1,0,1" }];
+    const transport = tableTransport({
+      "hello\n": HELLO_REPLY,
+      [`${JSON.stringify(protocol)}\n`]: '{"sample":[{"set":[', // no footer, ever
+    });
+    const driver = fastDriver();
+    await driver.initialize(transport);
+
+    const result = await driver.execute(protocol, { timeoutMs: 80 });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toBe("Response timeout");
   });
 
   it("parses the two-line get_par reply into par + channels", async () => {

--- a/packages/iot/src/driver/ambit/driver.ts
+++ b/packages/iot/src/driver/ambit/driver.ts
@@ -1,16 +1,21 @@
 /**
- * Ambit driver: plain-text serial console, command/response only.
+ * Ambit driver: dual-mode serial session, like MiniPAR.
  *
- * The firmware has NO reply framing (free-text lines, silent writers, no
- * terminator), so replies are collected until an RX quiet window elapses.
- * The device light-sleeps after console idle and prints a wake byte >127;
- * `initialize()`/`ensureAwake()` run the Calibratron-style hello poll until
- * the `NEW ... Ready` sentinel answers. Protocol JSON is rejected outright:
- * an Ambit measures via its Ambyte gateway, a direct session is for
- * calibration commands and spot readings.
+ * Text console (string commands): the firmware has NO reply framing
+ * (free-text lines, silent writers, no terminator), so replies are collected
+ * until an RX quiet window elapses. The device light-sleeps after console
+ * idle and prints a wake byte >127; `initialize()`/`ensureAwake()` run the
+ * Calibratron-style hello poll until the `NEW ... Ready` sentinel answers.
+ *
+ * JSON envelope (object/array commands): the firmware's openJII protocol
+ * module runs measurements (`arrun`) sent as protocol JSON and replies one
+ * envelope of `device_*` header fields plus a `sample` array, terminated by
+ * the constant `7A1E3AA1` footer. The wake poll still runs first: a
+ * protocol write must not race the sleep loop.
  */
 import type { DeviceIdentity, SensorFamily } from "../../core/families";
 import type { ITransportAdapter } from "../../transport/interface";
+import { extractChecksum } from "../../utils/framing/framing";
 import type { Logger } from "../../utils/logger/logger";
 import { DeviceDriver } from "../driver-base";
 import type { CommandResult, ExecuteOptions } from "../driver-base";
@@ -22,7 +27,7 @@ import {
 } from "./commands";
 import { AMBIT_FRAMING } from "./config";
 import type { AmbitDriverConfig } from "./config";
-import type { AmbitStreamEvents } from "./interface";
+import type { AmbitMeasurementEnvelope, AmbitStreamEvents } from "./interface";
 import { AMBIT_REPLY_PARSERS } from "./response-parsers";
 
 function delay(ms: number): Promise<void> {
@@ -34,6 +39,7 @@ export class AmbitDriver extends DeviceDriver<AmbitStreamEvents> {
 
   private readonly defaultTimeoutMs: number;
   private readonly quietWindowMs: number;
+  private readonly protocolTimeoutMs: number;
 
   private rxBuffer = "";
   private onChunk: (() => void) | undefined;
@@ -43,6 +49,7 @@ export class AmbitDriver extends DeviceDriver<AmbitStreamEvents> {
     super(logger);
     this.defaultTimeoutMs = config?.timeoutMs ?? AMBIT_FRAMING.DEFAULT_TIMEOUT;
     this.quietWindowMs = config?.quietWindowMs ?? AMBIT_FRAMING.QUIET_WINDOW_MS;
+    this.protocolTimeoutMs = config?.protocolTimeoutMs ?? AMBIT_FRAMING.PROTOCOL_TIMEOUT;
   }
 
   override async initialize(transport: ITransportAdapter): Promise<void> {
@@ -156,6 +163,127 @@ export class AmbitDriver extends DeviceDriver<AmbitStreamEvents> {
     await this.wake();
   }
 
+  /** Strip and verify the constant footer; null when the envelope is not complete yet. */
+  private static parseEnvelope(buffer: string): AmbitMeasurementEnvelope | null {
+    const trimmed = buffer.trim();
+    if (!trimmed.endsWith(AMBIT_FRAMING.FRAME_FOOTER)) return null;
+    const { data } = extractChecksum(trimmed, AMBIT_FRAMING.FOOTER_LENGTH);
+    try {
+      const parsed: unknown = JSON.parse(data);
+      if (parsed !== null && typeof parsed === "object") {
+        return parsed as AmbitMeasurementEnvelope;
+      }
+    } catch {
+      // footer seen but JSON incomplete/corrupt; keep buffering
+    }
+    return null;
+  }
+
+  /**
+   * Top-level protocol errors (json_parse, rx_overflow, json_timeout) are
+   * single JSON lines WITHOUT the footer. In-envelope errors (e.g. bad_arrun
+   * inside `set`) stay inline in the returned data, as with MiniPAR.
+   */
+  private static parseProtocolError(buffer: string): string | null {
+    for (const line of buffer.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith('{"error"')) continue;
+      try {
+        const parsed: unknown = JSON.parse(trimmed);
+        if (
+          parsed !== null &&
+          typeof parsed === "object" &&
+          typeof (parsed as Record<string, unknown>).error === "string"
+        ) {
+          return (parsed as Record<string, unknown>).error as string;
+        }
+      } catch {
+        // not a complete error line; keep buffering
+      }
+    }
+    return null;
+  }
+
+  /** Send one payload and collect until `isComplete`; reject on the overall timeout. */
+  private async sendAndCollectUntil(
+    payload: string,
+    isComplete: (buffer: string) => boolean,
+    timeoutMs: number,
+  ): Promise<string> {
+    if (!this.transport) {
+      throw new Error("Transport not initialized");
+    }
+    this.rxBuffer = "";
+    this.lastTrafficAt = Date.now();
+    await this.transport.send(payload);
+
+    return new Promise<string>((resolve, reject) => {
+      const overallTimer = setTimeout(() => {
+        cleanup();
+        reject(new Error("Response timeout"));
+      }, timeoutMs);
+
+      const cleanup = () => {
+        clearTimeout(overallTimer);
+        this.onChunk = undefined;
+      };
+
+      const check = () => {
+        if (!isComplete(this.rxBuffer)) return;
+        cleanup();
+        const reply = this.rxBuffer;
+        this.rxBuffer = "";
+        void this.emitter.emit("receivedReply", reply);
+        resolve(reply);
+      };
+
+      this.onChunk = check;
+      check();
+    });
+  }
+
+  /** Run protocol JSON through the firmware's openJII envelope: one write, footer-framed reply. */
+  private async executeProtocol<T>(
+    command: object,
+    options?: ExecuteOptions,
+  ): Promise<CommandResult<T>> {
+    return this.commandQueue.enqueue(async () => {
+      try {
+        await this.ensureAwake();
+
+        const payload = `${JSON.stringify(command)}${AMBIT_FRAMING.LINE_ENDING}`;
+        const reply = await this.sendAndCollectUntil(
+          payload,
+          (buffer) =>
+            AmbitDriver.parseEnvelope(buffer) !== null ||
+            AmbitDriver.parseProtocolError(buffer) !== null,
+          options?.timeoutMs ?? this.protocolTimeoutMs,
+        );
+
+        const envelope = AmbitDriver.parseEnvelope(reply);
+        if (envelope) {
+          void this.emitter.emit("receivedEnvelope", envelope);
+          return {
+            success: true,
+            data: envelope as T,
+            checksum: AMBIT_FRAMING.FRAME_FOOTER,
+          };
+        }
+        const errorCode = AmbitDriver.parseProtocolError(reply);
+        if (errorCode) {
+          throw new Error(`Ambit rejected the protocol: ${errorCode}`);
+        }
+        void this.emitter.emit("parseError", { line: reply, error: "incomplete envelope" });
+        throw new Error("Ambit reply was not a complete measurement envelope");
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error : new Error(String(error)),
+        };
+      }
+    });
+  }
+
   async execute<T = unknown>(
     command: string | object,
     options?: ExecuteOptions,
@@ -163,12 +291,7 @@ export class AmbitDriver extends DeviceDriver<AmbitStreamEvents> {
     this.ensureInitialized();
 
     if (typeof command !== "string") {
-      return {
-        success: false,
-        error: new Error(
-          "Ambit does not accept protocol JSON. Use a command cell (hello, get_par, set_spec, ...)",
-        ),
-      };
+      return this.executeProtocol<T>(command, options);
     }
 
     return this.commandQueue.enqueue(async () => {

--- a/packages/iot/src/driver/ambit/driver.ts
+++ b/packages/iot/src/driver/ambit/driver.ts
@@ -15,7 +15,12 @@
  */
 import type { DeviceIdentity, SensorFamily } from "../../core/families";
 import type { ITransportAdapter } from "../../transport/interface";
-import { extractChecksum } from "../../utils/framing/framing";
+import {
+  collectReply,
+  parseOpenJiiEnvelope,
+  parseOpenJiiTopLevelError,
+} from "../../utils/framing/openjii-envelope";
+import type { RxCollectorHooks } from "../../utils/framing/openjii-envelope";
 import type { Logger } from "../../utils/logger/logger";
 import { DeviceDriver } from "../driver-base";
 import type { CommandResult, ExecuteOptions } from "../driver-base";
@@ -27,7 +32,7 @@ import {
 } from "./commands";
 import { AMBIT_FRAMING } from "./config";
 import type { AmbitDriverConfig } from "./config";
-import type { AmbitMeasurementEnvelope, AmbitStreamEvents } from "./interface";
+import type { AmbitStreamEvents } from "./interface";
 import { AMBIT_REPLY_PARSERS } from "./response-parsers";
 
 function delay(ms: number): Promise<void> {
@@ -85,6 +90,19 @@ export class AmbitDriver extends DeviceDriver<AmbitStreamEvents> {
     this.onChunk?.();
   }
 
+  /** RX hooks over this driver's buffer for the shared reply collector. */
+  private readonly rxHooks: RxCollectorHooks = {
+    read: () => this.rxBuffer,
+    take: () => {
+      const reply = this.rxBuffer;
+      this.rxBuffer = "";
+      return reply;
+    },
+    setOnChunk: (cb) => {
+      this.onChunk = cb;
+    },
+  };
+
   /**
    * Send one payload and collect the unframed reply: resolves once data has
    * arrived and `quietWindowMs` passes without more, rejects on `timeoutMs`
@@ -102,39 +120,13 @@ export class AmbitDriver extends DeviceDriver<AmbitStreamEvents> {
     this.lastTrafficAt = Date.now();
     await this.transport.send(payload);
 
-    return new Promise<string>((resolve, reject) => {
-      let quietTimer: ReturnType<typeof setTimeout> | undefined;
-
-      const finish = () => {
-        cleanup();
-        const reply = this.rxBuffer;
-        this.rxBuffer = "";
-        void this.emitter.emit("receivedReply", reply);
-        resolve(reply);
-      };
-
-      const overallTimer = setTimeout(() => {
-        if (this.rxBuffer.trim().length > 0) {
-          finish();
-          return;
-        }
-        cleanup();
-        reject(new Error("Response timeout"));
-      }, timeoutMs);
-
-      const cleanup = () => {
-        clearTimeout(overallTimer);
-        if (quietTimer) clearTimeout(quietTimer);
-        this.onChunk = undefined;
-      };
-
-      this.onChunk = () => {
-        if (quietTimer) clearTimeout(quietTimer);
-        quietTimer = setTimeout(() => {
-          if (this.rxBuffer.trim().length > 0) finish();
-        }, quietWindowMs);
-      };
+    const reply = await collectReply(this.rxHooks, {
+      isComplete: () => false,
+      quietMs: quietWindowMs,
+      timeoutMs,
     });
+    void this.emitter.emit("receivedReply", reply);
+    return reply;
   }
 
   /** Poll hello until the ready sentinel answers (Calibratron's wake loop). */
@@ -163,85 +155,6 @@ export class AmbitDriver extends DeviceDriver<AmbitStreamEvents> {
     await this.wake();
   }
 
-  /** Strip and verify the constant footer; null when the envelope is not complete yet. */
-  private static parseEnvelope(buffer: string): AmbitMeasurementEnvelope | null {
-    const trimmed = buffer.trim();
-    if (!trimmed.endsWith(AMBIT_FRAMING.FRAME_FOOTER)) return null;
-    const { data } = extractChecksum(trimmed, AMBIT_FRAMING.FOOTER_LENGTH);
-    try {
-      const parsed: unknown = JSON.parse(data);
-      if (parsed !== null && typeof parsed === "object") {
-        return parsed as AmbitMeasurementEnvelope;
-      }
-    } catch {
-      // footer seen but JSON incomplete/corrupt; keep buffering
-    }
-    return null;
-  }
-
-  /**
-   * Top-level protocol errors (json_parse, rx_overflow, json_timeout) are
-   * single JSON lines WITHOUT the footer. In-envelope errors (e.g. bad_arrun
-   * inside `set`) stay inline in the returned data, as with MiniPAR.
-   */
-  private static parseProtocolError(buffer: string): string | null {
-    for (const line of buffer.split("\n")) {
-      const trimmed = line.trim();
-      if (!trimmed.startsWith('{"error"')) continue;
-      try {
-        const parsed: unknown = JSON.parse(trimmed);
-        if (
-          parsed !== null &&
-          typeof parsed === "object" &&
-          typeof (parsed as Record<string, unknown>).error === "string"
-        ) {
-          return (parsed as Record<string, unknown>).error as string;
-        }
-      } catch {
-        // not a complete error line; keep buffering
-      }
-    }
-    return null;
-  }
-
-  /** Send one payload and collect until `isComplete`; reject on the overall timeout. */
-  private async sendAndCollectUntil(
-    payload: string,
-    isComplete: (buffer: string) => boolean,
-    timeoutMs: number,
-  ): Promise<string> {
-    if (!this.transport) {
-      throw new Error("Transport not initialized");
-    }
-    this.rxBuffer = "";
-    this.lastTrafficAt = Date.now();
-    await this.transport.send(payload);
-
-    return new Promise<string>((resolve, reject) => {
-      const overallTimer = setTimeout(() => {
-        cleanup();
-        reject(new Error("Response timeout"));
-      }, timeoutMs);
-
-      const cleanup = () => {
-        clearTimeout(overallTimer);
-        this.onChunk = undefined;
-      };
-
-      const check = () => {
-        if (!isComplete(this.rxBuffer)) return;
-        cleanup();
-        const reply = this.rxBuffer;
-        this.rxBuffer = "";
-        void this.emitter.emit("receivedReply", reply);
-        resolve(reply);
-      };
-
-      this.onChunk = check;
-      check();
-    });
-  }
-
   /** Run protocol JSON through the firmware's openJII envelope: one write, footer-framed reply. */
   private async executeProtocol<T>(
     command: object,
@@ -250,17 +163,22 @@ export class AmbitDriver extends DeviceDriver<AmbitStreamEvents> {
     return this.commandQueue.enqueue(async () => {
       try {
         await this.ensureAwake();
+        if (!this.transport) {
+          throw new Error("Transport not initialized");
+        }
 
-        const payload = `${JSON.stringify(command)}${AMBIT_FRAMING.LINE_ENDING}`;
-        const reply = await this.sendAndCollectUntil(
-          payload,
-          (buffer) =>
-            AmbitDriver.parseEnvelope(buffer) !== null ||
-            AmbitDriver.parseProtocolError(buffer) !== null,
-          options?.timeoutMs ?? this.protocolTimeoutMs,
-        );
+        this.rxBuffer = "";
+        this.lastTrafficAt = Date.now();
+        await this.transport.send(`${JSON.stringify(command)}${AMBIT_FRAMING.LINE_ENDING}`);
+        const reply = await collectReply(this.rxHooks, {
+          isComplete: (buffer) =>
+            parseOpenJiiEnvelope(buffer) !== null || parseOpenJiiTopLevelError(buffer) !== null,
+          timeoutMs: options?.timeoutMs ?? this.protocolTimeoutMs,
+          strictTimeout: true,
+        });
+        void this.emitter.emit("receivedReply", reply);
 
-        const envelope = AmbitDriver.parseEnvelope(reply);
+        const envelope = parseOpenJiiEnvelope(reply);
         if (envelope) {
           void this.emitter.emit("receivedEnvelope", envelope);
           return {
@@ -269,7 +187,7 @@ export class AmbitDriver extends DeviceDriver<AmbitStreamEvents> {
             checksum: AMBIT_FRAMING.FRAME_FOOTER,
           };
         }
-        const errorCode = AmbitDriver.parseProtocolError(reply);
+        const errorCode = parseOpenJiiTopLevelError(reply);
         if (errorCode) {
           throw new Error(`Ambit rejected the protocol: ${errorCode}`);
         }

--- a/packages/iot/src/driver/ambit/interface.ts
+++ b/packages/iot/src/driver/ambit/interface.ts
@@ -1,3 +1,5 @@
+import type { OpenJiiMeasurementEnvelope } from "../../utils/framing/openjii-envelope";
+
 /** Events emitted by the Ambit driver */
 export interface AmbitStreamEvents extends Record<string, unknown> {
   /** A reply finished collecting (quiet window elapsed). */
@@ -12,14 +14,7 @@ export interface AmbitStreamEvents extends Record<string, unknown> {
  * JSON-envelope measurement reply (openjii_proto): `device_*` header fields
  * plus a `sample` array whose `set` carries one value per protocol command.
  */
-export interface AmbitMeasurementEnvelope {
-  device_name?: string;
-  device_version?: string;
-  device_battery?: number;
-  device_firmware?: string;
-  sample?: unknown[];
-  [key: string]: unknown;
-}
+export type AmbitMeasurementEnvelope = OpenJiiMeasurementEnvelope;
 
 /** Parsed `get_par` / `PAR` reply. */
 export interface AmbitParReading {

--- a/packages/iot/src/driver/ambit/interface.ts
+++ b/packages/iot/src/driver/ambit/interface.ts
@@ -2,7 +2,23 @@
 export interface AmbitStreamEvents extends Record<string, unknown> {
   /** A reply finished collecting (quiet window elapsed). */
   receivedReply: string;
+  /** A complete JSON-envelope reply (footer verified and stripped). */
+  receivedEnvelope: AmbitMeasurementEnvelope;
+  parseError: { line: string; error: unknown };
   bufferOverflow: { discardedBytes: number };
+}
+
+/**
+ * JSON-envelope measurement reply (openjii_proto): `device_*` header fields
+ * plus a `sample` array whose `set` carries one value per protocol command.
+ */
+export interface AmbitMeasurementEnvelope {
+  device_name?: string;
+  device_version?: string;
+  device_battery?: number;
+  device_firmware?: string;
+  sample?: unknown[];
+  [key: string]: unknown;
 }
 
 /** Parsed `get_par` / `PAR` reply. */

--- a/packages/iot/src/driver/minipar/config.ts
+++ b/packages/iot/src/driver/minipar/config.ts
@@ -1,3 +1,5 @@
+import { OPENJII_FRAME_FOOTER } from "../../utils/framing/openjii-envelope";
+
 /** MiniPAR serial defaults (ESP32 USB-CDC console). */
 export const MINIPAR_SERIAL_DEFAULTS = {
   baudRate: 115200,
@@ -12,8 +14,7 @@ export const MINIPAR_FRAMING = {
    * JSON-mode replies end with this constant sentinel before the newline
    * (a fixed footer, not a computed checksum).
    */
-  FRAME_FOOTER: "7A1E3AA1",
-  FOOTER_LENGTH: 8,
+  FRAME_FOOTER: OPENJII_FRAME_FOOTER,
   /** LINE-mode command timeout. */
   DEFAULT_TIMEOUT: 10_000,
   /** JSON protocol timeout; no estimator exists for MiniPAR protocols yet. */

--- a/packages/iot/src/driver/minipar/driver.ts
+++ b/packages/iot/src/driver/minipar/driver.ts
@@ -10,14 +10,15 @@
  */
 import type { DeviceIdentity, SensorFamily } from "../../core/families";
 import type { ITransportAdapter } from "../../transport/interface";
-import { extractChecksum } from "../../utils/framing/framing";
+import { collectReply, parseOpenJiiEnvelope } from "../../utils/framing/openjii-envelope";
+import type { RxCollectorHooks } from "../../utils/framing/openjii-envelope";
 import type { Logger } from "../../utils/logger/logger";
 import { DeviceDriver } from "../driver-base";
 import type { CommandResult, ExecuteOptions } from "../driver-base";
 import { MINIPAR_COMMANDS } from "./commands";
 import { MINIPAR_FRAMING } from "./config";
 import type { MiniParDriverConfig } from "./config";
-import type { MiniParMeasurementEnvelope, MiniParStreamEvents } from "./interface";
+import type { MiniParStreamEvents } from "./interface";
 
 /** RX silence that completes a LINE-mode reply lacking a newline. */
 const LINE_QUIET_MS = 200;
@@ -54,69 +55,26 @@ export class MiniParDriver extends DeviceDriver<MiniParStreamEvents> {
     this.onChunk?.();
   }
 
+  /** RX hooks over this driver's buffer for the shared reply collector. */
+  private readonly rxHooks: RxCollectorHooks = {
+    read: () => this.rxBuffer,
+    take: () => {
+      const reply = this.rxBuffer;
+      this.rxBuffer = "";
+      return reply;
+    },
+    setOnChunk: (cb) => {
+      this.onChunk = cb;
+    },
+  };
+
   /** Buffer until `isComplete` or a quiet window with data; reject on empty timeout. */
   private collect(
     isComplete: (buffer: string) => boolean,
     timeoutMs: number,
     quietMs?: number,
   ): Promise<string> {
-    return new Promise<string>((resolve, reject) => {
-      let quietTimer: ReturnType<typeof setTimeout> | undefined;
-
-      const finish = () => {
-        cleanup();
-        const reply = this.rxBuffer;
-        this.rxBuffer = "";
-        resolve(reply);
-      };
-
-      const overallTimer = setTimeout(() => {
-        if (this.rxBuffer.trim().length > 0) {
-          finish();
-          return;
-        }
-        cleanup();
-        reject(new Error("Response timeout"));
-      }, timeoutMs);
-
-      const cleanup = () => {
-        clearTimeout(overallTimer);
-        if (quietTimer) clearTimeout(quietTimer);
-        this.onChunk = undefined;
-      };
-
-      const check = () => {
-        if (isComplete(this.rxBuffer)) {
-          finish();
-          return;
-        }
-        if (quietMs !== undefined) {
-          if (quietTimer) clearTimeout(quietTimer);
-          quietTimer = setTimeout(() => {
-            if (this.rxBuffer.trim().length > 0) finish();
-          }, quietMs);
-        }
-      };
-
-      this.onChunk = check;
-      check();
-    });
-  }
-
-  /** Strip and verify the constant footer; null when the envelope is not complete yet. */
-  private static parseEnvelope(buffer: string): MiniParMeasurementEnvelope | null {
-    const trimmed = buffer.trim();
-    if (!trimmed.endsWith(MINIPAR_FRAMING.FRAME_FOOTER)) return null;
-    const { data } = extractChecksum(trimmed, MINIPAR_FRAMING.FOOTER_LENGTH);
-    try {
-      const parsed: unknown = JSON.parse(data);
-      if (parsed !== null && typeof parsed === "object") {
-        return parsed as MiniParMeasurementEnvelope;
-      }
-    } catch {
-      // footer seen but JSON incomplete/corrupt; keep buffering
-    }
-    return null;
+    return collectReply(this.rxHooks, { isComplete, timeoutMs, quietMs });
   }
 
   async execute<T = unknown>(
@@ -155,10 +113,10 @@ export class MiniParDriver extends DeviceDriver<MiniParStreamEvents> {
         // JSON protocol: one write, envelope + footer reply.
         await this.transport.send(`${JSON.stringify(command)}${MINIPAR_FRAMING.LINE_ENDING}`);
         const reply = await this.collect(
-          (buffer) => MiniParDriver.parseEnvelope(buffer) !== null,
+          (buffer) => parseOpenJiiEnvelope(buffer) !== null,
           options?.timeoutMs ?? this.protocolTimeoutMs,
         );
-        const envelope = MiniParDriver.parseEnvelope(reply);
+        const envelope = parseOpenJiiEnvelope(reply);
         if (!envelope) {
           void this.emitter.emit("parseError", { line: reply, error: "incomplete envelope" });
           throw new Error("MiniPAR reply was not a complete measurement envelope");

--- a/packages/iot/src/driver/minipar/interface.ts
+++ b/packages/iot/src/driver/minipar/interface.ts
@@ -1,3 +1,5 @@
+import type { OpenJiiMeasurementEnvelope } from "../../utils/framing/openjii-envelope";
+
 /** Events emitted by the MiniPAR driver */
 export interface MiniParStreamEvents extends Record<string, unknown> {
   /** A complete LINE-mode reply line. */
@@ -9,12 +11,4 @@ export interface MiniParStreamEvents extends Record<string, unknown> {
 }
 
 /** JSON-mode measurement envelope: `device_*` header fields plus a `sample` array. */
-export interface MiniParMeasurementEnvelope {
-  device_name?: string;
-  device_version?: string;
-  device_id?: string;
-  device_battery?: string;
-  device_firmware?: number | string;
-  sample?: unknown[];
-  [key: string]: unknown;
-}
+export type MiniParMeasurementEnvelope = OpenJiiMeasurementEnvelope;

--- a/packages/iot/src/utils/framing/openjii-envelope.spec.ts
+++ b/packages/iot/src/utils/framing/openjii-envelope.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  OPENJII_FRAME_FOOTER,
+  parseOpenJiiEnvelope,
+  parseOpenJiiTopLevelError,
+} from "./openjii-envelope";
+
+const ENVELOPE = '{"device_name":"Ambit","sample":[{"protocol_id":"NaN","set":[{"s_630":[1]}]}]}';
+
+describe("parseOpenJiiEnvelope", () => {
+  it("strips the footer and parses the envelope", () => {
+    const parsed = parseOpenJiiEnvelope(`${ENVELOPE}${OPENJII_FRAME_FOOTER}\n`);
+    expect(parsed?.device_name).toBe("Ambit");
+    expect(parsed?.sample).toHaveLength(1);
+  });
+
+  it("returns null while the footer has not arrived", () => {
+    expect(parseOpenJiiEnvelope(ENVELOPE)).toBeNull();
+  });
+
+  it("returns null when the footer is present but the JSON is corrupt", () => {
+    expect(parseOpenJiiEnvelope(`{"sample":[${OPENJII_FRAME_FOOTER}`)).toBeNull();
+  });
+});
+
+describe("parseOpenJiiTopLevelError", () => {
+  it("matches a complete footer-less error line", () => {
+    expect(parseOpenJiiTopLevelError('{"error":"json_parse","detail":"InvalidInput"}\n')).toBe(
+      "json_parse",
+    );
+  });
+
+  it("ignores an envelope carrying inline error objects", () => {
+    const inline = `{"sample":[{"set":[{"error":"bad_arrun"}]}]}${OPENJII_FRAME_FOOTER}\n`;
+    expect(parseOpenJiiTopLevelError(inline)).toBeNull();
+  });
+
+  it("returns null for an incomplete error line", () => {
+    expect(parseOpenJiiTopLevelError('{"error":"rx_over')).toBeNull();
+  });
+});

--- a/packages/iot/src/utils/framing/openjii-envelope.ts
+++ b/packages/iot/src/utils/framing/openjii-envelope.ts
@@ -1,0 +1,136 @@
+/**
+ * Shared framing for the openJII serial protocol (`openjii_proto` firmware
+ * module), spoken by every device embedding it (MiniPAR, Ambit): a protocol
+ * JSON request is answered with one envelope of `device_*` header fields plus
+ * a `sample` array, terminated by the constant `7A1E3AA1` footer (a fixed
+ * sentinel, not a computed checksum). Top-level firmware errors (json_parse,
+ * rx_overflow, json_timeout) are single JSON lines WITHOUT the footer.
+ */
+import { extractChecksum } from "./framing";
+
+/** Constant sentinel closing every envelope reply, before the newline. */
+export const OPENJII_FRAME_FOOTER = "7A1E3AA1";
+export const OPENJII_FOOTER_LENGTH = OPENJII_FRAME_FOOTER.length;
+
+/** Envelope reply: `device_*` header fields plus a `sample` array. */
+export interface OpenJiiMeasurementEnvelope {
+  device_name?: string;
+  device_version?: string;
+  device_id?: string;
+  device_battery?: number | string;
+  device_firmware?: number | string;
+  sample?: unknown[];
+  [key: string]: unknown;
+}
+
+/** Strip and verify the constant footer; null when the envelope is not complete yet. */
+export function parseOpenJiiEnvelope(buffer: string): OpenJiiMeasurementEnvelope | null {
+  const trimmed = buffer.trim();
+  if (!trimmed.endsWith(OPENJII_FRAME_FOOTER)) return null;
+  const { data } = extractChecksum(trimmed, OPENJII_FOOTER_LENGTH);
+  try {
+    const parsed: unknown = JSON.parse(data);
+    if (parsed !== null && typeof parsed === "object") {
+      return parsed as OpenJiiMeasurementEnvelope;
+    }
+  } catch {
+    // footer seen but JSON incomplete/corrupt; keep buffering
+  }
+  return null;
+}
+
+/**
+ * First complete footer-less `{"error": ...}` line in the buffer, if any.
+ * In-envelope errors (e.g. an error object inside `set`) are data, not
+ * failures; this only matches the firmware's top-level error replies.
+ */
+export function parseOpenJiiTopLevelError(buffer: string): string | null {
+  for (const line of buffer.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{"error"')) continue;
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (
+        parsed !== null &&
+        typeof parsed === "object" &&
+        typeof (parsed as Record<string, unknown>).error === "string"
+      ) {
+        return (parsed as Record<string, unknown>).error as string;
+      }
+    } catch {
+      // not a complete error line; keep buffering
+    }
+  }
+  return null;
+}
+
+/** Hooks a driver exposes over its RX buffer so replies can be collected. */
+export interface RxCollectorHooks {
+  /** Current accumulated buffer. */
+  read(): string;
+  /** Take ownership of the buffer and clear it. */
+  take(): string;
+  /** Replace the single chunk listener (undefined to clear). */
+  setOnChunk(cb: (() => void) | undefined): void;
+}
+
+export interface CollectReplyOptions {
+  /** Resolves as soon as this returns true. */
+  isComplete: (buffer: string) => boolean;
+  /** Overall deadline. */
+  timeoutMs: number;
+  /** Optional RX quiet window that completes a reply carrying data. */
+  quietMs?: number;
+  /**
+   * On deadline: reject outright (true), or resolve a non-empty partial
+   * buffer and only reject when nothing arrived (default).
+   */
+  strictTimeout?: boolean;
+}
+
+/**
+ * Collect one reply from an RX buffer: resolve when `isComplete`, when a
+ * quiet window elapses with data (if `quietMs` is set), or per the timeout
+ * policy. Rejects with "Response timeout" when nothing usable arrived.
+ */
+export function collectReply(rx: RxCollectorHooks, opts: CollectReplyOptions): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let quietTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = () => {
+      cleanup();
+      resolve(rx.take());
+    };
+
+    const overallTimer = setTimeout(() => {
+      if (!opts.strictTimeout && rx.read().trim().length > 0) {
+        finish();
+        return;
+      }
+      cleanup();
+      reject(new Error("Response timeout"));
+    }, opts.timeoutMs);
+
+    const cleanup = () => {
+      clearTimeout(overallTimer);
+      if (quietTimer) clearTimeout(quietTimer);
+      rx.setOnChunk(undefined);
+    };
+
+    const check = () => {
+      if (opts.isComplete(rx.read())) {
+        finish();
+        return;
+      }
+      if (opts.quietMs !== undefined) {
+        if (quietTimer) clearTimeout(quietTimer);
+        quietTimer = setTimeout(() => {
+          if (rx.read().trim().length > 0) finish();
+        }, opts.quietMs);
+      }
+    };
+
+    rx.setOnChunk(check);
+    check();
+  });
+}


### PR DESCRIPTION
## What

Restores the ability to run measurements (`arrun` protocols) on a directly connected Ambit, which regressed in #1791.

Since the device-identification handshake landed, the `hello` probe classifies an Ambit and routes to `AmbitDriver`, which rejected every protocol-JSON command, and the identified family outranks the toolbar selection — so the firmware's openJII JSON envelope (which fully supports `arrun`; it even documents the driver's `{"command":"INFO"}` probe) became unreachable from the app. Before #1791 this worked through the generic driver path.

## How

- **`AmbitDriver` is now dual-mode, mirroring `MiniParDriver`:**
  - strings → unchanged text console (wake poll, quiet-window collection, silent calibration writers);
  - objects/arrays → `ensureAwake()` first (the sensor light-sleeps; the old generic path never handled this), then one JSON write, collected to the constant `7A1E3AA1` footer and returned as the parsed envelope (`checksum` set).
  - Footer-less top-level firmware errors (`json_parse`, `rx_overflow`, `json_timeout`) fail the command with the code; in-envelope errors stay inline, consistent with MiniPAR.
  - New `PROTOCOL_TIMEOUT` (120 s — an `arrun` runs pulses × 0.854/freq seconds per segment) with per-call override.
- **`useIotProtocolExecution`**: the ambit hard-throw is gone; `ambit` rides the same direct-send branch as `multispeq`/`minipar`.

## Tests

- Driver: envelope round-trip (chunked), re-wake before protocol write after idle, top-level error → failure, incomplete envelope → timeout. Full `@repo/iot` suite: 329 passing.
- Hook: ambit direct-send block mirroring multispeq (24 passing).




Fixes OJD-1703
