### PR TITLE
fix(web): reconcile the workbook editor with the server copy

### DIFF
--- a/apps/web/components/workbook/workbook-draft-editor.test.tsx
+++ b/apps/web/components/workbook/workbook-draft-editor.test.tsx
@@ -1,0 +1,145 @@
+import { createMarkdownCell, createProtocolCell } from "@/test/factories";
+import { act, render, screen, waitFor } from "@/test/test-utils";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import type { WorkbookCell } from "@repo/api/domains/workbook/workbook-cells.schema";
+
+import { WorkbookDraftEditor } from "./workbook-draft-editor";
+
+const updateWorkbook = vi.fn().mockResolvedValue({});
+
+vi.mock("@/hooks/workbook/useWorkbookUpdate/useWorkbookUpdate", () => ({
+  useWorkbookUpdate: () => ({ mutateAsync: updateWorkbook, isPending: false }),
+}));
+
+vi.mock("@/hooks/workbook/useWorkbookExecution/useWorkbookExecution", () => ({
+  useWorkbookExecution: () => ({
+    isConnected: false,
+    isConnecting: false,
+    connectedDevices: [],
+    sensorFamily: "multispeq",
+    setSensorFamily: vi.fn(),
+    connectionType: "usb",
+    setConnectionType: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    disconnectDevice: vi.fn(),
+    executionStates: {},
+    isRunningAll: false,
+    runCell: vi.fn(),
+    runAll: vi.fn(),
+    stopExecution: vi.fn(),
+    clearOutputs: vi.fn(),
+  }),
+}));
+
+// Renders the cells it was handed; the button stands in for a keystroke.
+vi.mock("./workbook-editor", () => ({
+  WorkbookEditor: ({
+    cells,
+    onCellsChange,
+  }: {
+    cells: WorkbookCell[];
+    onCellsChange: (c: WorkbookCell[]) => void;
+  }) => (
+    <div>
+      <pre data-testid="cells">{JSON.stringify(cells)}</pre>
+      <button
+        onClick={() =>
+          onCellsChange([...cells, createMarkdownCell({ id: "local-edit" })] as WorkbookCell[])
+        }
+      >
+        local edit
+      </button>
+    </div>
+  ),
+}));
+
+function renderedCells(): WorkbookCell[] {
+  return JSON.parse(screen.getByTestId("cells").textContent) as WorkbookCell[];
+}
+
+function hasCell(id: string): boolean {
+  return renderedCells().some((c) => c.id === id);
+}
+
+describe("WorkbookDraftEditor server reconciliation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    updateWorkbook.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const base = [createProtocolCell({ id: "cell-1" })] as WorkbookCell[];
+
+  it("adopts a newer server copy while the editor is idle", async () => {
+    const { rerender } = render(
+      <WorkbookDraftEditor id="wb-1" initialCells={base} canEdit name="wb" />,
+    );
+    expect(hasCell("cell-1")).toBe(true);
+
+    const fromServer = [
+      createProtocolCell({ id: "cell-1" }),
+      createMarkdownCell({ id: "added-elsewhere" }),
+    ] as WorkbookCell[];
+    rerender(<WorkbookDraftEditor id="wb-1" initialCells={fromServer} canEdit name="wb" />);
+
+    await waitFor(() => expect(hasCell("added-elsewhere")).toBe(true));
+  });
+
+  it("does not echo the adopted copy back to the server", async () => {
+    const { rerender } = render(
+      <WorkbookDraftEditor id="wb-1" initialCells={base} canEdit name="wb" />,
+    );
+    const fromServer = [
+      createProtocolCell({ id: "cell-1" }),
+      createMarkdownCell({ id: "added-elsewhere" }),
+    ] as WorkbookCell[];
+    rerender(<WorkbookDraftEditor id="wb-1" initialCells={fromServer} canEdit name="wb" />);
+    await waitFor(() => expect(hasCell("added-elsewhere")).toBe(true));
+
+    // Past the debounce: adopting is not an edit.
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(updateWorkbook).not.toHaveBeenCalled();
+  });
+
+  it("keeps unsaved local edits instead of adopting over them", async () => {
+    const { rerender } = render(
+      <WorkbookDraftEditor id="wb-1" initialCells={base} canEdit name="wb" />,
+    );
+
+    screen.getByRole("button", { name: "local edit" }).click();
+    await waitFor(() => expect(hasCell("local-edit")).toBe(true));
+
+    const fromServer = [
+      createProtocolCell({ id: "cell-1" }),
+      createMarkdownCell({ id: "added-elsewhere" }),
+    ] as WorkbookCell[];
+    rerender(<WorkbookDraftEditor id="wb-1" initialCells={fromServer} canEdit name="wb" />);
+
+    expect(hasCell("local-edit")).toBe(true);
+    expect(hasCell("added-elsewhere")).toBe(false);
+  });
+
+  it("keeps a local edit batched into the same commit as a server update", () => {
+    const { rerender } = render(
+      <WorkbookDraftEditor id="wb-1" initialCells={base} canEdit name="wb" />,
+    );
+
+    const fromServer = [
+      createProtocolCell({ id: "cell-1" }),
+      createMarkdownCell({ id: "added-elsewhere" }),
+    ] as WorkbookCell[];
+
+    act(() => {
+      screen.getByRole("button", { name: "local edit" }).click();
+      rerender(<WorkbookDraftEditor id="wb-1" initialCells={fromServer} canEdit name="wb" />);
+    });
+
+    expect(hasCell("local-edit")).toBe(true);
+    expect(hasCell("added-elsewhere")).toBe(false);
+  });
+});

--- a/apps/web/components/workbook/workbook-draft-editor.tsx
+++ b/apps/web/components/workbook/workbook-draft-editor.tsx
@@ -5,7 +5,7 @@ import { WorkbookEditor } from "@/components/workbook/workbook-editor";
 import { useAutosave } from "@/hooks/useAutosave";
 import { useWorkbookExecution } from "@/hooks/workbook/useWorkbookExecution/useWorkbookExecution";
 import { useWorkbookUpdate } from "@/hooks/workbook/useWorkbookUpdate/useWorkbookUpdate";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { parseApiError } from "~/util/apiError";
 
 import { zWorkbookCellArray } from "@repo/api/domains/workbook/workbook-cells.schema";
@@ -85,6 +85,34 @@ export function WorkbookDraftEditor({
   });
 
   useReportAutosaveStatus(autosave);
+
+  // Adopt a newer server copy: fork pointers live inside `cells`, so a
+  // never-reconciling editor silently un-forks cells it overwrites (OJD-1722).
+  const serverKey = useMemo(() => JSON.stringify(initialCells), [initialCells]);
+  const localKey = useMemo(() => JSON.stringify(cells), [cells]);
+  const adoptedKeyRef = useRef(serverKey);
+  const adoptedCellsRef = useRef<WorkbookCell[] | null>(null);
+
+  useEffect(() => {
+    if (serverKey === adoptedKeyRef.current) return;
+    if (serverKey === localKey) {
+      adoptedKeyRef.current = serverKey;
+      return;
+    }
+    // Divergence from the last known server copy means unsaved work.
+    // `autosave.status` lags a commit, so it cannot be the guard.
+    if (localKey !== adoptedKeyRef.current) return;
+    adoptedKeyRef.current = serverKey;
+    adoptedCellsRef.current = initialCells;
+    setCells(initialCells);
+  }, [serverKey, localKey, initialCells]);
+
+  // Keyed on array identity: a flag would clear before the adopting commit.
+  useEffect(() => {
+    if (adoptedCellsRef.current === null || cells !== adoptedCellsRef.current) return;
+    adoptedCellsRef.current = null;
+    autosave.rebase();
+  }, [cells, autosave]);
 
   const handleCellsChange = useCallback((next: WorkbookCell[]) => {
     setCells(next);

--- a/apps/web/hooks/useAutosave.ts
+++ b/apps/web/hooks/useAutosave.ts
@@ -22,6 +22,8 @@ interface UseAutosaveReturn {
   hasError: boolean;
   error: unknown;
   flush: () => Promise<void>;
+  /** Treat the current value as saved, for hosts that adopt a server copy. */
+  rebase: () => void;
 }
 
 /**
@@ -137,6 +139,18 @@ export function useAutosave<T>({
     };
   }, [key, enabled, delayMs, runSave]);
 
+  // Call after the adopting `setState`; `keyRef` is assigned during render.
+  const rebase = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    pendingFlushRef.current = false;
+    lastSavedKeyRef.current = keyRef.current;
+    setStatus("idle");
+    setError(null);
+  }, []);
+
   const flush = useCallback(async (): Promise<void> => {
     if (timerRef.current || pendingFlushRef.current) {
       if (timerRef.current) {
@@ -166,5 +180,6 @@ export function useAutosave<T>({
     hasError: status === "error",
     error,
     flush,
+    rebase,
   };
 }


### PR DESCRIPTION
Fixes OJD-1722.

## Problem

Users collaborating on a workbook lose their protocol/macro cell forks: a cell they forked into their own editable copy reverts to pointing at the original owner's entity, and they have to fork it again.

The fork pointer (`cell.payload.protocolId` / `macroId`) lives inside the workbook's autosaved `cells` array. `WorkbookDraftEditor` seeded `cells` once at mount and never re-read the server, so a stale editor would write its mount-time array back over a newer one and silently un-fork the cell.

In prod one user forked the same protocol cell **three times** in one workbook (13:17:55Z, 13:23:35Z, 13:31:20Z), each fork superseding the last. Every request returned success, which is why nothing alerted.

## Fix

- `WorkbookDraftEditor` adopts the server copy when a refetch brings a newer one **and** the editor has nothing at stake (not dirty, not saving). Otherwise local keystrokes win.
- `useAutosave` gains `rebase()`, so the adoption re-anchors the saved baseline instead of looking like a local edit and being echoed straight back. Without it the adoption issues its own write and re-opens a narrower version of the same race.

Implementation note for reviewers: both effects run in the same commit as the adopting `setCells`, so a boolean flag gets consumed one render too early, before `useAutosave` has recomputed its key. The first version did exactly that and the echo test caught it. It now tracks the adopted array by identity.

## Verification

Reproduced first, then fixed. Local stack + Playwright, ground truth read from Postgres.

Before:

```
tab A forked -> X=f25caa24
tab B still offers 'Fork to edit' after being focused: True
tab B forked -> Y=138f2812
tab A's fork X=f25caa24 orphaned: True
LOST UPDATE REPRODUCED: True
```

After:

```
[PASS] tab B adopted the server copy: fork_button=0 forkedFrom=1
[PASS] tab A's fork still persisted
```

New `workbook-draft-editor.test.tsx` covers three cases: adopts when idle, does not echo the adopted copy back, and keeps unsaved local edits instead of adopting over them. `tsc --noEmit` clean; 369 tests pass across `hooks/useAutosave` and `components/workbook`.

## Known gap, deliberately not closed here

This only engages when something triggers a refetch. Two windows side by side never background, so nothing refetches and the lost update is still possible — verified, and called out in the code comment rather than left implied. Captured payloads show every `PATCH /workbooks/:id` body is exactly `{cells}`, with no `version`, `updatedAt`, `etag` or `baseVersion`, so the server cannot detect a stale write at all.

A concurrency precondition on `PATCH /workbooks/:id` is the real backstop and is tracked as remaining work on OJD-1722.
