### PR TITLE
fix(web): save experiment descriptions in Safari

### DIFF
--- a/apps/web/components/shared/inline-editable-description.test.tsx
+++ b/apps/web/components/shared/inline-editable-description.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen, userEvent, waitFor } from "@/test/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { InlineEditableDescription } from "./inline-editable-description";
+
+vi.mock("@repo/ui/components/rich-textarea", () => ({
+  RichTextarea: ({
+    value,
+    onChange,
+    onBlur,
+    placeholder,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    onBlur?: (event: React.FocusEvent) => void;
+    placeholder?: string;
+  }) => (
+    <textarea
+      aria-label={placeholder}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      onBlur={onBlur}
+    />
+  ),
+}));
+
+vi.mock("@repo/ui/components/rich-text-renderer", () => ({
+  RichTextRenderer: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+describe("InlineEditableDescription", () => {
+  const onSave = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps action buttons from blurring the editor before their click handlers run", async () => {
+    const user = userEvent.setup();
+    render(<InlineEditableDescription description="Original" hasAccess onSave={onSave} />);
+
+    await user.click(screen.getByText("Original"));
+    const editor = screen.getByRole("textbox");
+    await user.clear(editor);
+    await user.type(editor, "Updated");
+
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
+    const saveButton = screen.getByRole("button", { name: "Save" });
+
+    expect(fireEvent.mouseDown(cancelButton)).toBe(false);
+    expect(fireEvent.mouseDown(saveButton)).toBe(false);
+
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith("Updated");
+    });
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/shared/inline-editable-description.tsx
+++ b/apps/web/components/shared/inline-editable-description.tsx
@@ -89,6 +89,12 @@ export function InlineEditableDescription({
     handleCancel();
   };
 
+  const handleEditActionMouseDown = (e: React.MouseEvent) => {
+    // Safari may omit relatedTarget when a button click blurs the editor,
+    // causing handleBlur to cancel the edit before the click can save it.
+    e.preventDefault();
+  };
+
   return (
     <div className="space-y-0">
       <h2 className="font-bold">{title}</h2>
@@ -107,13 +113,19 @@ export function InlineEditableDescription({
             <Button
               variant="secondary"
               onClick={handleCancel}
+              onMouseDown={handleEditActionMouseDown}
               disabled={isPending}
               data-role="edit-action"
             >
               <X className="h-4 w-4" />
               <span>{cancelLabel}</span>
             </Button>
-            <Button onClick={handleSave} disabled={isPending} data-role="edit-action">
+            <Button
+              onClick={handleSave}
+              onMouseDown={handleEditActionMouseDown}
+              disabled={isPending}
+              data-role="edit-action"
+            >
               <Check className="h-4 w-4" />
               <span>{saveLabel}</span>
             </Button>


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [X] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [X] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Fixes the Safari-specific focus race that discarded inline description edits before the Save button click could run. Save and Cancel now preserve editor focus during mousedown, preventing the editor blur handler from cancelling the edit when Safari omits relatedTarget.

## Related Issues

* Closes Jan-IngenHousz-Institute/open-jii#1886
* Related to Jan-IngenHousz-Institute/open-jii#1886

## Testing Instructions

- [X] Run the focused shared, experiment, and workbook description tests:<br>pnpm --dir apps/web test:run components/shared/inline-editable-description.test.tsx components/experiment-overview/experiment-description.test.tsx components/workbook/workbook-description.test.tsx
- [X] Run pnpm --dir apps/web check-types
- [X] Run ESLint on the changed component and test
- [ ] In Safari, edit an experiment description, click Save, refresh, and confirm the updated description persists

## Changes Made

* Prevent Save and Cancel button mousedown events from blurring the rich-text editor
* Add regression coverage for the action-button focus behavior and successful save

## Checklist

- [X] I have added/updated tests for my changes
- [X] My code follows the project style guidelines
- [ ] I have updated the documentation accordingly
- [X] I have tested these changes locally
- [X] My changes generate no new warnings
- [X] I have reviewed my own code

## Screenshots/Recordings

Not applicable; this changes interaction behavior without changing the UI.

## Additional Notes

Automated verification passed: 3 test files and 15 tests. A manual smoke test in Safari is recommended before moving the PR out of draft.