### PR TITLE
feat(backend, web): device groups on the organization surface

### DIFF
--- a/apps/backend/src/iot/core/repositories/iot-device-group.repository.ts
+++ b/apps/backend/src/iot/core/repositories/iot-device-group.repository.ts
@@ -60,10 +60,18 @@ export class IotDeviceGroupRepository {
     });
   }
 
-  // Same tiering as devices: creators keep seeing groups they made even after
-  // leaving the owning org. The predicate's public arm is unreachable, groups
-  // are permanently private.
-  async listAccessible(userId: string): Promise<Result<IotDeviceGroupWithCountDto[]>> {
+  /**
+   * Groups the caller may read — every one of them, or one organization's, which is
+   * what lets the group list and the organization showcase share this method.
+   *
+   * Same tiering as devices: creators keep seeing groups they made even after
+   * leaving the owning org. The predicate's public arm is unreachable, groups
+   * are permanently private.
+   */
+  async listAccessible(
+    userId: string,
+    options?: { organizationId?: string },
+  ): Promise<Result<IotDeviceGroupWithCountDto[]>> {
     return tryCatch(async () => {
       const scope = accessibleResourceCondition({
         database: this.database,
@@ -73,6 +81,8 @@ export class IotDeviceGroupRepository {
         visibilityColumn: deviceGroups.visibility,
         userId,
       });
+      const visible = or(eq(deviceGroups.createdBy, userId), scope);
+      const organizationId = options?.organizationId;
       return this.database
         .select({
           id: deviceGroups.id,
@@ -86,7 +96,9 @@ export class IotDeviceGroupRepository {
           memberCount: this.memberCount(),
         })
         .from(deviceGroups)
-        .where(or(eq(deviceGroups.createdBy, userId), scope))
+        .where(
+          organizationId ? and(eq(deviceGroups.organizationId, organizationId), visible) : visible,
+        )
         .orderBy(desc(deviceGroups.createdAt));
     });
   }

--- a/apps/backend/src/iot/iot.module.ts
+++ b/apps/backend/src/iot/iot.module.ts
@@ -119,7 +119,8 @@ import { IotController } from "./presentation/iot.controller";
       useExisting: DatabricksAdapter,
     },
   ],
-  // For the organization showcase's device rows, scoped by the shared read predicate.
-  exports: [IotDeviceRepository],
+  // For the organization showcase's device and device-group rows, both scoped by the
+  // shared read predicate.
+  exports: [IotDeviceRepository, IotDeviceGroupRepository],
 })
 export class IotModule {}

--- a/apps/backend/src/organizations/application/use-cases/get-organization-deletion-blockers/get-organization-deletion-blockers.ts
+++ b/apps/backend/src/organizations/application/use-cases/get-organization-deletion-blockers/get-organization-deletion-blockers.ts
@@ -8,11 +8,11 @@ import { OrganizationRepository } from "../../../core/repositories/organization.
 /**
  * What still stands between this organization and deletion.
  *
- * Deleting is owner-only, so reading the reason is too — and the answer covers all
- * five owned resource types, devices included. The resources showcase cannot serve
- * this purpose: it is scoped to what the caller may read and carries only the four
- * shareable types, so an organization owning nothing but a device reads as empty
- * there while the delete guard refuses it.
+ * Deleting is owner-only, so reading the reason is too — and the answer covers every
+ * owned resource type. The resources showcase cannot serve this purpose even though it
+ * now lists the same set: it is scoped to what the caller may read, so an organization
+ * whose remaining resources are private to someone else reads as empty there while the
+ * delete guard refuses it. Counts, not rows, for the same reason.
  *
  * A non-owner gets the same "no such organization" a non-member gets on any other
  * organization read, rather than a 403 that would confirm the id.

--- a/apps/backend/src/organizations/application/use-cases/list-organization-resources/list-organization-resources.spec.ts
+++ b/apps/backend/src/organizations/application/use-cases/list-organization-resources/list-organization-resources.spec.ts
@@ -3,6 +3,8 @@ import { vi } from "vitest";
 import type { DatabaseInstance } from "@repo/database";
 
 import { assertSuccess } from "../../../../common/utils/fp-utils";
+import { CreateIotDeviceGroupUseCase } from "../../../../iot/application/use-cases/create-iot-device-group/create-iot-device-group";
+import { IotDeviceGroupRepository } from "../../../../iot/core/repositories/iot-device-group.repository";
 import { ListGrantsUseCase } from "../../../../sharing/application/use-cases/list-grants/list-grants";
 import { SharingRepository } from "../../../../sharing/core/repositories/sharing.repository";
 import { TestHarness } from "../../../../test/test-harness";
@@ -12,6 +14,8 @@ describe("listOrganizationResources", () => {
   const testApp = TestHarness.App;
   let listResources: ListOrganizationResourcesUseCase;
   let listGrants: ListGrantsUseCase;
+  let createGroup: CreateIotDeviceGroupUseCase;
+  let groupRepository: IotDeviceGroupRepository;
   let sharingRepository: SharingRepository;
   let owner: string;
   let member: string;
@@ -25,6 +29,8 @@ describe("listOrganizationResources", () => {
     await testApp.beforeEach();
     listResources = testApp.module.get(ListOrganizationResourcesUseCase);
     listGrants = testApp.module.get(ListGrantsUseCase);
+    createGroup = testApp.module.get(CreateIotDeviceGroupUseCase);
+    groupRepository = testApp.module.get(IotDeviceGroupRepository);
     sharingRepository = testApp.module.get(SharingRepository);
 
     owner = await testApp.createTestUser({ name: "Olive Owner" });
@@ -60,7 +66,10 @@ describe("listOrganizationResources", () => {
    * failing, whichever of them changes.
    */
   describe("collaborator counts agree with the collaborators surface", () => {
-    async function expectAgreement(resourceType: "macro" | "workbook", resourceId: string) {
+    async function expectAgreement(
+      resourceType: "macro" | "workbook" | "device_group",
+      resourceId: string,
+    ) {
       const grants = await listGrants.execute(owner, resourceType, resourceId);
       assertSuccess(grants);
       const row = await showcaseRow(owner, resourceId);
@@ -212,10 +221,98 @@ describe("listOrganizationResources", () => {
       // goes and the total is unchanged rather than incremented.
       expect(await expectAgreement("macro", macro.id)).toBe(3);
     });
+
+    /**
+     * The count is keyed by resource type, and a type the key builder does not reach
+     * reports zero for every one of its rows — which reads as "nobody has this" rather
+     * than as a bug. So a group is checked against the collaborators surface too, and
+     * against a number that is not zero.
+     */
+    it("counts a device group's collaborators like any other resource", async () => {
+      const created = await createGroup.execute({ name: "Rooftop array", organizationId }, owner);
+      assertSuccess(created);
+      const outsider = await testApp.createTestUser({ name: "Otto Outsider" });
+      await testApp.addResourceGrant({
+        resourceType: "device_group",
+        resourceId: created.value.id,
+        granteeType: "user",
+        granteeId: outsider,
+        role: "viewer",
+        createdBy: owner,
+      });
+
+      // Owner, the members summary, and the outsider's own row.
+      expect(await expectAgreement("device_group", created.value.id)).toBe(3);
+    });
+  });
+
+  describe("device group rows", () => {
+    it("carries the roster size the group list already reads", async () => {
+      const created = await createGroup.execute({ name: "Field array", organizationId }, owner);
+      assertSuccess(created);
+      const first = await testApp.createIotDevice({ createdBy: owner, organizationId });
+      const second = await testApp.createIotDevice({ createdBy: owner, organizationId });
+      const added = await groupRepository.addMembers(
+        created.value.id,
+        [first.id, second.id],
+        owner,
+      );
+      assertSuccess(added);
+
+      const row = await showcaseRow(owner, created.value.id);
+
+      expect(row.type).toBe("device_group");
+      // Two devices, not the two-member group's zero: the count rides on the row the
+      // list already selected, so a projection that dropped it would read as empty.
+      expect(row).toMatchObject({ type: "device_group", memberCount: 2 });
+    });
+
+    it("counts groups into the totals and leaves another organization's out", async () => {
+      const elsewhere = await testApp.createOrganization("Somewhere Else", {
+        visibility: "public",
+      });
+      await testApp.addOrganizationMember(elsewhere, owner, "owner");
+      const ours = await createGroup.execute({ name: "Ours", organizationId }, owner);
+      assertSuccess(ours);
+      const theirs = await createGroup.execute(
+        { name: "Theirs", organizationId: elsewhere },
+        owner,
+      );
+      assertSuccess(theirs);
+
+      const result = await listResources.execute(organizationId, owner);
+      assertSuccess(result);
+
+      // The caller created both and can read both, so only the organization filter
+      // keeps the other one off this page.
+      expect(result.value.resources.map((row) => row.id)).toEqual([ours.value.id]);
+      expect(result.value.totals.device_group).toBe(1);
+    });
+
+    it("shows a non-member none of them, groups being permanently private", async () => {
+      const created = await createGroup.execute({ name: "Private array", organizationId }, owner);
+      assertSuccess(created);
+      const outsider = await testApp.createTestUser({ name: "Nina Nonmember" });
+
+      const result = await listResources.execute(organizationId, outsider);
+      assertSuccess(result);
+
+      expect(result.value.resources).toEqual([]);
+      expect(result.value.totals.device_group).toBe(0);
+      // Not vacuous: the group is there, and the organization's own owner sees it.
+      const asOwner = await showcaseRow(owner, created.value.id);
+      expect(asOwner.id).toBe(created.value.id);
+    });
   });
 
   describe("a fixed number of reads for the whole page", () => {
-    /** A resource of every showcased type, so the page spans all four. */
+    /**
+     * One resource of every showcased type per round, so the page spans all of them —
+     * hardware included. A seed that stopped at the four authored types would leave the
+     * single-call assertion below true of only part of the page.
+     */
+    const SHOWCASED_TYPES = 6;
+
     async function seedOneOfEveryType(count: number) {
       for (let index = 0; index < count; index++) {
         const { experiment } = await testApp.createExperiment({
@@ -237,6 +334,9 @@ describe("listOrganizationResources", () => {
           createdBy: owner,
           organizationId,
         });
+        await testApp.createIotDevice({ createdBy: owner, organizationId });
+        const group = await createGroup.execute({ name: `Group ${index}`, organizationId }, owner);
+        assertSuccess(group);
       }
     }
 
@@ -247,12 +347,14 @@ describe("listOrganizationResources", () => {
       const result = await listResources.execute(organizationId, owner);
       assertSuccess(result);
 
-      // A loop over the rows would be twelve calls on an organization this small, and
+      // A loop over the rows would be eighteen calls on an organization this small, and
       // the showcase is uncapped — so the shape of the read, not its cost here, is
       // what this pins down.
       expect(countCollaborators).toHaveBeenCalledTimes(1);
       const [, asked] = countCollaborators.mock.calls[0];
-      expect(asked).toHaveLength(12);
+      expect(asked).toHaveLength(3 * SHOWCASED_TYPES);
+      // Every type is in that one call, not just the four that carry an author.
+      expect(new Set(asked.map((row) => row.resourceType)).size).toBe(SHOWCASED_TYPES);
       expect(new Set(asked.map((row) => row.resourceId))).toEqual(
         new Set(result.value.resources.map((row) => row.id)),
       );

--- a/apps/backend/src/organizations/application/use-cases/list-organization-resources/list-organization-resources.ts
+++ b/apps/backend/src/organizations/application/use-cases/list-organization-resources/list-organization-resources.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from "@nestjs/common";
 
 import { AppError, Result, failure, isFailure, success } from "../../../../common/utils/fp-utils";
 import { ExperimentRepository } from "../../../../experiments/core/repositories/experiment.repository";
+import { IotDeviceGroupRepository } from "../../../../iot/core/repositories/iot-device-group.repository";
 import { IotDeviceRepository } from "../../../../iot/core/repositories/iot-device.repository";
 import { MacroRepository } from "../../../../macros/core/repositories/macro.repository";
 import { ProtocolRepository } from "../../../../protocols/core/repositories/protocol.repository";
@@ -57,6 +58,7 @@ export class ListOrganizationResourcesUseCase {
     private readonly macroRepository: MacroRepository,
     private readonly workbookRepository: WorkbookRepository,
     private readonly iotDeviceRepository: IotDeviceRepository,
+    private readonly iotDeviceGroupRepository: IotDeviceGroupRepository,
     private readonly sharingRepository: SharingRepository,
   ) {}
 
@@ -82,25 +84,28 @@ export class ListOrganizationResourcesUseCase {
       return failure(AppError.notFound(`Organization with ID ${organizationId} not found`));
     }
 
-    const [experiments, protocols, macros, workbooks, devices, totals] = await Promise.all([
-      // Archived stay in: every other count of what an organization owns includes them,
-      // so dropping them here would let a group header promise a row the list cannot show.
-      this.experimentRepository.findAll(userId, undefined, undefined, undefined, undefined, {
-        organizationId,
-        includeArchived: true,
-      }),
-      this.protocolRepository.findAll(undefined, undefined, userId, undefined, organizationId),
-      this.macroRepository.findAll({ userId, organizationId }),
-      this.workbookRepository.findAll({ userId, organizationId }),
-      this.iotDeviceRepository.listAccessible(userId, { organizationId }),
-      this.organizationRepository.countAccessibleResources(organizationId, userId),
-    ]);
+    const [experiments, protocols, macros, workbooks, devices, deviceGroups, totals] =
+      await Promise.all([
+        // Archived stay in: every other count of what an organization owns includes them,
+        // so dropping them here would let a group header promise a row the list cannot show.
+        this.experimentRepository.findAll(userId, undefined, undefined, undefined, undefined, {
+          organizationId,
+          includeArchived: true,
+        }),
+        this.protocolRepository.findAll(undefined, undefined, userId, undefined, organizationId),
+        this.macroRepository.findAll({ userId, organizationId }),
+        this.workbookRepository.findAll({ userId, organizationId }),
+        this.iotDeviceRepository.listAccessible(userId, { organizationId }),
+        this.iotDeviceGroupRepository.listAccessible(userId, { organizationId }),
+        this.organizationRepository.countAccessibleResources(organizationId, userId),
+      ]);
 
     if (isFailure(experiments)) return failure(experiments.error);
     if (isFailure(protocols)) return failure(protocols.error);
     if (isFailure(macros)) return failure(macros.error);
     if (isFailure(workbooks)) return failure(workbooks.error);
     if (isFailure(devices)) return failure(devices.error);
+    if (isFailure(deviceGroups)) return failure(deviceGroups.error);
     if (totals.isFailure()) {
       return failure(AppError.internal("Failed to count an organization's resources"));
     }
@@ -114,6 +119,10 @@ export class ListOrganizationResourcesUseCase {
       ...macros.value.map((row) => ({ resourceType: "macro" as const, resourceId: row.id })),
       ...workbooks.value.map((row) => ({ resourceType: "workbook" as const, resourceId: row.id })),
       ...devices.value.map((row) => ({ resourceType: "device" as const, resourceId: row.id })),
+      ...deviceGroups.value.map((row) => ({
+        resourceType: "device_group" as const,
+        resourceId: row.id,
+      })),
     ]);
     if (collaborators.isFailure()) {
       return failure(AppError.internal("Failed to count an organization's collaborators"));
@@ -148,6 +157,13 @@ export class ListOrganizationResourcesUseCase {
         ...base({ ...row, name: deviceName(row), description: null }, countFor("device", row.id)),
         type: "device" as const,
         deviceType: row.deviceType,
+      })),
+      ...deviceGroups.value.map((row) => ({
+        ...base(row, countFor("device_group", row.id)),
+        type: "device_group" as const,
+        // Already on the row the list read: the group projection carries its roster
+        // size, so showing it costs no second query.
+        memberCount: row.memberCount,
       })),
     ].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
 

--- a/apps/backend/src/organizations/core/repositories/organization.repository.ts
+++ b/apps/backend/src/organizations/core/repositories/organization.repository.ts
@@ -52,7 +52,7 @@ import type {
 import { normalizeOrgRole } from "../organization-access";
 
 /**
- * The resource tables an organization can own, keyed by the grant enum so a sixth
+ * The resource tables an organization can own, keyed by the grant enum so a new
  * org-owning type cannot be added without this stopping compiling — the same total
  * `Record` the delete guard in `@repo/auth` keys its own count on. The two have to
  * agree: this one decides whether the danger zone offers deletion, that one decides
@@ -93,23 +93,18 @@ const RESOURCE_NAME_SQL: Record<ResourceType, SQL> = {
 };
 
 /**
- * The types the organization showcase lists and counts. Narrower than
- * {@link OWNED_RESOURCE_TABLES} on purpose: a device group is owned and grantable, so it
- * blocks a delete and can be named in a grant, but nothing lists one yet — counting it
- * would put a total on screen with no rows behind it.
+ * Every type the showcase lists and counts, which is every type an organization can
+ * own. Read off {@link OWNED_RESOURCE_TABLES} rather than listed again: a separate list
+ * is one nobody is forced to extend, so a newly grantable type would land, be counted
+ * nowhere, and leave the page quietly claiming a smaller estate than the organization
+ * has. The keys are exhaustive because that map's `satisfies` says so.
  */
-const SHOWN_RESOURCE_TYPES = [
-  "experiment",
-  "protocol",
-  "macro",
-  "workbook",
-  "device",
-] as const satisfies readonly ResourceType[];
+const OWNED_RESOURCE_TYPES = Object.keys(OWNED_RESOURCE_TABLES) as ResourceType[];
 
 /**
  * Every resource a grant can name, with the name to show for it —
  * {@link ALL_STAFFED_RESOURCES} plus that column. Generated from the same total map,
- * so a sixth grantable type joins this set by being added there.
+ * so a new grantable type joins this set by being added there.
  */
 const ALL_NAMED_RESOURCES: SQL = sql.join(
   Object.entries(OWNED_RESOURCE_TABLES).map(
@@ -175,7 +170,7 @@ function accessibleResourceCountSql(params: {
 /**
  * How much of the organization the caller can actually reach, summed across every type
  * it can own — one correlated count per table rather than a join, so a listing pays for
- * the sum once per row instead of fanning its rows out five times.
+ * the sum once per row instead of fanning its rows out once per owned type.
  *
  * Scoped, not absolute: the unscoped total promised a visitor 43 resources and then
  * showed them 3. So the same organization reports a different size to different
@@ -183,7 +178,7 @@ function accessibleResourceCountSql(params: {
  */
 function resourceCountSql(database: DatabaseInstance, userId: string | undefined): SQL<number> {
   return sql<number>`(${sql.join(
-    SHOWN_RESOURCE_TYPES.map((resourceType) =>
+    OWNED_RESOURCE_TYPES.map((resourceType) =>
       accessibleResourceCountSql({
         database,
         resourceType: resourceType,
@@ -244,8 +239,8 @@ export class OrganizationRepository {
   }
 
   /**
-   * How many resources of each type the organization owns. Counted across all five
-   * types regardless of who is asking — this answers "may this be deleted", which
+   * How many resources of each type the organization owns. Counted across every owned
+   * type regardless of who is asking — this answers "may this be deleted", which
    * is a fact about the organization, not about the caller's read access. Types
    * holding nothing are left out, so an empty array means deletable.
    */
@@ -471,16 +466,17 @@ export class OrganizationRepository {
   /**
    * How many resources of each owned type the caller may read in this organization.
    * The per-type breakdown of {@link resourceCountSql}, from the same fragment, so the
-   * profile's single number and these five agree by construction. One statement.
+   * profile's single number and these agree by construction. One statement.
    *
-   * Devices are permanently private, so a non-member always counts zero of them.
+   * Devices and device groups are permanently private, so a non-member always counts
+   * zero of both.
    */
   async countAccessibleResources(
     organizationId: string,
     userId: string,
   ): Promise<Result<OrganizationResourceTotalsDto>> {
     return tryCatch(async () => {
-      const counts = SHOWN_RESOURCE_TYPES.map(
+      const counts = OWNED_RESOURCE_TYPES.map(
         (resourceType) =>
           sql`${accessibleResourceCountSql({
             database: this.database,
@@ -504,6 +500,7 @@ export class OrganizationRepository {
         macro: row.macro ?? 0,
         workbook: row.workbook ?? 0,
         device: row.device ?? 0,
+        device_group: row.device_group ?? 0,
       };
     });
   }

--- a/apps/backend/src/organizations/presentation/organization.controller.spec.ts
+++ b/apps/backend/src/organizations/presentation/organization.controller.spec.ts
@@ -12,9 +12,11 @@ import type {
   OrganizationTeamGrantList,
   OrganizationTeamList,
 } from "@repo/api/domains/organization/organization.schema";
+import { zSharingResourceType } from "@repo/api/domains/sharing/sharing.schema";
 
 import { AuthorizationService } from "../../authorization/authorization.service";
 import { assertSuccess } from "../../common/utils/fp-utils";
+import { CreateIotDeviceGroupUseCase } from "../../iot/application/use-cases/create-iot-device-group/create-iot-device-group";
 import type { SuperTestResponse } from "../../test/test-harness";
 import { TestHarness } from "../../test/test-harness";
 import { OrganizationRepository } from "../core/repositories/organization.repository";
@@ -491,26 +493,32 @@ describe("OrganizationController", () => {
       await testApp.createMacro({ name: "Batch fit", createdBy: ownerId, organizationId });
       await testApp.createWorkbook({ name: "Synthesis", createdBy: ownerId, organizationId });
       await testApp.createIotDevice({ createdBy: ownerId, organizationId });
+      const group = await testApp.module
+        .get(CreateIotDeviceGroupUseCase)
+        .execute({ name: "Rooftop array", organizationId }, ownerId);
+      assertSuccess(group);
 
       return { live, archived };
     }
 
     /**
-     * Rows of each owned type, keyed the same way `totals` is — **all five**.
+     * Rows of each owned type, keyed the same way `totals` is. Built from the grant enum
+     * rather than written out, so a newly owned type joins this invariant by existing —
+     * a hand-keyed object would leave that type's rows and its total free to disagree
+     * while every assertion here stayed green.
      *
      * There was briefly a `showcaseTotals()` helper here that destructured `device` out,
      * because devices were counted and never listed. They are listed now, so the
      * exemption is gone and the invariant covers every type it counts. An exemption is
      * exactly where the two sides drift.
      */
-    function rowsPerType(body: OrganizationResources) {
-      return {
-        experiment: body.resources.filter((row) => row.type === "experiment").length,
-        protocol: body.resources.filter((row) => row.type === "protocol").length,
-        macro: body.resources.filter((row) => row.type === "macro").length,
-        workbook: body.resources.filter((row) => row.type === "workbook").length,
-        device: body.resources.filter((row) => row.type === "device").length,
-      };
+    function rowsPerType(body: OrganizationResources): Record<string, number> {
+      return Object.fromEntries(
+        zSharingResourceType.options.map((type) => [
+          type,
+          body.resources.filter((row) => row.type === type).length,
+        ]),
+      );
     }
 
     it("holds the totals-equal-rows invariant for a member, archived included", async () => {
@@ -530,6 +538,7 @@ describe("OrganizationController", () => {
         macro: 1,
         workbook: 1,
         device: 1,
+        device_group: 1,
       });
       // The archived row carries its status, which is the only surface that shows it.
       expect(response.body.resources.find((row) => row.id === archived.id)).toMatchObject({
@@ -616,6 +625,7 @@ describe("OrganizationController", () => {
         macro: 0,
         workbook: 0,
         device: 0,
+        device_group: 0,
       });
       // Scoped exactly like the rows: the private experiment is behind neither.
       expect(asOutsider.body.totals.experiment).toBe(1);
@@ -738,8 +748,8 @@ describe("OrganizationController", () => {
         .withAuth(outsiderId)
         .expect(StatusCodes.OK);
 
-      // Four groups and four segments for a visitor, five and five for a member — the
-      // rows and the counts narrow together.
+      // A visitor gets fewer groups and fewer segments than a member does — the rows
+      // and the counts narrow together.
       expect(response.body.resources.map((row) => row.type)).toEqual(["experiment"]);
       expect(response.body.totals.device).toBe(0);
     });
@@ -819,7 +829,7 @@ describe("OrganizationController", () => {
       return { shared };
     }
 
-    /** The profile's single number and the showcase's five, for one caller. */
+    /** The profile's single number and the showcase's per-type breakdown, for one caller. */
     async function countsFor(organizationId: string, userId: string) {
       const profile: SuperTestResponse<OrganizationProfile> = await testApp
         .get(profilePath(organizationId))

--- a/apps/backend/src/users/application/use-cases/get-deletion-blockers/get-deletion-blockers.spec.ts
+++ b/apps/backend/src/users/application/use-cases/get-deletion-blockers/get-deletion-blockers.spec.ts
@@ -74,8 +74,10 @@ describe("GetDeletionBlockersUseCase", () => {
     });
   });
 
-  // All four types are created with a creator admin grant, so all four can end up
-  // with a single named admin and block the deletion.
+  // Every staffed type is created with a creator admin grant — `seedCreatorControl` runs
+  // on all six create paths — so any of them can end up with a single named admin and
+  // block the deletion. The cases below cover four of the six; devices and device groups
+  // seed the same grant and are not exercised here.
   it.each([
     [
       "macro" as const,

--- a/apps/backend/src/users/core/repositories/user.repository.spec.ts
+++ b/apps/backend/src/users/core/repositories/user.repository.spec.ts
@@ -1715,8 +1715,10 @@ describe("UserRepository", () => {
       expect(await isStillLive(soleOwner)).toBe(true);
     });
 
-    // The re-check is polymorphic over all four types, so a sole-owned macro is as
-    // unclearable a blocker as a sole-owned experiment.
+    // The re-check spans every staffed type — its query reads `ALL_STAFFED_RESOURCES`,
+    // built from a total map — so a sole-owned macro is as unclearable a blocker as a
+    // sole-owned experiment. These three stand in for the set: devices and device groups
+    // reach the same predicate and are not exercised here.
     it.each(["macro", "protocol", "workbook"] as const)(
       "refuses a deletion that would leave a %s with no answerable owner",
       async (resourceType) => {

--- a/apps/docs/content/guide/sharing/moving-resources.mdx
+++ b/apps/docs/content/guide/sharing/moving-resources.mdx
@@ -40,11 +40,15 @@ Both sides are checked:
   be stranded in an organization nobody can act on.
 </Callout>
 
-## Devices cannot be moved
+## Devices and device groups cannot be moved
 
 Experiments, macros, protocols and workbooks can all be transferred. **Devices cannot** —
 there is no transfer route for them at all. A device stays with the organization that
 registered it until the device is deleted.
+
+**Device groups cannot be moved either**, for the same reason one step removed: a group is
+its list of devices, and those devices are pinned to the organization that registered
+them. A group that moved on its own would arrive without them.
 
 This matters when you are trying to empty an organization before
 [deleting it](/guide/organizations/deleting).

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -18989,6 +18989,58 @@
                               "type",
                               "deviceType"
                             ]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "visibility": {
+                                "enum": [
+                                  "private",
+                                  "public"
+                                ],
+                                "type": "string"
+                              },
+                              "updatedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "collaboratorCount": {
+                                "type": "integer"
+                              },
+                              "type": {
+                                "const": "device_group"
+                              },
+                              "memberCount": {
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name",
+                              "description",
+                              "visibility",
+                              "updatedAt",
+                              "collaboratorCount",
+                              "type",
+                              "memberCount"
+                            ]
                           }
                         ]
                       }
@@ -19010,6 +19062,9 @@
                         },
                         "device": {
                           "type": "integer"
+                        },
+                        "device_group": {
+                          "type": "integer"
                         }
                       },
                       "required": [
@@ -19017,7 +19072,8 @@
                         "protocol",
                         "macro",
                         "workbook",
-                        "device"
+                        "device",
+                        "device_group"
                       ]
                     }
                   },

--- a/apps/web/components/organizations/organization-and-sharing-strings.test.ts
+++ b/apps/web/components/organizations/organization-and-sharing-strings.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { zExperimentStatus } from "@repo/api/domains/experiment/experiment.schema";
+import { zSharingResourceType } from "@repo/api/domains/sharing/sharing.schema";
 import deCommon from "@repo/i18n/locales/de-DE/common.json";
 import deNavigation from "@repo/i18n/locales/de-DE/navigation.json";
 import enCommon from "@repo/i18n/locales/en-US/common.json";
@@ -169,16 +170,14 @@ describe("organization and sharing strings", () => {
       ...["pending", "approved", "rejected", "cancelled"].map(
         (status) => `organizations.requests.status.${status}`,
       ),
-      // Built from a template literal, so the source scan above cannot see these.
-      // This list is the only thing standing between a missing label and a row
-      // rendering its own key.
-      ...["experiment", "macro", "protocol", "workbook", "device"].map(
-        (type) => `organizations.resources.types.${type}`,
-      ),
-      // The delete-blocker breakdown names every owned type.
-      ...["experiment", "macro", "protocol", "workbook", "device"].map(
-        (type) => `organizations.delete.owned.${type}`,
-      ),
+      // Both are built from a template literal, so the source scan above cannot see
+      // them. Read from the schema rather than listed, so a newly owned type has to be
+      // given a label instead of shipping as a raw key on the showcase and in the
+      // delete-blocker breakdown.
+      ...zSharingResourceType.options.flatMap((type) => [
+        `organizations.resources.types.${type}`,
+        `organizations.delete.owned.${type}`,
+      ]),
       // An experiment row's meta badge. Read from the schema rather than listed, so a
       // sixth status has to be given a label instead of shipping as a raw key.
       ...zExperimentStatus.options.map((status) => `organizations.resources.status.${status}`),

--- a/apps/web/components/organizations/organization-danger-zone.test.tsx
+++ b/apps/web/components/organizations/organization-danger-zone.test.tsx
@@ -16,7 +16,7 @@ function mockSession(user: { id: string } | null) {
   } as ReturnType<typeof useSession>);
 }
 
-/** The authoritative blocker read: all five owned types, counts only. */
+/** The authoritative blocker read: every owned type, counts only. */
 function mountBlockers(blockers: OrganizationDeletionBlocker[]) {
   return server.mount(contract.organizations.getOrganizationDeletionBlockers, {
     body: { blockers, total: blockers.reduce((sum, { count }) => sum + count, 0) },

--- a/apps/web/components/organizations/organization-featured-selection.test.ts
+++ b/apps/web/components/organizations/organization-featured-selection.test.ts
@@ -1,13 +1,13 @@
 import { createOrganizationResource } from "@/test/factories";
 import { describe, expect, it } from "vitest";
 
-import type { OrganizationResourceType } from "@repo/api/domains/organization/organization.schema";
+import type { SharingResourceType } from "@repo/api/domains/sharing/sharing.schema";
 
 import { pickFeaturedResources } from "./organization-featured-selection";
 
 /** A resource of `type` with a known collaborator count, named so it is identifiable. */
 function resource(
-  type: OrganizationResourceType,
+  type: SharingResourceType,
   collaboratorCount: number,
   extra: { id?: string; updatedAt?: string } = {},
 ) {
@@ -111,13 +111,14 @@ describe("pickFeaturedResources", () => {
     expect(featured.map((row) => row.collaboratorCount)).toEqual([2, 1, 9]);
   });
 
-  it("rotates devices last, matching the order the resources card groups by", () => {
+  it("rotates the hardware last, matching the order the resources card groups by", () => {
     const resources = [
       ...[9, 8].map((n) => resource("experiment", n)),
       resource("protocol", 7),
       resource("macro", 6),
       resource("workbook", 5),
       ...[4, 3].map((n) => resource("device", n)),
+      resource("device_group", 2),
     ];
 
     expect(typesOf(pickFeaturedResources(resources))).toEqual([
@@ -126,8 +127,19 @@ describe("pickFeaturedResources", () => {
       "macro",
       "workbook",
       "device",
-      "experiment",
+      "device_group",
     ]);
+  });
+
+  it("can feature a device group, which is a resource like any other", () => {
+    // Same reason a device can be featured: a group is in the resources card and in the
+    // estate bar, so a featured card that could never show one would contradict both.
+    const resources = [resource("experiment", 2), resource("device_group", 9)];
+
+    const featured = pickFeaturedResources(resources);
+
+    expect(typesOf(featured)).toEqual(["experiment", "device_group"]);
+    expect(featured.map((row) => row.collaboratorCount)).toEqual([2, 9]);
   });
 
   it("does not consume the caller's array", () => {

--- a/apps/web/components/organizations/organization-resource-filter.test.ts
+++ b/apps/web/components/organizations/organization-resource-filter.test.ts
@@ -1,7 +1,7 @@
 import { createOrganizationResource } from "@/test/factories";
 import { describe, expect, it } from "vitest";
 
-import type { OrganizationResourceType } from "@repo/api/domains/organization/organization.schema";
+import type { SharingResourceType } from "@repo/api/domains/sharing/sharing.schema";
 
 import {
   DEFAULT_RESOURCE_FILTER,
@@ -11,7 +11,7 @@ import {
 
 function resource(
   name: string,
-  extra: { type?: OrganizationResourceType; updatedAt?: string; description?: string | null } = {},
+  extra: { type?: SharingResourceType; updatedAt?: string; description?: string | null } = {},
 ) {
   return createOrganizationResource({
     name,
@@ -75,6 +75,7 @@ describe("filterAndSortResources", () => {
         resource("Campaign", { type: "experiment" }),
         resource("Dark adaptation", { type: "protocol" }),
         resource("Ambyte 04", { type: "device" }),
+        resource("Rooftop array", { type: "device_group" }),
       ];
 
       expect(
@@ -83,7 +84,12 @@ describe("filterAndSortResources", () => {
       expect(
         namesOf(filterAndSortResources(rows, { ...DEFAULT_RESOURCE_FILTER, type: "device" })),
       ).toEqual(["Ambyte 04"]);
-      expect(filterAndSortResources(rows, DEFAULT_RESOURCE_FILTER)).toHaveLength(3);
+      // A group is its own type, not a kind of device: filtering to devices must not
+      // pick it up, and it has a chip of its own.
+      expect(
+        namesOf(filterAndSortResources(rows, { ...DEFAULT_RESOURCE_FILTER, type: "device_group" })),
+      ).toEqual(["Rooftop array"]);
+      expect(filterAndSortResources(rows, DEFAULT_RESOURCE_FILTER)).toHaveLength(4);
     });
 
     it("combines with the search rather than replacing it", () => {
@@ -136,10 +142,11 @@ describe("filterAndSortResources", () => {
         resource("Newer experiment", { type: "experiment", updatedAt: "2026-05-01T00:00:00.000Z" }),
         resource("A macro", { type: "macro" }),
         resource("A protocol", { type: "protocol" }),
+        resource("A device group", { type: "device_group" }),
       ];
 
-      // experiment, protocol, macro, workbook, device — the order the featured card
-      // rotates through and the estate bar segments by.
+      // experiment, protocol, macro, workbook, device, device group — the order the
+      // featured card rotates through and the estate bar segments by.
       expect(
         namesOf(filterAndSortResources(rows, { ...DEFAULT_RESOURCE_FILTER, sort: "type" })),
       ).toEqual([
@@ -149,6 +156,7 @@ describe("filterAndSortResources", () => {
         "A macro",
         "A workbook",
         "A device",
+        "A device group",
       ]);
     });
   });

--- a/apps/web/components/organizations/organization-resource-meta.test.ts
+++ b/apps/web/components/organizations/organization-resource-meta.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { zSharingResourceType } from "@repo/api/domains/sharing/sharing.schema";
+
+import { GROUP_ORDER, RESOURCE_SEGMENT, RESOURCE_TYPE_COLOR } from "./organization-resource-meta";
+
+/**
+ * The showcase covers every type an organization can own, and three constants have to
+ * agree on what that set is. Two of them are total `Record`s, so the compiler keeps
+ * them honest. {@link GROUP_ORDER} is an array — nothing about its type says it is
+ * complete, so this is what stands between a newly owned type and a page that silently
+ * leaves it out: no order means no group, no filter chip, no bar segment and no
+ * eligibility for the featured card.
+ */
+describe("the resource meta constants", () => {
+  it("orders every type a grant can name, exactly once", () => {
+    expect([...GROUP_ORDER].sort()).toEqual([...zSharingResourceType.options].sort());
+  });
+
+  it("gives every ordered type a colour and a platform section", () => {
+    for (const type of GROUP_ORDER) {
+      expect(RESOURCE_TYPE_COLOR[type], type).toMatch(/^bg-/u);
+      expect(RESOURCE_SEGMENT[type], type).toBeTruthy();
+    }
+  });
+
+  it("gives each type a colour of its own, so a bar segment identifies one type", () => {
+    const colors = Object.values(RESOURCE_TYPE_COLOR);
+
+    expect(new Set(colors).size).toBe(colors.length);
+  });
+});

--- a/apps/web/components/organizations/organization-resource-meta.ts
+++ b/apps/web/components/organizations/organization-resource-meta.ts
@@ -1,10 +1,8 @@
-import type { OrganizationResourceType } from "@repo/api/domains/organization/organization.schema";
 import type { SharingResourceType } from "@repo/api/domains/sharing/sharing.schema";
 
 /**
  * Where each grantable type's detail page lives on the platform: the resources card
- * links rows here, and so does the team-grants list, which can name a device or a
- * device group even though neither is listed in the showcase.
+ * links rows here, and so does the team-grants list.
  */
 export const RESOURCE_SEGMENT: Record<SharingResourceType, string> = {
   experiment: "experiments",
@@ -21,12 +19,13 @@ export const RESOURCE_SEGMENT: Record<SharingResourceType, string> = {
  * card groups by it, the featured card rotates through it, the estate bar segments by
  * it — so none of them can disagree about which types exist.
  */
-export const GROUP_ORDER: readonly OrganizationResourceType[] = [
+export const GROUP_ORDER: readonly SharingResourceType[] = [
   "experiment",
   "protocol",
   "macro",
   "workbook",
   "device",
+  "device_group",
 ];
 
 /**
@@ -35,10 +34,11 @@ export const GROUP_ORDER: readonly OrganizationResourceType[] = [
  * them gets dark mode for nothing. Devices take `--highlight` as the only token that
  * separates cleanly from a teal, two greens and a blue at 8px.
  */
-export const RESOURCE_TYPE_COLOR: Record<OrganizationResourceType, string> = {
+export const RESOURCE_TYPE_COLOR: Record<SharingResourceType, string> = {
   experiment: "bg-primary",
   protocol: "bg-tertiary",
   macro: "bg-sidebar-primary",
   workbook: "bg-accent",
   device: "bg-highlight",
+  device_group: "bg-secondary",
 };

--- a/apps/web/components/organizations/organization-resource-mix.test.tsx
+++ b/apps/web/components/organizations/organization-resource-mix.test.tsx
@@ -11,6 +11,7 @@ const NO_TOTALS: OrganizationResourceTotals = {
   macro: 0,
   workbook: 0,
   device: 0,
+  device_group: 0,
 };
 
 /**
@@ -34,7 +35,7 @@ describe("<OrganizationResourceMix />", () => {
   it("puts the total in the header — the number the resources stat tile used to carry", () => {
     render(
       <OrganizationResourceMix
-        totals={{ experiment: 4, protocol: 2, macro: 1, workbook: 1, device: 0 }}
+        totals={{ ...NO_TOTALS, experiment: 4, protocol: 2, macro: 1, workbook: 1 }}
         isMember
       />,
     );
@@ -46,7 +47,7 @@ describe("<OrganizationResourceMix />", () => {
   it("gives each type a segment proportional to its share", () => {
     const { container } = render(
       <OrganizationResourceMix
-        totals={{ experiment: 5, protocol: 3, macro: 1, workbook: 1, device: 0 }}
+        totals={{ ...NO_TOTALS, experiment: 5, protocol: 3, macro: 1, workbook: 1 }}
         isMember
       />,
     );
@@ -69,16 +70,17 @@ describe("<OrganizationResourceMix />", () => {
     ]);
   });
 
-  it("reads the four listed types in the resources card's order, then devices", () => {
+  it("reads every type in the resources card's order, hardware last", () => {
     const { container } = render(
       <OrganizationResourceMix
-        totals={{ experiment: 1, protocol: 1, macro: 1, workbook: 1, device: 1 }}
+        totals={{ experiment: 1, protocol: 1, macro: 1, workbook: 1, device: 1, device_group: 1 }}
         isMember
       />,
     );
 
-    // Devices last, after the four that have rows below — they are the type the
-    // resources card cannot show, so they read as the tail of the estate, not among it.
+    // The order the card below groups by, so a segment and its group read the same way
+    // — the two things you make, the two you write, then the hardware, a group directly
+    // after the devices it holds.
     expect(
       within(container)
         .getAllByRole("listitem")
@@ -89,6 +91,7 @@ describe("<OrganizationResourceMix />", () => {
       "organizations.resources.types.macro1",
       "organizations.resources.types.workbook1",
       "organizations.resources.types.device1",
+      "organizations.resources.types.device_group1",
     ]);
   });
 

--- a/apps/web/components/organizations/organization-resource-mix.tsx
+++ b/apps/web/components/organizations/organization-resource-mix.tsx
@@ -10,7 +10,7 @@ import { GROUP_ORDER, RESOURCE_TYPE_COLOR } from "./organization-resource-meta";
  * What kind of work this organization does, as one bar. The header carries the total,
  * which is what let the resources stat tile go.
  *
- * All five owned types, in the same order and from the same numbers the resources card
+ * Every owned type, in the same order and from the same numbers the resources card
  * below groups by, so every segment has a group beneath it and vice versa.
  *
  * Access-scoped: this is what *this caller* can see, deliberately not

--- a/apps/web/components/organizations/organization-resource-rows.test.tsx
+++ b/apps/web/components/organizations/organization-resource-rows.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, userEvent, waitFor, within } from "@/test/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { contract } from "@repo/api/contract";
+import { zTransferableResourceType } from "@repo/api/domains/sharing/transfer-org/sharing-transfer-org.schema";
 import { useSession } from "@repo/auth/client";
 import deCommon from "@repo/i18n/locales/de-DE/common.json";
 import enCommon from "@repo/i18n/locales/en-US/common.json";
@@ -57,6 +58,13 @@ function mixedEstate() {
       deviceType: "ambyte",
       updatedAt: "2026-01-01T00:00:00.000Z",
     }),
+    createOrganizationResource({
+      type: "device_group",
+      id: "g1",
+      name: "Rooftop array",
+      memberCount: 12,
+      updatedAt: "2025-12-01T00:00:00.000Z",
+    }),
   ];
 }
 
@@ -67,7 +75,7 @@ describe("<OrganizationResourceRows />", () => {
     // The grouped card put a heading and a count above each type. Both are gone; the
     // estate bar in the sidebar reports counts now.
     expect(within(container).queryAllByRole("heading")).toHaveLength(0);
-    expect(rowsIn(container)).toHaveLength(5);
+    expect(rowsIn(container)).toHaveLength(6);
     // Default order is most recently updated first.
     expect(rowNames(container)).toEqual([
       "Drought stress",
@@ -75,6 +83,7 @@ describe("<OrganizationResourceRows />", () => {
       "Batch fit",
       "Canopy synthesis",
       "Ambyte 04",
+      "Rooftop array",
     ]);
   });
 
@@ -138,7 +147,7 @@ describe("<OrganizationResourceRows />", () => {
 
       await user.click(clear);
 
-      expect(rowsIn(container)).toHaveLength(5);
+      expect(rowsIn(container)).toHaveLength(6);
       expect(search).toHaveValue("");
     });
 
@@ -199,6 +208,7 @@ describe("<OrganizationResourceRows />", () => {
         "Canopy synthesis",
         "Dark adaptation",
         "Drought stress",
+        "Rooftop array",
       ]);
     });
 
@@ -212,7 +222,7 @@ describe("<OrganizationResourceRows />", () => {
         }),
       );
 
-      // Five types and no sixth, in GROUP_ORDER — a hand-written list could drift.
+      // Six types and no seventh, in GROUP_ORDER — a hand-written list could drift.
       expect((await screen.findAllByRole("option")).map((o) => o.textContent)).toEqual([
         "organizations.resources.allTypes",
         "organizations.resources.types.experiment",
@@ -220,6 +230,7 @@ describe("<OrganizationResourceRows />", () => {
         "organizations.resources.types.macro",
         "organizations.resources.types.workbook",
         "organizations.resources.types.device",
+        "organizations.resources.types.device_group",
       ]);
     });
   });
@@ -235,6 +246,8 @@ describe("<OrganizationResourceRows />", () => {
       expect(href("Batch fit")).toBe("/en-US/platform/macros/m1");
       expect(href("Canopy synthesis")).toBe("/en-US/platform/workbooks/w1");
       expect(href("Ambyte 04")).toBe("/en-US/platform/devices/d1");
+      // Two segments, because a group's listing lives under the devices section.
+      expect(href("Rooftop array")).toBe("/en-US/platform/devices/groups/g1");
     });
 
     it("carries each type's meta badge in the platform's own colour", () => {
@@ -267,6 +280,28 @@ describe("<OrganizationResourceRows />", () => {
       expect(rowFor("Drought stress").querySelector("p")?.textContent).toBe(
         "Rain-out shelter, 12 plots",
       );
+    });
+
+    /**
+     * A group's extra fact is a quantity, and the badge slot is for categorical values
+     * that carry a colour from their own listing. So it has to be text in the footer,
+     * and there has to be no badge — a numeric badge would be the first in the set and
+     * would redefine what the slot means.
+     */
+    it("states a device group's roster size as footer text, with no badge", () => {
+      const { container } = render(<OrganizationResourceRows resources={mixedEstate()} />);
+
+      const row = within(container).getByRole("link", { name: "Rooftop array" }).closest("li");
+      if (!row) throw new Error("no row for Rooftop array");
+
+      const roster = within(row).getByText("organizations.resources.groupMemberCount");
+      expect(roster).toBeVisible();
+      // Sits with the type dot, not in the badge slot: `Badge` is the only thing on a
+      // row that renders as a `bg-*` pill, so no element here may be one.
+      expect(row.querySelector('[class*="bg-badge-"]')).toBeNull();
+      expect(roster.tagName).toBe("SPAN");
+      // Not vacuous: the same footer renders the type label right beside it.
+      expect(within(row).getByText("organizations.resources.types.device_group")).toBeVisible();
     });
 
     it("strips markup out of a description rather than printing it", () => {
@@ -333,7 +368,7 @@ describe("<OrganizationResourceRows />", () => {
       } as ReturnType<typeof useSession>);
     });
 
-    /** The row a resource is on, so a click can be aimed at one of five. */
+    /** The row a resource is on, so a click can be aimed at one of six. */
     function rowFor(container: HTMLElement, name: string): HTMLElement {
       const row = within(container).getByRole("link", { name }).closest("li");
       if (!row) throw new Error(`no row for ${name}`);
@@ -356,6 +391,19 @@ describe("<OrganizationResourceRows />", () => {
       );
     }
 
+    /**
+     * Pinned on the enum, not the render: transferring a group would strand its devices
+     * or force re-provisioning each one, so widening it must be a deliberate edit.
+     */
+    it("keeps devices and device groups out of the transferable set", () => {
+      expect(zTransferableResourceType.options).toEqual([
+        "experiment",
+        "macro",
+        "protocol",
+        "workbook",
+      ]);
+    });
+
     it("offers nothing to a member or a non-member", () => {
       // Neither is handed `transfer`, so one render covers both.
       const { container } = render(<OrganizationResourceRows resources={mixedEstate()} />);
@@ -363,15 +411,18 @@ describe("<OrganizationResourceRows />", () => {
       expect(transferButtons(container)).toHaveLength(0);
     });
 
-    it("offers it on the four transferable types and not on a device", () => {
+    it("offers it on the four transferable types and not on a device or a group", () => {
       const { container } = renderTransferable();
 
-      // Five rows, four controls: there is no transfer route for a device.
-      expect(rowsIn(container)).toHaveLength(5);
+      // Six rows, four controls: neither a device nor a device group has a transfer
+      // route, so neither gets a control that would only refuse.
+      expect(rowsIn(container)).toHaveLength(6);
       expect(transferButtons(container)).toHaveLength(4);
-      expect(
-        within(rowFor(container, "Ambyte 04")).queryByRole("button", { name: TRANSFER }),
-      ).toBeNull();
+      for (const name of ["Ambyte 04", "Rooftop array"]) {
+        expect(
+          within(rowFor(container, name)).queryByRole("button", { name: TRANSFER }),
+        ).toBeNull();
+      }
       for (const name of ["Drought stress", "Dark adaptation", "Batch fit", "Canopy synthesis"]) {
         expect(
           within(rowFor(container, name)).getByRole("button", { name: TRANSFER }),

--- a/apps/web/components/organizations/organization-resource-rows.tsx
+++ b/apps/web/components/organizations/organization-resource-rows.tsx
@@ -79,7 +79,11 @@ function metaBadge(
         label: getSensorFamilyLabel(resource.deviceType),
         colorClass: getSensorFamilyBadgeColor(resource.deviceType),
       };
+    // A workbook has no second fact. A group does — its roster size — but that is a
+    // quantity rather than a category, so it has no colour of its own to wear and
+    // reads as footer text beside the type instead.
     case "workbook":
+    case "device_group":
       return null;
   }
 }
@@ -229,7 +233,8 @@ function ResourceRow({
   const locale = useLocale();
 
   const meta = metaBadge(resource, t);
-  // A device has no transfer route, so it gets no control rather than one that refuses.
+  // Neither a device nor a device group has a transfer route, so they get no control
+  // rather than one that refuses.
   const transferableAs = onTransfer ? transferableType(resource.type) : null;
 
   return (
@@ -285,6 +290,12 @@ function ResourceRow({
           />
           {t(`organizations.resources.types.${resource.type}`, { count: 1 })}
         </span>
+
+        {resource.type === "device_group" ? (
+          <span className="shrink-0 tabular-nums">
+            {t("organizations.resources.groupMemberCount", { count: resource.memberCount })}
+          </span>
+        ) : null}
 
         {meta ? (
           <Badge className={`shrink-0 rounded px-1.5 py-0 font-medium ${meta.colorClass}`}>

--- a/apps/web/components/organizations/organization-team-grants.test.tsx
+++ b/apps/web/components/organizations/organization-team-grants.test.tsx
@@ -86,12 +86,15 @@ describe("<OrganizationTeamGrants />", () => {
           createOrganizationTeamGrant({ resourceType: "macro", resourceName: "Fit" }),
           createOrganizationTeamGrant({ resourceType: "workbook", resourceName: "Synthesis" }),
           createOrganizationTeamGrant({ resourceType: "device", resourceName: "Ambyte" }),
+          createOrganizationTeamGrant({ resourceType: "device_group", resourceName: "Fleet" }),
         ]}
       />,
     );
 
-    // The marks the sidebar and the command palette already use for these five types,
-    // so a row here is recognisable from anywhere else the type shows up.
+    // The marks the sidebar and the command palette already use for these types, so a
+    // row here is recognisable from anywhere else the type shows up. Every grantable
+    // type is here on purpose: an icon map missing one renders `undefined` as the
+    // component, which throws at render rather than falling back to something neutral.
     const iconFor = (name: string) =>
       within(container)
         .getByRole("link", { name })
@@ -103,6 +106,7 @@ describe("<OrganizationTeamGrants />", () => {
     expect(iconFor("Fit")).toHaveClass("lucide-code");
     expect(iconFor("Synthesis")).toHaveClass("lucide-book-open");
     expect(iconFor("Ambyte")).toHaveClass("lucide-radio-receiver");
+    expect(iconFor("Fleet")).toHaveClass("lucide-boxes");
 
     // The type is already stated in words on the right of the row; an accessible name
     // here would have it announced twice.

--- a/apps/web/hooks/organization/useOrganizationDeletionBlockers/useOrganizationDeletionBlockers.ts
+++ b/apps/web/hooks/organization/useOrganizationDeletionBlockers/useOrganizationDeletionBlockers.ts
@@ -6,10 +6,10 @@ import { useQuery } from "@tanstack/react-query";
 import { useSession } from "@repo/auth/client";
 
 /**
- * What stands between the organization and deletion, counted across all five owned
- * resource types. Deliberately not the resources showcase: that is scoped to what
- * the caller may read and carries only the four shareable types, so an organization
- * owning nothing but a device reads as empty there while the delete guard refuses it.
+ * What stands between the organization and deletion, counted across every owned
+ * resource type. Deliberately not the resources showcase: that is scoped to what the
+ * caller may read, so an organization whose remaining resources are all private to
+ * someone else reads as empty there while the delete guard refuses it.
  *
  * Owner-only, answering not-found otherwise — which is an answer, not a failure to
  * retry.

--- a/apps/web/test/factories.ts
+++ b/apps/web/test/factories.ts
@@ -500,7 +500,9 @@ export function createOrganizationResource(
           ? { language: "python" }
           : type === "device"
             ? { deviceType: "multispeq" }
-            : {};
+            : type === "device_group"
+              ? { memberCount: 3 }
+              : {};
 
   return {
     type,

--- a/packages/api/src/domains/organization/organization.contract.ts
+++ b/packages/api/src/domains/organization/organization.contract.ts
@@ -73,7 +73,7 @@ export const organizationContract = {
     .input(zOrganizationIdPathParam)
     .output(zOrganizationMembers),
   /**
-   * What blocks this organization's deletion, across all five owned resource types.
+   * What blocks this organization's deletion, across every owned resource type.
    * Owner-only, because deleting is: it answers the same question the delete guard
    * asks, so the danger zone can refuse up front instead of after a confirmation.
    */

--- a/packages/api/src/domains/organization/organization.schema.ts
+++ b/packages/api/src/domains/organization/organization.schema.ts
@@ -52,8 +52,8 @@ export const zOrganizationDirectoryEntry = z.object({
   location: z.string().nullable(),
   memberCount: z.number().int(),
   /**
-   * How much of what the organization owns *this caller* can reach, summed across all
-   * five owned types. Access-scoped, so two callers reading the same row can legitimately
+   * How much of what the organization owns *this caller* can reach, summed across every
+   * owned type. Access-scoped, so two callers reading the same row can legitimately
    * see different totals — a non-member's is the public part.
    */
   resourceCount: z.number().int(),
@@ -83,8 +83,8 @@ export const zOrganizationProfile = z.object({
   visibility: zOrganizationVisibility,
   memberCount: z.number().int(),
   /**
-   * How much of what the organization owns *this caller* can reach, summed across all
-   * five owned types — scoped the same way the directory row is, so the profile and the
+   * How much of what the organization owns *this caller* can reach, summed across every
+   * owned type — scoped the same way the directory row is, so the profile and the
    * listing cannot disagree about the same organization for the same caller.
    */
   resourceCount: z.number().int(),
@@ -106,8 +106,8 @@ export const zMyOrganization = z.object({
   isPersonal: z.boolean(),
   memberCount: z.number().int(),
   /**
-   * How much of what the organization owns this caller can reach, summed across all
-   * five owned types. Scoped like the rest, though the caller is always a member here.
+   * How much of what the organization owns this caller can reach, summed across every
+   * owned type. Scoped like the rest, though the caller is always a member here.
    */
   resourceCount: z.number().int(),
 });
@@ -150,13 +150,9 @@ const zOrganizationResourceBase = z.object({
 });
 
 /**
- * One row of the organization's resources showcase — all five owned types, keyed by
- * {@link zSharingResourceType} so the rows and the counts cannot cover different sets.
- *
- * Discriminated rather than flattened because the one extra fact worth showing differs
- * per type: an experiment's status, a protocol's family, a macro's language, a device's
- * class. A workbook adds nothing, and a device's `description` is structurally `null` —
- * no such column.
+ * One row of the organization's resources showcase, one variant per member of
+ * {@link zSharingResourceType}. Discriminated rather than flattened because the extra
+ * fact worth showing differs per type, and a workbook has none.
  */
 export const zOrganizationResource = z.discriminatedUnion("type", [
   zOrganizationResourceBase.extend({
@@ -174,36 +170,31 @@ export const zOrganizationResource = z.discriminatedUnion("type", [
   zOrganizationResourceBase.extend({ type: z.literal("workbook") }),
   zOrganizationResourceBase.extend({
     type: z.literal("device"),
-    /**
-     * The device's class — `zSensorFamily` under another name, so a device row wears
-     * the same badge a protocol row does for the same value. Chosen over its lifecycle
-     * `status`: a showcase asks what the org owns, not what a certificate is doing.
-     */
+    /** The device's class — `zSensorFamily` renamed, so it badges like a protocol's. */
     deviceType: zDeviceType,
+  }),
+  zOrganizationResourceBase.extend({
+    type: z.literal("device_group"),
+    /** How many devices the group holds; stated in the footer, not as a badge. */
+    memberCount: z.number().int(),
   }),
 ]);
 
 /**
- * The owned types this surface shows. Narrower than {@link zSharingResourceType} on
- * purpose: device groups are org-owned and shareable too, but nothing here lists or
- * counts them yet, and a total that always read zero would claim otherwise. Adding
- * them means giving them rows, a label and a badge first.
+ * Compile-time guard: a discriminated union is not exhaustive on its own, so without
+ * this a newly grantable type would type-check with no showcase row. Anything
+ * uncovered names itself in the error.
  */
-export const zOrganizationResourceType = z.enum([
-  "experiment",
-  "protocol",
-  "macro",
-  "workbook",
-  "device",
-]);
+type UncoveredOwnedType = Exclude<
+  z.infer<typeof zSharingResourceType>,
+  z.infer<typeof zOrganizationResource>["type"]
+>;
+type MustBeCovered<T extends never> = T;
+export type EveryOwnedTypeHasAShowcaseRow = MustBeCovered<UncoveredOwnedType>;
 
 /**
- * How many of each shown type the caller may read, alongside the rows. Scoped exactly
+ * How many of each owned type the caller may read, alongside the rows. Scoped exactly
  * as the rows are, so a group header cannot promise more than "view all" would show.
- *
- * Total over {@link zOrganizationResourceType} — the same five {@link zOrganizationResource}
- * carries, so every total has rows behind it and a newly *shown* type cannot be added
- * without being counted.
  */
 export const zOrganizationResourceTotals = z.object({
   experiment: z.number().int(),
@@ -211,7 +202,8 @@ export const zOrganizationResourceTotals = z.object({
   macro: z.number().int(),
   workbook: z.number().int(),
   device: z.number().int(),
-}) satisfies z.ZodType<Record<z.infer<typeof zOrganizationResourceType>, number>>;
+  device_group: z.number().int(),
+}) satisfies z.ZodType<Record<z.infer<typeof zSharingResourceType>, number>>;
 
 export const zOrganizationResources = z.object({
   resources: z.array(zOrganizationResource),
@@ -225,9 +217,6 @@ export const zOrganizationResources = z.object({
  * Deliberately not the resources showcase: that is access-scoped, while the delete
  * guard counts the whole estate. An organization holding one private resource the
  * caller cannot read would otherwise look deletable right up to the confirmation.
- *
- * Counts, not rows: the remedy is per resource type ("transfer or delete your
- * devices").
  */
 export const zOrganizationDeletionBlocker = z.object({
   resourceType: zSharingResourceType,
@@ -309,7 +298,6 @@ export type MyOrganizationList = z.infer<typeof zMyOrganizationList>;
 export type OrganizationMember = z.infer<typeof zOrganizationMember>;
 export type OrganizationMembers = z.infer<typeof zOrganizationMembers>;
 export type OrganizationResource = z.infer<typeof zOrganizationResource>;
-export type OrganizationResourceType = z.infer<typeof zOrganizationResourceType>;
 export type OrganizationResourceTotals = z.infer<typeof zOrganizationResourceTotals>;
 export type OrganizationResources = z.infer<typeof zOrganizationResources>;
 export type OrganizationDeletionBlocker = z.infer<typeof zOrganizationDeletionBlocker>;

--- a/packages/auth/src/access.spec.ts
+++ b/packages/auth/src/access.spec.ts
@@ -8,10 +8,10 @@ import type { ResourceAction, ResourceType } from "./access";
 /**
  * The capability matrix, pinned action by action. The asymmetry to hold: `contribute`
  * exists on experiments only, and there both the lowest grant tier and plain org
- * membership carry it — on the other four types both are read-only.
+ * membership carry it — on every other type both are read-only.
  *
  * The action and resource-type lists come from the matrix itself rather than being
- * restated here. A copied list would let a sixth resource type be added to
+ * restated here. A copied list would let a new resource type be added to
  * `RESOURCE_TYPES` and the `statement`, forgotten in `grantRoles`, and still leave
  * this suite green — while every grantee was silently read-only on it.
  */

--- a/packages/auth/src/access.ts
+++ b/packages/auth/src/access.ts
@@ -136,7 +136,7 @@ export type OrgRole = keyof typeof roles;
  * beat belonging to the organization that owns the experiment. A public experiment's
  * passer-by still gets read only — that comes from the `visibility` branch in `can()`,
  * not from either matrix. The two matrices stay separate because they disagree
- * elsewhere: `viewer` is read-only on the other four types, where `member` is too.
+ * elsewhere: `viewer` is read-only on every other type, where `member` is too.
  *
  * These keys are the whole set. `GRANT_ROLES` in `@repo/database` types every write
  * path against them, so anything else reaching `grantRoleCan` is a bug and is refused.

--- a/packages/i18n/locales/de-DE/common.json
+++ b/packages/i18n/locales/de-DE/common.json
@@ -588,8 +588,12 @@
         "workbook_one": "Arbeitsmappe",
         "workbook_other": "Arbeitsmappen",
         "device_one": "Gerät",
-        "device_other": "Geräte"
+        "device_other": "Geräte",
+        "device_group_one": "Gerätegruppe",
+        "device_group_other": "Gerätegruppen"
       },
+      "groupMemberCount_one": "{{count}} Gerät",
+      "groupMemberCount_other": "{{count}} Geräte",
       "emptyTitle": "Noch nichts zu sehen",
       "emptyMemberHint": "In dieser Organisation erstellte Ressourcen erscheinen hier.",
       "emptyVisitorHint": "Diese Organisation hat noch nichts veröffentlicht.",

--- a/packages/i18n/locales/en-US/common.json
+++ b/packages/i18n/locales/en-US/common.json
@@ -588,8 +588,12 @@
         "workbook_one": "Workbook",
         "workbook_other": "Workbooks",
         "device_one": "Device",
-        "device_other": "Devices"
+        "device_other": "Devices",
+        "device_group_one": "Device group",
+        "device_group_other": "Device groups"
       },
+      "groupMemberCount_one": "{{count}} device",
+      "groupMemberCount_other": "{{count}} devices",
       "emptyTitle": "Nothing to show yet",
       "emptyMemberHint": "Resources created in this organization appear here.",
       "emptyVisitorHint": "This organization has not published anything yet.",

--- a/packages/i18n/locales/nl-NL/common.json
+++ b/packages/i18n/locales/nl-NL/common.json
@@ -588,8 +588,12 @@
         "workbook_one": "Werkmap",
         "workbook_other": "Werkmappen",
         "device_one": "Apparaat",
-        "device_other": "Apparaten"
+        "device_other": "Apparaten",
+        "device_group_one": "Apparaatgroep",
+        "device_group_other": "Apparaatgroepen"
       },
+      "groupMemberCount_one": "{{count}} apparaat",
+      "groupMemberCount_other": "{{count}} apparaten",
       "emptyTitle": "Nog niets te zien",
       "emptyMemberHint": "Resources die in deze organisatie worden aangemaakt, staan hier.",
       "emptyVisitorHint": "Deze organisatie heeft nog niets gepubliceerd.",


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Device groups were already org-owned and grantable, but nothing on an organization's page listed or counted them — an org page could read "12 devices" and say nothing about its 3 groups. This adds them as a listed type.

## What changed

Device groups now appear on the organization page: rows in the resources showcase with their roster size, a share of the totals and the resource-mix bar, a filter chip, and eligibility for featured resources. A group row shows no type badge and no transfer control.

`zOrganizationResourceType` and `SHOWN_RESOURCE_TYPES` are deleted. They listed the showcase's types separately from the sharing type set, which is how a sixth type landed and was silently omitted here. The showcase now reads the shared set.

`listAccessible` on the device-group repository takes an optional `organizationId`, so the group list page and the showcase share one method, and the iot module exports the repository for the organizations module.

## Guards added

Removing those two lists is not by itself enough: a discriminated union is not exhaustive over an enum, so a seventh type would still have compiled with no row. There's now a compile-time check that every owned type has a showcase row, and a test pinning `GROUP_ORDER` against the type set, since an array can't be made exhaustive by a type.

## Verification

Backend and web suites green, typecheck and lint clean. The device-group rows, totals, mix bar and filter chip were checked in the running app against seeded data.
