### PR TITLE
fix(web): stop the design page flashing a skeleton on every autosave

### DIFF
--- a/apps/web/hooks/workbook/useWorkbookVersion/useWorkbookVersion.test.ts
+++ b/apps/web/hooks/workbook/useWorkbookVersion/useWorkbookVersion.test.ts
@@ -50,6 +50,52 @@ describe("useWorkbookVersion", () => {
     expect(result.current.data).toBeUndefined();
   });
 
+  it("holds the previous version while a new versionId loads", async () => {
+    const { result, rerender } = renderHook(
+      ({ v }: { v: string }) => useWorkbookVersion(workbookId, v),
+      { initialProps: { v: versionId } },
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual(versionBody));
+
+    const nextBody = {
+      ...createWorkbookVersionSummary({ id: "ver-2", workbookId, version: 2 }),
+      cells: [],
+      metadata: {},
+      entitySnapshots: { protocols: {}, macros: {} },
+    };
+    server.mount(contract.workbooks.getWorkbookVersion, { body: nextBody });
+    rerender({ v: "ver-2" });
+
+    // Re-pinning must not drop callers to a loading state (OJD-1723).
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toEqual(versionBody);
+
+    await waitFor(() => expect(result.current.data).toEqual(nextBody));
+  });
+
+  it("drops the placeholder when the workbook changes", async () => {
+    const { result, rerender } = renderHook(
+      ({ w }: { w: string }) => useWorkbookVersion(w, versionId),
+      { initialProps: { w: workbookId } },
+    );
+
+    await waitFor(() => expect(result.current.data).toEqual(versionBody));
+
+    server.mount(contract.workbooks.getWorkbookVersion, {
+      body: {
+        ...createWorkbookVersionSummary({ id: "ver-9", workbookId: "wb-2" }),
+        cells: [],
+        metadata: {},
+        entitySnapshots: { protocols: {}, macros: {} },
+      },
+    });
+    rerender({ w: "wb-2" });
+
+    // Another workbook's cells must never be shown as this one's.
+    expect(result.current.data).toBeUndefined();
+  });
+
   it("returns error on API failure", async () => {
     server.mount(contract.workbooks.getWorkbookVersion, { status: 500 });
 

--- a/apps/web/hooks/workbook/useWorkbookVersion/useWorkbookVersion.ts
+++ b/apps/web/hooks/workbook/useWorkbookVersion/useWorkbookVersion.ts
@@ -2,6 +2,8 @@ import { orpc } from "@/lib/orpc";
 import { shouldRetryQuery } from "@/util/query-retry";
 import { useQuery } from "@tanstack/react-query";
 
+import type { WorkbookVersion } from "@repo/api/domains/workbook/workbook-version.schema";
+
 /**
  * Hook to fetch a specific published workbook version (with full cell data).
  */
@@ -18,6 +20,11 @@ export function useWorkbookVersion(
       // A 403 here is an access answer, not a blip: retrying it would leave the
       // caller staring at a wrong interim state for the length of the backoff.
       retry: shouldRetryQuery,
+      // Re-pinning mints a new versionId, so a fresh key with no data would drop
+      // callers to `isLoading` and flash a skeleton (OJD-1723). Hold the last
+      // version, but only within the same workbook.
+      placeholderData: (previous?: WorkbookVersion) =>
+        previous?.workbookId === workbookId ? previous : undefined,
       enabled,
     }),
   );


### PR DESCRIPTION
Fixes OJD-1723.

## Problem

Editing anything on the experiment design page drops the whole page back to a loading skeleton, on every autosave. Reported from dev; the path is on `main`, so prod is affected too.

1. Every autosave re-pins the experiment (`handleDraftSaved` → `upgradeVersion.mutate()`).
2. While typing, the draft differs from the last published version, so the upgrade mints a new one.
3. `getExperiment` is invalidated, so `workbookVersionId` changes.
4. `useWorkbookVersion` is keyed on that id: a new id is a fresh cache key with no data, so `isLoading` is true.
5. The design page gates its entire render on `pinnedVersionLoading` and returns a full-page `<Skeleton>`, unmounting the editor.

## Fix

One react-query option. `placeholderData` holds the previous version while the new versionId loads, so re-pinning no longer drops callers to a loading state. Scoped to the same `workbookId` so switching workbooks can never render another workbook's cells as this one's.

## Verification

Measured on the running app with a MutationObserver recording every DOM transition, since the flash is ~100ms and polling misses it (my first attempt polled at 100ms and wrongly reported no flash on *both* code paths).

Before:

```
t=7284ms  skeleton=False editor=True
t=10731ms skeleton=True  editor=False   <- flash
t=10827ms skeleton=False editor=False
```

After:

```
t=7274ms  skeleton=False editor=True    (no further transitions)
```

`versions minted: 1, pin changed: True` in both runs, so the re-pin still happens; only the flash is gone. Videos recorded for both.

Unit tests: placeholder held across a versionId change, and dropped when the workbook changes. 310 tests pass across `components/experiment-flow`, `hooks/workbook` and the experiments pages.

## Deliberately not included

Re-pinning on every autosave also mints a version per typing burst, filling version history with noise. I had a debounce for that and dropped it: the window where the save has settled but the upgrade has not started would let the "updates available" banner flash on, which is exactly the flicker `linked-workbook-card.flicker.test.tsx` exists to prevent. It needs its own design rather than refs and effects bolted onto this page. Noted on the ticket.
