### PR TITLE
chore(infra): expose jii-file-share bucket as a Unity Catalog external location in sandbox

### DIFF
--- a/infrastructure/env/sandbox/main.tf
+++ b/infrastructure/env/sandbox/main.tf
@@ -103,6 +103,14 @@ module "storage_credential" {
   bucket_name     = var.centralized_metastore_bucket_name
   isolation_mode  = "ISOLATION_MODE_OPEN"
 
+  # The file-share bucket lives in this account and is SSE-S3 (AES256), so it
+  # needs no cross-account bucket policy and no KMS grants.
+  additional_bucket_access = {
+    "file-share" = {
+      bucket_name = var.file_share_bucket_name
+    }
+  }
+
   providers = {
     databricks.workspace = databricks.workspace
   }
@@ -121,6 +129,36 @@ module "external_location" {
   environment             = var.environment
   comment                 = "External location for ${var.environment} environment data"
   isolation_mode          = "ISOLATION_MODE_ISOLATED"
+
+  providers = {
+    databricks.workspace = databricks.workspace
+  }
+
+  depends_on = [module.storage_credential]
+}
+
+# External location for the pre-existing jii-file-share bucket (image data).
+# Registered against the whole bucket; Unity Catalog validates the credential
+# with a read/write probe at create time.
+module "file_share_external_location" {
+  source = "../../modules/databricks/external-location"
+
+  external_location_name  = "file-share-${var.environment}"
+  bucket_name             = var.file_share_bucket_name
+  external_location_path  = ""
+  storage_credential_name = module.storage_credential.storage_credential_name
+  environment             = var.environment
+  comment                 = "External location for ${var.file_share_bucket_name} (image data)"
+  isolation_mode          = "ISOLATION_MODE_ISOLATED"
+  read_only               = false
+
+  grants = {
+    for principal in var.file_share_grant_principals :
+    principal => {
+      principal  = principal
+      privileges = ["READ_FILES", "WRITE_FILES"]
+    }
+  }
 
   providers = {
     databricks.workspace = databricks.workspace

--- a/infrastructure/env/sandbox/variables.tf
+++ b/infrastructure/env/sandbox/variables.tf
@@ -34,6 +34,18 @@ variable "databricks_host" {
   sensitive   = true
 }
 
+variable "file_share_bucket_name" {
+  description = "Name of the pre-existing S3 bucket exposed to Databricks as the file-share external location"
+  type        = string
+  default     = "jii-file-share"
+}
+
+variable "file_share_grant_principals" {
+  description = "Databricks principals (group names, user emails, or service principal application IDs) granted READ_FILES/WRITE_FILES on the file-share external location. Defaults to the built-in all-users group; narrow this to a dedicated group once one exists."
+  type        = list(string)
+  default     = ["account users"]
+}
+
 variable "centralized_metastore_bucket_name" {
   description = "Name of the centralized S3 bucket for Unity Catalog metastore storage in data governance account"
   type        = string

--- a/infrastructure/env/sandbox/variables.tf
+++ b/infrastructure/env/sandbox/variables.tf
@@ -41,9 +41,9 @@ variable "file_share_bucket_name" {
 }
 
 variable "file_share_grant_principals" {
-  description = "Databricks principals (group names, user emails, or service principal application IDs) granted READ_FILES/WRITE_FILES on the file-share external location. Defaults to the built-in all-users group; narrow this to a dedicated group once one exists."
+  description = "Databricks principals (group names, user emails, or service principal application IDs) granted READ_FILES/WRITE_FILES on the file-share external location. Empty by default: grants are managed manually in Databricks"
   type        = list(string)
-  default     = ["account users"]
+  default     = []
 }
 
 variable "centralized_metastore_bucket_name" {

--- a/infrastructure/modules/databricks/workspace-storage-credential/main.tf
+++ b/infrastructure/modules/databricks/workspace-storage-credential/main.tf
@@ -81,3 +81,48 @@ resource "aws_iam_role_policy_attachment" "additional" {
   role       = aws_iam_role.storage_access.name
   policy_arn = var.additional_policy_arns[count.index]
 }
+
+# Policies for extra buckets registered as external locations (e.g. file share).
+# Buckets are SSE-S3 across the estate, so no KMS permissions are needed here.
+resource "aws_iam_policy" "additional_bucket_access" {
+  for_each = var.additional_bucket_access
+
+  name = "${var.role_name}-${each.key}-policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = each.value.read_only ? [
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation"
+          ] : [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetBucketLocation"
+        ]
+        Resource = [
+          "arn:aws:s3:::${each.value.bucket_name}",
+          "arn:aws:s3:::${each.value.bucket_name}/*"
+        ]
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "${var.environment} Unity Catalog ${each.key} bucket access IAM policy"
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "additional_bucket_access" {
+  for_each = var.additional_bucket_access
+
+  role       = aws_iam_role.storage_access.name
+  policy_arn = aws_iam_policy.additional_bucket_access[each.key].arn
+}

--- a/infrastructure/modules/databricks/workspace-storage-credential/variables.tf
+++ b/infrastructure/modules/databricks/workspace-storage-credential/variables.tf
@@ -29,3 +29,12 @@ variable "additional_policy_arns" {
   type        = list(string)
   default     = []
 }
+
+variable "additional_bucket_access" {
+  description = "Extra S3 buckets this role should reach, keyed by a short name used in the policy name. Renders and attaches one IAM policy per bucket. Use for buckets owned outside Terraform or by a module that does not emit its own policy; buckets whose owning module already exposes a policy ARN belong in additional_policy_arns instead."
+  type = map(object({
+    bucket_name = string
+    read_only   = optional(bool, false)
+  }))
+  default = {}
+}


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)

## Description
Makes the existing jii-file-share S3 bucket accessible from the sandbox Databricks workspace, following the same pattern as the large-iot bucket in dev/prod.

Three changes in infrastructure/env/sandbox/main.tf:
- New IAM policy `open-jii-sandbox-databricks-file-share-access` granting get/put/delete/list on the bucket.
- Attached to the existing `open-jii-sandbox-uc-access` role via `additional_policy_arns` on the storage credential.
- New `file-share-sandbox` external location over the whole bucket, read/write, isolated.

The bucket already exists and is in the same account as the workspace (AES256, no KMS), so no bucket policy or KMS grants are needed.

No grants are created — `file_share_grant_principals` is empty by default, and access will be granted manually in Databricks. Populating that variable makes Terraform authoritative for grants on this location.


<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #
- Related to #