### PR TITLE
fix(data): scrub bare NaN/Infinity tokens from samples before variant parsing in gold raw data

### DIFF
--- a/apps/data/src/lib/openjii/openjii/__init__.py
+++ b/apps/data/src/lib/openjii/openjii/__init__.py
@@ -13,6 +13,7 @@ from .helpers import (
     load_experiment_table,
     read_table,
 )
+from .json_scrub import scrub_non_finite_json, scrub_non_finite_json_value
 
 __all__ = [
     "decompress_sample",
@@ -22,5 +23,7 @@ __all__ = [
     "get_table_metadata",
     "load_experiment_table",
     "read_table",
+    "scrub_non_finite_json",
+    "scrub_non_finite_json_value",
 ]
 __version__ = "0.1.0"

--- a/apps/data/src/lib/openjii/openjii/json_scrub.py
+++ b/apps/data/src/lib/openjii/openjii/json_scrub.py
@@ -3,22 +3,24 @@
 Device firmware and calibration tooling serialize floats permissively, so
 samples can carry bare NaN / Infinity / -Infinity tokens. Strict JSON parsers
 (Spark's parse_json, Jackson) reject the whole record, which poisons the
-streaming flow. Reparsing with Python's json module maps those tokens to null
-and keeps the record.
+streaming flow. A string-literal-aware scan rewrites the tokens to null and
+leaves every other byte untouched, so high-precision numbers keep their exact
+text for variant parsing.
 """
-
-import json
 
 from pyspark.sql import functions as F
 from pyspark.sql.types import StringType
+
+_NON_FINITE_TOKENS = ("-Infinity", "Infinity", "NaN")
 
 
 def scrub_non_finite_json_value(payload: str | None) -> str | None:
     """Rewrite bare NaN / Infinity tokens to null so strict parsers accept the payload.
 
-    Payloads without suspicious substrings pass through untouched and unparsed,
-    so the happy path is a cheap scan. Payloads that fail to parse outright are
-    also returned unchanged; the caller's try_parse_json nulls them.
+    Payloads without suspicious substrings pass through untouched, so the happy
+    path is a cheap scan. Tokens inside string literals are preserved. The scan
+    does not validate JSON; unparseable payloads come out as unparseable, and
+    the caller's try_parse_json nulls them.
     """
     if payload is None:
         return None
@@ -26,12 +28,40 @@ def scrub_non_finite_json_value(payload: str | None) -> str | None:
     if "NaN" not in payload and "Infinity" not in payload:
         return payload
 
-    try:
-        parsed = json.loads(payload, parse_constant=lambda _token: None)
-    except (ValueError, RecursionError):
-        return payload
+    parts: list[str] = []
+    in_string = False
+    escaped = False
+    i = 0
 
-    return json.dumps(parsed, ensure_ascii=False)
+    while i < len(payload):
+        char = payload[i]
+
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            parts.append(char)
+            i += 1
+            continue
+
+        if char == '"':
+            in_string = True
+            parts.append(char)
+            i += 1
+            continue
+
+        token = next((t for t in _NON_FINITE_TOKENS if payload.startswith(t, i)), None)
+        if token is not None:
+            parts.append("null")
+            i += len(token)
+        else:
+            parts.append(char)
+            i += 1
+
+    return "".join(parts)
 
 
 #: Spark UDF wrapping :func:`scrub_non_finite_json_value`.

--- a/apps/data/src/lib/openjii/openjii/json_scrub.py
+++ b/apps/data/src/lib/openjii/openjii/json_scrub.py
@@ -3,15 +3,24 @@
 Device firmware and calibration tooling serialize floats permissively, so
 samples can carry bare NaN / Infinity / -Infinity tokens. Strict JSON parsers
 (Spark's parse_json, Jackson) reject the whole record, which poisons the
-streaming flow. A string-literal-aware scan rewrites the tokens to null and
-leaves every other byte untouched, so high-precision numbers keep their exact
-text for variant parsing.
+streaming flow. The scrub rewrites the tokens to null and leaves every other
+byte untouched, so high-precision numbers keep their exact text for variant
+parsing.
 """
+
+import re
 
 from pyspark.sql import functions as F
 from pyspark.sql.types import StringType
 
-_NON_FINITE_TOKENS = ("-Infinity", "Infinity", "NaN")
+# The string-literal branch wins the leftmost alternation and consumes
+# literals whole (escapes included), so tokens only match outside strings.
+_STRING_OR_NON_FINITE_TOKEN = re.compile(r'"(?:[^"\\]|\\.)*"|-?Infinity|NaN')
+
+
+def _null_unless_string(match: re.Match[str]) -> str:
+    text = match.group()
+    return text if text.startswith('"') else "null"
 
 
 def scrub_non_finite_json_value(payload: str | None) -> str | None:
@@ -28,40 +37,7 @@ def scrub_non_finite_json_value(payload: str | None) -> str | None:
     if "NaN" not in payload and "Infinity" not in payload:
         return payload
 
-    parts: list[str] = []
-    in_string = False
-    escaped = False
-    i = 0
-
-    while i < len(payload):
-        char = payload[i]
-
-        if in_string:
-            if escaped:
-                escaped = False
-            elif char == "\\":
-                escaped = True
-            elif char == '"':
-                in_string = False
-            parts.append(char)
-            i += 1
-            continue
-
-        if char == '"':
-            in_string = True
-            parts.append(char)
-            i += 1
-            continue
-
-        token = next((t for t in _NON_FINITE_TOKENS if payload.startswith(t, i)), None)
-        if token is not None:
-            parts.append("null")
-            i += len(token)
-        else:
-            parts.append(char)
-            i += 1
-
-    return "".join(parts)
+    return _STRING_OR_NON_FINITE_TOKEN.sub(_null_unless_string, payload)
 
 
 #: Spark UDF wrapping :func:`scrub_non_finite_json_value`.

--- a/apps/data/src/lib/openjii/openjii/json_scrub.py
+++ b/apps/data/src/lib/openjii/openjii/json_scrub.py
@@ -1,0 +1,39 @@
+"""Scrubbing of non-standard JSON tokens in device payloads.
+
+Device firmware and calibration tooling serialize floats permissively, so
+samples can carry bare NaN / Infinity / -Infinity tokens. Strict JSON parsers
+(Spark's parse_json, Jackson) reject the whole record, which poisons the
+streaming flow. Reparsing with Python's json module maps those tokens to null
+and keeps the record.
+"""
+
+import json
+
+from pyspark.sql import functions as F
+from pyspark.sql.types import StringType
+
+
+def scrub_non_finite_json_value(payload: str | None) -> str | None:
+    """Rewrite bare NaN / Infinity tokens to null so strict parsers accept the payload.
+
+    Payloads without suspicious substrings pass through untouched and unparsed,
+    so the happy path is a cheap scan. Payloads that fail to parse outright are
+    also returned unchanged; the caller's try_parse_json nulls them.
+    """
+    if payload is None:
+        return None
+
+    if "NaN" not in payload and "Infinity" not in payload:
+        return payload
+
+    try:
+        parsed = json.loads(payload, parse_constant=lambda _token: None)
+    except (ValueError, RecursionError):
+        return payload
+
+    return json.dumps(parsed, ensure_ascii=False)
+
+
+#: Spark UDF wrapping :func:`scrub_non_finite_json_value`.
+#: Use this directly in ``.withColumn()`` calls.
+scrub_non_finite_json = F.udf(scrub_non_finite_json_value, StringType())

--- a/apps/data/src/pipelines/centrum/gold/experiment_raw_data.py
+++ b/apps/data/src/pipelines/centrum/gold/experiment_raw_data.py
@@ -10,6 +10,7 @@ from pyspark.sql import functions as F
 from pyspark.sql.types import ArrayType, StringType, StructField, StructType
 
 from data_repair import apply_inline_repairs
+from openjii import scrub_non_finite_json
 from openjii.centrum import EXPERIMENT_RAW_DATA_TABLE
 from openjii.centrum.runtime import SILVER_TABLE
 
@@ -112,7 +113,12 @@ def experiment_raw_data():
     return (
         dlt.read_stream(SILVER_TABLE)
         .filter("experiment_id IS NOT NULL")
-        .withColumn("data", F.expr("parse_json(sample)"))
+        # Firmware serializes floats permissively, so calibration samples can
+        # carry bare NaN/Infinity tokens that strict parse_json rejects,
+        # poisoning the stream. The scrub UDF rewrites them to null and is a
+        # cheap passthrough for clean payloads.
+        .withColumn("sample_scrubbed", scrub_non_finite_json(F.col("sample")))
+        .withColumn("data", F.expr("try_parse_json(sample_scrubbed)"))
         .withColumn("output_data", F.expr("try_parse_json(output)"))
         .withColumn(
             "questions_sanitized",

--- a/apps/data/tests/lib/test_json_scrub.py
+++ b/apps/data/tests/lib/test_json_scrub.py
@@ -15,7 +15,7 @@ def _strict_loads(payload: str | None):
     return json.loads(payload, parse_constant=reject)
 
 
-class TestRepairNonFiniteJsonValue:
+class TestScrubNonFiniteJsonValue:
     def test_none_passes_through(self) -> None:
         assert scrub_non_finite_json_value(None) is None
 
@@ -58,3 +58,15 @@ class TestRepairNonFiniteJsonValue:
     def test_unparseable_payload_passes_through(self) -> None:
         truncated = '{"detail": "NaN", "cal": [1.0,'
         assert scrub_non_finite_json_value(truncated) == truncated
+
+    def test_high_precision_numbers_preserved_exactly(self) -> None:
+        payload = (
+            '{"a": 0.12345678901234567890123456789012345, "b": 123456789012345678901234567890, "t": NaN}'
+        )
+        assert scrub_non_finite_json_value(payload) == (
+            '{"a": 0.12345678901234567890123456789012345, "b": 123456789012345678901234567890, "t": null}'
+        )
+
+    def test_escaped_quotes_keep_string_state(self) -> None:
+        payload = '{"detail": "say \\"NaN\\" now", "t": NaN}'
+        assert scrub_non_finite_json_value(payload) == '{"detail": "say \\"NaN\\" now", "t": null}'

--- a/apps/data/tests/lib/test_json_scrub.py
+++ b/apps/data/tests/lib/test_json_scrub.py
@@ -1,0 +1,60 @@
+"""Tests for openjii.json_scrub."""
+
+from __future__ import annotations
+
+import json
+
+from openjii.json_scrub import scrub_non_finite_json_value
+
+
+def _strict_loads(payload: str | None):
+    def reject(token: str):
+        raise ValueError(f"non-standard token {token}")
+
+    assert payload is not None
+    return json.loads(payload, parse_constant=reject)
+
+
+class TestRepairNonFiniteJsonValue:
+    def test_none_passes_through(self) -> None:
+        assert scrub_non_finite_json_value(None) is None
+
+    def test_clean_payload_is_returned_unparsed(self) -> None:
+        payload = json.dumps({"a": 1.5, "b": [1, 2], "c": {"d": "x"}})
+        assert scrub_non_finite_json_value(payload) is payload
+
+    def test_object_value(self) -> None:
+        assert _strict_loads(scrub_non_finite_json_value('{"a": NaN}')) == {"a": None}
+
+    def test_array_elements(self) -> None:
+        scrubbed = scrub_non_finite_json_value('{"cal": [1.0, NaN, -Infinity, Infinity, 2]}')
+        assert _strict_loads(scrubbed) == {"cal": [1.0, None, None, None, 2]}
+
+    def test_nested_calibration_shape(self) -> None:
+        payload = (
+            '[{"protocol_id":"CALIBRATION","set":[{"device":{"temp_offset":NaN,'
+            '"adpd_calibration":[0,NaN,0]},"par_slope":1.0}]}]'
+        )
+        parsed = _strict_loads(scrub_non_finite_json_value(payload))
+        assert parsed[0]["set"][0]["device"]["temp_offset"] is None
+        assert parsed[0]["set"][0]["device"]["adpd_calibration"] == [0, None, 0]
+        assert parsed[0]["set"][0]["par_slope"] == 1.0
+
+    def test_quoted_token_strings_survive(self) -> None:
+        payload = '{"detail": "NaN", "name": "Infinity Ward", "temp": NaN}'
+        assert _strict_loads(scrub_non_finite_json_value(payload)) == {
+            "detail": "NaN",
+            "name": "Infinity Ward",
+            "temp": None,
+        }
+
+    def test_unicode_survives_scrub(self) -> None:
+        payload = '{"note": "🌱 öß", "temp": NaN}'
+        assert _strict_loads(scrub_non_finite_json_value(payload)) == {
+            "note": "🌱 öß",
+            "temp": None,
+        }
+
+    def test_unparseable_payload_passes_through(self) -> None:
+        truncated = '{"detail": "NaN", "cal": [1.0,'
+        assert scrub_non_finite_json_value(truncated) == truncated


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

The prod centrum pipeline is crash-looping on the gold `experiment_raw_data` flow. A CALIBRATION upload carries bare `NaN` tokens in its sample JSON (firmware serializes floats permissively), and the flow's strict `parse_json` rejects the whole record. Because the failing batch never commits, every restart replays the same record and dies again, which blocks all gold ingestion behind one poisoned row.

This adds a `json_scrub` module to the openjii wheel, a pure function with a Spark UDF wrapper in the same shape as the compression pair. Payloads without `NaN` or `Infinity` substrings pass through untouched, so the common case stays a cheap scan with no parse. Suspicious payloads are reparsed through Python's json module with the non-finite constants mapped to `null`, which is a real parse rather than a pattern match, so quoted strings like `"NaN"` survive intact. Payloads that fail to parse at all are returned unchanged and the gold flow's `try_parse_json` nulls them instead of killing the stream. The `data` column becomes `try_parse_json` over the scrubbed sample.

Verified against prod that exactly one poisoned record sits in `clean_data`, failing the strict parse and parsing cleanly after the scrub, and the exact gold expression was exercised in a local Spark session alongside unit tests on the pure function. No full refresh is needed on deploy: the poisoned batch never committed, so the checkpoint replays it through the new code, rows already in gold parse identically under the new logic, and downstream tables never saw the record.