### PR TITLE
fix(web): gate workbook adoption on the persisted baseline

### DIFF
--- a/apps/web/components/workbook/workbook-draft-editor.test.tsx
+++ b/apps/web/components/workbook/workbook-draft-editor.test.tsx
@@ -124,6 +124,29 @@ describe("WorkbookDraftEditor server reconciliation", () => {
     expect(hasCell("added-elsewhere")).toBe(false);
   });
 
+  it("still adopts after a save the server has already moved past", async () => {
+    // The editor saves B, then a third party's C arrives before B echoes back.
+    // Local (B) legitimately differs from the last copy seen (A), so a
+    // "local === last seen" test would refuse C, and every copy after it.
+    const { rerender } = render(
+      <WorkbookDraftEditor id="wb-1" initialCells={base} canEdit name="wb" />,
+    );
+
+    screen.getByRole("button", { name: "local edit" }).click();
+    await waitFor(() => expect(hasCell("local-edit")).toBe(true));
+    await vi.advanceTimersByTimeAsync(3000);
+    await waitFor(() => expect(updateWorkbook).toHaveBeenCalled());
+
+    const fromServer = [
+      createProtocolCell({ id: "cell-1" }),
+      createMarkdownCell({ id: "third-party" }),
+    ] as WorkbookCell[];
+    rerender(<WorkbookDraftEditor id="wb-1" initialCells={fromServer} canEdit name="wb" />);
+
+    await waitFor(() => expect(hasCell("third-party")).toBe(true));
+    expect(hasCell("local-edit")).toBe(false);
+  });
+
   it("keeps a local edit batched into the same commit as a server update", () => {
     const { rerender } = render(
       <WorkbookDraftEditor id="wb-1" initialCells={base} canEdit name="wb" />,

--- a/apps/web/components/workbook/workbook-draft-editor.tsx
+++ b/apps/web/components/workbook/workbook-draft-editor.tsx
@@ -90,22 +90,20 @@ export function WorkbookDraftEditor({
   // never-reconciling editor silently un-forks cells it overwrites (OJD-1722).
   const serverKey = useMemo(() => JSON.stringify(initialCells), [initialCells]);
   const localKey = useMemo(() => JSON.stringify(cells), [cells]);
-  const adoptedKeyRef = useRef(serverKey);
+  const seenKeyRef = useRef(serverKey);
   const adoptedCellsRef = useRef<WorkbookCell[] | null>(null);
 
   useEffect(() => {
-    if (serverKey === adoptedKeyRef.current) return;
-    if (serverKey === localKey) {
-      adoptedKeyRef.current = serverKey;
-      return;
-    }
-    // Divergence from the last known server copy means unsaved work.
-    // `autosave.status` lags a commit, so it cannot be the guard.
-    if (localKey !== adoptedKeyRef.current) return;
-    adoptedKeyRef.current = serverKey;
+    if (serverKey === seenKeyRef.current) return;
+    // Advance unconditionally: a copy we decline must not block later ones.
+    seenKeyRef.current = serverKey;
+    if (serverKey === localKey) return;
+    // Unsaved work is local diverging from what autosave last persisted, not
+    // from the last copy seen: after a save the two legitimately differ.
+    if (localKey !== autosave.savedKey) return;
     adoptedCellsRef.current = initialCells;
     setCells(initialCells);
-  }, [serverKey, localKey, initialCells]);
+  }, [serverKey, localKey, initialCells, autosave.savedKey]);
 
   // Keyed on array identity: a flag would clear before the adopting commit.
   useEffect(() => {

--- a/apps/web/hooks/useAutosave.ts
+++ b/apps/web/hooks/useAutosave.ts
@@ -22,6 +22,11 @@ interface UseAutosaveReturn {
   hasError: boolean;
   error: unknown;
   flush: () => Promise<void>;
+  /**
+   * `toKey` of the last value persisted. Compare against the current key to test
+   * for unsaved work without the commit lag `status` has.
+   */
+  savedKey: string;
   /** Treat the current value as saved, for hosts that adopt a server copy. */
   rebase: () => void;
 }
@@ -140,12 +145,15 @@ export function useAutosave<T>({
   }, [key, enabled, delayMs, runSave]);
 
   // Call after the adopting `setState`; `keyRef` is assigned during render.
+  // Supersedes any in-flight save, whose late resolve would otherwise restore
+  // the pre-adoption baseline and leave the adopted value unsaved with no timer.
   const rebase = useCallback(() => {
     if (timerRef.current) {
       clearTimeout(timerRef.current);
       timerRef.current = null;
     }
     pendingFlushRef.current = false;
+    latestAppliedSeqRef.current = ++seqRef.current;
     lastSavedKeyRef.current = keyRef.current;
     setStatus("idle");
     setError(null);
@@ -180,6 +188,7 @@ export function useAutosave<T>({
     hasError: status === "error",
     error,
     flush,
+    savedKey: lastSavedKeyRef.current,
     rebase,
   };
 }


### PR DESCRIPTION
Follow-up to #1925 (OJD-1722), which shipped an unsound guard. It is already on `main`.

## The defect

Adoption was gated on `localKey !== adoptedKeyRef.current`, which treats "local differs from the last server copy seen" as "there is unsaved work". After a save those legitimately differ.

- mount: server=A, local=A, seen=A
- user edits → local=B; autosave persists B. Server holds B, `adoptedKeyRef` is still A because no refetch has landed.
- a third party's C arrives before B echoes back: `C !== A` ✓, `C !== B` ✓, then `localKey(B) !== adoptedKeyRef(A)` → **refused**.
- the ref never advances past A, and `localKey` can never be A again, so **every later server copy is refused too**. The editor stops reconciling permanently and the next local edit overwrites C.

That is the same lost-update class #1925 set out to fix. CodeRabbit caught the first version of this guard (`autosave.status`, which lags a commit); the replacement fails differently.

## Fix

Unsaved work is local diverging from **what autosave last persisted**, so `useAutosave` exposes `savedKey` and the editor gates on that. It has no commit lag, unlike `status`. The ref is renamed to `seenKeyRef` and now only records which server copies have been considered, advancing unconditionally so a declined copy cannot block later ones.

Also: `rebase()` now bumps the sequence counter so it supersedes any in-flight save. Without that, an older save resolving after an adoption restores the pre-adoption baseline and flips status to dirty with no timer scheduled and nothing pending, so neither `flush()` nor unmount ever persists the adopted value.

## Verification

New regression test, `still adopts after a save the server has already moved past`. I checked out the merged version of the component and ran the test against it: it **fails** there and passes here, so it pins the real defect rather than my description of it.

Browser check against the running app, on this code:

```
Check 1: backgrounded editor adopts an out-of-band change
  PASS marker absent before the change
  PASS second client's PATCH accepted: status=200
  PASS stale editor adopted the server change
  PASS the adoption was not echoed back as an edit
Check 2: no visibility transition (known gap)
  PASS editor stays stale without a refetch trigger
```

371 tests pass across `hooks/useAutosave` and `components/workbook`; typecheck, eslint, prettier clean.

Note on method: the original two-tab script drove the protocol cell's "Fork to edit" button, which is now capability-gated. In this local environment the seed user reports `canUpdate: true` on a protocol owned by another user (private, no grants), so that read-only cell cannot be produced any more and I could not re-run that exact script. The check above exercises the same reconciliation path via an out-of-band `PATCH` instead.

## Still open on OJD-1722

The two-editors-both-dirty case, and a second window that never backgrounds and so never refetches. The concurrency precondition on `PATCH /workbooks/:id` is the backstop for those and is still unimplemented.
