### PR TITLE
fix(data): drop invalid timezones during enrichment

### DIFF
--- a/apps/data/src/lib/enrich/enrich/timezone.py
+++ b/apps/data/src/lib/enrich/enrich/timezone.py
@@ -1,0 +1,12 @@
+"""Timezone safety for enriched measurement views."""
+
+from pyspark.sql import Column
+from pyspark.sql import functions as F
+
+
+def drop_invalid_timezone(timezone: Column) -> Column:
+    """Return null when Spark cannot use the supplied timezone."""
+    valid = F.try_make_timestamp(
+        F.lit(2000), F.lit(1), F.lit(1), F.lit(0), F.lit(0), F.lit(0), timezone
+    ).isNotNull()
+    return F.when(valid, timezone)

--- a/apps/data/src/pipelines/centrum/enriched/enriched_experiment_macro_data.py
+++ b/apps/data/src/pipelines/centrum/enriched/enriched_experiment_macro_data.py
@@ -9,6 +9,7 @@ from pyspark.sql import functions as F
 
 from enrich.annotations_metadata import add_annotation_column
 from enrich.custom_metadata import add_custom_metadata_column
+from enrich.timezone import drop_invalid_timezone
 from openjii.centrum import (
     ANNOTATIONS_SOURCE_TABLE,
     ENRICHED_MACRO_DATA_VIEW,
@@ -64,7 +65,7 @@ def enriched_experiment_macro_data():
             macro_data.device_name,
             macro_data.timestamp,  # kept for backwards compatibility (downstream consumers order by timestamp)
             macro_data.timestamp.alias("measurement_time_utc"),
-            macro_data.timezone,
+            drop_invalid_timezone(macro_data.timezone).alias("timezone"),
             macro_data.date,
             contributors.user.alias("contributor"),
             devices.device.alias("device"),

--- a/apps/data/src/pipelines/centrum/enriched/enriched_experiment_raw_data.py
+++ b/apps/data/src/pipelines/centrum/enriched/enriched_experiment_raw_data.py
@@ -9,6 +9,7 @@ from pyspark.sql import functions as F
 
 from enrich.annotations_metadata import add_annotation_column
 from enrich.custom_metadata import add_custom_metadata_column
+from enrich.timezone import drop_invalid_timezone
 from openjii.centrum import (
     ANNOTATIONS_SOURCE_TABLE,
     ENRICHED_RAW_DATA_VIEW,
@@ -63,7 +64,7 @@ def enriched_experiment_raw_data():
             raw_data.device_name,
             raw_data.timestamp,  # kept for backwards compatibility (downstream consumers order by timestamp)
             raw_data.timestamp.alias("measurement_time_utc"),
-            raw_data.timezone,
+            drop_invalid_timezone(raw_data.timezone).alias("timezone"),
             raw_data.date,
             raw_data.macros,
             raw_data.questions_data,

--- a/apps/data/tests/lib/test_timezone.py
+++ b/apps/data/tests/lib/test_timezone.py
@@ -1,0 +1,106 @@
+"""Timezone safety tests for enriched Centrum measurements."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from enrich.timezone import drop_invalid_timezone
+from pyspark.sql import functions as F
+
+_ENRICHED_PIPELINE_DIR = Path(__file__).parents[2] / "src/pipelines/centrum/enriched"
+_HOSTILE_TIMEZONES = (
+    "ROC",
+    "Factory",
+    "Mars/Olympus",
+    " Europe/Amsterdam ",
+    "europe/amsterdam",
+    "Europe/Amsterdam\x00",
+    "') from x --",
+)
+
+
+@pytest.mark.spark
+def test_invalid_timezone_is_dropped_without_dropping_measurement(spark):
+    source = spark.createDataFrame(
+        [("valid", "Europe/Amsterdam"), ("missing", None)]
+        + [(f"invalid-{index}", timezone) for index, timezone in enumerate(_HOSTILE_TIMEZONES)],
+        "id string, timezone string",
+    ).withColumn("measurement_time_utc", F.to_timestamp(F.lit("2026-08-06 12:00:00")))
+
+    projected = (
+        source.withColumn("timezone", drop_invalid_timezone(F.col("timezone")))
+        .withColumn(
+            "measurement_time_local",
+            F.date_format(
+                F.from_utc_timestamp(F.col("measurement_time_utc"), F.col("timezone")),
+                "yyyy-MM-dd HH:mm:ss",
+            ),
+        )
+        .withColumn(
+            "local_time",
+            F.date_format(F.from_utc_timestamp(F.col("measurement_time_utc"), F.col("timezone")), "HH:mm"),
+        )
+    )
+    rows = {row.id: row.asDict() for row in projected.collect()}
+
+    assert len(rows) == len(_HOSTILE_TIMEZONES) + 2
+    assert rows["valid"]["timezone"] == "Europe/Amsterdam"
+    assert rows["valid"]["measurement_time_local"] == "2026-08-06 14:00:00"
+    assert rows["valid"]["local_time"] == "14:00"
+    for row_id, row in rows.items():
+        assert row["measurement_time_utc"] is not None
+        if row_id != "valid":
+            assert row["timezone"] is None
+            assert row["measurement_time_local"] is None
+            assert row["local_time"] is None
+
+
+@pytest.mark.spark
+@pytest.mark.parametrize(
+    ("pipeline_file", "view_function", "source_table_constant", "source_kind"),
+    [
+        (
+            "enriched_experiment_raw_data.py",
+            "enriched_experiment_raw_data",
+            "EXPERIMENT_RAW_DATA_TABLE",
+            "raw",
+        ),
+        (
+            "enriched_experiment_macro_data.py",
+            "enriched_experiment_macro_data",
+            "EXPERIMENT_MACRO_DATA_TABLE",
+            "macro",
+        ),
+    ],
+)
+def test_enriched_views_guard_timezone(
+    spark,
+    fake_dlt,
+    monkeypatch,
+    pipeline_file,
+    view_function,
+    source_table_constant,
+    source_kind,
+):
+    spec = importlib.util.spec_from_file_location(
+        f"timezone_regression_{source_kind}", _ENRICHED_PIPELINE_DIR / pipeline_file
+    )
+    assert spec is not None and spec.loader is not None
+    pipeline = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(pipeline)
+
+    source = MagicMock(name=f"{source_kind}_source")
+    source_table = getattr(pipeline, source_table_constant)
+    monkeypatch.setattr(
+        fake_dlt, "read", lambda name: source if name == source_table else MagicMock(name=name)
+    )
+    monkeypatch.setattr(pipeline, "add_annotation_column", lambda frame, _source: frame)
+    monkeypatch.setattr(pipeline, "add_custom_metadata_column", lambda frame, _source: frame)
+    guard = MagicMock(name="drop_invalid_timezone")
+    monkeypatch.setattr(pipeline, "drop_invalid_timezone", guard)
+
+    getattr(pipeline, view_function)()
+
+    guard.assert_called_once()
+    assert guard.call_args.args[0] is source.timezone


### PR DESCRIPTION
## Summary

- ask Spark whether the supplied timezone is usable
- replace unsupported timezones such as `AMT` with `NULL` in enriched output
- keep the measurement row and its UTC timestamp
- leave the existing local-time conversion flow unchanged

## Why

A producer-controlled timezone was passed directly to `from_utc_timestamp`. One unsupported value could fail the entire materialized-view update. The stable behavior is to discard only the bad timezone and continue ingestion.

## Deliberately not included

- no timezone alias translation
- no custom timezone catalog or offset parser
- no Python UDF or Py4J/JVM API
- no new validation-status columns

This draft supersedes the closed #1869 with the smaller availability-only fix.

## Validation

- `uv run pytest -q` — 79 passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — 38 files clean
- `uv run pyright` — 0 errors; 12 existing warnings outside this change
- `git diff --check` — passed

`databricks bundle validate -t dev` could not authenticate because this worktree has no configured Databricks credentials. No DEV or production deployment was attempted.