### PR TITLE
feat(mobile,iot): identify connected sensors and report stable device identity

### DIFF
--- a/apps/backend/src/iot/presentation/iot-device.controller.spec.ts
+++ b/apps/backend/src/iot/presentation/iot-device.controller.spec.ts
@@ -301,11 +301,32 @@ describe("IotDeviceController", () => {
       expect(second.body.id).toBe(first.body.id);
     });
 
-    it("rejects a non-uuid install id (400)", async () => {
+    // installId is the device's serial, not a minted uuid: a phone reports a
+    // hardware id. It is bounded by length and the AWS IoT thing-attribute
+    // charset, which is what CreateThing would otherwise 500 on.
+    it("accepts a hardware-shaped install id (200)", async () => {
+      const response: SuperTestResponse<IotDevice> = await testApp
+        .post(testApp.resolveOrpcPath(contract.iot.ensureMobileDevice))
+        .withAuth(userId)
+        .send({ installId: "9774d56d682e549c" })
+        .expect(StatusCodes.OK);
+
+      expect(response.body.serialNumber).toBe("9774d56d682e549c");
+    });
+
+    it("rejects an install id outside the thing-attribute charset (400)", async () => {
       await testApp
         .post(testApp.resolveOrpcPath(contract.iot.ensureMobileDevice))
         .withAuth(userId)
-        .send({ installId: "not-a-uuid" })
+        .send({ installId: "not a serial!" })
+        .expect(StatusCodes.BAD_REQUEST);
+    });
+
+    it("rejects an empty install id (400)", async () => {
+      await testApp
+        .post(testApp.resolveOrpcPath(contract.iot.ensureMobileDevice))
+        .withAuth(userId)
+        .send({ installId: "" })
         .expect(StatusCodes.BAD_REQUEST);
     });
 
@@ -368,7 +389,7 @@ describe("IotDeviceController", () => {
 
       expect(response.body.id).toBe(device.id);
       // The owner of the device's org holds every action through that role, and no
-      // grant of their own — so there is nothing for them to leave. `canTransfer`
+      // grant of their own, so there is nothing for them to leave. `canTransfer`
       // is false even for them: a device's AWS Thing and certificate are
       // provisioned against its organization, so there is no transfer route.
       expect(response.body.capabilities).toEqual({
@@ -831,10 +852,9 @@ describe("IotDeviceController", () => {
 
   describe("authorization", () => {
     // Each guarded route must delegate to AuthorizationService.can() with the
-    // resource/action declared by its @CanAccess decorator (device id in the
-    // `deviceId` param), and turn a denial into a 403. Mocking can() to deny
-    // pins the {resource, action} wiring, so a missing or wrong-action decorator
-    // fails here.
+    // resource/action from its @CanAccess decorator and turn a denial into 403.
+    // Mocking can() to deny pins that wiring, so a missing or wrong-action
+    // decorator fails here.
     it.each([
       {
         name: "get device",

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -13503,8 +13503,10 @@
                 "properties": {
                   "installId": {
                     "type": "string",
-                    "format": "uuid",
-                    "description": "Persisted per-install identifier; doubles as the serial"
+                    "minLength": 1,
+                    "maxLength": 255,
+                    "pattern": "^[a-zA-Z0-9_.,@/:#=[\\]-]+$",
+                    "description": "Stable per-device identifier reported by the phone; doubles as the serial"
                   },
                   "name": {
                     "type": "string",

--- a/apps/mobile/src/features/connection/hooks/use-battery-level.ts
+++ b/apps/mobile/src/features/connection/hooks/use-battery-level.ts
@@ -2,41 +2,37 @@ import { useQuery } from "@tanstack/react-query";
 import { useConnectedDevice } from "~/features/connection/hooks/use-device-connection";
 import { useScannerCommandExecutor } from "~/features/connection/hooks/use-scanner-command-executor";
 import { connectionKeys } from "~/features/connection/services/connection-keys";
-
-// `battery` is a trivial console command; a healthy device answers in well
-// under a second. Cap its wait far below the 60s protocol base timeout so an
-// unresponsive device can't hog the (serialized) command queue and block a
-// measurement queued behind it.
-const BATTERY_TIMEOUT_MS = 5_000;
+import { useScannerCommandExecutorStore } from "~/features/connection/stores/use-scanner-command-executor-store";
 
 /**
  * Battery level reported by the primary connected device. The react-query cache is the single
  * source: every consumer (header chip, Home device card, device sheet) mounts
  * this hook and shares one fetch per device.
  *
- * Polls run as `background` commands (they don't flip `isExecuting`), so the
- * `!isExecuting` gate reflects measurements only and pauses polling for their
- * whole duration: a battery refetch must never jump the queue ahead of, or
- * stall, a running measurement.
+ * Battery is read through the driver's own `getDeviceIdentity()` rather than a
+ * raw console command: `battery` is MultispeQ console syntax, and an Ambit
+ * rejects it outright. Each driver decides how to answer, and a family with no
+ * battery reading simply reports none.
+ *
+ * Reads go straight to the executor, so they never flip the store's
+ * `isExecuting`; the `!isExecuting` gate still pauses polling for a whole
+ * measurement so a refetch cannot stall the serialized command queue.
  */
 export function useBatteryLevel(): number | undefined {
   const { data: connectedDevice } = useConnectedDevice();
-  const { executeCommand, isExecuting } = useScannerCommandExecutor();
+  const { isExecuting } = useScannerCommandExecutor();
+  const executor = useScannerCommandExecutorStore((s) =>
+    connectedDevice ? s.executors.get(connectedDevice.id)?.executor : undefined,
+  );
 
   const { data } = useQuery({
     queryKey: connectionKeys.battery(connectedDevice?.id),
     queryFn: async () => {
-      if (!connectedDevice) return null;
-      const response = await executeCommand("battery", {
-        timeoutMs: BATTERY_TIMEOUT_MS,
-        background: true,
-      });
-      if (typeof response !== "string") return null;
-      const pct = parseInt(response.replace("battery:", ""));
-      if (isNaN(pct)) return null;
-      return pct;
+      if (!executor) return null;
+      const identity = await executor.getIdentity();
+      return identity.batteryPercent ?? null;
     },
-    enabled: !!connectedDevice && !isExecuting,
+    enabled: !!connectedDevice && !!executor && !isExecuting,
   });
 
   return data ?? undefined;

--- a/apps/mobile/src/features/connection/services/device-connection-manager/device-connection.ts
+++ b/apps/mobile/src/features/connection/services/device-connection-manager/device-connection.ts
@@ -1,12 +1,12 @@
 import RNBluetoothClassic from "react-native-bluetooth-classic";
 import type { DeviceCommandExecutor } from "~/features/connection/services/device-command-executor";
+import { createIdentifiedCommandExecutor } from "~/features/connection/services/identified-command-executor";
 import { createMockCommandExecutor } from "~/features/connection/services/multispeq/mock-device/create-mock-command-executor";
 import {
   closeMockDevice,
   openMockDevice,
 } from "~/features/connection/services/multispeq/mock-device/mock-device-registry";
 import { mockDevicesEnabled } from "~/features/connection/services/multispeq/mock-device/mock-devices-enabled";
-import { createMultispeqCommandExecutor } from "~/features/connection/services/multispeq/multispeq-command-executor";
 import { bluetoothClassicTransport } from "~/features/connection/services/multispeq/transports/bluetooth-classic-transport";
 import { serialPortTransport } from "~/features/connection/services/multispeq/transports/serial-port-transport";
 import type { Device, DeviceType } from "~/shared/types/device";
@@ -15,8 +15,9 @@ import { closeSerialPort, getSerialPortConnection, openSerialPort } from "./seri
 
 // The single decision table over device transports. Adding a transport =
 // adding one entry here; nothing else in the app switches on device.type.
-// Executors are built from the shared @repo/iot driver via per-transport
-// adapters (transports/), which also handle MultispeQ frame parsing.
+// Executors are built from the shared @repo/iot drivers via per-transport
+// adapters (transports/). Which driver binds is decided by the identification
+// handshake, not by the transport, so any supported family works on either.
 interface DeviceTypeOps {
   connect(device: Device): Promise<void>;
   disconnect(device: Device): Promise<void>;
@@ -53,7 +54,7 @@ const bluetoothClassicOps: DeviceTypeOps = {
   },
   async createExecutor(device) {
     const bluetoothDevice = await RNBluetoothClassic.getConnectedDevice(device.id);
-    return createMultispeqCommandExecutor(bluetoothClassicTransport(bluetoothDevice));
+    return createIdentifiedCommandExecutor(bluetoothClassicTransport(bluetoothDevice));
   },
 };
 
@@ -71,7 +72,7 @@ const usbOps: DeviceTypeOps = {
   async createExecutor(device) {
     const connection = getSerialPortConnection(device.id);
     if (!connection) return undefined;
-    return createMultispeqCommandExecutor(serialPortTransport(connection));
+    return createIdentifiedCommandExecutor(serialPortTransport(connection));
   },
 };
 

--- a/apps/mobile/src/features/connection/services/identified-command-executor.test.ts
+++ b/apps/mobile/src/features/connection/services/identified-command-executor.test.ts
@@ -5,9 +5,9 @@ import { Emitter } from "~/features/connection/utils/emitter";
 
 import { MULTISPEQ_FRAMING } from "@repo/iot";
 
-import { createMultispeqCommandExecutor } from "./multispeq-command-executor";
-import { bluetoothClassicTransport } from "./transports/bluetooth-classic-transport";
-import { serialPortTransport } from "./transports/serial-port-transport";
+import { createIdentifiedCommandExecutor } from "./identified-command-executor";
+import { bluetoothClassicTransport } from "./multispeq/transports/bluetooth-classic-transport";
+import { serialPortTransport } from "./multispeq/transports/serial-port-transport";
 
 // The transport subscribes to the native disconnect event; capture the callback
 // and the returned remove() so tests can drive an unexpected OS disconnect.
@@ -24,6 +24,10 @@ vi.mock("react-native-bluetooth-classic", () => ({
     }),
   },
 }));
+
+// These cases assert MultispeQ framing specifically, so they bind that family
+// rather than probing. Identification itself is covered separately below.
+const MULTISPEQ = { assumeFamily: "multispeq" } as const;
 
 const CANCEL_FRAME = `-1+${MULTISPEQ_FRAMING.LINE_ENDING}`;
 
@@ -50,14 +54,14 @@ const LONG_PROTOCOL = [
   },
 ];
 
-describe("createMultispeqCommandExecutor", () => {
+describe("createIdentifiedCommandExecutor", () => {
   it("unwraps a successful CommandResult to raw data", async () => {
     const transport = mockTransport();
     transport.send.mockImplementation(() => {
       setTimeout(() => transport.simulate('{"value":42}ABCD1234\n'), 0);
       return Promise.resolve();
     });
-    const executor = createMultispeqCommandExecutor(transport);
+    const executor = createIdentifiedCommandExecutor(transport, MULTISPEQ);
 
     await expect(executor.execute("cmd")).resolves.toEqual({ value: 42 });
   });
@@ -68,7 +72,7 @@ describe("createMultispeqCommandExecutor", () => {
       setTimeout(() => transport.simulate("battery:85\n"), 0);
       return Promise.resolve();
     });
-    const executor = createMultispeqCommandExecutor(transport);
+    const executor = createIdentifiedCommandExecutor(transport, MULTISPEQ);
 
     await expect(executor.execute("battery")).resolves.toBe("battery:85");
   });
@@ -77,7 +81,7 @@ describe("createMultispeqCommandExecutor", () => {
     vi.useFakeTimers();
     try {
       const transport = mockTransport(); // never replies
-      const executor = createMultispeqCommandExecutor(transport);
+      const executor = createIdentifiedCommandExecutor(transport, MULTISPEQ);
 
       const settled = executor.execute("cmd").catch((e: Error) => e);
       await vi.advanceTimersByTimeAsync(MULTISPEQ_FRAMING.DEFAULT_TIMEOUT + 1);
@@ -93,7 +97,7 @@ describe("createMultispeqCommandExecutor", () => {
 
   it("cancel() aborts the in-flight command, sends -1+, and rejects as cancelled", async () => {
     const transport = mockTransport(); // never replies on its own
-    const executor = createMultispeqCommandExecutor(transport);
+    const executor = createIdentifiedCommandExecutor(transport, MULTISPEQ);
 
     const settled = executor.execute(LONG_PROTOCOL).catch((e: Error) => e);
     // Let the serialized command reach the driver and register its response
@@ -118,7 +122,7 @@ describe("createMultispeqCommandExecutor", () => {
       }, 0);
       return Promise.resolve();
     });
-    const executor = createMultispeqCommandExecutor(transport);
+    const executor = createIdentifiedCommandExecutor(transport, MULTISPEQ);
 
     const events: DeviceCommandProgress[] = [];
     const off = executor.onProgress((p) => events.push(p));
@@ -146,7 +150,7 @@ describe("createMultispeqCommandExecutor", () => {
       setTimeout(() => transport.simulate('{"ok":1}ABCD1234\n'), 0);
       return Promise.resolve();
     });
-    const executor = createMultispeqCommandExecutor(transport);
+    const executor = createIdentifiedCommandExecutor(transport, MULTISPEQ);
 
     // A throwing listener must never break command execution.
     executor.onProgress(() => {
@@ -158,7 +162,7 @@ describe("createMultispeqCommandExecutor", () => {
 
   it("tears down the underlying driver on destroy()", async () => {
     const transport = mockTransport();
-    const executor = createMultispeqCommandExecutor(transport);
+    const executor = createIdentifiedCommandExecutor(transport, MULTISPEQ);
 
     await executor.destroy();
 
@@ -171,7 +175,7 @@ describe("createMultispeqCommandExecutor", () => {
     transport.onStatusChanged.mockImplementation((cb: (connected: boolean) => void) => {
       statusCb = cb;
     });
-    const executor = createMultispeqCommandExecutor(transport);
+    const executor = createIdentifiedCommandExecutor(transport, MULTISPEQ);
 
     const settled = executor.execute(LONG_PROTOCOL).catch((e: Error) => e);
     await new Promise((resolve) => setTimeout(resolve, 0));
@@ -205,10 +209,11 @@ describe("bluetoothClassicTransport", () => {
 
   it("re-appends the newline so the driver frames a delimiter-stripped message", async () => {
     const device = mockBtDevice('{"ok":1}ABCD1234'); // no trailing "\n"
-    const executor = createMultispeqCommandExecutor(
+    const executor = createIdentifiedCommandExecutor(
       bluetoothClassicTransport(
         device as unknown as Parameters<typeof bluetoothClassicTransport>[0],
       ),
+      MULTISPEQ,
     );
 
     await expect(executor.execute("cmd")).resolves.toEqual({ ok: 1 });
@@ -326,7 +331,7 @@ describe("serialPortTransport", () => {
       }, 0);
     });
 
-    const executor = createMultispeqCommandExecutor(serialPortTransport(emitter));
+    const executor = createIdentifiedCommandExecutor(serialPortTransport(emitter), MULTISPEQ);
 
     await expect(executor.execute("cmd")).resolves.toEqual({ v: 2 });
   });
@@ -369,5 +374,52 @@ describe("serialPortTransport", () => {
     await expect(transport.send("x")).rejects.toThrow("device not open");
     expect(onStatus).toHaveBeenCalledWith(false);
     expect(transport.isConnected()).toBe(false);
+  });
+});
+
+describe("identification handshake", () => {
+  /**
+   * Transport that answers the `hello` probe with the given reply, and every
+   * other command with a framed stub. The stub matters because a matched driver
+   * then runs its own `getDeviceIdentity()` over the same transport.
+   */
+  function helloTransport(reply: string) {
+    const transport = mockTransport();
+    transport.send.mockImplementation((payload: string) => {
+      const answer = payload.trim() === "hello" ? reply : `{"device_name":"stub"}ABCD1234\n`;
+      setTimeout(() => transport.simulate(answer), 0);
+      return Promise.resolve();
+    });
+    return transport;
+  }
+
+  it("reports ambit for a real Ambit, not the hardcoded multispeq", async () => {
+    // Verbatim hello from an Ambit on 1.1.4-3-g2a76435-dirty, captured over
+    // USB-OTG. Mobile used to bind the MultispeQ driver unconditionally, so an
+    // Ambit measurement uploaded device_family: "multispeq".
+    const transport = helloTransport("NEW AmbitV003 Ready FW:1.1.4-3-g2a76435-dirty\n");
+
+    const executor = createIdentifiedCommandExecutor(transport, { probeTimeoutMs: 50 });
+
+    await expect(executor.getIdentity()).resolves.toMatchObject({ family: "ambit" });
+  });
+
+  it("still reports multispeq for a MultispeQ", async () => {
+    const transport = helloTransport("MultispeQ Ready\n");
+
+    const executor = createIdentifiedCommandExecutor(transport, { probeTimeoutMs: 50 });
+
+    await expect(executor.getIdentity()).resolves.toMatchObject({ family: "multispeq" });
+  });
+
+  it("keeps the probe family when the driver would self-report generic", async () => {
+    // A silent device falls back to the raw connector; the reported family must
+    // be the probe's answer, never overwritten by the connector's own default.
+    const transport = helloTransport("NEW AmbitV003 Ready FW:1.1.4-3-g2a76435-dirty\n");
+
+    const executor = createIdentifiedCommandExecutor(transport, { probeTimeoutMs: 50 });
+    const identity = await executor.getIdentity();
+
+    expect(identity.family).toBe("ambit");
   });
 });

--- a/apps/mobile/src/features/connection/services/identified-command-executor.ts
+++ b/apps/mobile/src/features/connection/services/identified-command-executor.ts
@@ -9,10 +9,20 @@ import { createLogger } from "~/shared/observability/logger";
 import type { Trace } from "~/shared/observability/trace";
 import { startTrace } from "~/shared/observability/trace";
 
-import type { DeviceIdentity, ITransportAdapter, Logger as IotLogger } from "@repo/iot";
-import { MultispeqDriver } from "@repo/iot";
+import type {
+  DeviceIdentity,
+  IDeviceDriver,
+  ITransportAdapter,
+  Logger as IotLogger,
+  SensorFamily,
+} from "@repo/iot";
+import { identifyDevice } from "@repo/iot";
 
-const log = createLogger("multispeq");
+/** Namespace used until the handshake resolves which family answered. */
+const log = createLogger("device");
+
+/** Per-probe reply timeout, matching the web host's `useIotConnections`. */
+const PROBE_TIMEOUT_MS = 2000;
 
 let commandSeq = 0;
 
@@ -27,26 +37,50 @@ const PROGRESS_THROTTLE_MS = 100;
  */
 const HEARTBEAT_MS = 15_000;
 
-/**
- * Adapts the shared `@repo/iot` `MultispeqDriver` to the app's command-executor
- * contract: unwraps `CommandResult` to raw data (throwing on failure) and
- * exposes a preemptive `cancel()`. All framing, command queueing, dynamic
- * timeout sizing and cancel-on-timeout behaviour live in the driver; there is
- * no app-side reimplementation. See OJD-1565.
- *
- * Each execute() is captured as ONE wide trace event (`multispeq.command`):
- * the driver's debug logs are routed into the trace via a bridge logger, so a
- * long measurement produces a single fat entry (tx, rx summary, timings)
- * instead of hundreds of per-chunk debug lines.
- */
-export class MultispeqCommandExecutor implements DeviceCommandExecutor {
-  private readonly driver: MultispeqDriver;
+/** Options for building an executor over an already-connected transport. */
+export interface IdentifiedCommandExecutorOptions {
   /**
-   * Resolves once the driver has been initialized. `initialize()` is currently
-   * synchronous, but the interface allows it to be async (handshake/probe), so
-   * every public op awaits this first; that keeps execute/cancel/destroy from
-   * racing setup and turns any init failure into a controlled command error
-   * rather than an unhandled rejection.
+   * Skip the probe and bind this family directly. Used by transports that
+   * already know what they are (mock devices) and by tests that assert a
+   * specific driver's framing.
+   */
+  assumeFamily?: SensorFamily;
+  /** Override the per-probe reply timeout. */
+  probeTimeoutMs?: number;
+}
+
+/**
+ * Adapts a `@repo/iot` driver to the app's command-executor contract: unwraps
+ * `CommandResult` to raw data (throwing on failure) and exposes a preemptive
+ * `cancel()`. All framing, command queueing, dynamic timeout sizing and
+ * cancel-on-timeout behaviour live in the driver; there is no app-side
+ * reimplementation. See OJD-1565.
+ *
+ * Which driver is bound is decided by the `identifyDevice` handshake rather
+ * than assumed, so an Ambit or miniPAR on the same USB/Bluetooth transport gets
+ * its own driver and reports its own family. This mirrors what the web host has
+ * done since #1791 (`useIotConnections`); mobile previously hardcoded the
+ * MultispeQ driver, which made every device report `family: "multispeq"`.
+ *
+ * Each execute() is captured as ONE wide trace event (`<family>.command`): the
+ * driver's debug logs are routed into the trace via a bridge logger, so a long
+ * measurement produces a single fat entry (tx, rx summary, timings) instead of
+ * hundreds of per-chunk debug lines.
+ */
+export class IdentifiedCommandExecutor implements DeviceCommandExecutor {
+  /** Bound by the handshake; every public op awaits `initPromise` first. */
+  private driver: IDeviceDriver | undefined;
+  /** Family of record from the probe; the driver must not overwrite it. */
+  private family: SensorFamily = "generic";
+  /** Identity the probe resolved, merged under each live `getIdentity()`. */
+  private probeIdentity: DeviceIdentity | undefined;
+  /** Namespaced to the resolved family once known, so logs name the real device. */
+  private familyLog: ReturnType<typeof createLogger> | undefined;
+  /**
+   * Resolves once the handshake has picked a driver and initialized it. Every
+   * public op awaits this first; that keeps execute/cancel/destroy from racing
+   * setup and turns any init failure into a controlled command error rather
+   * than an unhandled rejection.
    */
   private readonly initPromise: Promise<void>;
   private activeTrace: Trace | null = null;
@@ -67,16 +101,48 @@ export class MultispeqCommandExecutor implements DeviceCommandExecutor {
   // wire, instead of a later call clobbering the in-flight command's trace.
   private commandTail: Promise<unknown> = Promise.resolve();
 
-  constructor(transport: ITransportAdapter) {
-    this.driver = new MultispeqDriver(this.createBridgeLogger());
-    // `initialize()` may return void or a promise; normalize so callers can
-    // always await it. Errors are swallowed here and re-surface per-command.
-    this.initPromise = Promise.resolve(this.driver.initialize(transport));
+  constructor(transport: ITransportAdapter, options?: IdentifiedCommandExecutorOptions) {
+    // `identifyDevice` probes, picks the connector and initializes it against
+    // this transport. Errors are swallowed here and re-surface per-command.
+    this.initPromise = this.identify(transport, options);
     // A transport-reported disconnect aborts the in-flight command at once;
-    // user-cancel is a separate path (it sets isCancelled).
+    // user-cancel is a separate path (it sets isCancelled). The driver may not
+    // be bound yet if the cable is pulled mid-handshake, hence the guard.
     transport.onStatusChanged((isConnected) => {
-      if (!isConnected) void this.driver.cancel();
+      if (!isConnected) void this.driver?.cancel?.();
     });
+  }
+
+  /**
+   * Run the identification handshake and adopt whatever answered. The probe's
+   * family is authoritative: fallback connectors self-report "generic" and must
+   * not overwrite a probe-resolved family.
+   */
+  private async identify(
+    transport: ITransportAdapter,
+    options?: IdentifiedCommandExecutorOptions,
+  ): Promise<void> {
+    const { family, info, connector } = await identifyDevice(transport, {
+      assumeFamily: options?.assumeFamily,
+      probeTimeoutMs: options?.probeTimeoutMs ?? PROBE_TIMEOUT_MS,
+      logger: this.createBridgeLogger(),
+    });
+    this.driver = connector;
+    this.family = family;
+    this.probeIdentity = info;
+    this.familyLog = createLogger(family);
+    this.familyLog.info("identified", { family, name: info.name });
+  }
+
+  /** The driver, once the handshake has bound one. */
+  private get boundDriver(): IDeviceDriver {
+    if (!this.driver) throw new Error("Device is not identified yet");
+    return this.driver;
+  }
+
+  /** Family-namespaced logger once known, the neutral one before that. */
+  private get activeLog(): ReturnType<typeof createLogger> {
+    return this.familyLog ?? log;
   }
 
   /**
@@ -117,18 +183,18 @@ export class MultispeqCommandExecutor implements DeviceCommandExecutor {
 
     return {
       debug: (msg, ...args) => {
-        if (!record(msg, args)) log.debug(msg, args[0] as LogFields | undefined);
+        if (!record(msg, args)) this.activeLog.debug(msg, args[0] as LogFields | undefined);
       },
       info: (msg, ...args) => {
-        if (!record(msg, args)) log.info(msg, args[0] as LogFields | undefined);
+        if (!record(msg, args)) this.activeLog.info(msg, args[0] as LogFields | undefined);
       },
       warn: (msg, ...args) => {
         record(msg, args);
-        log.warn(msg, args[0] as LogFields | undefined);
+        this.activeLog.warn(msg, args[0] as LogFields | undefined);
       },
       error: (msg, ...args) => {
         record(msg, args);
-        log.error(msg, args[0] as LogFields | undefined);
+        this.activeLog.error(msg, args[0] as LogFields | undefined);
       },
     };
   }
@@ -188,7 +254,7 @@ export class MultispeqCommandExecutor implements DeviceCommandExecutor {
   ): Promise<string | object> {
     // Ensure the driver finished initializing before sending anything.
     await this.initPromise;
-    const trace = startTrace("multispeq.command", `multispeq-cmd-${++commandSeq}`);
+    const trace = startTrace(`${this.family}.command`, `${this.family}-cmd-${++commandSeq}`);
     this.activeTrace = trace;
     this.chunkCount = 0;
     this.bytes = 0;
@@ -201,12 +267,12 @@ export class MultispeqCommandExecutor implements DeviceCommandExecutor {
     // wire; cleared in `finally`.
     const heartbeat = setInterval(() => {
       if (this.cmdStartedAt) {
-        log.info("measuring", { elapsedMs: Date.now() - this.cmdStartedAt });
+        this.activeLog.info("measuring", { elapsedMs: Date.now() - this.cmdStartedAt });
       }
     }, HEARTBEAT_MS);
 
     try {
-      const result = await this.driver.execute(command, options);
+      const result = await this.boundDriver.execute(command, options);
       if (!result.success) {
         throw result.error ?? new Error("Command failed");
       }
@@ -222,21 +288,39 @@ export class MultispeqCommandExecutor implements DeviceCommandExecutor {
   }
 
   cancel(): Promise<void> {
-    return this.initPromise.then(() => this.driver.cancel());
+    return this.initPromise.then(() => this.boundDriver.cancel?.());
   }
 
-  getIdentity(): Promise<DeviceIdentity> {
-    return this.initPromise.then(() => this.driver.getDeviceIdentity());
+  /**
+   * Re-reads the driver's identity each call so live fields (battery) stay
+   * fresh, layered over what the probe resolved. `family` is pinned to the
+   * probe's answer: a fallback connector self-reports "generic" and would
+   * otherwise erase a real classification.
+   */
+  async getIdentity(): Promise<DeviceIdentity> {
+    await this.initPromise;
+    const driver = this.boundDriver;
+    const live = await driver.getDeviceIdentity?.();
+    return {
+      ...this.probeIdentity,
+      ...live,
+      family: this.family,
+      raw: { ...this.probeIdentity?.raw, ...live?.raw },
+    };
   }
 
   destroy(): Promise<void> {
-    return this.initPromise.then(() => this.driver.destroy());
+    return this.initPromise.then(() => this.boundDriver.destroy());
   }
 }
 
-/** Build a command executor backed by the shared driver over the given transport. */
-export function createMultispeqCommandExecutor(
+/**
+ * Build a command executor over the given transport, probing to decide which
+ * driver to bind. Pass `assumeFamily` only when the caller already knows.
+ */
+export function createIdentifiedCommandExecutor(
   transport: ITransportAdapter,
+  options?: IdentifiedCommandExecutorOptions,
 ): DeviceCommandExecutor {
-  return new MultispeqCommandExecutor(transport);
+  return new IdentifiedCommandExecutor(transport, options);
 }

--- a/apps/mobile/src/features/measurement-flow/domain/flow-transitions.ts
+++ b/apps/mobile/src/features/measurement-flow/domain/flow-transitions.ts
@@ -9,7 +9,7 @@ export type ScanResult = Record<string, unknown>;
 
 /** One device's scan output; device is absent for legacy single-device results. */
 export interface ScanResultEntry {
-  device?: { id: string; name: string };
+  device?: { id: string; name: string; firmwareVersion?: string };
   result: ScanResult;
   /** Dispatch rounds: the protocol this device actually ran (per-device upload). */
   protocolId?: string;

--- a/apps/mobile/src/features/measurement-flow/domain/flow-transitions.ts
+++ b/apps/mobile/src/features/measurement-flow/domain/flow-transitions.ts
@@ -9,7 +9,7 @@ export type ScanResult = Record<string, unknown>;
 
 /** One device's scan output; device is absent for legacy single-device results. */
 export interface ScanResultEntry {
-  device?: { id: string; name: string; firmwareVersion?: string };
+  device?: { id: string; name: string; family?: string; firmwareVersion?: string };
   result: ScanResult;
   /** Dispatch rounds: the protocol this device actually ran (per-device upload). */
   protocolId?: string;

--- a/apps/mobile/src/features/measurement-flow/hooks/use-measurement-capture.test.tsx
+++ b/apps/mobile/src/features/measurement-flow/hooks/use-measurement-capture.test.tsx
@@ -24,6 +24,20 @@ const mocks = vi.hoisted(() => {
   const useMeasurementFlowStore = vi.fn(() => flowState);
   Object.assign(useMeasurementFlowStore, { getState: () => flowState });
 
+  const executorState = {
+    executors: new Map<
+      string,
+      { identity?: { firmwareVersion?: string }; progress?: number; scanStartedAt?: number }
+    >(),
+    progress: 0,
+    scanStartedAt: 0,
+    estimatedMs: 0,
+  };
+  const useScannerCommandExecutorStore = vi.fn(
+    (selector: (state: typeof executorState) => unknown) => selector(executorState),
+  );
+  Object.assign(useScannerCommandExecutorStore, { getState: () => executorState });
+
   return {
     devices: [] as Device[],
     refetchConnectedDevices: vi.fn(),
@@ -39,6 +53,8 @@ const mocks = vi.hoisted(() => {
     resolveInlineCommand: vi.fn(),
     flowState,
     useMeasurementFlowStore,
+    executorState,
+    useScannerCommandExecutorStore,
     isScanning: false,
   };
 });
@@ -65,9 +81,7 @@ vi.mock("~/features/connection/stores/use-device-sheet-store", () => ({
     selector({ open: mocks.openDeviceSheet }),
 }));
 vi.mock("~/features/connection/stores/use-scanner-command-executor-store", () => ({
-  useScannerCommandExecutorStore: (
-    selector: (state: { progress: number; scanStartedAt: number; estimatedMs: number }) => unknown,
-  ) => selector({ progress: 0, scanStartedAt: 0, estimatedMs: 0 }),
+  useScannerCommandExecutorStore: mocks.useScannerCommandExecutorStore,
 }));
 vi.mock("~/features/measurement-flow/stores/use-measurement-flow-store", () => ({
   useMeasurementFlowStore: mocks.useMeasurementFlowStore,
@@ -116,6 +130,10 @@ describe("useMeasurementCapture", () => {
       devicePlan: undefined,
       flowNodes: [],
     });
+    mocks.executorState.executors = new Map([
+      ["usb-a", { identity: { firmwareVersion: "2.311" } }],
+      ["usb-b", { identity: { firmwareVersion: "1.04" } }],
+    ]);
   });
 
   it("records a successful broadcast round in connection order and advances", async () => {
@@ -133,8 +151,14 @@ describe("useMeasurementCapture", () => {
     expect(mocks.executeScanAll).toHaveBeenCalledWith(CONTENT.protocol, [DEVICE_A, DEVICE_B]);
     expect(mocks.flowState.setScanResults).toHaveBeenCalledWith(
       [
-        { device: { id: "usb-a", name: "Device A" }, result: { value: 1 } },
-        { device: { id: "usb-b", name: "Device B" }, result: { value: 2 } },
+        {
+          device: { id: "usb-a", name: "Device A", firmwareVersion: "2.311" },
+          result: { value: 1 },
+        },
+        {
+          device: { id: "usb-b", name: "Device B", firmwareVersion: "1.04" },
+          result: { value: 2 },
+        },
       ],
       "measurement-cell",
     );
@@ -238,13 +262,13 @@ describe("useMeasurementCapture", () => {
     expect(mocks.flowState.setScanResults).toHaveBeenCalledWith(
       [
         {
-          device: { id: "usb-a", name: "Device A" },
+          device: { id: "usb-a", name: "Device A", firmwareVersion: "2.311" },
           result: { value: 1 },
           protocolId: "proto-a",
           protocolName: "Protocol A",
         },
         {
-          device: { id: "usb-b", name: "Device B" },
+          device: { id: "usb-b", name: "Device B", firmwareVersion: "1.04" },
           result: { value: 2 },
           protocolId: undefined,
           protocolName: "Command target",

--- a/apps/mobile/src/features/measurement-flow/hooks/use-measurement-capture.test.tsx
+++ b/apps/mobile/src/features/measurement-flow/hooks/use-measurement-capture.test.tsx
@@ -27,7 +27,11 @@ const mocks = vi.hoisted(() => {
   const executorState = {
     executors: new Map<
       string,
-      { identity?: { firmwareVersion?: string }; progress?: number; scanStartedAt?: number }
+      {
+        identity?: { family?: string; firmwareVersion?: string };
+        progress?: number;
+        scanStartedAt?: number;
+      }
     >(),
     progress: 0,
     scanStartedAt: 0,
@@ -131,8 +135,8 @@ describe("useMeasurementCapture", () => {
       flowNodes: [],
     });
     mocks.executorState.executors = new Map([
-      ["usb-a", { identity: { firmwareVersion: "2.311" } }],
-      ["usb-b", { identity: { firmwareVersion: "1.04" } }],
+      ["usb-a", { identity: { family: "multispeq", firmwareVersion: "2.311" } }],
+      ["usb-b", { identity: { family: "minipar", firmwareVersion: "1.04" } }],
     ]);
   });
 
@@ -152,11 +156,21 @@ describe("useMeasurementCapture", () => {
     expect(mocks.flowState.setScanResults).toHaveBeenCalledWith(
       [
         {
-          device: { id: "usb-a", name: "Device A", firmwareVersion: "2.311" },
+          device: {
+            id: "usb-a",
+            name: "Device A",
+            family: "multispeq",
+            firmwareVersion: "2.311",
+          },
           result: { value: 1 },
         },
         {
-          device: { id: "usb-b", name: "Device B", firmwareVersion: "1.04" },
+          device: {
+            id: "usb-b",
+            name: "Device B",
+            family: "minipar",
+            firmwareVersion: "1.04",
+          },
           result: { value: 2 },
         },
       ],
@@ -262,13 +276,23 @@ describe("useMeasurementCapture", () => {
     expect(mocks.flowState.setScanResults).toHaveBeenCalledWith(
       [
         {
-          device: { id: "usb-a", name: "Device A", firmwareVersion: "2.311" },
+          device: {
+            id: "usb-a",
+            name: "Device A",
+            family: "multispeq",
+            firmwareVersion: "2.311",
+          },
           result: { value: 1 },
           protocolId: "proto-a",
           protocolName: "Protocol A",
         },
         {
-          device: { id: "usb-b", name: "Device B", firmwareVersion: "1.04" },
+          device: {
+            id: "usb-b",
+            name: "Device B",
+            family: "minipar",
+            firmwareVersion: "1.04",
+          },
           result: { value: 2 },
           protocolId: undefined,
           protocolName: "Command target",

--- a/apps/mobile/src/features/measurement-flow/hooks/use-measurement-capture.ts
+++ b/apps/mobile/src/features/measurement-flow/hooks/use-measurement-capture.ts
@@ -149,14 +149,16 @@ export function useMeasurementCapture(content: MeasurementContent, nodeId?: stri
       ordered.map(({ device, result }) => {
         // Read after the scan so an identity handshake that finished while the
         // command was running is included in the persisted per-device result.
-        const firmwareVersion = useScannerCommandExecutorStore.getState().executors.get(device.id)
-          ?.identity?.firmwareVersion;
+        const identity = useScannerCommandExecutorStore
+          .getState()
+          .executors.get(device.id)?.identity;
 
         return {
           device: {
             id: device.id,
             name: device.name,
-            ...(firmwareVersion ? { firmwareVersion } : {}),
+            ...(identity?.family ? { family: identity.family } : {}),
+            ...(identity?.firmwareVersion ? { firmwareVersion: identity.firmwareVersion } : {}),
           },
           result: result as ScanResult,
           ...assignmentMetaRef.current[device.id],

--- a/apps/mobile/src/features/measurement-flow/hooks/use-measurement-capture.ts
+++ b/apps/mobile/src/features/measurement-flow/hooks/use-measurement-capture.ts
@@ -146,11 +146,22 @@ export function useMeasurementCapture(content: MeasurementContent, nodeId?: stri
     );
     successesRef.current = [];
     setScanResults(
-      ordered.map(({ device, result }) => ({
-        device: { id: device.id, name: device.name },
-        result: result as ScanResult,
-        ...assignmentMetaRef.current[device.id],
-      })),
+      ordered.map(({ device, result }) => {
+        // Read after the scan so an identity handshake that finished while the
+        // command was running is included in the persisted per-device result.
+        const firmwareVersion = useScannerCommandExecutorStore.getState().executors.get(device.id)
+          ?.identity?.firmwareVersion;
+
+        return {
+          device: {
+            id: device.id,
+            name: device.name,
+            ...(firmwareVersion ? { firmwareVersion } : {}),
+          },
+          result: result as ScanResult,
+          ...assignmentMetaRef.current[device.id],
+        };
+      }),
       nodeId,
     );
     assignmentMetaRef.current = {};

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
@@ -466,8 +466,14 @@ describe("AnalysisNode upload with a command in the flow", () => {
       currentFlowStep: 2,
       scanResult: { sample: [{ phi2: 0.8 }] },
       scanResults: [
-        { device: { id: "1", name: "MultispeQ #1" }, result: { sample: [{ phi2: 0.8 }] } },
-        { device: { id: "2", name: "MultispeQ #2" }, result: { sample: [{ phi2: 0.7 }] } },
+        {
+          device: { id: "1", name: "MultispeQ #1", firmwareVersion: "2.311" },
+          result: { sample: [{ phi2: 0.8 }] },
+        },
+        {
+          device: { id: "2", name: "MultispeQ #2", firmwareVersion: "2.312" },
+          result: { sample: [{ phi2: 0.7 }] },
+        },
       ],
       producerCellId: "p1",
       cells: [
@@ -510,12 +516,12 @@ describe("AnalysisNode upload with a command in the flow", () => {
       results: [
         {
           rawMeasurement: { sample: [{ phi2: 0.8 }] },
-          device: { id: "1" },
+          device: { id: "1", firmwareVersion: "2.311" },
           macroContext: { measurement: { phi2: 0.8 } },
         },
         {
           rawMeasurement: { sample: [{ phi2: 0.7 }] },
-          device: { id: "2" },
+          device: { id: "2", firmwareVersion: "2.312" },
           macroContext: { measurement: { phi2: 0.7 } },
         },
       ],

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/analysis-node/analysis-node.test.tsx
@@ -467,11 +467,21 @@ describe("AnalysisNode upload with a command in the flow", () => {
       scanResult: { sample: [{ phi2: 0.8 }] },
       scanResults: [
         {
-          device: { id: "1", name: "MultispeQ #1", firmwareVersion: "2.311" },
+          device: {
+            id: "1",
+            name: "MultispeQ #1",
+            family: "multispeq",
+            firmwareVersion: "2.311",
+          },
           result: { sample: [{ phi2: 0.8 }] },
         },
         {
-          device: { id: "2", name: "MultispeQ #2", firmwareVersion: "2.312" },
+          device: {
+            id: "2",
+            name: "MultispeQ #2",
+            family: "multispeq",
+            firmwareVersion: "2.312",
+          },
           result: { sample: [{ phi2: 0.7 }] },
         },
       ],
@@ -516,12 +526,12 @@ describe("AnalysisNode upload with a command in the flow", () => {
       results: [
         {
           rawMeasurement: { sample: [{ phi2: 0.8 }] },
-          device: { id: "1", firmwareVersion: "2.311" },
+          device: { id: "1", family: "multispeq", firmwareVersion: "2.311" },
           macroContext: { measurement: { phi2: 0.8 } },
         },
         {
           rawMeasurement: { sample: [{ phi2: 0.7 }] },
-          device: { id: "2", firmwareVersion: "2.312" },
+          device: { id: "2", family: "multispeq", firmwareVersion: "2.312" },
           macroContext: { measurement: { phi2: 0.7 } },
         },
       ],

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/measurement-node/measurement-node.test.tsx
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/measurement-node/measurement-node.test.tsx
@@ -19,23 +19,38 @@ const {
   toastError,
   playSound,
   scanState,
-} = vi.hoisted(() => ({
-  executeScanAll: vi.fn(),
-  resetScan: vi.fn(),
-  cancelAll: vi.fn(),
-  useConnectedDevices: vi.fn(),
-  refetchConnectedDevices: vi.fn(),
-  nextStep: vi.fn(),
-  setScanResults: vi.fn(),
-  navigateToQuestionFromOverview: vi.fn(),
-  openDeviceSheet: vi.fn(),
-  toastError: vi.fn(),
-  playSound: vi.fn(),
-  scanState: {
-    isScanning: false,
-    lastRound: undefined as { successes: unknown[]; failures: unknown[] } | undefined,
-  },
-}));
+  useScannerCommandExecutorStore,
+} = vi.hoisted(() => {
+  const executorState = {
+    executors: new Map(),
+    progress: undefined,
+    scanStartedAt: undefined,
+    estimatedMs: undefined,
+  };
+  const useScannerCommandExecutorStore = vi.fn((selector: (s: object) => unknown) =>
+    selector(executorState),
+  );
+  Object.assign(useScannerCommandExecutorStore, { getState: () => executorState });
+
+  return {
+    executeScanAll: vi.fn(),
+    resetScan: vi.fn(),
+    cancelAll: vi.fn(),
+    useConnectedDevices: vi.fn(),
+    refetchConnectedDevices: vi.fn(),
+    nextStep: vi.fn(),
+    setScanResults: vi.fn(),
+    navigateToQuestionFromOverview: vi.fn(),
+    openDeviceSheet: vi.fn(),
+    toastError: vi.fn(),
+    playSound: vi.fn(),
+    scanState: {
+      isScanning: false,
+      lastRound: undefined as { successes: unknown[]; failures: unknown[] } | undefined,
+    },
+    useScannerCommandExecutorStore,
+  };
+});
 
 vi.mock("~/features/connection/hooks/use-multi-scanner", () => ({
   useMultiScanner: () => ({
@@ -54,8 +69,7 @@ vi.mock("~/features/connection/hooks/use-device-connection", () => ({
 
 // The capture hook reads the Primary device's live progress off the store.
 vi.mock("~/features/connection/stores/use-scanner-command-executor-store", () => ({
-  useScannerCommandExecutorStore: (selector: (s: object) => unknown) =>
-    selector({ progress: undefined, scanStartedAt: undefined, estimatedMs: undefined }),
+  useScannerCommandExecutorStore,
 }));
 
 vi.mock("~/features/connection/stores/use-device-sheet-store", () => ({

--- a/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/hydrate-cells.ts
+++ b/apps/mobile/src/features/measurement-flow/screens/measurement-flow-screen/components/flow-nodes/utils/hydrate-cells.ts
@@ -1,3 +1,5 @@
+import type { ScanResultEntry } from "~/features/measurement-flow/domain/flow-transitions";
+
 import type { OutputCell, WorkbookCell } from "@repo/api/domains/workbook/workbook-cells.schema";
 
 export interface HydrationContext {
@@ -5,7 +7,7 @@ export interface HydrationContext {
   getAnswer: (cycle: number, cellId: string) => string | undefined;
   scanResult?: unknown;
   /** Per-device form of the live result, used to scope ctx/branches by connection id. */
-  scanResults?: { device?: { id: string; name: string }; result: unknown }[];
+  scanResults?: ScanResultEntry[];
   /** Cell id of the producer (protocol or command) whose output `scanResult` holds. */
   producerCellId?: string;
   /** Macro/analysis outputs keyed by cell id (store.cellOutputs). */

--- a/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.test.tsx
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.test.tsx
@@ -27,6 +27,9 @@ vi.mock("~/shared/measurements/measurement-topic", () => ({
 vi.mock("~/features/recent-measurements/services/export-measurements", () => ({
   exportSingleMeasurementToFile: vi.fn(),
 }));
+vi.mock("~/shared/measurements/client-metadata", () => ({
+  getClientMetadata: () => ({ client_model: "NX789J", client_os: "Android" }),
+}));
 vi.mock("~/shared/ui/AlertDialog", () => ({ showAlert: vi.fn() }));
 vi.mock("sonner-native", () => ({ toast: { error: vi.fn() } }));
 vi.mock("~/shared/i18n", () => ({ useTranslation: () => ({ t: (k: string) => k }) }));

--- a/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.test.tsx
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.test.tsx
@@ -57,6 +57,7 @@ type SavedCall = [
       protocol_id?: string;
       workbook_version_id?: string;
       macro_context?: string;
+      device_firmware?: string;
     };
     metadata: { protocolName: string };
   },
@@ -86,14 +87,14 @@ describe("useMeasurementUpload", () => {
         results: [
           {
             rawMeasurement: { a: 1 },
-            device: { id: "d1", name: "A" },
+            device: { id: "d1", name: "A", firmwareVersion: "2.311" },
             protocolId: "proto-a",
             protocolName: "Proto A",
             macroContext: { measurement: { a: 1 } },
           },
           {
             rawMeasurement: { b: 2 },
-            device: { id: "d2", name: "B" },
+            device: { id: "d2", name: "B", firmwareVersion: "1.04" },
             protocolId: "proto-b",
             protocolName: "Proto B",
           },
@@ -112,6 +113,11 @@ describe("useMeasurementUpload", () => {
       "proto-shared",
     ]);
     expect(calls.map(([m]) => m.metadata.protocolName)).toEqual(["Proto A", "Proto B", "Shared"]);
+    expect(calls.map(([m]) => m.measurementResult.device_firmware)).toEqual([
+      "2.311",
+      "1.04",
+      undefined,
+    ]);
 
     const runIds = calls.map(([m]) => m.measurementResult.workbook_run_id);
     expect(runIds).toEqual(["run-attempt-1", "run-attempt-1", "run-attempt-1"]);

--- a/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.test.tsx
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.test.tsx
@@ -57,6 +57,7 @@ type SavedCall = [
       protocol_id?: string;
       workbook_version_id?: string;
       macro_context?: string;
+      device_family?: string;
       device_firmware?: string;
     };
     metadata: { protocolName: string };
@@ -87,14 +88,19 @@ describe("useMeasurementUpload", () => {
         results: [
           {
             rawMeasurement: { a: 1 },
-            device: { id: "d1", name: "A", firmwareVersion: "2.311" },
+            device: {
+              id: "d1",
+              name: "A",
+              family: "multispeq",
+              firmwareVersion: "2.311",
+            },
             protocolId: "proto-a",
             protocolName: "Proto A",
             macroContext: { measurement: { a: 1 } },
           },
           {
             rawMeasurement: { b: 2 },
-            device: { id: "d2", name: "B", firmwareVersion: "1.04" },
+            device: { id: "d2", name: "B", family: "minipar", firmwareVersion: "1.04" },
             protocolId: "proto-b",
             protocolName: "Proto B",
           },
@@ -116,6 +122,11 @@ describe("useMeasurementUpload", () => {
     expect(calls.map(([m]) => m.measurementResult.device_firmware)).toEqual([
       "2.311",
       "1.04",
+      undefined,
+    ]);
+    expect(calls.map(([m]) => m.measurementResult.device_family)).toEqual([
+      "multispeq",
+      "minipar",
       undefined,
     ]);
 

--- a/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.ts
@@ -89,7 +89,7 @@ export function useMeasurementUpload() {
     }: SharedUploadArgs & {
       results: {
         rawMeasurement: any;
-        device?: { id: string; name: string; firmwareVersion?: string };
+        device?: { id: string; name: string; family?: string; firmwareVersion?: string };
         // Dispatch rounds: the protocol this device actually ran; overrides
         // the batch-level protocolId/protocolName for this result only.
         protocolId?: string;
@@ -139,6 +139,7 @@ export function useMeasurementUpload() {
           workbookId,
           macroContext,
           fallbackDeviceId: device?.id,
+          fallbackDeviceFamily: device?.family,
           fallbackDeviceFirmware: device?.firmwareVersion,
           location,
         });

--- a/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.ts
@@ -89,7 +89,7 @@ export function useMeasurementUpload() {
     }: SharedUploadArgs & {
       results: {
         rawMeasurement: any;
-        device?: { id: string; name: string };
+        device?: { id: string; name: string; firmwareVersion?: string };
         // Dispatch rounds: the protocol this device actually ran; overrides
         // the batch-level protocolId/protocolName for this result only.
         protocolId?: string;
@@ -139,6 +139,7 @@ export function useMeasurementUpload() {
           workbookId,
           macroContext,
           fallbackDeviceId: device?.id,
+          fallbackDeviceFirmware: device?.firmwareVersion,
           location,
         });
 

--- a/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.ts
@@ -6,6 +6,7 @@ import { exportSingleMeasurementToFile } from "~/features/recent-measurements/se
 import { getOutbox } from "~/shared/composition/upload";
 import { useTranslation } from "~/shared/i18n";
 import { getMeasurementLocation } from "~/shared/location/measurement-location";
+import { getClientMetadata } from "~/shared/measurements/client-metadata";
 import { AnswerData } from "~/shared/measurements/convert-cycle-answers-to-array";
 import { getMeasurementMqttTopic } from "~/shared/measurements/measurement-topic";
 import { createLogger } from "~/shared/observability/logger";
@@ -142,6 +143,7 @@ export function useMeasurementUpload() {
           fallbackDeviceFamily: device?.family,
           fallbackDeviceFirmware: device?.firmwareVersion,
           location,
+          client: getClientMetadata(),
         });
 
         const measurement = {

--- a/apps/mobile/src/features/recent-measurements/services/build-upload-payload.test.ts
+++ b/apps/mobile/src/features/recent-measurements/services/build-upload-payload.test.ts
@@ -287,7 +287,21 @@ describe("workbook run correlation", () => {
     expect(withNeither).not.toHaveProperty("device_id");
   });
 
-  it("reports the captured sensor version without overriding device-native provenance", () => {
+  it("reports captured sensor identity without overriding device-native provenance", () => {
+    const withCapturedFamily = buildUploadPayload({
+      ...baseArgs,
+      rawMeasurement: {},
+      fallbackDeviceFamily: "multispeq",
+    });
+    expect(withCapturedFamily.device_family).toBe("multispeq");
+
+    const withNativeFamily = buildUploadPayload({
+      ...baseArgs,
+      rawMeasurement: { device_family: "ambit" },
+      fallbackDeviceFamily: "multispeq",
+    });
+    expect(withNativeFamily.device_family).toBe("ambit");
+
     const withCapturedVersion = buildUploadPayload({
       ...baseArgs,
       rawMeasurement: {},
@@ -303,6 +317,7 @@ describe("workbook run correlation", () => {
     expect(withNativeVersion.device_firmware).toBe("1.04");
 
     const withNeither = buildUploadPayload({ ...baseArgs, rawMeasurement: {} });
+    expect(withNeither).not.toHaveProperty("device_family");
     expect(withNeither).not.toHaveProperty("device_firmware");
   });
 });

--- a/apps/mobile/src/features/recent-measurements/services/build-upload-payload.test.ts
+++ b/apps/mobile/src/features/recent-measurements/services/build-upload-payload.test.ts
@@ -1,4 +1,4 @@
-// Characterization tests for buildUploadPayload — pins the payload
+// Characterization tests for buildUploadPayload: pins the payload
 // construction (including quirks) so refactors can prove equivalence.
 // Pure since Stage 1: input mutation assertions flipped deliberately.
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -360,5 +360,41 @@ describe("measurement location", () => {
 
     expect(payload.latitude).toBe(52.0907);
     expect(payload.longitude).toBe(5.1214);
+  });
+});
+
+describe("client metadata", () => {
+  it("carries the phone and OS alongside the sensor's own device fields", () => {
+    const payload = buildUploadPayload({
+      ...baseArgs,
+      rawMeasurement: { device_name: "Ambit", device_firmware: "1.1.4" },
+      client: {
+        client_model: "NX789J",
+        client_manufacturer: "nubia",
+        client_os: "Android",
+        client_os_version: "16",
+        client_app_version: "1.1.0",
+      },
+    });
+
+    expect(payload).toMatchObject({
+      client_model: "NX789J",
+      client_os: "Android",
+      client_os_version: "16",
+      client_app_version: "1.1.0",
+      // The sensor's own fields are a separate namespace and must survive.
+      device_name: "Ambit",
+      device_firmware: "1.1.4",
+    });
+  });
+
+  it("omits the block entirely when the platform reports nothing", () => {
+    const payload = buildUploadPayload({
+      ...baseArgs,
+      rawMeasurement: {},
+      client: {},
+    }) as Record<string, unknown>;
+
+    expect(Object.keys(payload).some((key) => key.startsWith("client_"))).toBe(false);
   });
 });

--- a/apps/mobile/src/features/recent-measurements/services/build-upload-payload.test.ts
+++ b/apps/mobile/src/features/recent-measurements/services/build-upload-payload.test.ts
@@ -286,6 +286,25 @@ describe("workbook run correlation", () => {
     });
     expect(withNeither).not.toHaveProperty("device_id");
   });
+
+  it("reports the captured sensor version without overriding device-native provenance", () => {
+    const withCapturedVersion = buildUploadPayload({
+      ...baseArgs,
+      rawMeasurement: {},
+      fallbackDeviceFirmware: "2.311",
+    });
+    expect(withCapturedVersion.device_firmware).toBe("2.311");
+
+    const withNativeVersion = buildUploadPayload({
+      ...baseArgs,
+      rawMeasurement: { device_firmware: "1.04" },
+      fallbackDeviceFirmware: "2.311",
+    });
+    expect(withNativeVersion.device_firmware).toBe("1.04");
+
+    const withNeither = buildUploadPayload({ ...baseArgs, rawMeasurement: {} });
+    expect(withNeither).not.toHaveProperty("device_firmware");
+  });
 });
 
 describe("measurement location", () => {

--- a/apps/mobile/src/features/recent-measurements/services/build-upload-payload.ts
+++ b/apps/mobile/src/features/recent-measurements/services/build-upload-payload.ts
@@ -1,5 +1,6 @@
 import { compressSample } from "~/features/recent-measurements/utils/compress-sample";
 import { MeasurementLocation } from "~/shared/location/measurement-location";
+import type { ClientMetadata } from "~/shared/measurements/client-metadata";
 import { AnswerData } from "~/shared/measurements/convert-cycle-answers-to-array";
 import { buildAnnotations } from "~/shared/measurements/measurement-annotations";
 
@@ -36,6 +37,8 @@ export interface BuildUploadPayloadArgs {
   fallbackDeviceFirmware?: string;
   /** GPS fix at measurement time; null/absent uploads without location. */
   location?: MeasurementLocation | null;
+  /** Publishing phone and OS; distinct from the sensor's `device_*` fields. */
+  client?: ClientMetadata;
 }
 
 // Pure: never mutates rawMeasurement or its sample entries. Macro filenames
@@ -57,6 +60,7 @@ export function buildUploadPayload({
   fallbackDeviceFamily,
   fallbackDeviceFirmware,
   location,
+  client,
 }: BuildUploadPayloadArgs) {
   const macroFilenames = macro?.filename ? [macro.filename] : [];
 
@@ -103,6 +107,9 @@ export function buildUploadPayload({
     ...(workbookId ? { workbook_id: workbookId } : {}),
     ...(macroContext ? { macro_context: JSON.stringify(macroContext) } : {}),
     ...(location ? { latitude: location.latitude, longitude: location.longitude } : {}),
+    // Phone provenance. Spread last but never overwrites device-native keys:
+    // every key is `client_`-prefixed, disjoint from the sensor's `device_*`.
+    ...client,
   };
 
   // Compress the (large) sample field to reduce MQTT payload size.

--- a/apps/mobile/src/features/recent-measurements/services/build-upload-payload.ts
+++ b/apps/mobile/src/features/recent-measurements/services/build-upload-payload.ts
@@ -30,6 +30,8 @@ export interface BuildUploadPayloadArgs {
   /** Device-scoped upstream workbook values consumed by the macro as `ctx`. */
   macroContext?: Record<string, unknown>;
   fallbackDeviceId?: string;
+  /** Canonical sensor family captured by the connection handshake. */
+  fallbackDeviceFamily?: string;
   /** Physical sensor firmware captured by the connection handshake. */
   fallbackDeviceFirmware?: string;
   /** GPS fix at measurement time; null/absent uploads without location. */
@@ -52,6 +54,7 @@ export function buildUploadPayload({
   workbookId,
   macroContext,
   fallbackDeviceId,
+  fallbackDeviceFamily,
   fallbackDeviceFirmware,
   location,
 }: BuildUploadPayloadArgs) {
@@ -83,6 +86,12 @@ export function buildUploadPayload({
     // fallback (Android USB deviceIds are transient across replugs).
     ...(rawMeasurement.device_id == null && fallbackDeviceId
       ? { device_id: fallbackDeviceId }
+      : {}),
+    // Report the canonical driver family so downstream consumers can
+    // distinguish MultispeQ, Ambit, MiniPAR, and generic devices without
+    // interpreting a device-reported display name.
+    ...(rawMeasurement.device_family == null && fallbackDeviceFamily
+      ? { device_family: fallbackDeviceFamily }
       : {}),
     // Preserve an explicit device-native value; otherwise report the version
     // learned by the mobile connection handshake for this physical sensor.

--- a/apps/mobile/src/features/recent-measurements/services/build-upload-payload.ts
+++ b/apps/mobile/src/features/recent-measurements/services/build-upload-payload.ts
@@ -30,6 +30,8 @@ export interface BuildUploadPayloadArgs {
   /** Device-scoped upstream workbook values consumed by the macro as `ctx`. */
   macroContext?: Record<string, unknown>;
   fallbackDeviceId?: string;
+  /** Physical sensor firmware captured by the connection handshake. */
+  fallbackDeviceFirmware?: string;
   /** GPS fix at measurement time; null/absent uploads without location. */
   location?: MeasurementLocation | null;
 }
@@ -50,6 +52,7 @@ export function buildUploadPayload({
   workbookId,
   macroContext,
   fallbackDeviceId,
+  fallbackDeviceFirmware,
   location,
 }: BuildUploadPayloadArgs) {
   const macroFilenames = macro?.filename ? [macro.filename] : [];
@@ -80,6 +83,11 @@ export function buildUploadPayload({
     // fallback (Android USB deviceIds are transient across replugs).
     ...(rawMeasurement.device_id == null && fallbackDeviceId
       ? { device_id: fallbackDeviceId }
+      : {}),
+    // Preserve an explicit device-native value; otherwise report the version
+    // learned by the mobile connection handshake for this physical sensor.
+    ...(rawMeasurement.device_firmware == null && fallbackDeviceFirmware
+      ? { device_firmware: fallbackDeviceFirmware }
       : {}),
     workbook_run_id: workbookRunId,
     workbook_version_id: workbookVersionId,

--- a/apps/mobile/src/features/recent-measurements/services/outbox.test.ts
+++ b/apps/mobile/src/features/recent-measurements/services/outbox.test.ts
@@ -178,7 +178,7 @@ describe("Outbox", () => {
   describe("worker - happy path", () => {
     it("publishes the row payload with _client_id and marks the row successful", async () => {
       mockGetMeasurementById.mockResolvedValueOnce(
-        row({ id: "row-1", topic: "exp/p", result: { v: 42 } }),
+        row({ id: "row-1", topic: "exp/p", result: { v: 42, device_firmware: "2.311" } }),
       );
       const transport = makeTransport();
       const { outbox } = await freshOutbox(transport);
@@ -190,7 +190,11 @@ describe("Outbox", () => {
       for (let i = 0; i < 20 && transport.calls.length === 0; i++) await Promise.resolve();
       expect(transport.calls).toHaveLength(1);
       expect(transport.calls[0].topic).toBe("exp/p");
-      expect(transport.calls[0].payload).toEqual({ v: 42, _client_id: "row-1" });
+      expect(transport.calls[0].payload).toEqual({
+        v: 42,
+        device_firmware: "2.311",
+        _client_id: "row-1",
+      });
 
       transport.resolveNext();
       await flushMicrotasks(20);

--- a/apps/mobile/src/features/recent-measurements/services/outbox.test.ts
+++ b/apps/mobile/src/features/recent-measurements/services/outbox.test.ts
@@ -178,7 +178,11 @@ describe("Outbox", () => {
   describe("worker - happy path", () => {
     it("publishes the row payload with _client_id and marks the row successful", async () => {
       mockGetMeasurementById.mockResolvedValueOnce(
-        row({ id: "row-1", topic: "exp/p", result: { v: 42, device_firmware: "2.311" } }),
+        row({
+          id: "row-1",
+          topic: "exp/p",
+          result: { v: 42, device_family: "multispeq", device_firmware: "2.311" },
+        }),
       );
       const transport = makeTransport();
       const { outbox } = await freshOutbox(transport);
@@ -192,6 +196,7 @@ describe("Outbox", () => {
       expect(transport.calls[0].topic).toBe("exp/p");
       expect(transport.calls[0].payload).toEqual({
         v: 42,
+        device_family: "multispeq",
         device_firmware: "2.311",
         _client_id: "row-1",
       });

--- a/apps/mobile/src/shared/measurements/client-metadata.ts
+++ b/apps/mobile/src/shared/measurements/client-metadata.ts
@@ -1,0 +1,32 @@
+import * as Application from "expo-application";
+import * as ExpoDevice from "expo-device";
+
+/**
+ * The publishing phone, as opposed to the `device_*` fields which describe the
+ * sensor. `client_` matches the `client_id` the IoT rule already stamps on the
+ * envelope for the broker-authenticated thing name.
+ */
+export interface ClientMetadata {
+  client_model?: string;
+  client_manufacturer?: string;
+  client_os?: string;
+  client_os_version?: string;
+  client_app_version?: string;
+}
+
+/**
+ * Phone and OS provenance for a measurement. Every field is best-effort: a
+ * value the platform will not report is omitted rather than invented, so the
+ * envelope never carries a placeholder that reads like a real reading.
+ */
+export function getClientMetadata(): ClientMetadata {
+  return {
+    ...(ExpoDevice.modelName ? { client_model: ExpoDevice.modelName } : {}),
+    ...(ExpoDevice.manufacturer ? { client_manufacturer: ExpoDevice.manufacturer } : {}),
+    ...(ExpoDevice.osName ? { client_os: ExpoDevice.osName } : {}),
+    ...(ExpoDevice.osVersion ? { client_os_version: ExpoDevice.osVersion } : {}),
+    ...(Application.nativeApplicationVersion
+      ? { client_app_version: Application.nativeApplicationVersion }
+      : {}),
+  };
+}

--- a/apps/mobile/src/shared/stores/device-identity-store.ts
+++ b/apps/mobile/src/shared/stores/device-identity-store.ts
@@ -1,5 +1,7 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { v4 as uuidv4 } from "uuid";
+import * as Application from "expo-application";
+import { Platform } from "react-native";
+import { v4 as uuidv4, v5 as uuidv5 } from "uuid";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import { createLogger } from "~/shared/observability/logger";
@@ -8,6 +10,40 @@ import { getEnvName } from "~/shared/stores/environment-store";
 const MOBILE_THING_PREFIX = "mobile_";
 
 const log = createLogger("device-identity-store");
+
+/**
+ * Namespace for deriving the install id. NEVER change this: every Android
+ * phone's identity is a pure function of it, so a new value re-forks the fleet.
+ */
+const INSTALL_ID_NAMESPACE = "f579750d-c294-4302-b2f5-c4e57159ab03";
+
+/**
+ * A hardware-backed install id, so reinstalling the app does not create a new
+ * phone. Android's real serial is unreachable (`Build.getSerial()` has needed
+ * the privileged READ_PRIVILEGED_PHONE_STATE since Android 10), so this derives
+ * from `Settings.Secure.ANDROID_ID`: stable per device and signing key,
+ * survives uninstall, resets only on factory reset.
+ *
+ * Hashed into a deterministic uuidv5 rather than sent raw. The API now accepts
+ * either, but deployed environments predate that, and a uuid keeps this working
+ * against them; the value is still a pure function of the hardware id.
+ *
+ * iOS has no equivalent (`identifierForVendor` resets once every app from the
+ * vendor is removed), so it keeps the random id and stays reinstall-unstable.
+ */
+function hardwareInstallId(): string | undefined {
+  if (Platform.OS !== "android") return undefined;
+  try {
+    const androidId = Application.getAndroidId();
+    if (!androidId || androidId.trim() === "") return undefined;
+    return uuidv5(androidId.trim(), INSTALL_ID_NAMESPACE);
+  } catch (error) {
+    log.warn("ANDROID_ID unavailable; falling back to a random install id", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+}
 
 /**
  * This phone's device identity against one backend environment. The installId
@@ -44,11 +80,25 @@ export const useDeviceIdentityStore = create<
       isLoaded: false,
       mintInstallId: (envName) => {
         const existing = get().identities[envName];
+        const hardwareId = hardwareInstallId();
+
+        // Adopt the hardware id even over an existing random one, else that
+        // phone keeps forking on reinstall. Registration is dropped with it:
+        // the derived thing name no longer matches what was registered.
+        if (hardwareId && existing?.installId !== hardwareId) {
+          if (existing) {
+            log.info("adopting hardware install id; re-registration required", { envName });
+          }
+          const adopted: DeviceIdentity = { installId: hardwareId };
+          set((state) => ({ identities: { ...state.identities, [envName]: adopted } }));
+          return adopted;
+        }
+
         if (existing) {
           return existing;
         }
 
-        const minted: DeviceIdentity = { installId: uuidv4() };
+        const minted: DeviceIdentity = { installId: hardwareId ?? uuidv4() };
         set((state) => ({ identities: { ...state.identities, [envName]: minted } }));
         return minted;
       },

--- a/packages/api/src/domains/iot/iot.schema.spec.ts
+++ b/packages/api/src/domains/iot/iot.schema.spec.ts
@@ -13,6 +13,7 @@ import {
   zDeviceOnboardingConfig,
   zDeviceExperiment,
   zMonitoringRangeQuery,
+  zEnsureMobileDeviceBody,
 } from "./iot.schema";
 
 describe("Iot Schema", () => {
@@ -516,6 +517,34 @@ describe("Iot Schema", () => {
           from: "2026-08-15T00:00:00.000Z",
         }).success,
       ).toBe(false);
+    });
+  });
+
+  describe("zEnsureMobileDeviceBody", () => {
+    // The phone reports Settings.Secure.ANDROID_ID verbatim. It is a serial,
+    // not a minted uuid, and the column behind it is text.
+    it("accepts a raw Android SSAID", () => {
+      const parsed = zEnsureMobileDeviceBody.safeParse({ installId: "9774d56d682e549c" });
+
+      expect(parsed.success).toBe(true);
+    });
+
+    it("still accepts a uuid, which older installs and iOS keep using", () => {
+      const parsed = zEnsureMobileDeviceBody.safeParse({
+        installId: "59fcd852-7dfe-44a5-9bfe-5179d2d5f7cf",
+      });
+
+      expect(parsed.success).toBe(true);
+    });
+
+    it("rejects characters AWS CreateThing would refuse", () => {
+      const parsed = zEnsureMobileDeviceBody.safeParse({ installId: "not a serial!" });
+
+      expect(parsed.success).toBe(false);
+    });
+
+    it("rejects an empty install id", () => {
+      expect(zEnsureMobileDeviceBody.safeParse({ installId: "" }).success).toBe(false);
     });
   });
 });

--- a/packages/api/src/domains/iot/iot.schema.ts
+++ b/packages/api/src/domains/iot/iot.schema.ts
@@ -82,17 +82,24 @@ export const zIotDeviceDetail = zIotDeviceWithConnectivity.extend({
   capabilities: zResourceCapabilities,
 });
 
+/**
+ * A physical device identifier: a MAC, an eFuse id, an Android SSAID. Stored in
+ * a text column, so the only real constraints are length and the AWS IoT
+ * thing-attribute charset. Shared so the mobile and generic register paths
+ * cannot drift apart on what a serial may look like.
+ */
+export const zDeviceSerialNumber = z
+  .string()
+  .min(1)
+  .max(255)
+  // AWS IoT thing-attribute values only allow this charset; anything else
+  // would fail at CreateThing with an opaque 500.
+  .regex(/^[a-zA-Z0-9_.,@/:#=[\]-]+$/, {
+    message: "Only letters, numbers, and _ . , @ / : # = [ ] - are allowed",
+  });
+
 export const zRegisterIotDeviceBody = z.object({
-  serialNumber: z
-    .string()
-    .min(1)
-    .max(255)
-    // AWS IoT thing-attribute values only allow this charset; anything else
-    // would fail at CreateThing with an opaque 500.
-    .regex(/^[a-zA-Z0-9_.,@/:#=[\]-]+$/, {
-      message: "Only letters, numbers, and _ . , @ / : # = [ ] - are allowed",
-    })
-    .describe("Physical device identifier, e.g. MAC address"),
+  serialNumber: zDeviceSerialNumber.describe("Physical device identifier, e.g. MAC address"),
   name: z.string().min(1).max(255).optional(),
   deviceType: zRegisterableDeviceType.describe(
     "IotDevice class, maps to the ingest topic sensorType",
@@ -141,7 +148,12 @@ export const zBulkRegisterIotDevicesResult = z.object({
 // Silent per-phone self-registration: the app calls this on login with its
 // persisted install UUID; the route is an idempotent ensure, not a create.
 export const zEnsureMobileDeviceBody = z.object({
-  installId: z.string().uuid().describe("Persisted per-install identifier; doubles as the serial"),
+  // Not a uuid: this IS the serial, and phones report a hardware id (Android
+  // SSAID) rather than a minted one. The uuid rule was an artefact of the app
+  // generating uuidv4 install ids.
+  installId: zDeviceSerialNumber.describe(
+    "Stable per-device identifier reported by the phone; doubles as the serial",
+  ),
   name: z.string().min(1).max(255).optional().describe("Device model, e.g. iPhone 15"),
 });
 

--- a/packages/iot/src/core/identify-device.spec.ts
+++ b/packages/iot/src/core/identify-device.spec.ts
@@ -164,6 +164,25 @@ describe("identifyDevice", () => {
     expect(identified.info.raw.helloReply).toBe("NEW Name Here Ready");
   });
 
+  it("classifies shipping Ambit firmware that appends its build after the Ready sentinel", async () => {
+    // Verbatim hello from an Ambit on 1.1.4-3-g2a76435-dirty. The sentinel used
+    // to be anchored to end-of-line, so this real reply fell through to the raw
+    // fallback and the device reported as generic rather than ambit.
+    const realHello = "NEW AmbitV003 Ready FW:1.1.4-3-g2a76435-dirty\n";
+    const transport = createMockTransport((payload, reply) => {
+      if (payload === HELLO || payload === "hello\n") reply(realHello);
+    });
+
+    const identified = await identifyDevice(transport, { probeTimeoutMs: 50 });
+
+    expect(identified.family).toBe("ambit");
+    expect(identified.connector).toBeInstanceOf(AmbitDriver);
+    expect(identified.info.family).toBe("ambit");
+    // The name is firmware placeholder text, never a device name.
+    expect(identified.info.name).toBeUndefined();
+    expect(identified.info.raw.helloReply).toBe("NEW AmbitV003 Ready FW:1.1.4-3-g2a76435-dirty");
+  });
+
   it("classifies a JSON hello by its device key case-insensitively, capturing name and version", async () => {
     const jsonHello = '{"device":"Ambit","version":"2.0","name":"Greenhouse A"}\nAmbit Ready\n';
     const transport = createMockTransport((payload, reply) => {

--- a/packages/iot/src/core/identify-device.ts
+++ b/packages/iot/src/core/identify-device.ts
@@ -136,8 +136,9 @@ function parseJsonHello(text: string): JsonHello | null {
  *    key names the family
  *  - miniPAR line mode: `MiniPAR,1.1,1.04`
  *  - MultispeQ: `MultispeQ Ready`, older firmware `Instrument Ready`
- *  - Ambit: any other `<name> Ready` line (firmware prints a hardcoded
- *    `NEW Name Here Ready`; never trust the name, only the sentinel), skipped
+ *  - Ambit: any other `<name> Ready` line, with or without trailing build text
+ *    (`NEW AmbitV003 Ready FW:1.1.4-3-g2a76435-dirty`); never trust the name,
+ *    only the sentinel, skipped
  *    when a JSON line self-declared an unrecognized device (e.g. CO2Dot):
  *    that must fall through rather than be handed to the AmbitDriver
  */
@@ -175,7 +176,10 @@ function classifyHelloReply(reply: string): DeviceIdentity | null {
   // A self-declared unknown device outranks the weak Ready sentinel.
   if (jsonHello) return null;
 
-  const readyMatch = /^(.*?)\s*\bready\b\s*$/im.exec(text);
+  // Trailing text after the sentinel is allowed: shipping firmware appends its
+  // build to the line (`NEW AmbitV003 Ready FW:1.1.4-3-g2a76435-dirty`), so
+  // anchoring "ready" to end-of-line only ever matched the bare-name form.
+  const readyMatch = /^(.*?)\s*\bready\b(?:\s.*)?$/im.exec(text);
   if (readyMatch) {
     // Ambit firmware currently hardcodes the text before "Ready".  It is a
     // family signature, not a device name, so do not leak the placeholder into

--- a/packages/iot/src/driver/ambit/driver.spec.ts
+++ b/packages/iot/src/driver/ambit/driver.spec.ts
@@ -302,3 +302,42 @@ describe("AmbitDriver", () => {
     expect(result.error?.message).toBe("Response timeout");
   });
 });
+
+describe("AmbitDriver sensor_id", () => {
+  // The firmware nests its eFuse MAC as sample[].set[].sensor_id and never
+  // emits a top-level device_id, so the platform saw only the transient
+  // USB id until the driver lifted it.
+  const TRACE =
+    '{"device_name":"Ambit","device_firmware":"1.1.4","sample":[{"protocol_id":"NaN","set":[' +
+    '{"par_raw":11.35},{"schema":"ambit.trace/3","sensor_id":"10:91:A8:4F:53:48"}]}]}';
+
+  it("lifts the trace sensor_id into device_id and reports it as the identity", async () => {
+    const protocol = [{ label: "arrun,1,0,2,0,0,9,0,1,0,1" }];
+    const transport = tableTransport({
+      "hello\n": HELLO_REPLY,
+      [`${JSON.stringify(protocol)}\n`]: [TRACE, "7A1E3AA1\n"],
+    });
+    const driver = fastDriver();
+    await driver.initialize(transport);
+
+    const result = await driver.execute<{ device_id?: string }>(protocol);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.device_id).toBe("10:91:A8:4F:53:48");
+  });
+
+  it("leaves a firmware-supplied device_id alone", async () => {
+    const protocol = [{ label: "arrun,1,0,2,0,0,9,0,1,0,1" }];
+    const withDeviceId = TRACE.replace('"device_name"', '"device_id":"FW-SET","device_name"');
+    const transport = tableTransport({
+      "hello\n": HELLO_REPLY,
+      [`${JSON.stringify(protocol)}\n`]: [withDeviceId, "7A1E3AA1\n"],
+    });
+    const driver = fastDriver();
+    await driver.initialize(transport);
+
+    const result = await driver.execute<{ device_id?: string }>(protocol);
+
+    expect(result.data?.device_id).toBe("FW-SET");
+  });
+});

--- a/packages/iot/src/driver/ambit/driver.ts
+++ b/packages/iot/src/driver/ambit/driver.ts
@@ -49,6 +49,8 @@ export class AmbitDriver extends DeviceDriver<AmbitStreamEvents> {
   private rxBuffer = "";
   private onChunk: (() => void) | undefined;
   private lastTrafficAt = 0;
+  /** eFuse MAC from the last trace, remembered for identity reporting. */
+  private sensorId: string | undefined;
 
   constructor(config?: AmbitDriverConfig, logger?: Logger) {
     super(logger);
@@ -180,6 +182,7 @@ export class AmbitDriver extends DeviceDriver<AmbitStreamEvents> {
 
         const envelope = parseOpenJiiEnvelope(reply);
         if (envelope) {
+          this.adoptSensorId(envelope);
           void this.emitter.emit("receivedEnvelope", envelope);
           return {
             success: true,
@@ -261,13 +264,36 @@ export class AmbitDriver extends DeviceDriver<AmbitStreamEvents> {
     });
   }
 
-  /** Identity from the hello sentinel line; the printed name is hardcoded upstream. */
+  /**
+   * Promote the trace's `sensor_id` to the envelope's `device_id`.
+   *
+   * `sensor_id` is the ESP32 eFuse MAC, formatted uppercase colon-separated by
+   * the firmware (`format_sensor_id`, trace_v3.h) precisely so it is the one
+   * stable hardware identity for a unit. It only ever appears nested in the
+   * trace, while the platform reads `device_id` off the envelope, so lift it.
+   * A firmware-supplied `device_id` is left alone, and the value is remembered
+   * so `getDeviceIdentity()` can report it once a measurement has been seen.
+   */
+  private adoptSensorId(envelope: Record<string, unknown>): void {
+    const sensorId = findSensorId(envelope);
+    if (!sensorId) return;
+    this.sensorId = sensorId;
+    envelope.device_id ??= sensorId;
+  }
+
+  /**
+   * Identity from the hello sentinel line; the printed name is hardcoded
+   * upstream. The hardware MAC is not reachable over the text console (the
+   * firmware's cmd 33 writes a raw binary struct), so `deviceId` is only
+   * populated once a measurement has carried the trace's `sensor_id`.
+   */
   async getDeviceIdentity(): Promise<DeviceIdentity> {
     const result = await this.execute<unknown>(AMBIT_COMMANDS.HELLO);
     const text = typeof result.data === "string" ? result.data : "";
     return {
       family: this.family,
-      raw: { helloReply: text },
+      ...(this.sensorId ? { deviceId: this.sensorId } : {}),
+      raw: { helloReply: text, ...(this.sensorId ? { sensor_id: this.sensorId } : {}) },
     };
   }
 
@@ -276,4 +302,29 @@ export class AmbitDriver extends DeviceDriver<AmbitStreamEvents> {
     this.onChunk = undefined;
     await super.destroy();
   }
+}
+
+/**
+ * First `sensor_id` string in a measurement envelope. The firmware nests it in
+ * `sample[].set[]` alongside the trace schema, so walk the envelope rather than
+ * hardcoding a path that a future trace revision could move.
+ */
+function findSensorId(value: unknown, depth = 0): string | undefined {
+  if (depth > 6 || value === null || typeof value !== "object") return undefined;
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const found = findSensorId(entry, depth + 1);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.sensor_id === "string" && record.sensor_id.trim() !== "") {
+    return record.sensor_id;
+  }
+  for (const entry of Object.values(record)) {
+    const found = findSensorId(entry, depth + 1);
+    if (found) return found;
+  }
+  return undefined;
 }

--- a/packages/iot/src/driver/driver-base.ts
+++ b/packages/iot/src/driver/driver-base.ts
@@ -60,6 +60,13 @@ export interface IDeviceDriver {
     metadata?: Record<string, unknown>;
   }): Promise<void>;
 
+  /**
+   * Preemptively abort the in-flight command. Present only on drivers whose
+   * firmware has a device-side abort (MultispeQ's `-1+`); callers must treat a
+   * missing implementation as "nothing to abort" rather than an error.
+   */
+  cancel?(): Promise<void>;
+
   /** Cleanup and destroy driver */
   destroy(): Promise<void>;
 }
@@ -91,10 +98,10 @@ export abstract class DeviceDriver<
   /** Override to change the maximum receive buffer size per driver */
   protected maxBufferSize = DEFAULT_MAX_BUFFER_SIZE;
 
-  /** Logger instance — injected via constructor, defaults to console */
+  /** Logger instance, injected via constructor, defaults to console */
   protected readonly log: Logger;
 
-  /** Typed event emitter — subclasses emit/listen on their own event map */
+  /** Typed event emitter; subclasses emit/listen on their own event map */
   protected readonly emitter: Emitter<EventMap>;
 
   /** Serializes execute() calls so only one command is in-flight at a time */


### PR DESCRIPTION
Linear: [OJD-1726](https://linear.app/openjii/issue/OJD-1726/device-lineage-physical-sensor-serial-resolution-sensormix-sensor-node)

Follow-up that makes these fields reach silver: [OJD-1757](https://linear.app/openjii/issue/OJD-1757/data-pipeline-surface-device-family-and-phone-provenance-in-silver) / #1994 (stacked on this branch).

## What

Mobile measurements now report **which sensor actually produced them** and a **stable identity** for both the sensor and the phone.

The original slice added `device_family` / `device_firmware`. Hardware testing against a real Ambit showed `device_family` was reporting `multispeq`, so this PR also fixes the cause.

## Why

`apps/mobile` never called `identifyDevice`. Every connection, Bluetooth and USB serial alike, was built as `new MultispeqDriver(...)`, and `MultispeqDriver` hardcodes `family = "multispeq"`. So `DeviceIdentity.family` was **always** `multispeq`, whatever was plugged in, and an Ambit capture uploaded `device_family: "multispeq"`.

It went unnoticed because the transports are compatible enough that the wrong driver still works: the MultispeQ driver carried the full Ambit protocol (`arrun,3,0,2,…`, 1750-char reply, checksum `7A1E3AA1`) without erroring. The app just had the wrong idea of what the device was.

The identification handshake already existed in `packages/iot` and has been used by `apps/web` (`useIotConnections`) since #1791. Mobile was simply never migrated.

## Changes

**Device identification**
- Mobile runs `identifyDevice` on connect and binds the driver the probe resolves. `multispeq-command-executor` → `identified-command-executor` (it is no longer MultispeQ-specific).
- Fixed the ambit hello sentinel. It was `/^(.*?)\s*\bready\b\s*$/im`, requiring "Ready" to end the line, but shipping firmware appends its build: `NEW AmbitV003 Ready FW:1.1.4-3-g2a76435-dirty`. Real devices fell through to `generic`; the `NEW Name Here Ready` fixture was the only reason CI looked green.
- `useBatteryLevel` reads `identity.batteryPercent` instead of sending the MultispeQ-only `battery` console command, which an Ambit rejects.
- `IDeviceDriver.cancel` is now optional: only MultispeQ has a device-side abort.

**Sensor serial**
- `AmbitDriver` lifts the trace's `sensor_id` onto `device_id`. That value is the ESP32 eFuse MAC, which the firmware formats specifically so traces "join ambit.device/1 on one stable identity" (`src/PAM.cpp:364`, `src/trace_v3.h:18`). Previously `device_id` was the Android USB device id (`1002`), which the code itself calls a weak fallback because it changes across replugs. A firmware-supplied `device_id` still wins.

**Phone identity**
- The install id derives from `Settings.Secure.ANDROID_ID` instead of a random `uuidv4`, so reinstalling no longer creates a new phone. Android's real serial is unreachable (`Build.getSerial()` has needed privileged `READ_PRIVILEGED_PHONE_STATE` since Android 10).
- Hashed into a deterministic `uuidv5`: deployed environments predate the relaxed serial contract below, and a raw SSAID fails their validation.
- This makes self-registration work as designed. `ensure-mobile-device` looks the phone up by `findBySerialNumber(installId)`; with a random id per install that lookup could never hit, so every reinstall created a new AWS IoT Thing and device row. Re-registering now returns the same `deviceId`.
- iOS keeps the random id: `identifierForVendor` resets once every vendor app is removed, so it is no more reinstall-stable than a uuid.

**Client metadata**
- Measurements carry `client_model`, `client_manufacturer`, `client_os`, `client_os_version`, `client_app_version`. Previously the phone model was sent only at registration and the OS version nowhere. `client_` matches the `client_id` the IoT rule already stamps, and is disjoint from the sensor's `device_*` namespace.

**API serial contract**
- `installId` was `z.string().uuid()`, but `serial_number` is a `text` column and the generic register contract already accepts MAC-shaped values ("Physical device identifier, e.g. MAC address"). Only the mobile endpoint had narrowed it. Both now share `zDeviceSerialNumber`. Strict widening: uuids still validate.

## Testing

Verified end to end on a physical Ambit over USB-OTG (CH9102 bridge) attached to an Android phone, running this branch through Metro against dev.

Same hardware, same experiment, before and after:

| Field | Before | After |
| --- | --- | --- |
| `device_family` | `multispeq` | `ambit` |
| `device_id` | `1002` | `10:91:A8:4F:53:48` |
| `device_firmware` | `1.1.4-3-g2a76435-dirty` | unchanged |
| `client_*` | absent | `NX789J` / `nubia` / `Android` / `16` / `1.1.0` |

Decoded from the persisted upload envelope (`measurements.db`, gzip+base64), and the measurement published to dev over MQTT with a `puback`. Device logs went from `[multispeq] tx(command=battery)` to `[ambit] identified family=ambit`.

Automated: mobile 1118 tests / 106 files, `@repo/iot` 348 / 22, `@repo/api` 1701 / 43. Mobile typecheck and ESLint clean.

## Notes for reviewers

- `AmbitDriver` validates commands against its own list, so a cell holding non-Ambit syntax now fails with "Ambit rejected the command: …" instead of being forwarded and returning the device's own `BAD COMMAND` text.
- Every device adopts the new install id on first launch, which changes existing thing names and forces one re-registration. Old uuid-keyed device rows become orphans that no phone will claim, so they want a cleanup pass.
- SSAID is scoped per app signing key, so a dev build and a store build register as two devices on one phone.
- **These fields do not reach silver yet.** Bronze parses with a fixed `StructType` (`raw_data.py:50` / `schemas.py:59`), and `device_family` is not in it, so it is dropped before silver. Bronze retains the raw JSON, so nothing is lost. A stacked PR adds the extraction using the `get_json_object` pattern already used for `client_id`, which avoids evolving the non-resettable bronze struct.

