### PR TITLE
test(data): pin the AsyncAPI ingest contract to the pipeline schema

### DIFF
--- a/apps/data/pyproject.toml
+++ b/apps/data/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
     "pytest-cov>=5.0",
     "responses>=0.25",
     "ruff>=0.7",
+    "pyyaml>=6.0",
 ]
 
 [tool.uv]

--- a/apps/data/tests/lib/test_asyncapi_contract.py
+++ b/apps/data/tests/lib/test_asyncapi_contract.py
@@ -1,0 +1,64 @@
+"""Drift check: the AsyncAPI ingest message must mirror the pipeline schema.
+
+The published contract (asyncapi.yaml) tells device integrators what payload
+fields exist; the pipeline's sensor_schema decides what actually parses. The
+two live in different files and drift silently, so this test pins them to
+each other. CI coverage comes from the data test gate: asyncapi.yaml is
+declared a turbo input of this package, so contract-only changes still mark
+`data` affected and run this suite.
+"""
+
+from pathlib import Path
+
+import yaml
+from openjii.centrum import annotation_schema, macro_schema, question_schema, sensor_schema
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+# Injected into the stored envelope by the broker rule; never sent by publishers.
+RULE_INJECTED = {"topic"}
+
+# Payload fields bronze extracts as top-level columns instead of through
+# sensor_schema; part of the publish contract all the same.
+BRONZE_TOP_LEVEL = {"macro_context", "workbook_version_id"}
+
+
+def _message_payload() -> dict:
+    doc = yaml.safe_load((REPO_ROOT / "asyncapi.yaml").read_text())
+    return doc["components"]["messages"]["ExperimentDataMessage"]["payload"]
+
+
+def test_contract_fields_mirror_the_pipeline_schema():
+    contract = set(_message_payload()["properties"])
+    pipeline = (set(sensor_schema.fieldNames()) - RULE_INJECTED) | BRONZE_TOP_LEVEL
+
+    assert contract == pipeline, (
+        f"asyncapi.yaml and sensor_schema drifted. "
+        f"contract-only: {sorted(contract - pipeline)}, "
+        f"pipeline-only: {sorted(pipeline - contract)}"
+    )
+
+
+def test_contract_item_shapes_mirror_the_nested_schemas():
+    properties = _message_payload()["properties"]
+
+    for field, schema in [
+        ("macros", macro_schema),
+        ("questions", question_schema),
+        ("annotations", annotation_schema),
+    ]:
+        contract_items = set(properties[field]["items"]["properties"])
+        assert contract_items == set(schema.fieldNames()), (
+            f"asyncapi.yaml `{field}` items drifted from the pipeline schema"
+        )
+
+
+def test_both_ingest_channels_carry_the_same_message():
+    doc = yaml.safe_load((REPO_ROOT / "asyncapi.yaml").read_text())
+    ingest_channels = [
+        channel for name, channel in doc["channels"].items() if name.startswith("experiment/data_ingest/")
+    ]
+
+    assert len(ingest_channels) == 2
+    for channel in ingest_channels:
+        assert channel["subscribe"]["message"]["$ref"] == "#/components/messages/ExperimentDataMessage"

--- a/apps/data/uv.lock
+++ b/apps/data/uv.lock
@@ -393,6 +393,7 @@ dev = [
     { name = "pyspark" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pyyaml" },
     { name = "responses" },
     { name = "ruff" },
 ]
@@ -414,6 +415,7 @@ dev = [
     { name = "pyspark", specifier = "==4.0.1" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "responses", specifier = ">=0.25" },
     { name = "ruff", specifier = ">=0.7" },
 ]

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["asyncapi.yaml"],
   "ui": "tui",
   "tasks": {
     "build": {


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

The AsyncAPI contract (asyncapi.yaml) tells device integrators which payload fields exist, while the pipeline's sensor_schema decides what actually parses. They live in separate files with no link between them, so a field added to one and not the other drifts silently until a device sends something the pipeline drops. This adds a test that pins the two together, the same way CI already pins the committed OpenAPI copy to the generated one.

The check asserts the contract's message properties equal the pipeline schema's field names, accounting for the two known, legitimate differences: `topic`, which the broker rule injects into the stored envelope and no publisher sends, and the fields bronze lifts to top-level columns (macro_context, workbook_version_id) rather than reading through sensor_schema. It also verifies the nested item shapes (macros, questions, annotations) match their pipeline schemas, and that both ingest channels reference the one shared message rather than diverging.

Adds pyyaml as a dev dependency to read the contract.