### PR TITLE
chore(security): suppress CVE-2026-73566 for bundled npm tar in docker image scans

### DIFF
--- a/.trivyignore.docker-images.yaml
+++ b/.trivyignore.docker-images.yaml
@@ -25,12 +25,15 @@ vulnerabilities:
     statement: "DoS via unbounded arrays, same copy."
     expired_at: 2026-11-05
 
-  # tar@7.5.16, fixed in 7.5.19.
+  # tar@7.5.16, fixed in 7.5.21.
   - id: CVE-2026-59873
     statement: "tar DoS via crafted archives. npm extracts nothing at runtime."
     expired_at: 2026-11-05
   - id: CVE-2026-59874
     statement: "Same tar DoS family, different CVE id."
+    expired_at: 2026-11-05
+  - id: CVE-2026-73566
+    statement: "tar DoS via crafted long-path archive, same copy."
     expired_at: 2026-11-05
 
   # ip-address@10.2.0 (via socks), fixed in 10.3.1. Not in our lockfile at all.

--- a/.trivyignore.docker-images.yaml
+++ b/.trivyignore.docker-images.yaml
@@ -25,14 +25,21 @@ vulnerabilities:
     statement: "DoS via unbounded arrays, same copy."
     expired_at: 2026-11-05
 
-  # tar@7.5.16, fixed in 7.5.21.
+  # tar@7.5.16, fixed in 7.5.21. Pinned by purl: a bumped base that still
+  # ships a vulnerable tar re-fails the scan instead of inheriting these.
   - id: CVE-2026-59873
+    purls:
+      - "pkg:npm/tar@7.5.16"
     statement: "tar DoS via crafted archives. npm extracts nothing at runtime."
     expired_at: 2026-11-05
   - id: CVE-2026-59874
+    purls:
+      - "pkg:npm/tar@7.5.16"
     statement: "Same tar DoS family, different CVE id."
     expired_at: 2026-11-05
   - id: CVE-2026-73566
+    purls:
+      - "pkg:npm/tar@7.5.16"
     statement: "tar DoS via crafted long-path archive, same copy."
     expired_at: 2026-11-05
 


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [x] Chore
- [ ] Other (please describe)