### PR TITLE
feat(mobile): lean questions-only payload, required workbook_version_id

### DIFF
--- a/apps/mobile/CONTEXT.md
+++ b/apps/mobile/CONTEXT.md
@@ -22,7 +22,7 @@ There is no `uploading` status — in-flight state lives in the Outbox's in-memo
 
 ### Topic
 
-The MQTT destination string that routes a Measurement to the correct AWS IoT rule. Built by `getMeasurementMqttTopic({ experimentId })` on the lean 7-segment ingest shape: the shared `@repo/api` prefix transform plus `mobile/{appVersion}/{thingName}`, where the thing name is this phone's registered device identity (also the MQTT client id). Protocol attribution rides in the payload as `protocol_id`; the value `"questions"` is a sentinel for question-only uploads (no device sample). Topics are frozen per row at save time, so rows queued by older builds keep their legacy 8-segment topics and drain through the transitional channel.
+The MQTT destination string that routes a Measurement to the correct AWS IoT rule. Built by `getMeasurementMqttTopic({ experimentId })` on the lean 7-segment ingest shape: the shared `@repo/api` prefix transform plus `mobile/{appVersion}/{thingName}`, where the thing name is this phone's registered device identity (also the MQTT client id). Protocol attribution rides in the payload as `protocol_id`, which is optional — question-only uploads (no device sample) omit it entirely. Topics are frozen per row at save time, so rows queued by older builds keep their legacy 8-segment topics and drain through the transitional channel.
 
 ### Workbook run
 

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
@@ -416,8 +416,15 @@ describe("AnalysisNode upload with a command in the flow", () => {
     const props = actionBarProps.mock.calls.at(-1)?.[0] as
       | { onUpload: () => Promise<void> }
       | undefined;
+    // Assert the action bar rendered before invoking: with optional chaining a
+    // missing bar would no-op and the negative assertion below would pass
+    // vacuously.
+    expect(props).toBeDefined();
+    if (!props) {
+      throw new Error("AnalysisActionBar did not render");
+    }
     await act(async () => {
-      await props?.onUpload();
+      await props.onUpload();
     });
 
     expect(uploadMeasurements).not.toHaveBeenCalled();

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
@@ -497,6 +497,7 @@ describe("AnalysisNode upload with a command in the flow", () => {
       experimentId: "exp-1",
       experimentLabel: "Trial",
       workbookRunId: "run-1",
+      workbookVersionId: "version-1",
       flowNodes: commandProtocolMacroNodes,
       currentFlowStep: 2,
       scanResult: { sample: [{ phi2: 0.8 }] },

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
@@ -398,6 +398,31 @@ describe("AnalysisNode upload with a command in the flow", () => {
     });
   });
 
+  it("does not upload when the workbook version id is missing", async () => {
+    const uploadMeasurements = vi.fn().mockResolvedValue(undefined);
+    useMeasurementUpload.mockReturnValue({ isUploading: false, uploadMeasurements });
+    useMeasurementFlowStore.setState({
+      experimentId: "exp-1",
+      experimentLabel: "Trial",
+      workbookRunId: "run-1",
+      workbookVersionId: undefined,
+      flowNodes: commandProtocolMacroNodes,
+      currentFlowStep: 2,
+      scanResult: { sample: [{ phi2: 0.8 }] },
+    });
+
+    render(<AnalysisNode content={withMacro} nodeId="m1" />);
+
+    const props = actionBarProps.mock.calls.at(-1)?.[0] as
+      | { onUpload: () => Promise<void> }
+      | undefined;
+    await act(async () => {
+      await props?.onUpload();
+    });
+
+    expect(uploadMeasurements).not.toHaveBeenCalled();
+  });
+
   it("does not upload when the workbook run id is missing", async () => {
     const uploadMeasurements = vi.fn().mockResolvedValue(undefined);
     useMeasurementUpload.mockReturnValue({ isUploading: false, uploadMeasurements });

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.tsx
@@ -215,6 +215,10 @@ export function AnalysisNode({ content, nodeId }: AnalysisNodeProps) {
       throw new Error("Missing workbook run id");
     }
 
+    if (!workbookVersionId) {
+      throw new Error("Missing workbook version id");
+    }
+
     if (!session?.data?.user?.id) {
       throw new Error("Missing user id");
     }

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/questions-only-submit-node.test.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/questions-only-submit-node.test.tsx
@@ -207,6 +207,23 @@ describe("QuestionsOnlySubmitNode", () => {
     expect(dismissQuestionsSubmit).not.toHaveBeenCalled();
   });
 
+  it("does not upload or continue when the workbook version id is missing", async () => {
+    const dismissQuestionsSubmit = vi.fn();
+    useMeasurementFlowStore.setState({
+      experimentId: "exp-1",
+      workbookRunId: "run-1",
+      workbookVersionId: undefined,
+      flowNodes: [makeQuestion("q1")],
+      dismissQuestionsSubmit,
+    });
+
+    render(<QuestionsOnlySubmitNode />);
+    fireEvent.press(screen.getByText("Submit & Continue"));
+
+    await waitFor(() => expect(uploadQuestions).not.toHaveBeenCalled());
+    expect(dismissQuestionsSubmit).not.toHaveBeenCalled();
+  });
+
   it("'Finish' uploads then exits the flow to Recent Measurements", async () => {
     useMeasurementFlowStore.setState({
       experimentId: "exp-1",

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/questions-only-submit-node.test.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/questions-only-submit-node.test.tsx
@@ -211,6 +211,7 @@ describe("QuestionsOnlySubmitNode", () => {
     useMeasurementFlowStore.setState({
       experimentId: "exp-1",
       workbookRunId: "run-1",
+      workbookVersionId: "version-1",
       flowNodes: [makeQuestion("q1")],
     });
     uploadQuestions.mockResolvedValueOnce(undefined);
@@ -227,6 +228,7 @@ describe("QuestionsOnlySubmitNode", () => {
     useMeasurementFlowStore.setState({
       experimentId: "exp-missing",
       workbookRunId: "run-1",
+      workbookVersionId: "version-1",
       flowNodes: [makeQuestion("q1")],
     });
     useFlowAnswersStore.setState({
@@ -248,6 +250,7 @@ describe("QuestionsOnlySubmitNode", () => {
     useMeasurementFlowStore.setState({
       experimentId: "exp-1",
       workbookRunId: "run-1",
+      workbookVersionId: "version-1",
       flowNodes: [makeQuestion("q1")],
     });
     const err = new Error("boom");

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/questions-only-submit-node.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/questions-only-submit-node.tsx
@@ -83,6 +83,10 @@ export function QuestionsOnlySubmitNode() {
       log.warn("handleUpload missing workbook run id");
       return false;
     }
+    if (!workbookVersionId) {
+      log.warn("handleUpload missing workbook version id");
+      return false;
+    }
 
     const timestamp = getSyncedUtcISO();
     const timezone = getTimeSyncState().timezone;

--- a/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.test.tsx
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.test.tsx
@@ -46,6 +46,7 @@ const SHARED = {
   macro: null,
   questions: [],
   workbookRunId: "run-attempt-1",
+  workbookVersionId: "version-1",
 };
 
 type SavedCall = [

--- a/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.ts
@@ -56,7 +56,7 @@ interface SharedUploadArgs {
   macro: { id: string; name: string; filename: string } | null;
   questions: AnswerData[];
   commentText?: string;
-  workbookVersionId?: string;
+  workbookVersionId: string;
   /** The workbook that version belongs to; stored so re-runs survive re-linking. */
   workbookId?: string;
   /** Stable UUID for the complete workbook attempt, across sequential nodes. */

--- a/apps/mobile/src/features/recent-measurements/hooks/use-questions-upload.test.tsx
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-questions-upload.test.tsx
@@ -21,9 +21,7 @@ vi.mock("~/shared/stores/device-identity-store", () => ({
   whenDeviceIdentityLoaded: () => Promise.resolve(),
 }));
 vi.mock("~/shared/measurements/measurement-topic", () => ({
-  QUESTIONS_PROTOCOL_ID: "questions",
-  getMeasurementMqttTopic: ({ experimentId, protocolId }: Record<string, string>) =>
-    `topic/${experimentId}/${protocolId}`,
+  getMeasurementMqttTopic: ({ experimentId }: { experimentId: string }) => `topic/${experimentId}`,
 }));
 vi.mock("~/shared/location/measurement-location", () => ({
   getMeasurementLocation: vi.fn(() => Promise.resolve(null)),

--- a/apps/mobile/src/features/recent-measurements/hooks/use-questions-upload.test.tsx
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-questions-upload.test.tsx
@@ -40,6 +40,7 @@ const shared = {
   userId: "user-1",
   questions: [],
   workbookRunId: "run-1",
+  workbookVersionId: "version-1",
 };
 
 describe("useQuestionsUpload", () => {

--- a/apps/mobile/src/features/recent-measurements/hooks/use-questions-upload.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-questions-upload.ts
@@ -6,10 +6,7 @@ import { useTranslation } from "~/shared/i18n";
 import { getMeasurementLocation } from "~/shared/location/measurement-location";
 import { AnswerData } from "~/shared/measurements/convert-cycle-answers-to-array";
 import { buildAnnotations } from "~/shared/measurements/measurement-annotations";
-import {
-  getMeasurementMqttTopic,
-  QUESTIONS_PROTOCOL_ID,
-} from "~/shared/measurements/measurement-topic";
+import { getMeasurementMqttTopic } from "~/shared/measurements/measurement-topic";
 import { createLogger } from "~/shared/observability/logger";
 import { whenDeviceIdentityLoaded } from "~/shared/stores/device-identity-store";
 
@@ -44,7 +41,7 @@ export function useQuestionsUpload() {
       commentText?: string;
       flagType?: ExperimentAnnotationFlagType | null;
       workbookRunId: string;
-      workbookVersionId?: string;
+      workbookVersionId: string;
     }) => {
       await whenDeviceIdentityLoaded();
       const topic = getMeasurementMqttTopic({ experimentId });
@@ -53,14 +50,11 @@ export function useQuestionsUpload() {
 
       const payload = {
         questions,
-        macros: null,
-        device_id: null,
         timestamp,
         timezone,
         user_id: userId,
-        protocol_id: QUESTIONS_PROTOCOL_ID,
         workbook_run_id: workbookRunId,
-        ...(workbookVersionId ? { workbook_version_id: workbookVersionId } : {}),
+        workbook_version_id: workbookVersionId,
         annotations: buildAnnotations(commentText, flagType),
         ...(location ? { latitude: location.latitude, longitude: location.longitude } : {}),
       };

--- a/apps/mobile/src/features/recent-measurements/services/build-upload-payload.test.ts
+++ b/apps/mobile/src/features/recent-measurements/services/build-upload-payload.test.ts
@@ -22,6 +22,7 @@ const baseArgs = {
   timezone: "Europe/Amsterdam",
   questions: QUESTIONS,
   workbookRunId: "run-1",
+  workbookVersionId: "version-1",
   commentText: undefined as string | undefined,
 };
 
@@ -50,6 +51,7 @@ describe("buildUploadPayload payload construction", () => {
       user_id: "user-1",
       protocol_id: "protocol-9",
       workbook_run_id: "run-1",
+      workbook_version_id: "version-1",
       device_id: "d-1",
       sample: 'compressed:[{"v":1,"macros":["macro_one.js"]},{"v":2,"macros":["macro_one.js"]}]',
       _sample_encoding: "gzip+base64",

--- a/apps/mobile/src/features/recent-measurements/services/build-upload-payload.ts
+++ b/apps/mobile/src/features/recent-measurements/services/build-upload-payload.ts
@@ -12,7 +12,7 @@ export interface MacroInfo {
 export interface BuildUploadPayloadArgs {
   rawMeasurement: any;
   userId: string;
-  /** Real protocol uuid, or the "questions" sentinel for question-only rows. */
+  /** Real protocol uuid. */
   protocolId: string;
   macro: MacroInfo | null;
   timestamp: string;
@@ -22,7 +22,7 @@ export interface BuildUploadPayloadArgs {
   /** Stable UUID for the complete workbook attempt (see CONTEXT.md: Workbook run). */
   workbookRunId: string;
   /** Immutable workbook version that owns the macro snapshot. */
-  workbookVersionId?: string;
+  workbookVersionId: string;
   /** The workbook that version belongs to, so a stored measurement's macro can
    * be re-run against the producing workbook even after the experiment is
    * detached or re-attached elsewhere. */
@@ -72,7 +72,7 @@ export function buildUploadPayload({
     ...rawMeasurement,
     // After the spread: device-native output can carry its own protocol_id
     // (device-defined, not a platform id) and must not clobber the platform
-    // attribution, including the "questions" sentinel.
+    // attribution.
     protocol_id: protocolId,
     ...(hasInjectableSample ? { sample: injectedSample } : {}),
     annotations: buildAnnotations(commentText),
@@ -82,7 +82,7 @@ export function buildUploadPayload({
       ? { device_id: fallbackDeviceId }
       : {}),
     workbook_run_id: workbookRunId,
-    ...(workbookVersionId ? { workbook_version_id: workbookVersionId } : {}),
+    workbook_version_id: workbookVersionId,
     ...(workbookId ? { workbook_id: workbookId } : {}),
     ...(macroContext ? { macro_context: JSON.stringify(macroContext) } : {}),
     ...(location ? { latitude: location.latitude, longitude: location.longitude } : {}),

--- a/apps/mobile/src/shared/measurements/measurement-topic.test.ts
+++ b/apps/mobile/src/shared/measurements/measurement-topic.test.ts
@@ -1,10 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  getMeasurementMqttTopic,
-  parseMeasurementTopic,
-  QUESTIONS_PROTOCOL_ID,
-} from "./measurement-topic";
+import { getMeasurementMqttTopic, parseMeasurementTopic } from "./measurement-topic";
 
 vi.mock("~/shared/stores/device-identity-store", () => ({
   getLocalThingName: () => "mobile_9f2c1a2e-1111-4111-8111-111111111111",
@@ -40,12 +36,6 @@ describe("getMeasurementMqttTopic", () => {
     appVersion = "2.4.1(beta)";
 
     expect(getMeasurementMqttTopic({ experimentId: "experiment-42" })).toContain("/2.4.1-beta-/");
-  });
-
-  it("keeps the questions sentinel exported for payload attribution", () => {
-    // The lean topic carries no protocol segment; question-only uploads mark
-    // themselves in the payload instead.
-    expect(QUESTIONS_PROTOCOL_ID).toBe("questions");
   });
 });
 

--- a/apps/mobile/src/shared/measurements/measurement-topic.ts
+++ b/apps/mobile/src/shared/measurements/measurement-topic.ts
@@ -3,11 +3,6 @@ import { getLocalThingName } from "~/shared/stores/device-identity-store";
 
 import { buildIngestTopicPrefix } from "@repo/api/transforms/iot-topic";
 
-// Sentinel protocol_id for question-only uploads (no device sample). Carried
-// in the payload since the lean topic has no protocol segment; the pipeline
-// treats it like any other protocol_id value.
-export const QUESTIONS_PROTOCOL_ID = "questions";
-
 const SENSOR_TYPE = "mobile";
 
 function appVersionSegment(): string {


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Refactor

## Description

Cleans up the questions-only upload payload now that the lean ingest topic (PR #1919) carries no protocol segment:

- Questions-only uploads no longer send `protocol_id: "questions"` — `protocol_id` is optional in the pipeline schema (`apps/data` `clean_data.py` coalesces topic tail / payload, no non-null expectation) and question-only rows simply omit it. The `QUESTIONS_PROTOCOL_ID` sentinel is deleted.
- The `macros: null` / `device_id: null` markers are gone from the questions payload — they carried no information (`macros` falls through to `array()` when absent, `valid_device_id` is a warning-level expectation).
- `workbook_version_id` is now required on every upload path (questions and measurements). Every running flow is workbook-backed (`use-load-experiment-flow` errors out otherwise), so it is always available and always sent.

## Testing Instructions

- [x] `apps/mobile`: measurement-topic, use-questions-upload, use-measurement-upload, build-upload-payload, questions-only-submit-node, analysis-node suites pass; `tsc --noEmit` clean

## Changes Made

- `use-questions-upload.ts`: payload is `questions`, `timestamp`, `timezone`, `user_id`, `workbook_run_id`, `workbook_version_id`, `annotations`, optional location — nothing else
- `build-upload-payload.ts` / `use-measurement-upload.ts`: `workbookVersionId` required, unconditional in the payload
- Guards for missing `workbookVersionId` at both submit nodes
- `CONTEXT.md` Topic section updated

## Checklist

- [x] I have added/updated tests for my changes
- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have tested these changes locally
- [x] My changes generate no new warnings

## Additional Notes

Historical rows (and outbox rows queued by older builds) still carry `protocol_id: "questions"`, so `protocolMix` keeps showing it for older ranges, rendered as `Private protocol N`. Cosmetic, pre-existing.

## Related Issues

- Related to OJD-1725