### PR TITLE
fix(web): keep map zoom outside navigation guard

### DIFF
--- a/apps/web/components/new-experiment/__tests__/new-experiment.test.tsx
+++ b/apps/web/components/new-experiment/__tests__/new-experiment.test.tsx
@@ -38,7 +38,7 @@ vi.mock("@repo/ui/components/wizard-form", async (importOriginal) => {
         }}
       >
         <input aria-label="Experiment name" />
-        <a href="#zoom-in">Zoom in</a>
+        <a href="#">Zoom in</a>
         <Link href="/en-US/platform/experiments">Experiments</Link>
         <button type="submit" disabled={isSubmitting}>
           Submit
@@ -58,17 +58,41 @@ describe("NewExperimentForm", () => {
 
   it("allows same-document controls while guarding internal navigation", async () => {
     const user = userEvent.setup();
+    const push = vi.mocked(useRouter().push);
+    push.mockClear();
 
     render(<NewExperimentForm />);
 
     await user.type(screen.getByRole("textbox", { name: "Experiment name" }), "Dirty form");
-    await user.click(screen.getByRole("link", { name: "Zoom in" }));
+    const zoomLink = screen.getByRole("link", { name: "Zoom in" });
+    let zoomClickDefaultPrevented: boolean | undefined;
+    zoomLink.addEventListener("click", (event) => {
+      zoomClickDefaultPrevented = event.defaultPrevented;
+    });
+
+    await user.click(zoomLink);
 
     expect(screen.queryByText("experiments.unsavedChangesTitle")).not.toBeInTheDocument();
+    expect(zoomClickDefaultPrevented).toBe(false);
 
-    await user.click(screen.getByRole("link", { name: "Experiments" }));
+    const experimentsLink = screen.getByRole("link", { name: "Experiments" });
+    // Keep jsdom from attempting its unsupported navigation after the guard
+    // deliberately leaves this modified click alone.
+    experimentsLink.addEventListener("click", (event) => event.preventDefault(), { once: true });
+    experimentsLink.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true, ctrlKey: true }),
+    );
+
+    expect(screen.queryByText("experiments.unsavedChangesTitle")).not.toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+
+    await user.click(experimentsLink);
 
     expect(screen.getByText("experiments.unsavedChangesTitle")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "experiments.unsavedLeave" }));
+
+    expect(push).toHaveBeenCalledWith("/en-US/platform/experiments");
   });
 
   it("submits experiment and navigates on success", async () => {

--- a/apps/web/components/new-experiment/__tests__/new-experiment.test.tsx
+++ b/apps/web/components/new-experiment/__tests__/new-experiment.test.tsx
@@ -1,5 +1,6 @@
 import { server } from "@/test/msw/server";
 import { render, screen, userEvent, waitFor } from "@/test/test-utils";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { describe, it, expect, vi } from "vitest";
 
@@ -36,6 +37,9 @@ vi.mock("@repo/ui/components/wizard-form", async (importOriginal) => {
           });
         }}
       >
+        <input aria-label="Experiment name" />
+        <a href="#zoom-in">Zoom in</a>
+        <Link href="/en-US/platform/experiments">Experiments</Link>
         <button type="submit" disabled={isSubmitting}>
           Submit
         </button>
@@ -50,6 +54,21 @@ describe("NewExperimentForm", () => {
     expect(screen.getByRole("form", { name: "wizard form" })).toBeInTheDocument();
     // Dialog starts closed (open={false}), so Radix Dialog content is not in the DOM
     expect(screen.queryByText("experiments.unsavedChangesTitle")).not.toBeInTheDocument();
+  });
+
+  it("allows same-document controls while guarding internal navigation", async () => {
+    const user = userEvent.setup();
+
+    render(<NewExperimentForm />);
+
+    await user.type(screen.getByRole("textbox", { name: "Experiment name" }), "Dirty form");
+    await user.click(screen.getByRole("link", { name: "Zoom in" }));
+
+    expect(screen.queryByText("experiments.unsavedChangesTitle")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("link", { name: "Experiments" }));
+
+    expect(screen.getByText("experiments.unsavedChangesTitle")).toBeInTheDocument();
   });
 
   it("submits experiment and navigates on success", async () => {

--- a/apps/web/components/new-experiment/new-experiment.tsx
+++ b/apps/web/components/new-experiment/new-experiment.tsx
@@ -41,7 +41,7 @@ export function NewExperimentForm() {
   const [hasFormData, setHasFormData] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showDialog, setShowDialog] = useState(false);
-  const [pendingNavigation, setPendingNavigation] = useState<(() => void) | null>(null);
+  const [pendingNavigation, setPendingNavigation] = useState<string | null>(null);
 
   // Helper to create FormStep with specific cards
   const createFormStep = (cards: Parameters<typeof FormStep>[0]["cards"]) => {
@@ -131,6 +131,17 @@ export function NewExperimentForm() {
 
     // Intercept internal Next.js link clicks
     const handleLinkClick = (e: MouseEvent) => {
+      if (
+        e.defaultPrevented ||
+        e.button !== 0 ||
+        e.metaKey ||
+        e.ctrlKey ||
+        e.shiftKey ||
+        e.altKey
+      ) {
+        return;
+      }
+
       const target = e.target as HTMLElement;
       const link = target.closest("a");
       // Same-document controls such as Leaflet's zoom anchors do not leave the form.
@@ -146,9 +157,7 @@ export function NewExperimentForm() {
         e.preventDefault();
         e.stopPropagation();
 
-        setPendingNavigation(() => () => {
-          window.location.href = link.href;
-        });
+        setPendingNavigation(link.pathname + link.search + link.hash);
         setShowDialog(true);
       }
     };
@@ -177,7 +186,8 @@ export function NewExperimentForm() {
   const handleConfirmNavigation = () => {
     setShowDialog(false);
     if (pendingNavigation) {
-      pendingNavigation();
+      router.push(pendingNavigation);
+      setPendingNavigation(null);
     }
   };
 

--- a/apps/web/components/new-experiment/new-experiment.tsx
+++ b/apps/web/components/new-experiment/new-experiment.tsx
@@ -133,8 +133,16 @@ export function NewExperimentForm() {
     const handleLinkClick = (e: MouseEvent) => {
       const target = e.target as HTMLElement;
       const link = target.closest("a");
+      // Same-document controls such as Leaflet's zoom anchors do not leave the form.
+      const staysOnCurrentDocument =
+        link?.pathname === window.location.pathname && link.search === window.location.search;
 
-      if (link?.href && !link.target && link.origin === window.location.origin) {
+      if (
+        link?.href &&
+        !link.target &&
+        link.origin === window.location.origin &&
+        !staysOnCurrentDocument
+      ) {
         e.preventDefault();
         e.stopPropagation();
 


### PR DESCRIPTION
## Type of PR

- [x] Bug fix
- [x] Test update

## Description

Leaflet renders its zoom and popup controls as same-document anchor links. The dirty new-experiment navigation guard treated every same-origin anchor as route navigation, opened the unsaved-changes dialog, and stopped Leaflet from receiving the click.

The guard now leaves same-document controls and modified clicks alone while continuing to protect real internal route changes. Confirmed navigation uses the Next.js router instead of assigning `window.location.href`, avoiding a hard reload and a second native unload prompt.

## Related issues

- Closes #884
- Related to OJD-481

## Changes

- Allow same-document controls such as Leaflet zoom and popup anchors through the dirty-form navigation guard.
- Preserve Cmd/Ctrl/Shift/Alt-click and non-primary click behavior.
- Store the pending relative URL as state and navigate with `router.push()`.
- Add a component regression proving the map-style anchor receives an unblocked click, modified links are not hijacked, real internal links open the dialog, and confirmation uses the router.

## Validation

- [x] Focused `NewExperimentForm` Vitest suite: 3 tests passed
- [x] Web TypeScript check passed
- [x] Targeted ESLint passed
- [x] Prettier and `git diff --check` passed
- [x] Browser reproduction validated in Chromium, Firefox, and WebKit before narrowing the test harness during review

## Review note

Two independent review passes shaped the final change. The initial standalone Playwright harness was removed because Vitest would collect it and break PR CI. The follow-up review identified the hard-reload confirmation path, modified-click interception, and a weak propagation assertion; all three were corrected before this update.
