### PR TITLE
fix(backend): count org and team access in the experiment "member" filter (OJD-1724)

### DIFF
--- a/apps/backend/src/common/utils/resource-access-scope.ts
+++ b/apps/backend/src/common/utils/resource-access-scope.ts
@@ -10,40 +10,25 @@ import {
 import type { AnyColumn, DatabaseInstance, ResourceType, SQL } from "@repo/database";
 
 /**
- * Build the list-scoping predicate for an org-owned, shareable resource, matching
- * `can()`'s read precedence: a row is visible when it is public, the caller is a
- * member of the owning organization, or the caller holds a grant on it (direct,
- * team or org).
+ * Every path that ties a caller to a row personally: membership of the owning
+ * organization, or a grant on it (direct, team or org). Visibility is deliberately
+ * not part of it, so this is the access scope minus rows reachable by anyone.
  *
- * Shared by every type's `findAll`, so listing **and** global search — which
- * delegates to the same `findAll`s — enforce undiscoverability identically: a
- * private row the caller cannot reach is never revealed, not even by name.
- *
- * With no authenticated caller only public rows match: membership and grants cannot
- * be resolved without a user.
+ * Returned separately from {@link accessibleResourceCondition} so a "mine" listing
+ * can narrow to these paths without re-deriving them, and so the two can never
+ * drift apart. Undefined with no authenticated caller: none of it resolves.
  */
-export function accessibleResourceCondition(params: {
+export function relatedResourceCondition(params: {
   database: DatabaseInstance;
   resourceType: ResourceType;
   resourceIdColumn: AnyColumn;
   organizationIdColumn: AnyColumn;
-  visibilityColumn: AnyColumn;
   userId: string | undefined;
 }): SQL | undefined {
-  const {
-    database,
-    resourceType,
-    resourceIdColumn,
-    organizationIdColumn,
-    visibilityColumn,
-    userId,
-  } = params;
+  const { database, resourceType, resourceIdColumn, organizationIdColumn, userId } = params;
 
-  const isPublic = eq(visibilityColumn, "public");
-
-  // Without a caller we can only reason about public visibility.
   if (!userId) {
-    return isPublic;
+    return undefined;
   }
 
   const userGrantExists = exists(
@@ -102,5 +87,32 @@ export function accessibleResourceCondition(params: {
       ),
   );
 
-  return or(isPublic, userGrantExists, teamGrantExists, orgGrantExists, owningOrgMemberExists);
+  return or(userGrantExists, teamGrantExists, orgGrantExists, owningOrgMemberExists);
+}
+
+/**
+ * Build the list-scoping predicate for an org-owned, shareable resource, matching
+ * `can()`'s read precedence: a row is visible when it is public, the caller is a
+ * member of the owning organization, or the caller holds a grant on it (direct,
+ * team or org).
+ *
+ * Shared by every type's `findAll`, so listing **and** global search, which
+ * delegates to the same `findAll`s, enforce undiscoverability identically: a
+ * private row the caller cannot reach is never revealed, not even by name.
+ *
+ * With no authenticated caller only public rows match: membership and grants cannot
+ * be resolved without a user.
+ */
+export function accessibleResourceCondition(params: {
+  database: DatabaseInstance;
+  resourceType: ResourceType;
+  resourceIdColumn: AnyColumn;
+  organizationIdColumn: AnyColumn;
+  visibilityColumn: AnyColumn;
+  userId: string | undefined;
+}): SQL | undefined {
+  const isPublic = eq(params.visibilityColumn, "public");
+  const related = relatedResourceCondition(params);
+
+  return related ? or(isPublic, related) : isPublic;
 }

--- a/apps/backend/src/experiments/core/repositories/experiment.repository.spec.ts
+++ b/apps/backend/src/experiments/core/repositories/experiment.repository.spec.ts
@@ -235,6 +235,98 @@ describe("ExperimentRepository", () => {
       expect(experiments[0].name).toBe("My Experiment");
     });
 
+    it("returns experiments reached through the owning organization under the 'member' filter", async () => {
+      const org = await testApp.createOrganization();
+      const author = await testApp.createTestUser({ email: "org-author@example.com" });
+      const orgMember = await testApp.createTestUser({ email: "org-member@example.com" });
+      await testApp.addOrganizationMember(org, author, "admin");
+      await testApp.addOrganizationMember(org, orgMember, "member");
+
+      const { experiment } = await testApp.createExperiment({
+        name: "Org Experiment",
+        userId: author,
+        visibility: "private",
+        organizationId: org,
+      });
+
+      const result = await repository.findAll(orgMember, "member");
+
+      assertSuccess(result);
+      expect(result.value.map((e) => e.id)).toEqual([experiment.id]);
+    });
+
+    it("returns experiments reached through a team grant under the 'member' filter", async () => {
+      const org = await testApp.createOrganization();
+      const author = await testApp.createTestUser({ email: "team-author@example.com" });
+      const teammate = await testApp.createTestUser({ email: "teammate@example.com" });
+      await testApp.addOrganizationMember(org, author, "admin");
+      const team = await testApp.createTeam(org);
+      await testApp.addTeamMember(team, teammate);
+
+      const { experiment } = await testApp.createExperiment({
+        name: "Team Experiment",
+        userId: author,
+        visibility: "private",
+        organizationId: org,
+      });
+      await testApp.addResourceGrant({
+        resourceType: "experiment",
+        resourceId: experiment.id,
+        granteeType: "team",
+        granteeId: team,
+        role: "viewer",
+      });
+
+      const result = await repository.findAll(teammate, "member");
+
+      assertSuccess(result);
+      expect(result.value.map((e) => e.id)).toEqual([experiment.id]);
+    });
+
+    it("returns experiments reached through an organization grant under the 'member' filter", async () => {
+      const author = await testApp.createTestUser({ email: "org-grant-author@example.com" });
+      const outsider = await testApp.createTestUser({ email: "org-grantee@example.com" });
+      // The grantee's own org holds the grant; they are not in the owning org.
+      const granteeOrg = await testApp.createOrganization();
+      await testApp.addOrganizationMember(granteeOrg, outsider, "member");
+
+      const { experiment } = await testApp.createExperiment({
+        name: "Org Granted Experiment",
+        userId: author,
+        visibility: "private",
+      });
+      await testApp.addResourceGrant({
+        resourceType: "experiment",
+        resourceId: experiment.id,
+        granteeType: "organization",
+        granteeId: granteeOrg,
+        role: "viewer",
+      });
+
+      const result = await repository.findAll(outsider, "member");
+
+      assertSuccess(result);
+      expect(result.value.map((e) => e.id)).toEqual([experiment.id]);
+    });
+
+    it("still excludes public experiments the caller is unrelated to under the 'member' filter", async () => {
+      const mainUserId = await testApp.createTestUser({ email: "member-public@example.com" });
+      const otherUserId = await testApp.createTestUser({
+        email: "member-public-other@example.com",
+      });
+
+      await testApp.createExperiment({
+        name: "Public Experiment",
+        userId: otherUserId,
+        visibility: "public",
+      });
+
+      const result = await repository.findAll(mainUserId, "member");
+
+      assertSuccess(result);
+      expect(result.value).toHaveLength(0);
+    });
+
     it("should not return duplicate experiments when user has access to multiple experiments", async () => {
       // Arrange - Test case where a user is a member of multiple experiments
       // Ensures the CTE-based code doesn't cause duplicates

--- a/apps/backend/src/experiments/core/repositories/experiment.repository.ts
+++ b/apps/backend/src/experiments/core/repositories/experiment.repository.ts
@@ -35,7 +35,10 @@ import {
   getAnonymizedFirstName,
   getAnonymizedLastName,
 } from "../../../common/utils/profile-anonymization";
-import { accessibleResourceCondition } from "../../../common/utils/resource-access-scope";
+import {
+  accessibleResourceCondition,
+  relatedResourceCondition,
+} from "../../../common/utils/resource-access-scope";
 import { userIsSelectableGrantee } from "../../../sharing/core/grantee-selectability";
 import {
   findOwningOrgOwnerIds,
@@ -277,20 +280,6 @@ export class ExperimentRepository {
         conditions.push(ne(experiments.status, "archived"));
       }
 
-      const userGrantExists = exists(
-        this.database
-          .select()
-          .from(resourceGrants)
-          .where(
-            and(
-              eq(resourceGrants.resourceType, "experiment"),
-              eq(resourceGrants.resourceId, experiments.id),
-              eq(resourceGrants.granteeType, "user"),
-              eq(resourceGrants.granteeId, userId),
-            ),
-          ),
-      );
-
       // Unconditional, "member" included: a view may narrow what the caller sees but
       // never widen it. Authorship is not an access path, so a creator since removed
       // from the owning org must not get the body back through a listing.
@@ -314,9 +303,18 @@ export class ExperimentRepository {
       }
 
       if (filter === "member") {
-        // "Mine": made or explicitly given, narrowed out of what I can already see.
-        // Authorship counts because a creator holds no grant on their own work.
-        conditions.push(or(userGrantExists, eq(experiments.createdBy, userId)));
+        // "Mine": every path tying me to the experiment personally, so only rows I
+        // reach purely by their being public drop out. Access held through an org or
+        // team counts, it is how most members reach anything; so does authorship,
+        // because a creator holds no grant on their own work.
+        const related = relatedResourceCondition({
+          database: this.database,
+          resourceType: "experiment",
+          resourceIdColumn: experiments.id,
+          organizationIdColumn: experiments.organizationId,
+          userId,
+        });
+        conditions.push(or(related, eq(experiments.createdBy, userId)));
       }
 
       if (status) {


### PR DESCRIPTION
## Problem

A user whose rights on an experiment come **through an organization** rather than a direct share sees nothing under the default experiments filter, on web and on mobile.

`ExperimentRepository.findAll` applies the shared access scope unconditionally, then narrows further when `filter === "member"`. That narrowing only ever matched a **direct user grant** or **authorship**:

```ts
conditions.push(or(userGrantExists, eq(experiments.createdBy, userId)));
```

But `accessibleResourceCondition` resolves five paths: public, direct user grant, **team grant**, **org grant**, and **owning-org membership**. The three org-shaped paths were dropped by the narrowing, so an org member matched the scope and then got filtered right back out.

Symptoms map cleanly onto that:

- **Web** (`/platform/experiments`) defaults to `filter: "member"`. The experiment was only visible after switching to "All Experiments", which sends no filter and therefore skips the narrowing.
- **Mobile** hardcodes `filter: "member"` in every call site (`use-experiments`, `use-experiment-workbook-ref`, `use-precached-experiment-data`, `use-load-experiment-flow`, `prefetch-offline-data`) with no UI to change it. An org-rights user saw an empty list and could not start a measurement at all.

Access control itself was never wrong: `can()` and the unfiltered listing both honoured org access. Only the "mine" narrowing was out of step.

## Fix

Split the shared predicate in `common/utils/resource-access-scope.ts` so the two views are derived from one definition:

- `relatedResourceCondition` — every path tying a caller to a row personally (user grant, team grant, org grant, owning-org membership). No visibility tier.
- `accessibleResourceCondition` — `or(isPublic, related)`. Unchanged behaviour, now expressed in terms of the above.

`filter === "member"` narrows to `or(related, createdBy)`, so it drops only rows the caller reaches purely by their being public. Authorship stays in for the reason the original comment gives: a creator holds no grant on their own work.

The pre-existing guarantee that a view may narrow but never widen is intact. The access scope is still applied unconditionally and the narrowing is a further `AND`, so a creator since removed from the owning org still does not get a private experiment back through the listing.

## Scope

- No contract, schema or migration change. The `filter` enum is still `["member"]`; both clients pick this up as-is.
- Experiments are the only list with this narrowing. Macros, protocols, workbooks and devices call `accessibleResourceCondition` and nothing more, so they were never affected.
- Global search delegates to the same `findAll`s with no filter, so it is untouched.

## Tests

Four regression cases added to `experiment.repository.spec.ts`, one per previously-broken path plus a negative:

- reached through owning-organization membership
- reached through a team grant
- reached through an organization grant
- an unrelated **public** experiment still does *not* leak into `"member"`

Verified:

- `experiment.repository.spec.ts` — 45/45 pass
- `src/experiments src/search src/authorization src/common/utils src/macros src/protocols src/workbooks src/organizations src/sharing src/iot` — 198 files, 2254 tests pass
- eslint clean, `tsc --noEmit` reports nothing on the changed files

## Follow-up (not in this PR)

The web label still reads "Member Experiments" (`packages/i18n/locales/{en-US,de-DE}/common.json`). With the corrected semantics, "My Experiments" would describe it better.

Closes OJD-1724
