### PR TITLE
fix(ci): skip infra deploy when the toggle is off

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,7 +104,9 @@ jobs:
   deploy-infrastructure:
     name: Deploy Infrastructure
     needs: [detect, approval-gate]
-    if: inputs.deploy_infrastructure || needs.detect.outputs.infra_changed == 'true'
+    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.deploy_infrastructure) ||
+      (github.event_name != 'workflow_dispatch' && needs.detect.outputs.infra_changed == 'true')
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
Before submitting a Pull Request, please ensure you've done the following:
- Create small, focused PRs when possible
- Provide tests for your changes
- Use descriptive commit messages
- Update relevant documentation and include screenshots if needed
-->

## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description
Manual deploys now obey the `deploy_infrastructure` toggle; pushes still deploy infra when `infrastructure/` changes.


<!-- Provide a clear and concise description of your changes -->

## Related Issues

<!-- Link any related issues using "closes #123" or "relates to #123" -->

- Closes #
- Related to #