### PR TITLE
feat(backend,api): scope-related, paginated listings & tier-ranked search (OJD-1728)

### DIFF
--- a/apps/backend/src/common/utils/fts.spec.ts
+++ b/apps/backend/src/common/utils/fts.spec.ts
@@ -1,4 +1,6 @@
-import { buildTsQuery, escapeLike } from "./fts";
+import { sql } from "@repo/database";
+
+import { buildTsQuery, crossTableBonus, escapeLike } from "./fts";
 
 describe("fts buildTsQuery", () => {
   it("appends :* to a single term for prefix matching", () => {
@@ -43,5 +45,26 @@ describe("fts escapeLike", () => {
 
   it("leaves ordinary text untouched", () => {
     expect(escapeLike("photosynthesis study")).toBe("photosynthesis study");
+  });
+});
+
+describe("fts crossTableBonus", () => {
+  const render = (expression: { getSQL: () => { queryChunks: unknown[] } }) =>
+    JSON.stringify(expression.getSQL().queryChunks);
+
+  it("caps the summed per-match steps", () => {
+    const text = render(crossTableBonus(sql`a`, sql`b`, sql`c`));
+
+    expect(text).toContain("LEAST(");
+    expect(text.match(/CASE WHEN/g)).toHaveLength(3);
+    expect(text).toContain("0.1");
+  });
+
+  it("yields a plain zero with no probes, not an empty LEAST", () => {
+    // An empty term list would join into `LEAST(, 0.1)`, which Postgres cannot parse.
+    const text = render(crossTableBonus());
+
+    expect(text).not.toContain("LEAST(");
+    expect(text).toContain("0::numeric");
   });
 });

--- a/apps/backend/src/common/utils/fts.ts
+++ b/apps/backend/src/common/utils/fts.ts
@@ -85,7 +85,10 @@ export const CROSS_TABLE_BONUS_CAP = 0.1;
 /**
  * Capped bonus for matches on related tables (creator, members, linked entities). One shared
  * ceiling across every entity keeps scores comparable in cross-type global search, where entities
- * differ in how many related tables they can match.
+ * differ in how many related tables they can match. The ceiling bounds the skew rather than
+ * erasing it: protocols and macros have a single probe so they top out at one step (0.05), while
+ * experiments and workbooks can reach the full cap. Bounded was preferred over identical because
+ * a flat any-match bonus would flatten within-entity ordering.
  */
 export function crossTableBonus(...matches: SQL[]): SQL<number> {
   const terms = matches.map(

--- a/apps/backend/src/common/utils/fts.ts
+++ b/apps/backend/src/common/utils/fts.ts
@@ -74,3 +74,27 @@ export function ftsMatch(vector: SQLWrapper, name: SQLWrapper, raw: string): SQL
 export function ftsRank(vector: SQLWrapper, name: SQLWrapper, raw: string): SQL<number> {
   return sql<number>`(ts_rank(${vector}, ${tsQuery(raw)}) + 0.3 * similarity(${name}, ${raw}))`;
 }
+
+/** Score added per relationship tier. Relevance dominates; tier breaks near-ties. */
+export const TIER_WEIGHT = 0.15;
+
+/** Per-match increment and the uniform ceiling on the summed cross-table bonus. */
+const CROSS_TABLE_BONUS_STEP = 0.05;
+export const CROSS_TABLE_BONUS_CAP = 0.1;
+
+/**
+ * Capped bonus for matches on related tables (creator, members, linked entities). One shared
+ * ceiling across every entity keeps scores comparable in cross-type global search, where entities
+ * differ in how many related tables they can match.
+ */
+export function crossTableBonus(...matches: SQL[]): SQL<number> {
+  const terms = matches.map(
+    (match) => sql`(CASE WHEN ${match} THEN ${sql.raw(String(CROSS_TABLE_BONUS_STEP))} ELSE 0 END)`,
+  );
+  return sql<number>`LEAST(${sql.join(terms, sql` + `)}, ${sql.raw(String(CROSS_TABLE_BONUS_CAP))})`;
+}
+
+/** Lexical relevance plus the tier bonus: the single key both browse and search order by. */
+export function searchScore(rank: SQL<number>, tier: SQL<number>): SQL<number> {
+  return sql<number>`(${rank} + ${sql.raw(String(TIER_WEIGHT))} * ${tier})`;
+}

--- a/apps/backend/src/common/utils/fts.ts
+++ b/apps/backend/src/common/utils/fts.ts
@@ -91,6 +91,12 @@ export const CROSS_TABLE_BONUS_CAP = 0.1;
  * a flat any-match bonus would flatten within-entity ordering.
  */
 export function crossTableBonus(...matches: SQL[]): SQL<number> {
+  // No probes means no bonus. Falling through would join an empty term list into
+  // `LEAST(, 0.1)`, which Postgres rejects at parse time.
+  if (matches.length === 0) {
+    return sql<number>`0::numeric`;
+  }
+
   const terms = matches.map(
     (match) => sql`(CASE WHEN ${match} THEN ${sql.raw(String(CROSS_TABLE_BONUS_STEP))} ELSE 0 END)`,
   );

--- a/apps/backend/src/common/utils/pagination.ts
+++ b/apps/backend/src/common/utils/pagination.ts
@@ -1,0 +1,18 @@
+/**
+ * Wrap a page of rows in the shared list envelope. `totalPages` is 0 for an empty set,
+ * so an out-of-range page reports empty items against the real totals rather than failing.
+ */
+export function toPage<T, R>(
+  result: { items: T[]; totalCount: number },
+  page: number,
+  pageSize: number,
+  map: (items: T[]) => R[],
+): { items: R[]; page: number; pageSize: number; totalPages: number; totalCount: number } {
+  return {
+    items: map(result.items),
+    page,
+    pageSize,
+    totalPages: Math.ceil(result.totalCount / pageSize),
+    totalCount: result.totalCount,
+  };
+}

--- a/apps/backend/src/common/utils/resource-access-scope.ts
+++ b/apps/backend/src/common/utils/resource-access-scope.ts
@@ -5,9 +5,82 @@ import {
   or,
   organizationMembers,
   resourceGrants,
+  sql,
   teamMembers,
 } from "@repo/database";
 import type { AnyColumn, DatabaseInstance, ResourceType, SQL } from "@repo/database";
+
+/**
+ * The individual relationship probes, kept separately so both the "mine" predicate and
+ * the ranking tier are built from the same subqueries and can never drift apart.
+ */
+function resourceRelationshipParts(params: {
+  database: DatabaseInstance;
+  resourceType: ResourceType;
+  resourceIdColumn: AnyColumn;
+  organizationIdColumn: AnyColumn;
+  userId: string;
+}) {
+  const { database, resourceType, resourceIdColumn, organizationIdColumn, userId } = params;
+
+  return {
+    userGrantExists: exists(
+      database
+        .select()
+        .from(resourceGrants)
+        .where(
+          and(
+            eq(resourceGrants.resourceType, resourceType),
+            eq(resourceGrants.resourceId, resourceIdColumn),
+            eq(resourceGrants.granteeType, "user"),
+            eq(resourceGrants.granteeId, userId),
+          ),
+        ),
+    ),
+    teamGrantExists: exists(
+      database
+        .select()
+        .from(resourceGrants)
+        .innerJoin(teamMembers, eq(teamMembers.teamId, resourceGrants.granteeId))
+        .where(
+          and(
+            eq(resourceGrants.resourceType, resourceType),
+            eq(resourceGrants.resourceId, resourceIdColumn),
+            eq(resourceGrants.granteeType, "team"),
+            eq(teamMembers.userId, userId),
+          ),
+        ),
+    ),
+    orgGrantExists: exists(
+      database
+        .select()
+        .from(resourceGrants)
+        .innerJoin(
+          organizationMembers,
+          eq(organizationMembers.organizationId, resourceGrants.granteeId),
+        )
+        .where(
+          and(
+            eq(resourceGrants.resourceType, resourceType),
+            eq(resourceGrants.resourceId, resourceIdColumn),
+            eq(resourceGrants.granteeType, "organization"),
+            eq(organizationMembers.userId, userId),
+          ),
+        ),
+    ),
+    owningOrgMemberExists: exists(
+      database
+        .select()
+        .from(organizationMembers)
+        .where(
+          and(
+            eq(organizationMembers.organizationId, organizationIdColumn),
+            eq(organizationMembers.userId, userId),
+          ),
+        ),
+    ),
+  };
+}
 
 /**
  * Every path that ties a caller to a row personally: membership of the owning
@@ -25,69 +98,48 @@ export function relatedResourceCondition(params: {
   organizationIdColumn: AnyColumn;
   userId: string | undefined;
 }): SQL | undefined {
-  const { database, resourceType, resourceIdColumn, organizationIdColumn, userId } = params;
-
-  if (!userId) {
+  if (!params.userId) {
     return undefined;
   }
 
-  const userGrantExists = exists(
-    database
-      .select()
-      .from(resourceGrants)
-      .where(
-        and(
-          eq(resourceGrants.resourceType, resourceType),
-          eq(resourceGrants.resourceId, resourceIdColumn),
-          eq(resourceGrants.granteeType, "user"),
-          eq(resourceGrants.granteeId, userId),
-        ),
-      ),
-  );
-  const teamGrantExists = exists(
-    database
-      .select()
-      .from(resourceGrants)
-      .innerJoin(teamMembers, eq(teamMembers.teamId, resourceGrants.granteeId))
-      .where(
-        and(
-          eq(resourceGrants.resourceType, resourceType),
-          eq(resourceGrants.resourceId, resourceIdColumn),
-          eq(resourceGrants.granteeType, "team"),
-          eq(teamMembers.userId, userId),
-        ),
-      ),
-  );
-  const orgGrantExists = exists(
-    database
-      .select()
-      .from(resourceGrants)
-      .innerJoin(
-        organizationMembers,
-        eq(organizationMembers.organizationId, resourceGrants.granteeId),
-      )
-      .where(
-        and(
-          eq(resourceGrants.resourceType, resourceType),
-          eq(resourceGrants.resourceId, resourceIdColumn),
-          eq(resourceGrants.granteeType, "organization"),
-          eq(organizationMembers.userId, userId),
-        ),
-      ),
-  );
-  const owningOrgMemberExists = exists(
-    database
-      .select()
-      .from(organizationMembers)
-      .where(
-        and(
-          eq(organizationMembers.organizationId, organizationIdColumn),
-          eq(organizationMembers.userId, userId),
-        ),
-      ),
-  );
+  const { userGrantExists, teamGrantExists, orgGrantExists, owningOrgMemberExists } =
+    resourceRelationshipParts({ ...params, userId: params.userId });
 
   return or(userGrantExists, teamGrantExists, orgGrantExists, owningOrgMemberExists);
+}
+
+/** Relationship tiers, highest wins. Ordering only: access is decided elsewhere. */
+export const RESOURCE_TIER = { owned: 3, shared: 2, org: 1, public: 0 } as const;
+
+/**
+ * How closely the caller is tied to each row, as a rank key. Anonymous callers get a
+ * constant 0, so ordering degrades to pure relevance/recency.
+ */
+export function resourceTierExpression(params: {
+  database: DatabaseInstance;
+  resourceType: ResourceType;
+  resourceIdColumn: AnyColumn;
+  organizationIdColumn: AnyColumn;
+  createdByColumn: AnyColumn;
+  userId: string | undefined;
+}): SQL<number> {
+  const { createdByColumn, userId } = params;
+
+  // Cast, never a bare integer: Postgres reads an unadorned constant in ORDER BY as
+  // an ordinal position, so a plain `0` would fail the query rather than sort by it.
+  if (!userId) {
+    return sql<number>`${sql.raw(String(RESOURCE_TIER.public))}::int`;
+  }
+
+  const { userGrantExists, teamGrantExists, orgGrantExists, owningOrgMemberExists } =
+    resourceRelationshipParts({ ...params, userId });
+
+  return sql<number>`(CASE
+    WHEN ${eq(createdByColumn, userId)} THEN ${sql.raw(String(RESOURCE_TIER.owned))}
+    WHEN ${or(userGrantExists, teamGrantExists)} THEN ${sql.raw(String(RESOURCE_TIER.shared))}
+    WHEN ${or(orgGrantExists, owningOrgMemberExists)} THEN ${sql.raw(String(RESOURCE_TIER.org))}
+    ELSE ${sql.raw(String(RESOURCE_TIER.public))}
+  END)`;
 }
 
 /**

--- a/apps/backend/src/experiments/application/use-cases/list-experiments/list-experiments.spec.ts
+++ b/apps/backend/src/experiments/application/use-cases/list-experiments/list-experiments.spec.ts
@@ -76,8 +76,8 @@ describe("ListExperimentsUseCase", () => {
       userId: otherUserId,
     });
 
-    // Act - filter by "member" to only get experiments where mainUserId is a member
-    const result = await useCase.execute(mainUserId, "member");
+    // Act - scope to "related" to only get experiments tied to mainUserId
+    const result = await useCase.execute(mainUserId, "related");
 
     expect(result.isSuccess()).toBe(true);
 
@@ -162,8 +162,8 @@ describe("ListExperimentsUseCase", () => {
       status: "active",
     });
 
-    // Act - filter by "member" and "active" status
-    const result = await useCase.execute(mainUserId, "member", "active");
+    // Act - scope to "related" with "active" status
+    const result = await useCase.execute(mainUserId, "related", "active");
 
     expect(result.isSuccess()).toBe(true);
 
@@ -258,7 +258,7 @@ describe("ListExperimentsUseCase", () => {
     });
 
     // Act
-    const result = await useCase.execute(mainUserId, "member", "active", "Searchable");
+    const result = await useCase.execute(mainUserId, "related", "active", "Searchable");
 
     // Assert
     expect(result.isSuccess()).toBe(true);

--- a/apps/backend/src/experiments/application/use-cases/list-experiments/list-experiments.ts
+++ b/apps/backend/src/experiments/application/use-cases/list-experiments/list-experiments.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from "@nestjs/common";
 
-import { ExperimentFilter, ExperimentStatus } from "@repo/api/domains/experiment/experiment.schema";
+import { ExperimentStatus } from "@repo/api/domains/experiment/experiment.schema";
+import type { ResourceScope } from "@repo/api/shared/listing";
 
 import { AppError, Result } from "../../../../common/utils/fp-utils";
 import { ExperimentDto } from "../../../core/models/experiment.model";
@@ -14,7 +15,7 @@ export class ListExperimentsUseCase {
 
   async execute(
     userId: string,
-    filter?: ExperimentFilter,
+    scope?: ResourceScope,
     status?: ExperimentStatus,
     search?: string,
   ): Promise<Result<ExperimentDto[]>> {
@@ -22,12 +23,12 @@ export class ListExperimentsUseCase {
       msg: "Listing experiments",
       operation: "list",
       userId,
-      filter,
+      scope,
       status,
       search,
     });
 
-    const result = await this.experimentRepository.findAll(userId, filter, status, search);
+    const result = await this.experimentRepository.findAll(userId, scope, status, search);
 
     result.fold(
       (experiments: ExperimentDto[]) => {
@@ -50,5 +51,27 @@ export class ListExperimentsUseCase {
     );
 
     return result;
+  }
+
+  async executePaginated(
+    userId: string,
+    page: number,
+    pageSize: number,
+    scope?: ResourceScope,
+    status?: ExperimentStatus,
+    search?: string,
+  ): Promise<Result<{ items: ExperimentDto[]; totalCount: number }>> {
+    this.logger.log({
+      msg: "Listing experiments",
+      operation: "listPaginated",
+      userId,
+      page,
+      pageSize,
+      scope,
+      status,
+      search,
+    });
+
+    return this.experimentRepository.findPage(userId, page, pageSize, scope, status, search);
   }
 }

--- a/apps/backend/src/experiments/core/repositories/experiment-tier-ranking.spec.ts
+++ b/apps/backend/src/experiments/core/repositories/experiment-tier-ranking.spec.ts
@@ -96,6 +96,19 @@ describe("ExperimentRepository relationship-tier ordering", () => {
     expect(ids).toEqual([newer.id, older.id]);
   });
 
+  it("admits nothing for scope=related without a caller, rather than matching on undefined", async () => {
+    await testApp.createExperiment({
+      name: "Anonprobe public",
+      userId: author,
+      visibility: "public",
+    });
+
+    const result = await repository.findAll(undefined as unknown as string, "related");
+
+    assertSuccess(result);
+    expect(result.value).toEqual([]);
+  });
+
   it("lets a strong public match outrank a weak owned one when searching", async () => {
     await testApp.createExperiment({
       name: "Quorndalf",

--- a/apps/backend/src/experiments/core/repositories/experiment-tier-ranking.spec.ts
+++ b/apps/backend/src/experiments/core/repositories/experiment-tier-ranking.spec.ts
@@ -1,0 +1,119 @@
+import { assertSuccess } from "../../../common/utils/fp-utils";
+import { TestHarness } from "../../../test/test-harness";
+import { ExperimentRepository } from "./experiment.repository";
+
+/**
+ * Browse ordering ranks by how closely the caller is tied to each row (owned, shared,
+ * org, public) before the per-entity secondary key. Access is settled elsewhere: every
+ * row here is already readable, the tier only decides what comes first.
+ */
+describe("ExperimentRepository relationship-tier ordering", () => {
+  const testApp = TestHarness.App;
+  let repository: ExperimentRepository;
+  let caller: string;
+  let author: string;
+
+  beforeAll(async () => {
+    await testApp.setup();
+  });
+
+  beforeEach(async () => {
+    await testApp.beforeEach();
+    repository = testApp.module.get(ExperimentRepository);
+    caller = await testApp.createTestUser({});
+    author = await testApp.createTestUser({});
+  });
+
+  afterEach(() => {
+    testApp.afterEach();
+  });
+
+  afterAll(async () => {
+    await testApp.teardown();
+  });
+
+  it("orders owned above shared above org above public", async () => {
+    const publicOrg = await testApp.createOrganization();
+    await testApp.addOrganizationMember(publicOrg, author, "owner");
+    const { experiment: publicExp } = await testApp.createExperiment({
+      name: "Tierprobe public",
+      userId: author,
+      visibility: "public",
+      organizationId: publicOrg,
+    });
+
+    const memberOrg = await testApp.createOrganization();
+    await testApp.addOrganizationMember(memberOrg, author, "owner");
+    await testApp.addOrganizationMember(memberOrg, caller, "member");
+    const { experiment: orgExp } = await testApp.createExperiment({
+      name: "Tierprobe org",
+      userId: author,
+      visibility: "private",
+      organizationId: memberOrg,
+    });
+
+    const sharedOrg = await testApp.createOrganization();
+    await testApp.addOrganizationMember(sharedOrg, author, "owner");
+    const { experiment: sharedExp } = await testApp.createExperiment({
+      name: "Tierprobe shared",
+      userId: author,
+      visibility: "private",
+      organizationId: sharedOrg,
+    });
+    await testApp.addExperimentCollaborator(sharedExp.id, caller);
+
+    const { experiment: ownedExp } = await testApp.createExperiment({
+      name: "Tierprobe owned",
+      userId: caller,
+      visibility: "private",
+    });
+
+    const result = await repository.findAll(caller);
+
+    assertSuccess(result);
+    const ranked = result.value
+      .filter((e) => e.name.startsWith("Tierprobe"))
+      .map((e) => e.id)
+      .filter((id) => [ownedExp.id, sharedExp.id, orgExp.id, publicExp.id].includes(id));
+
+    expect(ranked).toEqual([ownedExp.id, sharedExp.id, orgExp.id, publicExp.id]);
+  });
+
+  it("keeps recency as the tiebreak inside a tier", async () => {
+    const { experiment: older } = await testApp.createExperiment({
+      name: "Recencyprobe older",
+      userId: caller,
+    });
+    const { experiment: newer } = await testApp.createExperiment({
+      name: "Recencyprobe newer",
+      userId: caller,
+    });
+
+    const result = await repository.findAll(caller);
+
+    assertSuccess(result);
+    const ids = result.value.filter((e) => e.name.startsWith("Recencyprobe")).map((e) => e.id);
+    expect(ids).toEqual([newer.id, older.id]);
+  });
+
+  it("lets a strong public match outrank a weak owned one when searching", async () => {
+    await testApp.createExperiment({
+      name: "Quorndalf",
+      userId: author,
+      visibility: "public",
+    });
+    await testApp.createExperiment({
+      name: "Unrelated title",
+      description: "mentions quorndalf once in passing",
+      userId: caller,
+      visibility: "private",
+    });
+
+    const result = await repository.findAll(caller, undefined, undefined, "quorndalf");
+
+    assertSuccess(result);
+    // Tier weights near-ties, it does not bury relevance: the exact name match wins
+    // even though the caller owns the other row.
+    expect(result.value[0].name).toBe("Quorndalf");
+  });
+});

--- a/apps/backend/src/experiments/core/repositories/experiment.repository.spec.ts
+++ b/apps/backend/src/experiments/core/repositories/experiment.repository.spec.ts
@@ -223,7 +223,7 @@ describe("ExperimentRepository", () => {
       });
 
       // Act
-      const result = await repository.findAll(mainUserId, "member");
+      const result = await repository.findAll(mainUserId, "related");
 
       // Assert
       expect(result.isSuccess()).toBe(true);
@@ -249,7 +249,7 @@ describe("ExperimentRepository", () => {
         organizationId: org,
       });
 
-      const result = await repository.findAll(orgMember, "member");
+      const result = await repository.findAll(orgMember, "related");
 
       assertSuccess(result);
       expect(result.value.map((e) => e.id)).toEqual([experiment.id]);
@@ -277,7 +277,7 @@ describe("ExperimentRepository", () => {
         role: "viewer",
       });
 
-      const result = await repository.findAll(teammate, "member");
+      const result = await repository.findAll(teammate, "related");
 
       assertSuccess(result);
       expect(result.value.map((e) => e.id)).toEqual([experiment.id]);
@@ -303,7 +303,7 @@ describe("ExperimentRepository", () => {
         role: "viewer",
       });
 
-      const result = await repository.findAll(outsider, "member");
+      const result = await repository.findAll(outsider, "related");
 
       assertSuccess(result);
       expect(result.value.map((e) => e.id)).toEqual([experiment.id]);
@@ -321,7 +321,7 @@ describe("ExperimentRepository", () => {
         visibility: "public",
       });
 
-      const result = await repository.findAll(mainUserId, "member");
+      const result = await repository.findAll(mainUserId, "related");
 
       assertSuccess(result);
       expect(result.value).toHaveLength(0);
@@ -483,7 +483,7 @@ describe("ExperimentRepository", () => {
       });
 
       // Act - query with member filter as mainUser
-      const result = await repository.findAll(mainUserId, "member");
+      const result = await repository.findAll(mainUserId, "related");
 
       // Assert - should see nothing (not a member of any experiments)
       expect(result.isSuccess()).toBe(true);
@@ -663,7 +663,7 @@ describe("ExperimentRepository", () => {
         status: "active",
       });
 
-      // Act - filter by "member" relationship and "active" status
+      // Act - scope to "related" with "active" status
       const result = await repository.findAll(mainUserId, "member", "active");
 
       // Assert

--- a/apps/backend/src/experiments/core/repositories/experiment.repository.spec.ts
+++ b/apps/backend/src/experiments/core/repositories/experiment.repository.spec.ts
@@ -664,7 +664,7 @@ describe("ExperimentRepository", () => {
       });
 
       // Act - scope to "related" with "active" status
-      const result = await repository.findAll(mainUserId, "member", "active");
+      const result = await repository.findAll(mainUserId, "related", "active");
 
       // Assert
       expect(result.isSuccess()).toBe(true);

--- a/apps/backend/src/experiments/core/repositories/experiment.repository.ts
+++ b/apps/backend/src/experiments/core/repositories/experiment.repository.ts
@@ -1,8 +1,10 @@
 import { Injectable, Inject } from "@nestjs/common";
 
 import type { ExperimentContributor } from "@repo/api/domains/experiment/contributors/experiment-contributors.schema";
-import { ExperimentFilter, ExperimentStatus } from "@repo/api/domains/experiment/experiment.schema";
+import { ExperimentStatus } from "@repo/api/domains/experiment/experiment.schema";
+import type { ResourceScope } from "@repo/api/shared/listing";
 import {
+  asc,
   desc,
   eq,
   and,
@@ -28,7 +30,13 @@ import type { DatabaseInstance, DbOrTx, SQL } from "@repo/database";
 
 import { AuthorizationService } from "../../../authorization/authorization.service";
 import { AppError, Result, tryCatch } from "../../../common/utils/fp-utils";
-import { escapeLike, ftsMatch, ftsRank } from "../../../common/utils/fts";
+import {
+  crossTableBonus,
+  escapeLike,
+  ftsMatch,
+  ftsRank,
+  searchScore,
+} from "../../../common/utils/fts";
 import { owningOrganizationNameSql } from "../../../common/utils/owning-organization";
 import {
   getAnonymizedAvatarUrl,
@@ -38,6 +46,7 @@ import {
 import {
   accessibleResourceCondition,
   relatedResourceCondition,
+  resourceTierExpression,
 } from "../../../common/utils/resource-access-scope";
 import { userIsSelectableGrantee } from "../../../sharing/core/grantee-selectability";
 import {
@@ -50,6 +59,9 @@ import {
   UpdateExperimentDto,
   ExperimentDto,
 } from "../models/experiment.model";
+
+/** A listing row plus its relevance score, which global search merges on across types. */
+export type ExperimentSearchRow = ExperimentDto & { score: number };
 
 /**
  * Contributors plus the experiment's anonymization setting, so no caller can publish
@@ -242,17 +254,20 @@ export class ExperimentRepository {
     });
   }
 
-  async findAll(
+  /**
+   * Shared shape behind the array and paginated listings, so both apply identical
+   * scoping, ranking and ordering and the count matches the rows exactly.
+   */
+  private buildListing(
     userId: string,
-    filter?: ExperimentFilter,
+    scope?: ResourceScope,
     status?: ExperimentStatus,
     search?: string,
-    limit?: number,
     options?: {
       organizationId?: string;
       includeArchived?: boolean;
     },
-  ): Promise<Result<ExperimentDto[]>> {
+  ) {
     const { organizationId, includeArchived = false } = options ?? {};
 
     const experimentFields = {
@@ -271,7 +286,7 @@ export class ExperimentRepository {
       updatedAt: experiments.updatedAt,
     };
 
-    return tryCatch(async () => {
+    {
       const conditions: (SQL | undefined)[] = [];
 
       // Archived rows are hidden unless asked for, either by filtering to them or by
@@ -280,10 +295,10 @@ export class ExperimentRepository {
         conditions.push(ne(experiments.status, "archived"));
       }
 
-      // Unconditional, "member" included: a view may narrow what the caller sees but
+      // Unconditional, `related` included: a view may narrow what the caller sees but
       // never widen it. Authorship is not an access path, so a creator since removed
       // from the owning org must not get the body back through a listing.
-      const scope = accessibleResourceCondition({
+      const accessScope = accessibleResourceCondition({
         database: this.database,
         resourceType: "experiment",
         resourceIdColumn: experiments.id,
@@ -291,8 +306,8 @@ export class ExperimentRepository {
         visibilityColumn: experiments.visibility,
         userId,
       });
-      if (scope) {
-        conditions.push(scope);
+      if (accessScope) {
+        conditions.push(accessScope);
       }
 
       // Narrow to one owning organization (the org profile's resources showcase).
@@ -302,7 +317,7 @@ export class ExperimentRepository {
         conditions.push(eq(experiments.organizationId, organizationId));
       }
 
-      if (filter === "member") {
+      if (scope === "related") {
         // "Mine": every path tying me to the experiment personally, so only rows I
         // reach purely by their being public drop out. Access held through an org or
         // team counts, it is how most members reach anything; so does authorship,
@@ -379,25 +394,108 @@ export class ExperimentRepository {
 
       // Relevance: vector/name rank dominates; cross-table matches add a small capped bonus, so a
       // name match always outranks one matched only by a related field.
-      const rank = sql<number>`(${ftsRank(experiments.searchVector, experiments.name, search ?? "")} + 0.05 * (CASE WHEN ${creatorMatch(search ?? "")} THEN 1 ELSE 0 END) + 0.05 * (CASE WHEN (${memberMatch(search ?? "")} OR ${locationMatch(search ?? "")}) THEN 1 ELSE 0 END))`;
+      const rank = sql<number>`(${ftsRank(experiments.searchVector, experiments.name, search ?? "")} + ${crossTableBonus(
+        creatorMatch(search ?? ""),
+        sql`(${memberMatch(search ?? "")} OR ${locationMatch(search ?? "")})`,
+      )})`;
+
+      const tier = resourceTierExpression({
+        database: this.database,
+        resourceType: "experiment",
+        resourceIdColumn: experiments.id,
+        organizationIdColumn: experiments.organizationId,
+        createdByColumn: experiments.createdBy,
+        userId,
+      });
+      const score = searchScore(rank, tier);
+
+      // Browse keeps tiers strict and recency within them; search folds tier into one
+      // score so a strong public match can still beat a weak owned one. Both end on
+      // `id` so paging never drops or repeats a row on ties.
+      const orderBy = search
+        ? [desc(score), asc(experiments.id)]
+        : [desc(tier), desc(experiments.updatedAt), asc(experiments.id)];
+
+      const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+      return { where, orderBy, score, fields: { ...experimentFields, score } };
+    }
+  }
+
+  async findAll(
+    userId: string,
+    scope?: ResourceScope,
+    status?: ExperimentStatus,
+    search?: string,
+    limit?: number,
+    options?: {
+      organizationId?: string;
+      includeArchived?: boolean;
+    },
+  ): Promise<Result<ExperimentSearchRow[]>> {
+    return tryCatch(async () => {
+      const { where, orderBy, fields } = this.buildListing(userId, scope, status, search, options);
 
       let query = this.database
-        .select(experimentFields)
+        .select(fields)
         .from(experiments)
         .leftJoin(profiles, eq(experiments.createdBy, profiles.userId))
         .$dynamic();
 
-      if (conditions.length > 0) {
-        query = query.where(and(...conditions));
+      if (where) {
+        query = query.where(where);
       }
-
-      query = query.orderBy(search ? desc(rank) : desc(experiments.updatedAt));
+      query = query.orderBy(...orderBy);
 
       if (limit !== undefined) {
         query = query.limit(limit);
       }
 
       return query;
+    });
+  }
+
+  /** One page plus the total, counted separately so an out-of-range page still reports it. */
+  async findPage(
+    userId: string,
+    page: number,
+    pageSize: number,
+    scope?: ResourceScope,
+    status?: ExperimentStatus,
+    search?: string,
+    options?: {
+      organizationId?: string;
+      includeArchived?: boolean;
+    },
+  ): Promise<Result<{ items: ExperimentSearchRow[]; totalCount: number }>> {
+    return tryCatch(async () => {
+      const { where, orderBy, fields } = this.buildListing(userId, scope, status, search, options);
+
+      let rows = this.database
+        .select(fields)
+        .from(experiments)
+        .leftJoin(profiles, eq(experiments.createdBy, profiles.userId))
+        .$dynamic();
+      let total = this.database
+        .select({ count: sql<number>`count(*)::int` })
+        .from(experiments)
+        .leftJoin(profiles, eq(experiments.createdBy, profiles.userId))
+        .$dynamic();
+
+      if (where) {
+        rows = rows.where(where);
+        total = total.where(where);
+      }
+
+      const [items, [{ count }]] = await Promise.all([
+        rows
+          .orderBy(...orderBy)
+          .limit(pageSize)
+          .offset((page - 1) * pageSize),
+        total,
+      ]);
+
+      return { items, totalCount: count };
     });
   }
 

--- a/apps/backend/src/experiments/core/repositories/experiment.repository.ts
+++ b/apps/backend/src/experiments/core/repositories/experiment.repository.ts
@@ -322,6 +322,7 @@ export class ExperimentRepository {
         // reach purely by their being public drop out. Access held through an org or
         // team counts, it is how most members reach anything; so does authorship,
         // because a creator holds no grant on their own work.
+        // Without a caller nothing resolves, so the scope admits nothing.
         const related = relatedResourceCondition({
           database: this.database,
           resourceType: "experiment",
@@ -329,7 +330,7 @@ export class ExperimentRepository {
           organizationIdColumn: experiments.organizationId,
           userId,
         });
-        conditions.push(or(related, eq(experiments.createdBy, userId)));
+        conditions.push(userId ? or(related, eq(experiments.createdBy, userId)) : sql`false`);
       }
 
       if (status) {
@@ -392,13 +393,6 @@ export class ExperimentRepository {
         );
       }
 
-      // Relevance: vector/name rank dominates; cross-table matches add a small capped bonus, so a
-      // name match always outranks one matched only by a related field.
-      const rank = sql<number>`(${ftsRank(experiments.searchVector, experiments.name, search ?? "")} + ${crossTableBonus(
-        creatorMatch(search ?? ""),
-        sql`(${memberMatch(search ?? "")} OR ${locationMatch(search ?? "")})`,
-      )})`;
-
       const tier = resourceTierExpression({
         database: this.database,
         resourceType: "experiment",
@@ -407,7 +401,19 @@ export class ExperimentRepository {
         createdByColumn: experiments.createdBy,
         userId,
       });
-      const score = searchScore(rank, tier);
+
+      // Relevance: vector/name rank dominates; cross-table matches add a small capped bonus, so a
+      // name match always outranks one matched only by a related field. Browsing has no term to
+      // rank against, so it selects a constant rather than paying for empty-term probes per row.
+      const score = search
+        ? searchScore(
+            sql<number>`(${ftsRank(experiments.searchVector, experiments.name, search)} + ${crossTableBonus(
+              creatorMatch(search),
+              sql`(${memberMatch(search)} OR ${locationMatch(search)})`,
+            )})`,
+            tier,
+          )
+        : sql<number>`0::int`;
 
       // Browse keeps tiers strict and recency within them; search folds tier into one
       // score so a strong public match can still beat a weak owned one. Both end on

--- a/apps/backend/src/experiments/core/repositories/experiment.repository.ts
+++ b/apps/backend/src/experiments/core/repositories/experiment.repository.ts
@@ -90,7 +90,7 @@ export class ExperimentRepository {
 
   /**
    * Insert, seed creator control, and grant the picked collaborators in one
-   * transaction — a failure anywhere leaves no experiment at all. An unselectable
+   * transaction; a failure anywhere leaves no experiment at all. An unselectable
    * `collaboratorUserIds` entry fails the whole create with a 400.
    */
   async create(
@@ -125,7 +125,7 @@ export class ExperimentRepository {
   /**
    * Direct `viewer` grants for collaborators picked at create time. Grantees are
    * validated first: `resource_grants` has no FK on `grantee_id`, so an unchecked
-   * write would store a row for a uuid naming nobody. Non-destructive — an existing
+   * write would store a row for a uuid naming nobody. Non-destructive: an existing
    * grant is left alone, so it never lowers access and needs no staffing guard.
    */
   private async grantCollaborators(
@@ -183,7 +183,7 @@ export class ExperimentRepository {
           createdBy: experiments.createdBy,
           userId: resourceGrants.granteeId,
           // Whether the profile join matched. The name columns below can't answer
-          // that — they fall back to "Unknown"/"User" for a NULL row.
+          // that; they fall back to "Unknown"/"User" for a NULL row.
           profileUserId: profiles.userId,
           firstName: getAnonymizedFirstName(),
           lastName: getAnonymizedLastName(),
@@ -284,6 +284,14 @@ export class ExperimentRepository {
       createdAt: experiments.createdAt,
       createdBy: experiments.createdBy,
       updatedAt: experiments.updatedAt,
+      ownerFirstName: getAnonymizedFirstName(),
+      ownerLastName: getAnonymizedLastName(),
+      organizationName: owningOrganizationNameSql("experiments"),
+      // Direct collaborator grants only; org/team reach is unbounded and not a count.
+      membersCount: sql<number>`(select count(*)::int from ${resourceGrants}
+        where ${resourceGrants.resourceType} = 'experiment'
+        and ${resourceGrants.resourceId} = ${experiments.id}
+        and ${resourceGrants.granteeType} = 'user')`,
     };
 
     {
@@ -318,11 +326,8 @@ export class ExperimentRepository {
       }
 
       if (scope === "related") {
-        // "Mine": every path tying me to the experiment personally, so only rows I
-        // reach purely by their being public drop out. Access held through an org or
-        // team counts, it is how most members reach anything; so does authorship,
-        // because a creator holds no grant on their own work.
-        // Without a caller nothing resolves, so the scope admits nothing.
+        // Every personal path counts (grants, org/team access, authorship); only
+        // purely-public rows drop out. No caller: the scope admits nothing.
         const related = relatedResourceCondition({
           database: this.database,
           resourceType: "experiment",
@@ -558,7 +563,7 @@ export class ExperimentRepository {
       await this.database.transaction(async (tx) => {
         await lockStaffedResource(tx, "experiment", id, "update");
 
-        // Referential only — the roster carries no access, but the FK still blocks.
+        // Referential only: the roster carries no access, but the FK still blocks.
         await tx.delete(experimentMembers).where(eq(experimentMembers.experimentId, id));
 
         await deleteResourceGrants(tx, "experiment", id);

--- a/apps/backend/src/experiments/presentation/experiment.controller.spec.ts
+++ b/apps/backend/src/experiments/presentation/experiment.controller.spec.ts
@@ -10,9 +10,11 @@ import { eq, experiments } from "@repo/database";
 
 import { AuthorizationService } from "../../authorization/authorization.service";
 import { AnalyticsAdapter } from "../../common/modules/analytics/analytics.adapter";
+import { AppError, failure } from "../../common/utils/fp-utils";
 import type { MockAnalyticsAdapter } from "../../test/mocks/adapters/analytics.adapter.mock";
 import type { SuperTestResponse } from "../../test/test-harness";
 import { TestHarness } from "../../test/test-harness";
+import { ListExperimentsUseCase } from "../application/use-cases/list-experiments/list-experiments";
 
 describe("ExperimentController", () => {
   const testApp = TestHarness.App;
@@ -188,6 +190,17 @@ describe("ExperimentController", () => {
 
       expect(response.body.totalCount).toBe(1);
       expect(response.body.items).toHaveLength(1);
+    });
+
+    it("returns 500 when the paginated use case fails", async () => {
+      vi.spyOn(testApp.module.get(ListExperimentsUseCase), "executePaginated").mockResolvedValue(
+        failure(AppError.internal("Database error")),
+      );
+
+      await testApp
+        .get(testApp.resolveOrpcPath(contract.experiments.listExperimentsPaginated))
+        .withAuth(testUserId)
+        .expect(StatusCodes.INTERNAL_SERVER_ERROR);
     });
   });
 

--- a/apps/backend/src/experiments/presentation/experiment.controller.spec.ts
+++ b/apps/backend/src/experiments/presentation/experiment.controller.spec.ts
@@ -176,14 +176,13 @@ describe("ExperimentController", () => {
     });
   });
 
-  describe("listExperimentsPaginated", () => {
-    // Guards the route-ordering trap: the literal path must resolve before `{id}`.
-    it("returns the page envelope rather than falling through to the detail route", async () => {
+  describe("listExperiments paginated", () => {
+    it("returns the page envelope when a page is requested", async () => {
       await testApp.createExperiment({ name: "Paged one", userId: testUserId });
 
       const response: SuperTestResponse<{ items: { id: string }[]; totalCount: number }> =
         await testApp
-          .get(testApp.resolveOrpcPath(contract.experiments.listExperimentsPaginated))
+          .get(testApp.resolveOrpcPath(contract.experiments.listExperiments))
           .query({ page: 1, pageSize: 10 })
           .withAuth(testUserId)
           .expect(StatusCodes.OK);
@@ -198,7 +197,8 @@ describe("ExperimentController", () => {
       );
 
       await testApp
-        .get(testApp.resolveOrpcPath(contract.experiments.listExperimentsPaginated))
+        .get(testApp.resolveOrpcPath(contract.experiments.listExperiments))
+        .query({ page: 1 })
         .withAuth(testUserId)
         .expect(StatusCodes.INTERNAL_SERVER_ERROR);
     });

--- a/apps/backend/src/experiments/presentation/experiment.controller.spec.ts
+++ b/apps/backend/src/experiments/presentation/experiment.controller.spec.ts
@@ -174,6 +174,23 @@ describe("ExperimentController", () => {
     });
   });
 
+  describe("listExperimentsPaginated", () => {
+    // Guards the route-ordering trap: the literal path must resolve before `{id}`.
+    it("returns the page envelope rather than falling through to the detail route", async () => {
+      await testApp.createExperiment({ name: "Paged one", userId: testUserId });
+
+      const response: SuperTestResponse<{ items: { id: string }[]; totalCount: number }> =
+        await testApp
+          .get(testApp.resolveOrpcPath(contract.experiments.listExperimentsPaginated))
+          .query({ page: 1, pageSize: 10 })
+          .withAuth(testUserId)
+          .expect(StatusCodes.OK);
+
+      expect(response.body.totalCount).toBe(1);
+      expect(response.body.items).toHaveLength(1);
+    });
+  });
+
   describe("listExperiments", () => {
     it("should return an empty array if no experiments exist", async () => {
       const response = await testApp

--- a/apps/backend/src/experiments/presentation/experiment.controller.ts
+++ b/apps/backend/src/experiments/presentation/experiment.controller.ts
@@ -5,7 +5,7 @@ import type { UserSession } from "@thallesp/nestjs-better-auth";
 
 import { FEATURE_FLAGS } from "@repo/analytics";
 import { experimentContract } from "@repo/api/domains/experiment/experiment.contract";
-import { resolveListScope } from "@repo/api/shared/listing";
+import { DEFAULT_PAGE_SIZE, resolveListScope } from "@repo/api/shared/listing";
 
 import { CanAccess } from "../../authorization/can-access.decorator";
 import { CanCreateInOrg } from "../../authorization/can-create-in-org.guard";
@@ -62,35 +62,37 @@ export class ExperimentController {
     });
   }
 
+  // One listing, two shapes: `page` presence is the only thing that switches it from a
+  // bare array to the paged envelope, so a caller that sends no page is untouched.
   @Implement(experimentContract.listExperiments)
   listExperiments(@Session() session: UserSession) {
     return implement(experimentContract.listExperiments).handler(async ({ input }) => {
+      const scope = resolveListScope(input);
+
+      if (input.page !== undefined) {
+        const pageSize = input.pageSize ?? DEFAULT_PAGE_SIZE;
+        const paged = await this.listExperimentsUseCase.executePaginated(
+          session.user.id,
+          input.page,
+          pageSize,
+          scope,
+          input.status,
+          input.search,
+        );
+        if (paged.isSuccess()) {
+          return toPage(paged.value, input.page, pageSize, formatDatesList);
+        }
+        return throwOrpcFailure(paged, this.logger);
+      }
+
       const result = await this.listExperimentsUseCase.execute(
         session.user.id,
-        resolveListScope(input),
+        scope,
         input.status,
         input.search,
       );
       if (result.isSuccess()) {
         return formatDatesList(result.value);
-      }
-      return throwOrpcFailure(result, this.logger);
-    });
-  }
-
-  @Implement(experimentContract.listExperimentsPaginated)
-  listExperimentsPaginated(@Session() session: UserSession) {
-    return implement(experimentContract.listExperimentsPaginated).handler(async ({ input }) => {
-      const result = await this.listExperimentsUseCase.executePaginated(
-        session.user.id,
-        input.page,
-        input.pageSize,
-        resolveListScope(input),
-        input.status,
-        input.search,
-      );
-      if (result.isSuccess()) {
-        return toPage(result.value, input.page, input.pageSize, formatDatesList);
       }
       return throwOrpcFailure(result, this.logger);
     });

--- a/apps/backend/src/experiments/presentation/experiment.controller.ts
+++ b/apps/backend/src/experiments/presentation/experiment.controller.ts
@@ -5,12 +5,14 @@ import type { UserSession } from "@thallesp/nestjs-better-auth";
 
 import { FEATURE_FLAGS } from "@repo/analytics";
 import { experimentContract } from "@repo/api/domains/experiment/experiment.contract";
+import { resolveListScope } from "@repo/api/shared/listing";
 
 import { CanAccess } from "../../authorization/can-access.decorator";
 import { CanCreateInOrg } from "../../authorization/can-create-in-org.guard";
 import { formatDates, formatDatesList } from "../../common/utils/date-formatter";
 import { AppError } from "../../common/utils/fp-utils";
 import { throwOrpcError, throwOrpcFailure } from "../../common/utils/orpc-fp";
+import { toPage } from "../../common/utils/pagination";
 import { SetVisibilityUseCase } from "../../visibility/application/use-cases/set-visibility/set-visibility";
 import { CreateExperimentUseCase } from "../application/use-cases/create-experiment/create-experiment";
 import { DeleteExperimentUseCase } from "../application/use-cases/delete-experiment/delete-experiment";
@@ -65,12 +67,30 @@ export class ExperimentController {
     return implement(experimentContract.listExperiments).handler(async ({ input }) => {
       const result = await this.listExperimentsUseCase.execute(
         session.user.id,
-        input.filter,
+        resolveListScope(input),
         input.status,
         input.search,
       );
       if (result.isSuccess()) {
         return formatDatesList(result.value);
+      }
+      return throwOrpcFailure(result, this.logger);
+    });
+  }
+
+  @Implement(experimentContract.listExperimentsPaginated)
+  listExperimentsPaginated(@Session() session: UserSession) {
+    return implement(experimentContract.listExperimentsPaginated).handler(async ({ input }) => {
+      const result = await this.listExperimentsUseCase.executePaginated(
+        session.user.id,
+        input.page,
+        input.pageSize,
+        resolveListScope(input),
+        input.status,
+        input.search,
+      );
+      if (result.isSuccess()) {
+        return toPage(result.value, input.page, input.pageSize, formatDatesList);
       }
       return throwOrpcFailure(result, this.logger);
     });

--- a/apps/backend/src/macros/application/use-cases/list-macros/list-macros.ts
+++ b/apps/backend/src/macros/application/use-cases/list-macros/list-macros.ts
@@ -19,4 +19,20 @@ export class ListMacrosUseCase {
     });
     return await this.macroRepository.findAll(filter);
   }
+
+  async executePaginated(
+    page: number,
+    pageSize: number,
+    filter?: MacroFilter,
+  ): Promise<Result<{ items: MacroDto[]; totalCount: number }>> {
+    this.logger.log({
+      msg: "Listing macros",
+      operation: "listMacrosPaginated",
+      page,
+      pageSize,
+      language: filter?.language,
+      hasSearch: !!filter?.search,
+    });
+    return await this.macroRepository.findPage(page, pageSize, filter);
+  }
 }

--- a/apps/backend/src/macros/core/repositories/macro.repository.spec.ts
+++ b/apps/backend/src/macros/core/repositories/macro.repository.spec.ts
@@ -171,7 +171,7 @@ describe("MacroRepository", () => {
         .where(eq(macrosTable.id, macro.id));
 
       // They can still see it while they belong to the organization...
-      const before = await repository.findAll({ filter: "my", userId: author });
+      const before = await repository.findAll({ scope: "related", userId: author });
       assertSuccess(before);
       expect(before.value.map((m) => m.id)).toContain(macro.id);
 
@@ -182,7 +182,7 @@ describe("MacroRepository", () => {
           and(eq(organizationMembers.organizationId, org), eq(organizationMembers.userId, author)),
         );
 
-      const after = await repository.findAll({ filter: "my", userId: author });
+      const after = await repository.findAll({ scope: "related", userId: author });
       assertSuccess(after);
       // Authorship is not an access path: "My macros" must narrow what the caller
       // can already read, never hand back a body `can(read)` would refuse.
@@ -1560,7 +1560,7 @@ describe("MacroRepository — list access scoping", () => {
       visibility: "public",
     });
 
-    const result = await repository.findAll({ filter: "my", userId: owner });
+    const result = await repository.findAll({ scope: "related", userId: owner });
     assertSuccess(result);
     const ids = result.value.map((m) => m.id);
 

--- a/apps/backend/src/macros/core/repositories/macro.repository.spec.ts
+++ b/apps/backend/src/macros/core/repositories/macro.repository.spec.ts
@@ -1552,7 +1552,7 @@ describe("MacroRepository — list access scoping", () => {
       .expect(StatusCodes.FORBIDDEN);
   });
 
-  it('keeps the "my" filter as an ownership view, unaffected by visibility', async () => {
+  it("keeps scope=related as a relationship view, unaffected by visibility", async () => {
     const other = await testApp.createTestUser({ name: "Other Author" });
     const othersMacro = await testApp.createMacro({
       name: "Someone else's macro",

--- a/apps/backend/src/macros/core/repositories/macro.repository.ts
+++ b/apps/backend/src/macros/core/repositories/macro.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable, Inject } from "@nestjs/common";
 
+import type { ResourceScope } from "@repo/api/shared/listing";
 import {
   and,
   asc,
@@ -10,6 +11,7 @@ import {
   isNull,
   inArray,
   macros,
+  or,
   profiles,
   sql,
   getTableColumns,
@@ -18,13 +20,23 @@ import {
 import type { DatabaseInstance, SQL } from "@repo/database";
 
 import { Result, success, tryCatch } from "../../../common/utils/fp-utils";
-import { escapeLike, ftsMatch, ftsRank } from "../../../common/utils/fts";
+import {
+  crossTableBonus,
+  escapeLike,
+  ftsMatch,
+  ftsRank,
+  searchScore,
+} from "../../../common/utils/fts";
 import { owningOrganizationNameSql } from "../../../common/utils/owning-organization";
 import {
   getAnonymizedFirstName,
   getAnonymizedLastName,
 } from "../../../common/utils/profile-anonymization";
-import { accessibleResourceCondition } from "../../../common/utils/resource-access-scope";
+import {
+  accessibleResourceCondition,
+  relatedResourceCondition,
+  resourceTierExpression,
+} from "../../../common/utils/resource-access-scope";
 import { lockStaffedResource, seedCreatorControl } from "../../../sharing/core/resource-staffing";
 import {
   CreateMacroDto,
@@ -38,7 +50,7 @@ import { CACHE_PORT, CachePort } from "../ports/cache.port";
 export interface MacroFilter {
   search?: string;
   language?: "python" | "r" | "javascript";
-  filter?: "my";
+  scope?: ResourceScope;
   userId?: string;
   /** Narrow to one owning organization (the org profile's resources showcase). */
   organizationId?: string;
@@ -46,6 +58,22 @@ export interface MacroFilter {
 
 // All macro columns except the internal full-text `search_vector` (never returned to clients).
 const { searchVector: _macroSearchVector, ...macroColumns } = getTableColumns(macros);
+
+/** A listing row plus its relevance score, which global search merges on across types. */
+export type MacroSearchRow = MacroDto & { score: number };
+
+function toMacroRow(result: {
+  macros: unknown;
+  firstName: string | null;
+  lastName: string | null;
+  score: number;
+}): MacroSearchRow {
+  const augmentedResult = result.macros as MacroSearchRow;
+  const { firstName, lastName } = result;
+  augmentedResult.createdByName = firstName && lastName ? `${firstName} ${lastName}` : undefined;
+  augmentedResult.score = result.score;
+  return augmentedResult;
+}
 
 @Injectable()
 export class MacroRepository {
@@ -87,19 +115,12 @@ export class MacroRepository {
     });
   }
 
-  async findAll(filter?: MacroFilter, limit?: number): Promise<Result<MacroDto[]>> {
-    return tryCatch(async () => {
-      let query = this.database
-        .select({
-          macros: macroColumns,
-          firstName: getAnonymizedFirstName(),
-          lastName: getAnonymizedLastName(),
-        })
-        .from(macros)
-        .innerJoin(profiles, eq(macros.createdBy, profiles.userId))
-        .$dynamic();
-
-      // Build array of conditions for filters
+  /**
+   * Shared shape behind the array and paginated listings, so both apply identical
+   * scoping, ranking and ordering and the count matches the rows exactly.
+   */
+  private buildListing(filter?: MacroFilter) {
+    {
       const conditions: (SQL | undefined)[] = [];
 
       const search = filter?.search;
@@ -120,7 +141,7 @@ export class MacroRepository {
         conditions.push(eq(macros.language, filter.language));
       }
 
-      const scope = accessibleResourceCondition({
+      const accessScope = accessibleResourceCondition({
         database: this.database,
         resourceType: "macro",
         resourceIdColumn: macros.id,
@@ -128,8 +149,8 @@ export class MacroRepository {
         visibilityColumn: macros.visibility,
         userId: filter?.userId,
       });
-      if (scope) {
-        conditions.push(scope);
+      if (accessScope) {
+        conditions.push(accessScope);
       }
 
       // Applied on top of the access scope, never instead of it: an org's page shows
@@ -138,35 +159,106 @@ export class MacroRepository {
         conditions.push(eq(macros.organizationId, filter.organizationId));
       }
 
-      if (filter?.filter === "my" && filter.userId) {
-        conditions.push(eq(macros.createdBy, filter.userId));
+      if (filter?.scope === "related") {
+        // "Mine": authorship plus every path tying the caller to the row personally.
+        // Without a caller nothing resolves, so the scope admits nothing.
+        const related = relatedResourceCondition({
+          database: this.database,
+          resourceType: "macro",
+          resourceIdColumn: macros.id,
+          organizationIdColumn: macros.organizationId,
+          userId: filter.userId,
+        });
+        conditions.push(
+          filter.userId ? or(related, eq(macros.createdBy, filter.userId)) : sql`false`,
+        );
       }
 
-      // Apply all conditions with AND logic if there are any
-      if (conditions.length > 0) {
-        query = query.where(and(...conditions));
-      }
+      const rank = sql<number>`(${ftsRank(macros.searchVector, macros.name, search ?? "")} + ${crossTableBonus(
+        sql`(${creatorMatch(search ?? "")} OR ${ilike(languageText, `%${escapeLike(search ?? "")}%`)})`,
+      )})`;
+      const tier = resourceTierExpression({
+        database: this.database,
+        resourceType: "macro",
+        resourceIdColumn: macros.id,
+        organizationIdColumn: macros.organizationId,
+        createdByColumn: macros.createdBy,
+        userId: filter?.userId,
+      });
+      const score = searchScore(rank, tier);
 
-      if (search) {
-        const rank = sql<number>`(${ftsRank(macros.searchVector, macros.name, search)} + 0.05 * (CASE WHEN (${creatorMatch(search)} OR ${ilike(languageText, `%${escapeLike(search)}%`)}) THEN 1 ELSE 0 END))`;
-        query = query.orderBy(desc(rank), asc(macros.name));
-      } else {
-        query = query.orderBy(asc(macros.sortOrder), asc(macros.name));
-      }
+      // Browse keeps tiers strict, with the curated `sortOrder` surviving as a
+      // within-tier tiebreak. Both orderings end on `id` so paging is stable.
+      const orderBy = search
+        ? [desc(score), asc(macros.id)]
+        : [desc(tier), asc(macros.sortOrder), asc(macros.name), asc(macros.id)];
 
+      const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+      return { where, orderBy, score };
+    }
+  }
+
+  private baseQuery(score: SQL<number>) {
+    return this.database
+      .select({
+        macros: macroColumns,
+        firstName: getAnonymizedFirstName(),
+        lastName: getAnonymizedLastName(),
+        score,
+      })
+      .from(macros)
+      .innerJoin(profiles, eq(macros.createdBy, profiles.userId))
+      .$dynamic();
+  }
+
+  async findAll(filter?: MacroFilter, limit?: number): Promise<Result<MacroSearchRow[]>> {
+    return tryCatch(async () => {
+      const { where, orderBy, score } = this.buildListing(filter);
+
+      let query = this.baseQuery(score);
+      if (where) {
+        query = query.where(where);
+      }
+      query = query.orderBy(...orderBy);
       if (limit !== undefined) {
         query = query.limit(limit);
       }
 
-      const results = await query;
-      return results.map((result) => {
-        const augmentedResult = result.macros as MacroDto;
-        const firstName = result.firstName;
-        const lastName = result.lastName;
-        augmentedResult.createdByName =
-          firstName && lastName ? `${firstName} ${lastName}` : undefined;
-        return augmentedResult;
-      });
+      return (await query).map(toMacroRow);
+    });
+  }
+
+  /** One page plus the total, counted separately so an out-of-range page still reports it. */
+  async findPage(
+    page: number,
+    pageSize: number,
+    filter?: MacroFilter,
+  ): Promise<Result<{ items: MacroSearchRow[]; totalCount: number }>> {
+    return tryCatch(async () => {
+      const { where, orderBy, score } = this.buildListing(filter);
+
+      let rows = this.baseQuery(score);
+      let total = this.database
+        .select({ count: sql<number>`count(*)::int` })
+        .from(macros)
+        .innerJoin(profiles, eq(macros.createdBy, profiles.userId))
+        .$dynamic();
+
+      if (where) {
+        rows = rows.where(where);
+        total = total.where(where);
+      }
+
+      const [items, [{ count }]] = await Promise.all([
+        rows
+          .orderBy(...orderBy)
+          .limit(pageSize)
+          .offset((page - 1) * pageSize),
+        total,
+      ]);
+
+      return { items: items.map(toMacroRow), totalCount: count };
     });
   }
 

--- a/apps/backend/src/macros/core/repositories/macro.repository.ts
+++ b/apps/backend/src/macros/core/repositories/macro.repository.ts
@@ -174,9 +174,6 @@ export class MacroRepository {
         );
       }
 
-      const rank = sql<number>`(${ftsRank(macros.searchVector, macros.name, search ?? "")} + ${crossTableBonus(
-        sql`(${creatorMatch(search ?? "")} OR ${ilike(languageText, `%${escapeLike(search ?? "")}%`)})`,
-      )})`;
       const tier = resourceTierExpression({
         database: this.database,
         resourceType: "macro",
@@ -185,7 +182,15 @@ export class MacroRepository {
         createdByColumn: macros.createdBy,
         userId: filter?.userId,
       });
-      const score = searchScore(rank, tier);
+      // Browsing has no term to rank against, so it skips the scoring probes entirely.
+      const score = search
+        ? searchScore(
+            sql<number>`(${ftsRank(macros.searchVector, macros.name, search)} + ${crossTableBonus(
+              sql`(${creatorMatch(search)} OR ${ilike(languageText, `%${escapeLike(search)}%`)})`,
+            )})`,
+            tier,
+          )
+        : sql<number>`0::int`;
 
       // Browse keeps tiers strict, with the curated `sortOrder` surviving as a
       // within-tier tiebreak. Both orderings end on `id` so paging is stable.

--- a/apps/backend/src/macros/presentation/macro.controller.spec.ts
+++ b/apps/backend/src/macros/presentation/macro.controller.spec.ts
@@ -254,6 +254,19 @@ describe("MacroController", () => {
     });
   });
 
+  describe("listMacrosPaginated", () => {
+    // Guards the route-ordering trap: the literal path must resolve before `{id}`.
+    it("returns the page envelope rather than falling through to the detail route", async () => {
+      const response = await testApp
+        .get(testApp.resolveOrpcPath(contract.macros.listMacrosPaginated))
+        .query({ page: 1, pageSize: 10 })
+        .withAuth(testUserId)
+        .expect(StatusCodes.OK);
+
+      expect(response.body).toMatchObject({ page: 1, pageSize: 10, items: [] });
+    });
+  });
+
   describe("listMacros", () => {
     it("should successfully list macros", async () => {
       // Arrange
@@ -326,7 +339,7 @@ describe("MacroController", () => {
       expect(listMacrosUseCase.execute).toHaveBeenCalledWith({
         search: "test",
         language: "python",
-        filter: undefined,
+        scope: "all",
         userId: testUserId,
       });
     });

--- a/apps/backend/src/macros/presentation/macro.controller.spec.ts
+++ b/apps/backend/src/macros/presentation/macro.controller.spec.ts
@@ -254,11 +254,10 @@ describe("MacroController", () => {
     });
   });
 
-  describe("listMacrosPaginated", () => {
-    // Guards the route-ordering trap: the literal path must resolve before `{id}`.
-    it("returns the page envelope rather than falling through to the detail route", async () => {
+  describe("listMacros paginated", () => {
+    it("returns the page envelope when a page is requested", async () => {
       const response = await testApp
-        .get(testApp.resolveOrpcPath(contract.macros.listMacrosPaginated))
+        .get(testApp.resolveOrpcPath(contract.macros.listMacros))
         .query({ page: 1, pageSize: 10 })
         .withAuth(testUserId)
         .expect(StatusCodes.OK);
@@ -272,7 +271,8 @@ describe("MacroController", () => {
       );
 
       await testApp
-        .get(testApp.resolveOrpcPath(contract.macros.listMacrosPaginated))
+        .get(testApp.resolveOrpcPath(contract.macros.listMacros))
+        .query({ page: 1 })
         .withAuth(testUserId)
         .expect(StatusCodes.INTERNAL_SERVER_ERROR);
     });

--- a/apps/backend/src/macros/presentation/macro.controller.spec.ts
+++ b/apps/backend/src/macros/presentation/macro.controller.spec.ts
@@ -265,6 +265,17 @@ describe("MacroController", () => {
 
       expect(response.body).toMatchObject({ page: 1, pageSize: 10, items: [] });
     });
+
+    it("returns 500 when the paginated use case fails", async () => {
+      vi.spyOn(listMacrosUseCase, "executePaginated").mockResolvedValue(
+        failure(AppError.internal("Database error")),
+      );
+
+      await testApp
+        .get(testApp.resolveOrpcPath(contract.macros.listMacrosPaginated))
+        .withAuth(testUserId)
+        .expect(StatusCodes.INTERNAL_SERVER_ERROR);
+    });
   });
 
   describe("listMacros", () => {

--- a/apps/backend/src/macros/presentation/macro.controller.ts
+++ b/apps/backend/src/macros/presentation/macro.controller.ts
@@ -5,7 +5,7 @@ import type { UserSession } from "@thallesp/nestjs-better-auth";
 
 import { FEATURE_FLAGS } from "@repo/analytics";
 import { macroContract } from "@repo/api/domains/macro/macro.contract";
-import { resolveListScope } from "@repo/api/shared/listing";
+import { DEFAULT_PAGE_SIZE, resolveListScope } from "@repo/api/shared/listing";
 
 import { AuthorizationService } from "../../authorization/authorization.service";
 import { CanAccess } from "../../authorization/can-access.decorator";
@@ -65,35 +65,30 @@ export class MacroController {
     });
   }
 
+  // One listing, two shapes: `page` presence is the only thing that switches it from a
+  // bare array to the paged envelope, so a caller that sends no page is untouched.
   @Implement(macroContract.listMacros)
   listMacros(@Session() session: UserSession) {
     return implement(macroContract.listMacros).handler(async ({ input }) => {
-      const result = await this.listMacrosUseCase.execute({
+      const filter = {
         search: input.search,
         language: input.language,
         scope: resolveListScope(input),
         userId: session.user.id,
-      });
+      };
+
+      if (input.page !== undefined) {
+        const pageSize = input.pageSize ?? DEFAULT_PAGE_SIZE;
+        const paged = await this.listMacrosUseCase.executePaginated(input.page, pageSize, filter);
+        if (paged.isSuccess()) {
+          return toPage(paged.value, input.page, pageSize, formatDatesList);
+        }
+        return throwOrpcFailure(paged, this.logger);
+      }
+
+      const result = await this.listMacrosUseCase.execute(filter);
       if (result.isSuccess()) {
         return formatDatesList(result.value);
-      }
-      return throwOrpcFailure(result, this.logger);
-    });
-  }
-
-  // Declared above `getMacro`: routes resolve in declaration order, so the literal
-  // path has to win before `{id}` claims it and rejects "paginated" as a uuid.
-  @Implement(macroContract.listMacrosPaginated)
-  listMacrosPaginated(@Session() session: UserSession) {
-    return implement(macroContract.listMacrosPaginated).handler(async ({ input }) => {
-      const result = await this.listMacrosUseCase.executePaginated(input.page, input.pageSize, {
-        search: input.search,
-        language: input.language,
-        scope: resolveListScope(input),
-        userId: session.user.id,
-      });
-      if (result.isSuccess()) {
-        return toPage(result.value, input.page, input.pageSize, formatDatesList);
       }
       return throwOrpcFailure(result, this.logger);
     });

--- a/apps/backend/src/macros/presentation/macro.controller.ts
+++ b/apps/backend/src/macros/presentation/macro.controller.ts
@@ -5,6 +5,7 @@ import type { UserSession } from "@thallesp/nestjs-better-auth";
 
 import { FEATURE_FLAGS } from "@repo/analytics";
 import { macroContract } from "@repo/api/domains/macro/macro.contract";
+import { resolveListScope } from "@repo/api/shared/listing";
 
 import { AuthorizationService } from "../../authorization/authorization.service";
 import { CanAccess } from "../../authorization/can-access.decorator";
@@ -13,6 +14,7 @@ import { resolveResourceCapabilities } from "../../authorization/resource-capabi
 import { formatDates, formatDatesList } from "../../common/utils/date-formatter";
 import { AppError, isSuccess } from "../../common/utils/fp-utils";
 import { throwOrpcError, throwOrpcFailure } from "../../common/utils/orpc-fp";
+import { toPage } from "../../common/utils/pagination";
 import { SetVisibilityUseCase } from "../../visibility/application/use-cases/set-visibility/set-visibility";
 import { AddCompatibleProtocolsUseCase } from "../application/use-cases/add-compatible-protocols/add-compatible-protocols";
 import { CreateMacroUseCase } from "../application/use-cases/create-macro/create-macro";
@@ -63,6 +65,40 @@ export class MacroController {
     });
   }
 
+  @Implement(macroContract.listMacros)
+  listMacros(@Session() session: UserSession) {
+    return implement(macroContract.listMacros).handler(async ({ input }) => {
+      const result = await this.listMacrosUseCase.execute({
+        search: input.search,
+        language: input.language,
+        scope: resolveListScope(input),
+        userId: session.user.id,
+      });
+      if (result.isSuccess()) {
+        return formatDatesList(result.value);
+      }
+      return throwOrpcFailure(result, this.logger);
+    });
+  }
+
+  // Declared above `getMacro`: routes resolve in declaration order, so the literal
+  // path has to win before `{id}` claims it and rejects "paginated" as a uuid.
+  @Implement(macroContract.listMacrosPaginated)
+  listMacrosPaginated(@Session() session: UserSession) {
+    return implement(macroContract.listMacrosPaginated).handler(async ({ input }) => {
+      const result = await this.listMacrosUseCase.executePaginated(input.page, input.pageSize, {
+        search: input.search,
+        language: input.language,
+        scope: resolveListScope(input),
+        userId: session.user.id,
+      });
+      if (result.isSuccess()) {
+        return toPage(result.value, input.page, input.pageSize, formatDatesList);
+      }
+      return throwOrpcFailure(result, this.logger);
+    });
+  }
+
   @CanAccess({ resource: "macro", action: "read" })
   @Implement(macroContract.getMacro)
   getMacro(@Session() session: UserSession) {
@@ -79,22 +115,6 @@ export class MacroController {
           input.id,
         );
         return { ...formatDates(result.value), capabilities };
-      }
-      return throwOrpcFailure(result, this.logger);
-    });
-  }
-
-  @Implement(macroContract.listMacros)
-  listMacros(@Session() session: UserSession) {
-    return implement(macroContract.listMacros).handler(async ({ input }) => {
-      const result = await this.listMacrosUseCase.execute({
-        search: input.search,
-        language: input.language,
-        filter: input.filter,
-        userId: session.user.id,
-      });
-      if (result.isSuccess()) {
-        return formatDatesList(result.value);
       }
       return throwOrpcFailure(result, this.logger);
     });

--- a/apps/backend/src/protocols/application/use-cases/list-protocols/list-protocols.ts
+++ b/apps/backend/src/protocols/application/use-cases/list-protocols/list-protocols.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 
 import { ProtocolFilter } from "@repo/api/domains/protocol/protocol.schema";
+import type { ResourceScope } from "@repo/api/shared/listing";
 
 import { Result } from "../../../../common/utils/fp-utils";
 import { ProtocolDto } from "../../../core/models/protocol.model";
@@ -12,9 +13,19 @@ export class ListProtocolsUseCase {
 
   async execute(
     search?: ProtocolFilter,
-    filter?: "my",
+    scope?: ResourceScope,
     userId?: string,
   ): Promise<Result<ProtocolDto[]>> {
-    return this.protocolRepository.findAll(search, filter, userId);
+    return this.protocolRepository.findAll(search, scope, userId);
+  }
+
+  async executePaginated(
+    page: number,
+    pageSize: number,
+    search?: ProtocolFilter,
+    scope?: ResourceScope,
+    userId?: string,
+  ): Promise<Result<{ items: ProtocolDto[]; totalCount: number }>> {
+    return this.protocolRepository.findPage(page, pageSize, search, scope, userId);
   }
 }

--- a/apps/backend/src/protocols/core/repositories/protocol.repository.spec.ts
+++ b/apps/backend/src/protocols/core/repositories/protocol.repository.spec.ts
@@ -927,7 +927,7 @@ describe("ProtocolRepository — list access scoping", () => {
     expect(ids).not.toContain(privateId);
   });
 
-  it('keeps the "my" filter as an ownership view, unaffected by visibility', async () => {
+  it("keeps scope=related as a relationship view, unaffected by visibility", async () => {
     const other = await testApp.createTestUser({ name: "Other Author" });
     const othersProtocol = await testApp.createProtocol({
       name: "Someone else's protocol",
@@ -935,7 +935,7 @@ describe("ProtocolRepository — list access scoping", () => {
       visibility: "public",
     });
 
-    const result = await repository.findAll(undefined, "my", owner);
+    const result = await repository.findAll(undefined, "related", owner);
     assertSuccess(result);
     const ids = result.value.map((p) => p.id);
 

--- a/apps/backend/src/protocols/core/repositories/protocol.repository.ts
+++ b/apps/backend/src/protocols/core/repositories/protocol.repository.ts
@@ -151,9 +151,6 @@ export class ProtocolRepository {
         conditions.push(userId ? or(related, eq(protocols.createdBy, userId)) : sql`false`);
       }
 
-      const rank = sql<number>`(${ftsRank(protocols.searchVector, protocols.name, search ?? "")} + ${crossTableBonus(
-        sql`(${creatorMatch(search ?? "")} OR ${ilike(familyText, `%${escapeLike(search ?? "")}%`)})`,
-      )})`;
       const tier = resourceTierExpression({
         database: this.database,
         resourceType: "protocol",
@@ -162,7 +159,15 @@ export class ProtocolRepository {
         createdByColumn: protocols.createdBy,
         userId,
       });
-      const score = searchScore(rank, tier);
+      // Browsing has no term to rank against, so it skips the scoring probes entirely.
+      const score = search
+        ? searchScore(
+            sql<number>`(${ftsRank(protocols.searchVector, protocols.name, search)} + ${crossTableBonus(
+              sql`(${creatorMatch(search)} OR ${ilike(familyText, `%${escapeLike(search)}%`)})`,
+            )})`,
+            tier,
+          )
+        : sql<number>`0::int`;
 
       // Browse keeps tiers strict, with the curated `sortOrder` surviving as a
       // within-tier tiebreak. Both orderings end on `id` so paging is stable.

--- a/apps/backend/src/protocols/core/repositories/protocol.repository.ts
+++ b/apps/backend/src/protocols/core/repositories/protocol.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable, Inject } from "@nestjs/common";
 
 import { ProtocolFilter } from "@repo/api/domains/protocol/protocol.schema";
+import type { ResourceScope } from "@repo/api/shared/listing";
 import {
   and,
   asc,
@@ -10,6 +11,7 @@ import {
   ilike,
   isNull,
   inArray,
+  or,
   protocols,
   users,
   sql,
@@ -20,18 +22,44 @@ import { profiles } from "@repo/database";
 import type { DatabaseInstance, SQL } from "@repo/database";
 
 import { Result, success, tryCatch } from "../../../common/utils/fp-utils";
-import { escapeLike, ftsMatch, ftsRank } from "../../../common/utils/fts";
+import {
+  crossTableBonus,
+  escapeLike,
+  ftsMatch,
+  ftsRank,
+  searchScore,
+} from "../../../common/utils/fts";
 import { owningOrganizationNameSql } from "../../../common/utils/owning-organization";
 import {
   getAnonymizedFirstName,
   getAnonymizedLastName,
 } from "../../../common/utils/profile-anonymization";
-import { accessibleResourceCondition } from "../../../common/utils/resource-access-scope";
+import {
+  accessibleResourceCondition,
+  relatedResourceCondition,
+  resourceTierExpression,
+} from "../../../common/utils/resource-access-scope";
 import { lockStaffedResource, seedCreatorControl } from "../../../sharing/core/resource-staffing";
 import { CreateProtocolDto, UpdateProtocolDto, ProtocolDto } from "../models/protocol.model";
 
 // All protocol columns except the internal full-text `search_vector` (never returned to clients).
 const { searchVector: _protocolSearchVector, ...protocolColumns } = getTableColumns(protocols);
+
+/** A listing row plus its relevance score, which global search merges on across types. */
+export type ProtocolSearchRow = ProtocolDto & { score: number };
+
+function toProtocolRow(result: {
+  protocols: unknown;
+  firstName: string | null;
+  lastName: string | null;
+  score: number;
+}): ProtocolSearchRow {
+  const augmentedResult = result.protocols as ProtocolSearchRow;
+  const { firstName, lastName } = result;
+  augmentedResult.createdByName = firstName && lastName ? `${firstName} ${lastName}` : undefined;
+  augmentedResult.score = result.score;
+  return augmentedResult;
+}
 
 @Injectable()
 export class ProtocolRepository {
@@ -66,24 +94,17 @@ export class ProtocolRepository {
     });
   }
 
-  async findAll(
+  /**
+   * Shared shape behind the array and paginated listings, so both apply identical
+   * scoping, ranking and ordering and the count matches the rows exactly.
+   */
+  private buildListing(
     search?: ProtocolFilter,
-    filter?: "my",
+    scope?: ResourceScope,
     userId?: string,
-    limit?: number,
     organizationId?: string,
-  ): Promise<Result<ProtocolDto[]>> {
-    return tryCatch(async () => {
-      let query = this.database
-        .select({
-          protocols: protocolColumns,
-          firstName: getAnonymizedFirstName(),
-          lastName: getAnonymizedLastName(),
-        })
-        .from(protocols)
-        .innerJoin(profiles, eq(protocols.createdBy, profiles.userId))
-        .$dynamic();
-
+  ) {
+    {
       const conditions: (SQL | undefined)[] = [];
 
       // Creator name + family enum matched at query time (alongside the name/description vector).
@@ -99,7 +120,7 @@ export class ProtocolRepository {
         );
       }
 
-      const scope = accessibleResourceCondition({
+      const accessScope = accessibleResourceCondition({
         database: this.database,
         resourceType: "protocol",
         resourceIdColumn: protocols.id,
@@ -107,8 +128,8 @@ export class ProtocolRepository {
         visibilityColumn: protocols.visibility,
         userId: userId,
       });
-      if (scope) {
-        conditions.push(scope);
+      if (accessScope) {
+        conditions.push(accessScope);
       }
 
       // Narrow to one owning organization (the org profile's resources showcase).
@@ -117,35 +138,113 @@ export class ProtocolRepository {
         conditions.push(eq(protocols.organizationId, organizationId));
       }
 
-      if (filter === "my" && userId) {
-        // "My protocols" narrows that down to what the caller authored.
-        conditions.push(eq(protocols.createdBy, userId));
+      if (scope === "related") {
+        // "Mine": authorship plus every path tying the caller to the row personally.
+        // Without a caller nothing resolves, so the scope admits nothing.
+        const related = relatedResourceCondition({
+          database: this.database,
+          resourceType: "protocol",
+          resourceIdColumn: protocols.id,
+          organizationIdColumn: protocols.organizationId,
+          userId,
+        });
+        conditions.push(userId ? or(related, eq(protocols.createdBy, userId)) : sql`false`);
       }
 
-      if (conditions.length > 0) {
-        query = query.where(and(...conditions));
-      }
+      const rank = sql<number>`(${ftsRank(protocols.searchVector, protocols.name, search ?? "")} + ${crossTableBonus(
+        sql`(${creatorMatch(search ?? "")} OR ${ilike(familyText, `%${escapeLike(search ?? "")}%`)})`,
+      )})`;
+      const tier = resourceTierExpression({
+        database: this.database,
+        resourceType: "protocol",
+        resourceIdColumn: protocols.id,
+        organizationIdColumn: protocols.organizationId,
+        createdByColumn: protocols.createdBy,
+        userId,
+      });
+      const score = searchScore(rank, tier);
 
-      if (search) {
-        const rank = sql<number>`(${ftsRank(protocols.searchVector, protocols.name, search)} + 0.05 * (CASE WHEN (${creatorMatch(search)} OR ${ilike(familyText, `%${escapeLike(search)}%`)}) THEN 1 ELSE 0 END))`;
-        query = query.orderBy(desc(rank), asc(protocols.name));
-      } else {
-        query = query.orderBy(asc(protocols.sortOrder), asc(protocols.name));
-      }
+      // Browse keeps tiers strict, with the curated `sortOrder` surviving as a
+      // within-tier tiebreak. Both orderings end on `id` so paging is stable.
+      const orderBy = search
+        ? [desc(score), asc(protocols.id)]
+        : [desc(tier), asc(protocols.sortOrder), asc(protocols.name), asc(protocols.id)];
 
+      const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+      return { where, orderBy, score };
+    }
+  }
+
+  private baseQuery(score: SQL<number>) {
+    return this.database
+      .select({
+        protocols: protocolColumns,
+        firstName: getAnonymizedFirstName(),
+        lastName: getAnonymizedLastName(),
+        score,
+      })
+      .from(protocols)
+      .innerJoin(profiles, eq(protocols.createdBy, profiles.userId))
+      .$dynamic();
+  }
+
+  async findAll(
+    search?: ProtocolFilter,
+    scope?: ResourceScope,
+    userId?: string,
+    limit?: number,
+    organizationId?: string,
+  ): Promise<Result<ProtocolSearchRow[]>> {
+    return tryCatch(async () => {
+      const { where, orderBy, score } = this.buildListing(search, scope, userId, organizationId);
+
+      let query = this.baseQuery(score);
+      if (where) {
+        query = query.where(where);
+      }
+      query = query.orderBy(...orderBy);
       if (limit !== undefined) {
         query = query.limit(limit);
       }
 
-      const results = await query;
-      return results.map((result) => {
-        const augmentedResult = result.protocols as ProtocolDto;
-        const firstName = result.firstName;
-        const lastName = result.lastName;
-        augmentedResult.createdByName =
-          firstName && lastName ? `${firstName} ${lastName}` : undefined;
-        return augmentedResult;
-      });
+      return (await query).map(toProtocolRow);
+    });
+  }
+
+  /** One page plus the total, counted separately so an out-of-range page still reports it. */
+  async findPage(
+    page: number,
+    pageSize: number,
+    search?: ProtocolFilter,
+    scope?: ResourceScope,
+    userId?: string,
+    organizationId?: string,
+  ): Promise<Result<{ items: ProtocolSearchRow[]; totalCount: number }>> {
+    return tryCatch(async () => {
+      const { where, orderBy, score } = this.buildListing(search, scope, userId, organizationId);
+
+      let rows = this.baseQuery(score);
+      let total = this.database
+        .select({ count: sql<number>`count(*)::int` })
+        .from(protocols)
+        .innerJoin(profiles, eq(protocols.createdBy, profiles.userId))
+        .$dynamic();
+
+      if (where) {
+        rows = rows.where(where);
+        total = total.where(where);
+      }
+
+      const [items, [{ count }]] = await Promise.all([
+        rows
+          .orderBy(...orderBy)
+          .limit(pageSize)
+          .offset((page - 1) * pageSize),
+        total,
+      ]);
+
+      return { items: items.map(toProtocolRow), totalCount: count };
     });
   }
 

--- a/apps/backend/src/protocols/presentation/protocol.controller.spec.ts
+++ b/apps/backend/src/protocols/presentation/protocol.controller.spec.ts
@@ -143,6 +143,25 @@ describe("ProtocolController - read and update endpoints", () => {
     expect(response.body.some((p) => p.id === protocol.id)).toBe(true);
   });
 
+  // Guards the route-ordering trap: the literal path must resolve before `{id}`.
+  it("listProtocolsPaginated returns the page envelope, not the detail route", async () => {
+    const protocol = await testApp.createProtocol({
+      name: "Paged Protocol",
+      createdBy: testUserId,
+    });
+
+    const path = testApp.resolveOrpcPath(contract.protocols.listProtocolsPaginated);
+    const response: SuperTestResponse<{ items: { id: string }[]; totalCount: number }> =
+      await testApp
+        .get(path)
+        .query({ page: 1, pageSize: 10 })
+        .withAuth(testUserId)
+        .expect(StatusCodes.OK);
+
+    expect(response.body.items.some((p) => p.id === protocol.id)).toBe(true);
+    expect(response.body.totalCount).toBeGreaterThan(0);
+  });
+
   it("updateProtocol returns 403 when a non-creator tries to update", async () => {
     const protocol = await testApp.createProtocol({
       name: "Owned Protocol",

--- a/apps/backend/src/protocols/presentation/protocol.controller.spec.ts
+++ b/apps/backend/src/protocols/presentation/protocol.controller.spec.ts
@@ -10,6 +10,7 @@ import { AppError, failure } from "../../common/utils/fp-utils";
 import { TestHarness } from "../../test/test-harness";
 import type { SuperTestResponse } from "../../test/test-harness";
 import { CreateProtocolUseCase } from "../application/use-cases/create-protocol/create-protocol";
+import { ListProtocolsUseCase } from "../application/use-cases/list-protocols/list-protocols";
 import { ProtocolMacroRepository } from "../core/repositories/protocol-macro.repository";
 
 describe("ProtocolController - createProtocol", () => {
@@ -160,6 +161,17 @@ describe("ProtocolController - read and update endpoints", () => {
 
     expect(response.body.items.some((p) => p.id === protocol.id)).toBe(true);
     expect(response.body.totalCount).toBeGreaterThan(0);
+  });
+
+  it("listProtocolsPaginated returns 500 when the paginated use case fails", async () => {
+    vi.spyOn(testApp.module.get(ListProtocolsUseCase), "executePaginated").mockResolvedValue(
+      failure(AppError.internal("Database error")),
+    );
+
+    await testApp
+      .get(testApp.resolveOrpcPath(contract.protocols.listProtocolsPaginated))
+      .withAuth(testUserId)
+      .expect(StatusCodes.INTERNAL_SERVER_ERROR);
   });
 
   it("updateProtocol returns 403 when a non-creator tries to update", async () => {

--- a/apps/backend/src/protocols/presentation/protocol.controller.spec.ts
+++ b/apps/backend/src/protocols/presentation/protocol.controller.spec.ts
@@ -144,14 +144,13 @@ describe("ProtocolController - read and update endpoints", () => {
     expect(response.body.some((p) => p.id === protocol.id)).toBe(true);
   });
 
-  // Guards the route-ordering trap: the literal path must resolve before `{id}`.
-  it("listProtocolsPaginated returns the page envelope, not the detail route", async () => {
+  it("listProtocols returns the page envelope when a page is requested", async () => {
     const protocol = await testApp.createProtocol({
       name: "Paged Protocol",
       createdBy: testUserId,
     });
 
-    const path = testApp.resolveOrpcPath(contract.protocols.listProtocolsPaginated);
+    const path = testApp.resolveOrpcPath(contract.protocols.listProtocols);
     const response: SuperTestResponse<{ items: { id: string }[]; totalCount: number }> =
       await testApp
         .get(path)
@@ -163,13 +162,14 @@ describe("ProtocolController - read and update endpoints", () => {
     expect(response.body.totalCount).toBeGreaterThan(0);
   });
 
-  it("listProtocolsPaginated returns 500 when the paginated use case fails", async () => {
+  it("listProtocols paginated returns 500 when the paginated use case fails", async () => {
     vi.spyOn(testApp.module.get(ListProtocolsUseCase), "executePaginated").mockResolvedValue(
       failure(AppError.internal("Database error")),
     );
 
     await testApp
-      .get(testApp.resolveOrpcPath(contract.protocols.listProtocolsPaginated))
+      .get(testApp.resolveOrpcPath(contract.protocols.listProtocols))
+      .query({ page: 1 })
       .withAuth(testUserId)
       .expect(StatusCodes.INTERNAL_SERVER_ERROR);
   });

--- a/apps/backend/src/protocols/presentation/protocol.controller.ts
+++ b/apps/backend/src/protocols/presentation/protocol.controller.ts
@@ -8,6 +8,7 @@ import { validateProtocolJson } from "@repo/api/domains/protocol/protocol-valida
 import { protocolContract } from "@repo/api/domains/protocol/protocol.contract";
 import { zJsonValue } from "@repo/api/domains/protocol/protocol.schema";
 import type { JsonValue } from "@repo/api/domains/protocol/protocol.schema";
+import { resolveListScope } from "@repo/api/shared/listing";
 
 import { AuthorizationService } from "../../authorization/authorization.service";
 import { CanAccess } from "../../authorization/can-access.decorator";
@@ -17,6 +18,7 @@ import { formatDates, formatDatesList } from "../../common/utils/date-formatter"
 import { ErrorCodes } from "../../common/utils/error-codes";
 import { AppError, failure, success } from "../../common/utils/fp-utils";
 import { throwOrpcError, throwOrpcFailure } from "../../common/utils/orpc-fp";
+import { toPage } from "../../common/utils/pagination";
 import { SetVisibilityUseCase } from "../../visibility/application/use-cases/set-visibility/set-visibility";
 import { AddCompatibleMacrosUseCase } from "../application/use-cases/add-compatible-macros/add-compatible-macros";
 import { CreateProtocolUseCase } from "../application/use-cases/create-protocol/create-protocol";
@@ -124,7 +126,7 @@ export class ProtocolController {
     return implement(protocolContract.listProtocols).handler(async ({ input }) => {
       const result = await this.listProtocolsUseCase.execute(
         input.search,
-        input.filter,
+        resolveListScope(input),
         session.user.id,
       );
 
@@ -132,6 +134,25 @@ export class ProtocolController {
         // The list contract deliberately treats code as unknown so large protocol
         // documents are not recursively validated on the synchronous request path.
         return formatDatesList(result.value);
+      }
+
+      return throwOrpcFailure(result, this.logger);
+    });
+  }
+
+  @Implement(protocolContract.listProtocolsPaginated)
+  listProtocolsPaginated(@Session() session: UserSession) {
+    return implement(protocolContract.listProtocolsPaginated).handler(async ({ input }) => {
+      const result = await this.listProtocolsUseCase.executePaginated(
+        input.page,
+        input.pageSize,
+        input.search,
+        resolveListScope(input),
+        session.user.id,
+      );
+
+      if (result.isSuccess()) {
+        return toPage(result.value, input.page, input.pageSize, formatDatesList);
       }
 
       return throwOrpcFailure(result, this.logger);

--- a/apps/backend/src/protocols/presentation/protocol.controller.ts
+++ b/apps/backend/src/protocols/presentation/protocol.controller.ts
@@ -8,7 +8,7 @@ import { validateProtocolJson } from "@repo/api/domains/protocol/protocol-valida
 import { protocolContract } from "@repo/api/domains/protocol/protocol.contract";
 import { zJsonValue } from "@repo/api/domains/protocol/protocol.schema";
 import type { JsonValue } from "@repo/api/domains/protocol/protocol.schema";
-import { resolveListScope } from "@repo/api/shared/listing";
+import { DEFAULT_PAGE_SIZE, resolveListScope } from "@repo/api/shared/listing";
 
 import { AuthorizationService } from "../../authorization/authorization.service";
 import { CanAccess } from "../../authorization/can-access.decorator";
@@ -121,38 +121,34 @@ export class ProtocolController {
     private readonly authz: AuthorizationService,
   ) {}
 
+  // One listing, two shapes: `page` presence is the only thing that switches it from a
+  // bare array to the paged envelope, so a caller that sends no page is untouched.
   @Implement(protocolContract.listProtocols)
   listProtocols(@Session() session: UserSession) {
     return implement(protocolContract.listProtocols).handler(async ({ input }) => {
-      const result = await this.listProtocolsUseCase.execute(
-        input.search,
-        resolveListScope(input),
-        session.user.id,
-      );
+      const scope = resolveListScope(input);
+
+      if (input.page !== undefined) {
+        const pageSize = input.pageSize ?? DEFAULT_PAGE_SIZE;
+        const paged = await this.listProtocolsUseCase.executePaginated(
+          input.page,
+          pageSize,
+          input.search,
+          scope,
+          session.user.id,
+        );
+        if (paged.isSuccess()) {
+          return toPage(paged.value, input.page, pageSize, formatDatesList);
+        }
+        return throwOrpcFailure(paged, this.logger);
+      }
+
+      const result = await this.listProtocolsUseCase.execute(input.search, scope, session.user.id);
 
       if (result.isSuccess()) {
         // The list contract deliberately treats code as unknown so large protocol
         // documents are not recursively validated on the synchronous request path.
         return formatDatesList(result.value);
-      }
-
-      return throwOrpcFailure(result, this.logger);
-    });
-  }
-
-  @Implement(protocolContract.listProtocolsPaginated)
-  listProtocolsPaginated(@Session() session: UserSession) {
-    return implement(protocolContract.listProtocolsPaginated).handler(async ({ input }) => {
-      const result = await this.listProtocolsUseCase.executePaginated(
-        input.page,
-        input.pageSize,
-        input.search,
-        resolveListScope(input),
-        session.user.id,
-      );
-
-      if (result.isSuccess()) {
-        return toPage(result.value, input.page, input.pageSize, formatDatesList);
       }
 
       return throwOrpcFailure(result, this.logger);

--- a/apps/backend/src/search/application/use-cases/global-search/global-search.spec.ts
+++ b/apps/backend/src/search/application/use-cases/global-search/global-search.spec.ts
@@ -187,6 +187,74 @@ describe("GlobalSearchUseCase", () => {
     expect(result.value.results.some((r) => r.title === "Open photosynthesis study")).toBe(true);
   });
 
+  // Cross-type order is one comparable score, not a round-robin over types.
+  describe("cross-type ranking", () => {
+    it("ranks an exact name match above weaker matches of other types", async () => {
+      await testApp.createMacro({
+        name: "Helper utilities",
+        description: "supporting zephyrine calculations",
+        createdBy: userId,
+      });
+      await testApp.createProtocol({
+        name: "Field routine",
+        description: "records zephyrine readings",
+        createdBy: userId,
+      });
+      await testApp.createExperiment({ name: "Zephyrine", userId, visibility: "public" });
+
+      const result = await useCase.execute(userId, "zephyrine", 20);
+
+      assertSuccess(result);
+      // The experiment wins on its name hit, not because experiments are listed first.
+      expect(result.value.results[0].title).toBe("Zephyrine");
+      expect(result.value.results[0].type).toBe("experiment");
+    });
+
+    it("lets one type take more than its share when it holds the best matches", async () => {
+      for (let i = 0; i < 10; i++) {
+        await testApp.createProtocol({ name: `Vorbulon protocol ${i}`, createdBy: userId });
+      }
+      await testApp.createMacro({
+        name: "Unrelated macro",
+        description: "mentions vorbulon in passing",
+        createdBy: userId,
+      });
+
+      const result = await useCase.execute(userId, "vorbulon", 8);
+
+      assertSuccess(result);
+      // The old fan-out capped every type at 8; overfetching removes that ceiling, so a
+      // limit of 8 can now be filled entirely from the type that matched best.
+      expect(result.value.results).toHaveLength(8);
+      expect(result.value.results.every((r) => r.type === "protocol")).toBe(true);
+    });
+
+    it("orders results by descending score", async () => {
+      await testApp.createExperiment({ name: "Grindelwax", userId, visibility: "public" });
+      await testApp.createProtocol({
+        name: "Grindelwax assay",
+        createdBy: userId,
+      });
+      await testApp.createMacro({
+        name: "Unrelated helper",
+        description: "grindelwax post-processing",
+        createdBy: userId,
+      });
+
+      const result = await useCase.execute(userId, "grindelwax", 20);
+
+      assertSuccess(result);
+      const titles = result.value.results.map((r) => r.title);
+      expect(titles).toContain("Grindelwax");
+      expect(titles).toContain("Grindelwax assay");
+      // A description-only hit ranks below both name hits regardless of its type.
+      expect(titles.indexOf("Unrelated helper")).toBeGreaterThan(titles.indexOf("Grindelwax"));
+      expect(titles.indexOf("Unrelated helper")).toBeGreaterThan(
+        titles.indexOf("Grindelwax assay"),
+      );
+    });
+  });
+
   // Global search delegates to the same per-type findAlls, so their access scoping
   // applies here too: a private macro/protocol/workbook is undiscoverable to a
   // non-grantee but visible once a grant is held.

--- a/apps/backend/src/search/application/use-cases/global-search/global-search.ts
+++ b/apps/backend/src/search/application/use-cases/global-search/global-search.ts
@@ -8,14 +8,12 @@ import { MacroRepository } from "../../../../macros/core/repositories/macro.repo
 import { ProtocolRepository } from "../../../../protocols/core/repositories/protocol.repository";
 import { WorkbookRepository } from "../../../../workbooks/core/repositories/workbook.repository";
 
-/** Max results taken per entity type before cross-type merging. */
-const PER_TYPE_LIMIT = 8;
-
 /** Minimal shape every entity DTO shares; all global search needs to render a result row. */
 interface SearchableEntity {
   id: string;
   name: string;
   description: string | null;
+  score: number;
 }
 
 @Injectable()
@@ -37,17 +35,17 @@ export class GlobalSearchUseCase {
     this.logger.log({ msg: "Global search", operation: "globalSearch" });
 
     // Delegate to the per-entity focused search (`findAll`) so global search matches and ranks
-    // by exactly the same rules — there is one search definition per entity, and global search
-    // is purely a consumer of it. Each `findAll` already returns rows in descending relevance.
-    const perType = Math.min(PER_TYPE_LIMIT, limit);
+    // by exactly the same rules: there is one search definition per entity, and global search
+    // is purely a consumer of it. Overfetching `limit` per type removes any per-type recall
+    // ceiling, so the 9th-best experiment can still outrank every macro.
     const [experiments, protocols, macros, workbooks] = await Promise.all([
-      this.experimentRepository.findAll(userId, undefined, undefined, query, perType),
+      this.experimentRepository.findAll(userId, undefined, undefined, query, limit),
       // Pass the caller so each findAll applies the same access scoping it uses
-      // for listing — global search must not surface private resources the caller
+      // for listing: global search must not surface private resources the caller
       // cannot access.
-      this.protocolRepository.findAll(query, undefined, userId, perType),
-      this.macroRepository.findAll({ search: query, userId }, perType),
-      this.workbookRepository.findAll({ search: query, userId }, perType),
+      this.protocolRepository.findAll(query, undefined, userId, limit),
+      this.macroRepository.findAll({ search: query, userId }, limit),
+      this.workbookRepository.findAll({ search: query, userId }, limit),
     ]);
 
     if (isFailure(experiments)) return experiments;
@@ -55,17 +53,16 @@ export class GlobalSearchUseCase {
     if (isFailure(macros)) return macros;
     if (isFailure(workbooks)) return workbooks;
 
-    // Each `findAll` ranks within its own type, but those scores aren't exposed (or comparable)
-    // across types, so we merge by rank position: the top hit of every type scores ~1, and items
-    // interleave by their standing within their type. `score` is an internal sort key only — a
-    // positional rank, not a true cross-type relevance — so it is stripped before returning.
+    // The repositories compute one comparable score per row (same lexical base, same capped
+    // cross-table bonus, same tier weight), so merging is a plain sort. `id` breaks ties, making
+    // the order stable across identical queries. The key is internal and stripped before returning.
     const ranked = [
       ...toResults(experiments.value, "experiment", () => null),
       ...toResults(protocols.value, "protocol", (p) => p.family),
       ...toResults(macros.value, "macro", (m) => m.language),
       ...toResults(workbooks.value, "workbook", () => null),
     ]
-      .sort((a, b) => b.score - a.score)
+      .sort((a, b) => b.score - a.score || a.id.localeCompare(b.id))
       .slice(0, limit);
 
     const results: SearchResult[] = ranked.map(({ score: _score, ...result }) => result);
@@ -74,24 +71,21 @@ export class GlobalSearchUseCase {
   }
 }
 
-/** A `SearchResult` plus the internal positional sort key used to merge across entity types. */
+/** A `SearchResult` plus the cross-type sort key carried out of the repositories. */
 type RankedResult = SearchResult & { score: number };
 
-/**
- * Score already-relevance-ordered rows by rank position (the repo caps the count via `limit`).
- * `meta` extracts the optional type-specific label shown beside the title (language / family).
- */
+/** `meta` extracts the optional type-specific label shown beside the title (language / family). */
 function toResults<T extends SearchableEntity>(
   rows: T[],
   type: SearchResultType,
   meta: (row: T) => string | null,
 ): RankedResult[] {
-  return rows.map((row, index) => ({
+  return rows.map((row) => ({
     type,
     id: row.id,
     title: row.name,
     subtitle: row.description,
     meta: meta(row),
-    score: (rows.length - index) / rows.length,
+    score: row.score,
   }));
 }

--- a/apps/backend/src/workbooks/application/use-cases/list-workbooks/list-workbooks.spec.ts
+++ b/apps/backend/src/workbooks/application/use-cases/list-workbooks/list-workbooks.spec.ts
@@ -50,11 +50,11 @@ describe("ListWorkbooksUseCase", () => {
     expect(result.value[0].name).toBe("Alpha Workbook");
   });
 
-  it("filters by 'my' to show only user's workbooks", async () => {
+  it("scopes to related to show only the caller's workbooks", async () => {
     const otherUser = await testApp.createTestUser({});
     await testApp.createWorkbook({ name: "Mine", createdBy: userId });
     await testApp.createWorkbook({ name: "Theirs", createdBy: otherUser });
-    const result = await useCase.execute({ filter: "my", userId });
+    const result = await useCase.execute({ scope: "related", userId });
     assertSuccess(result);
     expect(result.value).toHaveLength(1);
     expect(result.value[0].name).toBe("Mine");

--- a/apps/backend/src/workbooks/application/use-cases/list-workbooks/list-workbooks.ts
+++ b/apps/backend/src/workbooks/application/use-cases/list-workbooks/list-workbooks.ts
@@ -18,4 +18,19 @@ export class ListWorkbooksUseCase {
     });
     return await this.workbookRepository.findAll(filter);
   }
+
+  async executePaginated(
+    page: number,
+    pageSize: number,
+    filter?: WorkbookFilter,
+  ): Promise<Result<{ items: WorkbookListItemDto[]; totalCount: number }>> {
+    this.logger.log({
+      msg: "Listing workbooks",
+      operation: "listWorkbooksPaginated",
+      page,
+      pageSize,
+      hasSearch: !!filter?.search,
+    });
+    return await this.workbookRepository.findPage(page, pageSize, filter);
+  }
 }

--- a/apps/backend/src/workbooks/core/repositories/workbook-listing.spec.ts
+++ b/apps/backend/src/workbooks/core/repositories/workbook-listing.spec.ts
@@ -1,0 +1,149 @@
+import { assertSuccess } from "../../../common/utils/fp-utils";
+import { TestHarness } from "../../../test/test-harness";
+import { WorkbookRepository } from "./workbook.repository";
+
+/**
+ * `scope=related` and paging, the two contract changes OJD-1728 adds. Workbooks stand in
+ * for protocols and macros here: all three moved from bare authorship to the shared
+ * relationship predicate, and all three page through the same helper.
+ */
+describe("WorkbookRepository listing scope and pagination", () => {
+  const testApp = TestHarness.App;
+  let repository: WorkbookRepository;
+  let owner: string;
+  let stranger: string;
+
+  beforeAll(async () => {
+    await testApp.setup();
+  });
+
+  beforeEach(async () => {
+    await testApp.beforeEach();
+    repository = testApp.module.get(WorkbookRepository);
+    owner = await testApp.createTestUser({});
+    stranger = await testApp.createTestUser({});
+  });
+
+  afterEach(() => {
+    testApp.afterEach();
+  });
+
+  afterAll(async () => {
+    await testApp.teardown();
+  });
+
+  describe("scope=related", () => {
+    it("counts a shared workbook the caller did not author", async () => {
+      const orgId = await testApp.createOrganization();
+      await testApp.addOrganizationMember(orgId, owner, "owner");
+      const shared = await testApp.createWorkbook({
+        name: "Shared with me",
+        createdBy: owner,
+        visibility: "private",
+        organizationId: orgId,
+      });
+      await testApp.addResourceGrant({
+        resourceType: "workbook",
+        resourceId: shared.id,
+        granteeType: "user",
+        granteeId: stranger,
+        role: "viewer",
+      });
+
+      const result = await repository.findAll({ scope: "related", userId: stranger });
+
+      assertSuccess(result);
+      // The semantic upgrade: bare `created_by` would have dropped this row.
+      expect(result.value.map((w) => w.id)).toContain(shared.id);
+    });
+
+    it("counts a workbook reached through membership of its owning organization", async () => {
+      const orgId = await testApp.createOrganization();
+      await testApp.addOrganizationMember(orgId, owner, "owner");
+      await testApp.addOrganizationMember(orgId, stranger, "member");
+      const orgWorkbook = await testApp.createWorkbook({
+        name: "Team workbook",
+        createdBy: owner,
+        visibility: "private",
+        organizationId: orgId,
+      });
+
+      const result = await repository.findAll({ scope: "related", userId: stranger });
+
+      assertSuccess(result);
+      expect(result.value.map((w) => w.id)).toContain(orgWorkbook.id);
+    });
+
+    it("drops a public workbook the caller is merely able to read", async () => {
+      const theirs = await testApp.createWorkbook({
+        name: "Public elsewhere",
+        createdBy: owner,
+        visibility: "public",
+      });
+
+      const related = await repository.findAll({ scope: "related", userId: stranger });
+      const all = await repository.findAll({ scope: "all", userId: stranger });
+
+      assertSuccess(related);
+      assertSuccess(all);
+      expect(related.value.map((w) => w.id)).not.toContain(theirs.id);
+      expect(all.value.map((w) => w.id)).toContain(theirs.id);
+    });
+
+    it("admits nothing without a caller, rather than throwing", async () => {
+      await testApp.createWorkbook({ name: "Public one", createdBy: owner, visibility: "public" });
+
+      const result = await repository.findAll({ scope: "related" });
+
+      assertSuccess(result);
+      expect(result.value).toEqual([]);
+    });
+  });
+
+  describe("findPage", () => {
+    beforeEach(async () => {
+      for (const name of ["Alpha", "Bravo", "Charlie", "Delta", "Echo"]) {
+        await testApp.createWorkbook({ name, createdBy: owner, visibility: "public" });
+      }
+    });
+
+    it("returns one page alongside the totals for the whole set", async () => {
+      const result = await repository.findPage(1, 2, { userId: owner });
+
+      assertSuccess(result);
+      expect(result.value.items.map((w) => w.name)).toEqual(["Alpha", "Bravo"]);
+      expect(result.value.totalCount).toBe(5);
+    });
+
+    it("walks pages without dropping or repeating a row", async () => {
+      const [first, second, third] = await Promise.all([
+        repository.findPage(1, 2, { userId: owner }),
+        repository.findPage(2, 2, { userId: owner }),
+        repository.findPage(3, 2, { userId: owner }),
+      ]);
+
+      assertSuccess(first);
+      assertSuccess(second);
+      assertSuccess(third);
+      const seen = [...first.value.items, ...second.value.items, ...third.value.items].map(
+        (w) => w.name,
+      );
+      expect(seen).toEqual(["Alpha", "Bravo", "Charlie", "Delta", "Echo"]);
+    });
+
+    it("reports the real totals for a page past the end instead of failing", async () => {
+      const result = await repository.findPage(99, 20, { userId: owner });
+
+      assertSuccess(result);
+      expect(result.value.items).toEqual([]);
+      expect(result.value.totalCount).toBe(5);
+    });
+
+    it("counts the scoped set, not the whole table", async () => {
+      const result = await repository.findPage(1, 20, { scope: "related", userId: stranger });
+
+      assertSuccess(result);
+      expect(result.value.totalCount).toBe(0);
+    });
+  });
+});

--- a/apps/backend/src/workbooks/core/repositories/workbook-listing.spec.ts
+++ b/apps/backend/src/workbooks/core/repositories/workbook-listing.spec.ts
@@ -146,4 +146,59 @@ describe("WorkbookRepository listing scope and pagination", () => {
       expect(result.value.totalCount).toBe(0);
     });
   });
+
+  /**
+   * Search orders by `score DESC, id ASC`, and identically-worded rows score
+   * identically, so it is the ordering most exposed to ties. Without the `id`
+   * tiebreak the pages below could overlap or skip rows.
+   */
+  describe("findPage over the search ordering", () => {
+    const TIED = 6;
+
+    beforeEach(async () => {
+      for (let i = 0; i < TIED; i++) {
+        await testApp.createWorkbook({
+          name: `Tiebreak probe ${i}`,
+          description: "identical scoring text",
+          createdBy: owner,
+          visibility: "public",
+        });
+      }
+    });
+
+    it("walks tied rows without dropping or repeating any", async () => {
+      const filter = { search: "tiebreak", userId: owner };
+
+      const [first, second, third] = await Promise.all([
+        repository.findPage(1, 2, filter),
+        repository.findPage(2, 2, filter),
+        repository.findPage(3, 2, filter),
+      ]);
+
+      assertSuccess(first);
+      assertSuccess(second);
+      assertSuccess(third);
+
+      const ids = [...first.value.items, ...second.value.items, ...third.value.items].map(
+        (w) => w.id,
+      );
+      expect(ids).toHaveLength(TIED);
+      expect(new Set(ids).size).toBe(TIED);
+      expect(first.value.totalCount).toBe(TIED);
+
+      // The rows tie on score, so `id ASC` is the only thing making the walk stable.
+      expect(ids).toEqual([...ids].sort());
+    });
+
+    it("returns the same page on a repeated identical query", async () => {
+      const filter = { search: "tiebreak", userId: owner };
+
+      const once = await repository.findPage(2, 2, filter);
+      const twice = await repository.findPage(2, 2, filter);
+
+      assertSuccess(once);
+      assertSuccess(twice);
+      expect(twice.value.items.map((w) => w.id)).toEqual(once.value.items.map((w) => w.id));
+    });
+  });
 });

--- a/apps/backend/src/workbooks/core/repositories/workbook.repository.spec.ts
+++ b/apps/backend/src/workbooks/core/repositories/workbook.repository.spec.ts
@@ -467,7 +467,7 @@ describe("WorkbookRepository — list access scoping", () => {
     expect(ids).not.toContain(privateId);
   });
 
-  it('keeps the "my" filter as an ownership view, unaffected by visibility', async () => {
+  it("keeps scope=related as a relationship view, unaffected by visibility", async () => {
     const other = await testApp.createTestUser({ name: "Other Author" });
     const othersWorkbook = await testApp.createWorkbook({
       name: "Someone else's workbook",
@@ -475,7 +475,7 @@ describe("WorkbookRepository — list access scoping", () => {
       visibility: "public",
     });
 
-    const result = await repository.findAll({ filter: "my", userId: owner });
+    const result = await repository.findAll({ scope: "related", userId: owner });
     assertSuccess(result);
     const ids = result.value.map((w) => w.id);
 

--- a/apps/backend/src/workbooks/core/repositories/workbook.repository.ts
+++ b/apps/backend/src/workbooks/core/repositories/workbook.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable, Inject } from "@nestjs/common";
 
+import type { ResourceScope } from "@repo/api/shared/listing";
 import {
   and,
   asc,
@@ -14,6 +15,7 @@ import {
   isNull,
   macros,
   ne,
+  or,
   profiles,
   protocols,
   sql,
@@ -22,13 +24,23 @@ import {
 import type { DatabaseInstance, SQL } from "@repo/database";
 
 import { Result, tryCatch } from "../../../common/utils/fp-utils";
-import { escapeLike, ftsMatch, ftsRank } from "../../../common/utils/fts";
+import {
+  crossTableBonus,
+  escapeLike,
+  ftsMatch,
+  ftsRank,
+  searchScore,
+} from "../../../common/utils/fts";
 import { owningOrganizationNameSql } from "../../../common/utils/owning-organization";
 import {
   getAnonymizedFirstName,
   getAnonymizedLastName,
 } from "../../../common/utils/profile-anonymization";
-import { accessibleResourceCondition } from "../../../common/utils/resource-access-scope";
+import {
+  accessibleResourceCondition,
+  relatedResourceCondition,
+  resourceTierExpression,
+} from "../../../common/utils/resource-access-scope";
 import { lockStaffedResource, seedCreatorControl } from "../../../sharing/core/resource-staffing";
 import {
   CreateWorkbookDto,
@@ -39,11 +51,14 @@ import {
 
 export interface WorkbookFilter {
   search?: string;
-  filter?: "my";
+  scope?: ResourceScope;
   userId?: string;
   /** Narrow to one owning organization (the org profile's resources showcase). */
   organizationId?: string;
 }
+
+/** A listing row plus its relevance score, which global search merges on across types. */
+export type WorkbookSearchRow = WorkbookListItemDto & { score: number };
 
 // All workbook columns except the internal full-text `search_vector` (never returned to clients).
 const { searchVector: _workbookSearchVector, ...workbookColumns } = getTableColumns(workbooks);
@@ -88,6 +103,23 @@ function cellRefIds(cellType: "protocol" | "macro", idKey: "protocolId" | "macro
   )`;
 }
 
+function toWorkbookRow(result: {
+  workbooks: unknown;
+  firstName: string | null;
+  lastName: string | null;
+  experimentCount: number;
+  cellTypeCounts: WorkbookListItemDto["cellTypeCounts"];
+  score: number;
+}): WorkbookSearchRow {
+  const augmented = result.workbooks as WorkbookSearchRow;
+  const { firstName, lastName } = result;
+  augmented.createdByName = firstName && lastName ? `${firstName} ${lastName}` : undefined;
+  augmented.experimentCount = result.experimentCount;
+  augmented.cellTypeCounts = result.cellTypeCounts;
+  augmented.score = result.score;
+  return augmented;
+}
+
 @Injectable()
 export class WorkbookRepository {
   constructor(
@@ -121,20 +153,12 @@ export class WorkbookRepository {
     });
   }
 
-  async findAll(filter?: WorkbookFilter, limit?: number): Promise<Result<WorkbookListItemDto[]>> {
-    return tryCatch(async () => {
-      let query = this.database
-        .select({
-          workbooks: workbookListColumns,
-          firstName: getAnonymizedFirstName(),
-          lastName: getAnonymizedLastName(),
-          experimentCount: experimentCountSql(),
-          cellTypeCounts: cellTypeCountsSql(),
-        })
-        .from(workbooks)
-        .innerJoin(profiles, eq(workbooks.createdBy, profiles.userId))
-        .$dynamic();
-
+  /**
+   * Shared shape behind the array and paginated listings, so both apply identical
+   * scoping, ranking and ordering and the count matches the rows exactly.
+   */
+  private buildListing(filter?: WorkbookFilter) {
+    {
       const conditions: (SQL | undefined)[] = [];
 
       const search = filter?.search;
@@ -222,11 +246,10 @@ export class WorkbookRepository {
         );
       }
 
-      // Unconditional, the "my" view included: a view may narrow what the caller
-      // sees but must never widen it. Authorship is not an access path (`can()`
-      // does not consult `created_by`), so a creator since removed from the owning
-      // org, holding no grant, must not get the workbook's body back through a listing.
-      const scope = accessibleResourceCondition({
+      // Unconditional, the `related` view included: a view may narrow what the caller
+      // sees but must never widen it. Authorship is not an access path, so a creator
+      // since removed from the owning org must not get the body back through a listing.
+      const accessScope = accessibleResourceCondition({
         database: this.database,
         resourceType: "workbook",
         resourceIdColumn: workbooks.id,
@@ -234,8 +257,8 @@ export class WorkbookRepository {
         visibilityColumn: workbooks.visibility,
         userId: filter?.userId,
       });
-      if (scope) {
-        conditions.push(scope);
+      if (accessScope) {
+        conditions.push(accessScope);
       }
 
       // Applied on top of the access scope, never instead of it: an org's page shows
@@ -244,36 +267,110 @@ export class WorkbookRepository {
         conditions.push(eq(workbooks.organizationId, filter.organizationId));
       }
 
-      if (filter?.filter === "my" && filter.userId) {
-        // "My workbooks" narrows that down to what the caller authored.
-        conditions.push(eq(workbooks.createdBy, filter.userId));
+      if (filter?.scope === "related") {
+        // "Mine": authorship plus every path tying the caller to the row personally.
+        // Without a caller nothing resolves, so the scope admits nothing.
+        const related = relatedResourceCondition({
+          database: this.database,
+          resourceType: "workbook",
+          resourceIdColumn: workbooks.id,
+          organizationIdColumn: workbooks.organizationId,
+          userId: filter.userId,
+        });
+        conditions.push(
+          filter.userId ? or(related, eq(workbooks.createdBy, filter.userId)) : sql`false`,
+        );
       }
 
-      if (conditions.length > 0) {
-        query = query.where(and(...conditions));
-      }
+      const rank = sql<number>`(${ftsRank(workbooks.searchVector, workbooks.name, search ?? "")} + ${crossTableBonus(
+        creatorMatch(search ?? ""),
+        linkedExperimentMatch(search ?? ""),
+        linkedProtocolMatch(search ?? ""),
+        linkedMacroMatch(search ?? ""),
+      )})`;
+      const tier = resourceTierExpression({
+        database: this.database,
+        resourceType: "workbook",
+        resourceIdColumn: workbooks.id,
+        organizationIdColumn: workbooks.organizationId,
+        createdByColumn: workbooks.createdBy,
+        userId: filter?.userId,
+      });
+      const score = searchScore(rank, tier);
 
-      if (search) {
-        const rank = sql<number>`(${ftsRank(workbooks.searchVector, workbooks.name, search)} + 0.05 * (CASE WHEN ${creatorMatch(search)} THEN 1 ELSE 0 END) + 0.05 * (CASE WHEN ${linkedExperimentMatch(search)} THEN 1 ELSE 0 END) + 0.05 * (CASE WHEN ${linkedProtocolMatch(search)} THEN 1 ELSE 0 END) + 0.05 * (CASE WHEN ${linkedMacroMatch(search)} THEN 1 ELSE 0 END))`;
-        query = query.orderBy(desc(rank), asc(workbooks.name));
-      } else {
-        query = query.orderBy(asc(workbooks.name));
-      }
+      // Both orderings end on `id` so paging never drops or repeats a row on ties.
+      const orderBy = search
+        ? [desc(score), asc(workbooks.id)]
+        : [desc(tier), asc(workbooks.name), asc(workbooks.id)];
 
+      const where = conditions.length > 0 ? and(...conditions) : undefined;
+
+      return { where, orderBy, score };
+    }
+  }
+
+  private baseQuery(score: SQL<number>) {
+    return this.database
+      .select({
+        workbooks: workbookListColumns,
+        firstName: getAnonymizedFirstName(),
+        lastName: getAnonymizedLastName(),
+        experimentCount: experimentCountSql(),
+        cellTypeCounts: cellTypeCountsSql(),
+        score,
+      })
+      .from(workbooks)
+      .innerJoin(profiles, eq(workbooks.createdBy, profiles.userId))
+      .$dynamic();
+  }
+
+  async findAll(filter?: WorkbookFilter, limit?: number): Promise<Result<WorkbookSearchRow[]>> {
+    return tryCatch(async () => {
+      const { where, orderBy, score } = this.buildListing(filter);
+
+      let query = this.baseQuery(score);
+      if (where) {
+        query = query.where(where);
+      }
+      query = query.orderBy(...orderBy);
       if (limit !== undefined) {
         query = query.limit(limit);
       }
 
-      const results = await query;
-      return results.map((result) => {
-        const augmented = result.workbooks as WorkbookListItemDto;
-        const firstName = result.firstName;
-        const lastName = result.lastName;
-        augmented.createdByName = firstName && lastName ? `${firstName} ${lastName}` : undefined;
-        augmented.experimentCount = result.experimentCount;
-        augmented.cellTypeCounts = result.cellTypeCounts;
-        return augmented;
-      });
+      return (await query).map(toWorkbookRow);
+    });
+  }
+
+  /** One page plus the total, counted separately so an out-of-range page still reports it. */
+  async findPage(
+    page: number,
+    pageSize: number,
+    filter?: WorkbookFilter,
+  ): Promise<Result<{ items: WorkbookSearchRow[]; totalCount: number }>> {
+    return tryCatch(async () => {
+      const { where, orderBy, score } = this.buildListing(filter);
+
+      let rows = this.baseQuery(score);
+      let total = this.database
+        .select({ count: sql<number>`count(*)::int` })
+        .from(workbooks)
+        .innerJoin(profiles, eq(workbooks.createdBy, profiles.userId))
+        .$dynamic();
+
+      if (where) {
+        rows = rows.where(where);
+        total = total.where(where);
+      }
+
+      const [items, [{ count }]] = await Promise.all([
+        rows
+          .orderBy(...orderBy)
+          .limit(pageSize)
+          .offset((page - 1) * pageSize),
+        total,
+      ]);
+
+      return { items: items.map(toWorkbookRow), totalCount: count };
     });
   }
 

--- a/apps/backend/src/workbooks/core/repositories/workbook.repository.ts
+++ b/apps/backend/src/workbooks/core/repositories/workbook.repository.ts
@@ -282,12 +282,6 @@ export class WorkbookRepository {
         );
       }
 
-      const rank = sql<number>`(${ftsRank(workbooks.searchVector, workbooks.name, search ?? "")} + ${crossTableBonus(
-        creatorMatch(search ?? ""),
-        linkedExperimentMatch(search ?? ""),
-        linkedProtocolMatch(search ?? ""),
-        linkedMacroMatch(search ?? ""),
-      )})`;
       const tier = resourceTierExpression({
         database: this.database,
         resourceType: "workbook",
@@ -296,7 +290,19 @@ export class WorkbookRepository {
         createdByColumn: workbooks.createdBy,
         userId: filter?.userId,
       });
-      const score = searchScore(rank, tier);
+      // Browsing has no term to rank against. Skipping the score here matters most for
+      // workbooks: its rank re-runs four correlated linked-entity probes per row.
+      const score = search
+        ? searchScore(
+            sql<number>`(${ftsRank(workbooks.searchVector, workbooks.name, search)} + ${crossTableBonus(
+              creatorMatch(search),
+              linkedExperimentMatch(search),
+              linkedProtocolMatch(search),
+              linkedMacroMatch(search),
+            )})`,
+            tier,
+          )
+        : sql<number>`0::int`;
 
       // Both orderings end on `id` so paging never drops or repeats a row on ties.
       const orderBy = search

--- a/apps/backend/src/workbooks/presentation/workbook.controller.spec.ts
+++ b/apps/backend/src/workbooks/presentation/workbook.controller.spec.ts
@@ -6,6 +6,7 @@ import { contract } from "@repo/api/contract";
 import { AuthorizationService } from "../../authorization/authorization.service";
 import { assertSuccess, success, failure, AppError } from "../../common/utils/fp-utils";
 import { TestHarness } from "../../test/test-harness";
+import type { SuperTestResponse } from "../../test/test-harness";
 import { CreateWorkbookUseCase } from "../application/use-cases/create-workbook/create-workbook";
 import { DeleteWorkbookUseCase } from "../application/use-cases/delete-workbook/delete-workbook";
 import { GetWorkbookVersionUseCase } from "../application/use-cases/get-workbook-version/get-workbook-version";
@@ -16,6 +17,14 @@ import { UpdateWorkbookUseCase } from "../application/use-cases/update-workbook/
 import type { WorkbookVersionDto } from "../core/models/workbook-version.model";
 import type { WorkbookDto } from "../core/models/workbook.model";
 import { WorkbookVersionRepository } from "../core/repositories/workbook-version.repository";
+
+interface WorkbookPage {
+  items: { id: string }[];
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  totalCount: number;
+}
 
 describe("WorkbookController", () => {
   const testApp = TestHarness.App;
@@ -162,7 +171,7 @@ describe("WorkbookController", () => {
       expect(response.body).toHaveLength(2);
     });
 
-    it("should pass search and filter to use case", async () => {
+    it("maps the deprecated filter=my alias to scope=related", async () => {
       const executeSpy = vi.spyOn(listWorkbooksUseCase, "execute").mockResolvedValue(success([]));
 
       await testApp
@@ -173,9 +182,88 @@ describe("WorkbookController", () => {
 
       expect(executeSpy).toHaveBeenCalledWith({
         search: "test",
-        filter: "my",
+        scope: "related",
         userId: testUserId,
       });
+    });
+
+    it("lets an explicit scope win over the deprecated filter alias", async () => {
+      const executeSpy = vi.spyOn(listWorkbooksUseCase, "execute").mockResolvedValue(success([]));
+
+      await testApp
+        .get(testApp.resolveOrpcPath(contract.workbooks.listWorkbooks))
+        .query({ filter: "my", scope: "all" })
+        .withAuth(testUserId)
+        .expect(StatusCodes.OK);
+
+      expect(executeSpy).toHaveBeenCalledWith({
+        search: undefined,
+        scope: "all",
+        userId: testUserId,
+      });
+    });
+  });
+
+  describe("listWorkbooksPaginated", () => {
+    it("returns the page envelope with totals", async () => {
+      for (const name of ["Alpha", "Bravo", "Charlie"]) {
+        await testApp.createWorkbook({ name, createdBy: testUserId, visibility: "public" });
+      }
+
+      const response: SuperTestResponse<WorkbookPage> = await testApp
+        .get(testApp.resolveOrpcPath(contract.workbooks.listWorkbooksPaginated))
+        .query({ page: 1, pageSize: 2 })
+        .withAuth(testUserId)
+        .expect(StatusCodes.OK);
+
+      expect(response.body.items).toHaveLength(2);
+      expect(response.body.page).toBe(1);
+      expect(response.body.pageSize).toBe(2);
+      expect(response.body.totalPages).toBe(2);
+      expect(response.body.totalCount).toBe(3);
+    });
+
+    it("defaults to the first page when no page params are sent", async () => {
+      await testApp.createWorkbook({
+        name: "Solo",
+        createdBy: testUserId,
+        visibility: "public",
+      });
+
+      const response: SuperTestResponse<WorkbookPage> = await testApp
+        .get(testApp.resolveOrpcPath(contract.workbooks.listWorkbooksPaginated))
+        .withAuth(testUserId)
+        .expect(StatusCodes.OK);
+
+      expect(response.body.page).toBe(1);
+      expect(response.body.pageSize).toBe(20);
+      expect(response.body.totalCount).toBe(1);
+    });
+
+    it("returns an empty page with real totals past the end", async () => {
+      await testApp.createWorkbook({
+        name: "Only one",
+        createdBy: testUserId,
+        visibility: "public",
+      });
+
+      const response: SuperTestResponse<WorkbookPage> = await testApp
+        .get(testApp.resolveOrpcPath(contract.workbooks.listWorkbooksPaginated))
+        .query({ page: 5, pageSize: 10 })
+        .withAuth(testUserId)
+        .expect(StatusCodes.OK);
+
+      expect(response.body.items).toEqual([]);
+      expect(response.body.totalCount).toBe(1);
+      expect(response.body.totalPages).toBe(1);
+    });
+
+    it("rejects a page below one", async () => {
+      await testApp
+        .get(testApp.resolveOrpcPath(contract.workbooks.listWorkbooksPaginated))
+        .query({ page: 0 })
+        .withAuth(testUserId)
+        .expect(StatusCodes.BAD_REQUEST);
     });
 
     it("should return 500 when use case fails", async () => {

--- a/apps/backend/src/workbooks/presentation/workbook.controller.spec.ts
+++ b/apps/backend/src/workbooks/presentation/workbook.controller.spec.ts
@@ -200,14 +200,14 @@ describe("WorkbookController", () => {
     });
   });
 
-  describe("listWorkbooksPaginated", () => {
+  describe("listWorkbooks paginated", () => {
     it("returns the page envelope with totals", async () => {
       for (const name of ["Alpha", "Bravo", "Charlie"]) {
         await testApp.createWorkbook({ name, createdBy: testUserId, visibility: "public" });
       }
 
       const response: SuperTestResponse<WorkbookPage> = await testApp
-        .get(testApp.resolveOrpcPath(contract.workbooks.listWorkbooksPaginated))
+        .get(testApp.resolveOrpcPath(contract.workbooks.listWorkbooks))
         .query({ page: 1, pageSize: 2 })
         .withAuth(testUserId)
         .expect(StatusCodes.OK);
@@ -219,7 +219,23 @@ describe("WorkbookController", () => {
       expect(response.body.totalCount).toBe(3);
     });
 
-    it("defaults to the first page when no page params are sent", async () => {
+    it("returns a bare array when no page is sent, not a defaulted envelope", async () => {
+      await testApp.createWorkbook({
+        name: "Solo",
+        createdBy: testUserId,
+        visibility: "public",
+      });
+
+      const response: SuperTestResponse<unknown> = await testApp
+        .get(testApp.resolveOrpcPath(contract.workbooks.listWorkbooks))
+        .withAuth(testUserId)
+        .expect(StatusCodes.OK);
+
+      expect(Array.isArray(response.body)).toBe(true);
+      expect(response.body).toHaveLength(1);
+    });
+
+    it("defaults pageSize once a page is requested without one", async () => {
       await testApp.createWorkbook({
         name: "Solo",
         createdBy: testUserId,
@@ -227,7 +243,8 @@ describe("WorkbookController", () => {
       });
 
       const response: SuperTestResponse<WorkbookPage> = await testApp
-        .get(testApp.resolveOrpcPath(contract.workbooks.listWorkbooksPaginated))
+        .get(testApp.resolveOrpcPath(contract.workbooks.listWorkbooks))
+        .query({ page: 1 })
         .withAuth(testUserId)
         .expect(StatusCodes.OK);
 
@@ -244,7 +261,7 @@ describe("WorkbookController", () => {
       });
 
       const response: SuperTestResponse<WorkbookPage> = await testApp
-        .get(testApp.resolveOrpcPath(contract.workbooks.listWorkbooksPaginated))
+        .get(testApp.resolveOrpcPath(contract.workbooks.listWorkbooks))
         .query({ page: 5, pageSize: 10 })
         .withAuth(testUserId)
         .expect(StatusCodes.OK);
@@ -256,7 +273,7 @@ describe("WorkbookController", () => {
 
     it("rejects a page below one", async () => {
       await testApp
-        .get(testApp.resolveOrpcPath(contract.workbooks.listWorkbooksPaginated))
+        .get(testApp.resolveOrpcPath(contract.workbooks.listWorkbooks))
         .query({ page: 0 })
         .withAuth(testUserId)
         .expect(StatusCodes.BAD_REQUEST);
@@ -268,7 +285,8 @@ describe("WorkbookController", () => {
       );
 
       await testApp
-        .get(testApp.resolveOrpcPath(contract.workbooks.listWorkbooksPaginated))
+        .get(testApp.resolveOrpcPath(contract.workbooks.listWorkbooks))
+        .query({ page: 1 })
         .withAuth(testUserId)
         .expect(StatusCodes.INTERNAL_SERVER_ERROR);
     });

--- a/apps/backend/src/workbooks/presentation/workbook.controller.spec.ts
+++ b/apps/backend/src/workbooks/presentation/workbook.controller.spec.ts
@@ -2,6 +2,7 @@ import { faker } from "@faker-js/faker";
 import { StatusCodes } from "http-status-codes";
 
 import { contract } from "@repo/api/contract";
+import type { WorkbookPaginatedList } from "@repo/api/domains/workbook/workbook.schema";
 
 import { AuthorizationService } from "../../authorization/authorization.service";
 import { assertSuccess, success, failure, AppError } from "../../common/utils/fp-utils";
@@ -18,13 +19,8 @@ import type { WorkbookVersionDto } from "../core/models/workbook-version.model";
 import type { WorkbookDto } from "../core/models/workbook.model";
 import { WorkbookVersionRepository } from "../core/repositories/workbook-version.repository";
 
-interface WorkbookPage {
-  items: { id: string }[];
-  page: number;
-  pageSize: number;
-  totalPages: number;
-  totalCount: number;
-}
+// Inferred from the contract's output schema, so any drift in the envelope fails here.
+type WorkbookPage = WorkbookPaginatedList;
 
 describe("WorkbookController", () => {
   const testApp = TestHarness.App;

--- a/apps/backend/src/workbooks/presentation/workbook.controller.spec.ts
+++ b/apps/backend/src/workbooks/presentation/workbook.controller.spec.ts
@@ -266,6 +266,17 @@ describe("WorkbookController", () => {
         .expect(StatusCodes.BAD_REQUEST);
     });
 
+    it("returns 500 when the paginated use case fails", async () => {
+      vi.spyOn(listWorkbooksUseCase, "executePaginated").mockResolvedValue(
+        failure(AppError.internal("Database error")),
+      );
+
+      await testApp
+        .get(testApp.resolveOrpcPath(contract.workbooks.listWorkbooksPaginated))
+        .withAuth(testUserId)
+        .expect(StatusCodes.INTERNAL_SERVER_ERROR);
+    });
+
     it("should return 500 when use case fails", async () => {
       vi.spyOn(listWorkbooksUseCase, "execute").mockResolvedValue(
         failure(AppError.internal("Database error")),

--- a/apps/backend/src/workbooks/presentation/workbook.controller.ts
+++ b/apps/backend/src/workbooks/presentation/workbook.controller.ts
@@ -4,7 +4,7 @@ import { Session } from "@thallesp/nestjs-better-auth";
 import type { UserSession } from "@thallesp/nestjs-better-auth";
 
 import { workbookContract } from "@repo/api/domains/workbook/workbook.contract";
-import { resolveListScope } from "@repo/api/shared/listing";
+import { DEFAULT_PAGE_SIZE, resolveListScope } from "@repo/api/shared/listing";
 
 import { AuthorizationService } from "../../authorization/authorization.service";
 import { CanAccess } from "../../authorization/can-access.decorator";
@@ -58,36 +58,34 @@ export class WorkbookController {
     });
   }
 
+  // One listing, two shapes: `page` presence is the only thing that switches it from a
+  // bare array to the paged envelope, so a caller that sends no page is untouched.
   @Implement(workbookContract.listWorkbooks)
   listWorkbooks(@Session() session: UserSession) {
     return implement(workbookContract.listWorkbooks).handler(async ({ input }) => {
-      const result = await this.listWorkbooksUseCase.execute({
+      const filter = {
         search: input.search,
         scope: resolveListScope(input),
         userId: session.user.id,
-      });
+      };
+
+      if (input.page !== undefined) {
+        const pageSize = input.pageSize ?? DEFAULT_PAGE_SIZE;
+        const paged = await this.listWorkbooksUseCase.executePaginated(
+          input.page,
+          pageSize,
+          filter,
+        );
+        if (paged.isSuccess()) {
+          return toPage(paged.value, input.page, pageSize, formatDatesList);
+        }
+        return throwOrpcFailure(paged, this.logger);
+      }
+
+      const result = await this.listWorkbooksUseCase.execute(filter);
 
       if (result.isSuccess()) {
         return formatDatesList(result.value);
-      }
-
-      return throwOrpcFailure(result, this.logger);
-    });
-  }
-
-  // Declared above `getWorkbook`: routes resolve in declaration order, so the literal
-  // path has to win before `{id}` claims it and rejects "paginated" as a uuid.
-  @Implement(workbookContract.listWorkbooksPaginated)
-  listWorkbooksPaginated(@Session() session: UserSession) {
-    return implement(workbookContract.listWorkbooksPaginated).handler(async ({ input }) => {
-      const result = await this.listWorkbooksUseCase.executePaginated(input.page, input.pageSize, {
-        search: input.search,
-        scope: resolveListScope(input),
-        userId: session.user.id,
-      });
-
-      if (result.isSuccess()) {
-        return toPage(result.value, input.page, input.pageSize, formatDatesList);
       }
 
       return throwOrpcFailure(result, this.logger);

--- a/apps/backend/src/workbooks/presentation/workbook.controller.ts
+++ b/apps/backend/src/workbooks/presentation/workbook.controller.ts
@@ -4,6 +4,7 @@ import { Session } from "@thallesp/nestjs-better-auth";
 import type { UserSession } from "@thallesp/nestjs-better-auth";
 
 import { workbookContract } from "@repo/api/domains/workbook/workbook.contract";
+import { resolveListScope } from "@repo/api/shared/listing";
 
 import { AuthorizationService } from "../../authorization/authorization.service";
 import { CanAccess } from "../../authorization/can-access.decorator";
@@ -12,6 +13,7 @@ import { resolveResourceCapabilities } from "../../authorization/resource-capabi
 import { formatDates, formatDatesList } from "../../common/utils/date-formatter";
 import { isSuccess } from "../../common/utils/fp-utils";
 import { throwOrpcFailure } from "../../common/utils/orpc-fp";
+import { toPage } from "../../common/utils/pagination";
 import { SetVisibilityUseCase } from "../../visibility/application/use-cases/set-visibility/set-visibility";
 import { CreateWorkbookUseCase } from "../application/use-cases/create-workbook/create-workbook";
 import { DeleteWorkbookUseCase } from "../application/use-cases/delete-workbook/delete-workbook";
@@ -56,6 +58,42 @@ export class WorkbookController {
     });
   }
 
+  @Implement(workbookContract.listWorkbooks)
+  listWorkbooks(@Session() session: UserSession) {
+    return implement(workbookContract.listWorkbooks).handler(async ({ input }) => {
+      const result = await this.listWorkbooksUseCase.execute({
+        search: input.search,
+        scope: resolveListScope(input),
+        userId: session.user.id,
+      });
+
+      if (result.isSuccess()) {
+        return formatDatesList(result.value);
+      }
+
+      return throwOrpcFailure(result, this.logger);
+    });
+  }
+
+  // Declared above `getWorkbook`: routes resolve in declaration order, so the literal
+  // path has to win before `{id}` claims it and rejects "paginated" as a uuid.
+  @Implement(workbookContract.listWorkbooksPaginated)
+  listWorkbooksPaginated(@Session() session: UserSession) {
+    return implement(workbookContract.listWorkbooksPaginated).handler(async ({ input }) => {
+      const result = await this.listWorkbooksUseCase.executePaginated(input.page, input.pageSize, {
+        search: input.search,
+        scope: resolveListScope(input),
+        userId: session.user.id,
+      });
+
+      if (result.isSuccess()) {
+        return toPage(result.value, input.page, input.pageSize, formatDatesList);
+      }
+
+      return throwOrpcFailure(result, this.logger);
+    });
+  }
+
   @CanAccess({ resource: "workbook", action: "read" })
   @Implement(workbookContract.getWorkbook)
   getWorkbook(@Session() session: UserSession) {
@@ -71,23 +109,6 @@ export class WorkbookController {
           input.id,
         );
         return { ...formatDates(result.value), capabilities };
-      }
-
-      return throwOrpcFailure(result, this.logger);
-    });
-  }
-
-  @Implement(workbookContract.listWorkbooks)
-  listWorkbooks(@Session() session: UserSession) {
-    return implement(workbookContract.listWorkbooks).handler(async ({ input }) => {
-      const result = await this.listWorkbooksUseCase.execute({
-        search: input.search,
-        filter: input.filter,
-        userId: session.user.id,
-      });
-
-      if (result.isSuccess()) {
-        return formatDatesList(result.value);
       }
 
       return throwOrpcFailure(result, this.logger);

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -274,6 +274,9 @@
                         }
                       ]
                     },
+                    "membersCount": {
+                      "type": "integer"
+                    },
                     "createdAt": {
                       "type": "string",
                       "format": "date-time"
@@ -588,6 +591,9 @@
                             "type": "null"
                           }
                         ]
+                      },
+                      "membersCount": {
+                        "type": "integer"
                       },
                       "createdAt": {
                         "type": "string",
@@ -935,6 +941,9 @@
                               }
                             ]
                           },
+                          "membersCount": {
+                            "type": "integer"
+                          },
                           "createdAt": {
                             "type": "string",
                             "format": "date-time"
@@ -1228,6 +1237,9 @@
                           "type": "null"
                         }
                       ]
+                    },
+                    "membersCount": {
+                      "type": "integer"
                     },
                     "createdAt": {
                       "type": "string",
@@ -1584,6 +1596,9 @@
                         }
                       ]
                     },
+                    "membersCount": {
+                      "type": "integer"
+                    },
                     "createdAt": {
                       "type": "string",
                       "format": "date-time"
@@ -1892,6 +1907,9 @@
                               "type": "null"
                             }
                           ]
+                        },
+                        "membersCount": {
+                          "type": "integer"
                         },
                         "createdAt": {
                           "type": "string",
@@ -6586,6 +6604,9 @@
                           "type": "null"
                         }
                       ]
+                    },
+                    "membersCount": {
+                      "type": "integer"
                     },
                     "createdAt": {
                       "type": "string",

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -473,333 +473,11 @@
             },
             "allowEmptyValue": true,
             "allowReserved": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "format": "uuid"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "status": {
-                        "enum": [
-                          "active",
-                          "stale",
-                          "archived",
-                          "published"
-                        ],
-                        "type": "string"
-                      },
-                      "visibility": {
-                        "enum": [
-                          "private",
-                          "public"
-                        ],
-                        "type": "string"
-                      },
-                      "embargoUntil": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "anonymizeContributors": {
-                        "type": "boolean"
-                      },
-                      "workbookId": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "workbookVersionId": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "organizationId": {
-                        "anyOf": [
-                          {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "organizationName": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "createdBy": {
-                        "type": "string",
-                        "format": "uuid"
-                      },
-                      "ownerFirstName": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "ownerLastName": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "membersCount": {
-                        "type": "integer"
-                      },
-                      "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "data": {
-                        "type": "object",
-                        "properties": {
-                          "columns": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string"
-                                },
-                                "type_name": {
-                                  "type": "string"
-                                },
-                                "type_text": {
-                                  "type": "string"
-                                }
-                              },
-                              "required": [
-                                "name",
-                                "type_name",
-                                "type_text"
-                              ]
-                            }
-                          },
-                          "rows": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "additionalProperties": {
-                                "anyOf": [
-                                  {},
-                                  {
-                                    "type": "null"
-                                  }
-                                ]
-                              }
-                            }
-                          },
-                          "totalRows": {
-                            "type": "integer"
-                          },
-                          "truncated": {
-                            "type": "boolean"
-                          }
-                        },
-                        "required": [
-                          "columns",
-                          "rows",
-                          "totalRows",
-                          "truncated"
-                        ]
-                      },
-                      "locations": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string",
-                              "format": "uuid"
-                            },
-                            "name": {
-                              "type": "string",
-                              "minLength": 1,
-                              "maxLength": 255
-                            },
-                            "latitude": {
-                              "type": "number",
-                              "minimum": -90,
-                              "maximum": 90
-                            },
-                            "longitude": {
-                              "type": "number",
-                              "minimum": -180,
-                              "maximum": 180
-                            },
-                            "country": {
-                              "type": "string"
-                            },
-                            "region": {
-                              "type": "string"
-                            },
-                            "municipality": {
-                              "type": "string"
-                            },
-                            "postalCode": {
-                              "type": "string"
-                            },
-                            "addressLabel": {
-                              "type": "string"
-                            },
-                            "createdAt": {
-                              "type": "string",
-                              "format": "date-time"
-                            },
-                            "updatedAt": {
-                              "type": "string",
-                              "format": "date-time"
-                            }
-                          },
-                          "required": [
-                            "id",
-                            "name",
-                            "latitude",
-                            "longitude",
-                            "createdAt",
-                            "updatedAt"
-                          ]
-                        }
-                      }
-                    },
-                    "required": [
-                      "id",
-                      "name",
-                      "description",
-                      "status",
-                      "visibility",
-                      "embargoUntil",
-                      "anonymizeContributors",
-                      "workbookId",
-                      "workbookVersionId",
-                      "organizationId",
-                      "createdBy",
-                      "createdAt",
-                      "updatedAt"
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/experiments/paginated": {
-      "get": {
-        "operationId": "experiments.listExperimentsPaginated",
-        "parameters": [
-          {
-            "name": "filter",
-            "in": "query",
-            "schema": {
-              "enum": [
-                "member"
-              ],
-              "type": "string",
-              "description": "Deprecated alias for scope=related"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          },
-          {
-            "name": "scope",
-            "in": "query",
-            "schema": {
-              "enum": [
-                "related",
-                "all"
-              ],
-              "type": "string",
-              "description": "Which slice of the accessible set to return"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "schema": {
-              "enum": [
-                "active",
-                "stale",
-                "archived",
-                "published"
-              ],
-              "type": "string",
-              "description": "Filter experiments by their status"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          },
-          {
-            "name": "search",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "description": "Search term for experiment name"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
           },
           {
             "name": "page",
             "in": "query",
             "schema": {
-              "default": 1,
               "type": "integer",
               "minimum": 1,
               "description": "1-based page number"
@@ -811,7 +489,6 @@
             "name": "pageSize",
             "in": "query",
             "schema": {
-              "default": 20,
               "type": "integer",
               "minimum": 1,
               "maximum": 100,
@@ -827,9 +504,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "items": {
+                  "anyOf": [
+                    {
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -1081,25 +757,282 @@
                         ]
                       }
                     },
-                    "page": {
-                      "type": "integer"
-                    },
-                    "pageSize": {
-                      "type": "integer"
-                    },
-                    "totalPages": {
-                      "type": "integer"
-                    },
-                    "totalCount": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "status": {
+                                "enum": [
+                                  "active",
+                                  "stale",
+                                  "archived",
+                                  "published"
+                                ],
+                                "type": "string"
+                              },
+                              "visibility": {
+                                "enum": [
+                                  "private",
+                                  "public"
+                                ],
+                                "type": "string"
+                              },
+                              "embargoUntil": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "anonymizeContributors": {
+                                "type": "boolean"
+                              },
+                              "workbookId": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "uuid"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "workbookVersionId": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "uuid"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "organizationId": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "uuid"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "organizationName": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "createdBy": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "ownerFirstName": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "ownerLastName": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "membersCount": {
+                                "type": "integer"
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "updatedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "data": {
+                                "type": "object",
+                                "properties": {
+                                  "columns": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "type_name": {
+                                          "type": "string"
+                                        },
+                                        "type_text": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "type_name",
+                                        "type_text"
+                                      ]
+                                    }
+                                  },
+                                  "rows": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "additionalProperties": {
+                                        "anyOf": [
+                                          {},
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "totalRows": {
+                                    "type": "integer"
+                                  },
+                                  "truncated": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "columns",
+                                  "rows",
+                                  "totalRows",
+                                  "truncated"
+                                ]
+                              },
+                              "locations": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "minLength": 1,
+                                      "maxLength": 255
+                                    },
+                                    "latitude": {
+                                      "type": "number",
+                                      "minimum": -90,
+                                      "maximum": 90
+                                    },
+                                    "longitude": {
+                                      "type": "number",
+                                      "minimum": -180,
+                                      "maximum": 180
+                                    },
+                                    "country": {
+                                      "type": "string"
+                                    },
+                                    "region": {
+                                      "type": "string"
+                                    },
+                                    "municipality": {
+                                      "type": "string"
+                                    },
+                                    "postalCode": {
+                                      "type": "string"
+                                    },
+                                    "addressLabel": {
+                                      "type": "string"
+                                    },
+                                    "createdAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "updatedAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "name",
+                                    "latitude",
+                                    "longitude",
+                                    "createdAt",
+                                    "updatedAt"
+                                  ]
+                                }
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name",
+                              "description",
+                              "status",
+                              "visibility",
+                              "embargoUntil",
+                              "anonymizeContributors",
+                              "workbookId",
+                              "workbookVersionId",
+                              "organizationId",
+                              "createdBy",
+                              "createdAt",
+                              "updatedAt"
+                            ]
+                          }
+                        },
+                        "page": {
+                          "type": "integer"
+                        },
+                        "pageSize": {
+                          "type": "integer"
+                        },
+                        "totalPages": {
+                          "type": "integer"
+                        },
+                        "totalCount": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "items",
+                        "page",
+                        "pageSize",
+                        "totalPages",
+                        "totalCount"
+                      ]
                     }
-                  },
-                  "required": [
-                    "items",
-                    "page",
-                    "pageSize",
-                    "totalPages",
-                    "totalCount"
                   ]
                 }
               }
@@ -17925,6 +17858,29 @@
             },
             "allowEmptyValue": true,
             "allowReserved": true
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "1-based page number"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "description": "Rows per page"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
           }
         ],
         "responses": {
@@ -17933,120 +17889,264 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "format": "uuid"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "filename": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "language": {
-                        "enum": [
-                          "python",
-                          "r",
-                          "javascript"
-                        ],
-                        "type": "string"
-                      },
-                      "code": {
-                        "type": "string"
-                      },
-                      "sortOrder": {
-                        "anyOf": [
-                          {
-                            "type": "number"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "createdBy": {
-                        "type": "string",
-                        "format": "uuid"
-                      },
-                      "createdByName": {
-                        "type": "string"
-                      },
-                      "forkedFrom": {
-                        "anyOf": [
-                          {
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
                             "type": "string",
                             "format": "uuid"
                           },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "organizationId": {
-                        "anyOf": [
-                          {
+                          "name": {
+                            "type": "string"
+                          },
+                          "filename": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "language": {
+                            "enum": [
+                              "python",
+                              "r",
+                              "javascript"
+                            ],
+                            "type": "string"
+                          },
+                          "code": {
+                            "type": "string"
+                          },
+                          "sortOrder": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "createdBy": {
                             "type": "string",
                             "format": "uuid"
                           },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "organizationName": {
-                        "anyOf": [
-                          {
+                          "createdByName": {
                             "type": "string"
                           },
-                          {
-                            "type": "null"
+                          "forkedFrom": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "organizationId": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "organizationName": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "visibility": {
+                            "enum": [
+                              "private",
+                              "public"
+                            ],
+                            "type": "string"
                           }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "filename",
+                          "description",
+                          "language",
+                          "code",
+                          "createdBy",
+                          "createdAt",
+                          "updatedAt",
+                          "organizationId",
+                          "visibility"
                         ]
-                      },
-                      "visibility": {
-                        "enum": [
-                          "private",
-                          "public"
-                        ],
-                        "type": "string"
                       }
                     },
-                    "required": [
-                      "id",
-                      "name",
-                      "filename",
-                      "description",
-                      "language",
-                      "code",
-                      "createdBy",
-                      "createdAt",
-                      "updatedAt",
-                      "organizationId",
-                      "visibility"
-                    ]
-                  }
+                    {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "filename": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "language": {
+                                "enum": [
+                                  "python",
+                                  "r",
+                                  "javascript"
+                                ],
+                                "type": "string"
+                              },
+                              "code": {
+                                "type": "string"
+                              },
+                              "sortOrder": {
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "createdBy": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "createdByName": {
+                                "type": "string"
+                              },
+                              "forkedFrom": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "uuid"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "updatedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "organizationId": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "uuid"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "organizationName": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "visibility": {
+                                "enum": [
+                                  "private",
+                                  "public"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name",
+                              "filename",
+                              "description",
+                              "language",
+                              "code",
+                              "createdBy",
+                              "createdAt",
+                              "updatedAt",
+                              "organizationId",
+                              "visibility"
+                            ]
+                          }
+                        },
+                        "page": {
+                          "type": "integer"
+                        },
+                        "pageSize": {
+                          "type": "integer"
+                        },
+                        "totalPages": {
+                          "type": "integer"
+                        },
+                        "totalCount": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "items",
+                        "page",
+                        "pageSize",
+                        "totalPages",
+                        "totalCount"
+                      ]
+                    }
+                  ]
                 }
               }
             }
@@ -18223,237 +18323,6 @@
                     "updatedAt",
                     "organizationId",
                     "visibility"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/macros/paginated": {
-      "get": {
-        "operationId": "macros.listMacrosPaginated",
-        "parameters": [
-          {
-            "name": "search",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          },
-          {
-            "name": "language",
-            "in": "query",
-            "schema": {
-              "enum": [
-                "python",
-                "r",
-                "javascript"
-              ],
-              "type": "string"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          },
-          {
-            "name": "filter",
-            "in": "query",
-            "schema": {
-              "enum": [
-                "my"
-              ],
-              "type": "string",
-              "description": "Deprecated alias for scope=related"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          },
-          {
-            "name": "scope",
-            "in": "query",
-            "schema": {
-              "enum": [
-                "related",
-                "all"
-              ],
-              "type": "string",
-              "description": "Which slice of the accessible set to return"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "schema": {
-              "default": 1,
-              "type": "integer",
-              "minimum": 1,
-              "description": "1-based page number"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "schema": {
-              "default": 20,
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100,
-              "description": "Rows per page"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "items": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "filename": {
-                            "type": "string"
-                          },
-                          "description": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "language": {
-                            "enum": [
-                              "python",
-                              "r",
-                              "javascript"
-                            ],
-                            "type": "string"
-                          },
-                          "code": {
-                            "type": "string"
-                          },
-                          "sortOrder": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "createdBy": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "createdByName": {
-                            "type": "string"
-                          },
-                          "forkedFrom": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "createdAt": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "updatedAt": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "organizationId": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "organizationName": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "visibility": {
-                            "enum": [
-                              "private",
-                              "public"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "name",
-                          "filename",
-                          "description",
-                          "language",
-                          "code",
-                          "createdBy",
-                          "createdAt",
-                          "updatedAt",
-                          "organizationId",
-                          "visibility"
-                        ]
-                      }
-                    },
-                    "page": {
-                      "type": "integer"
-                    },
-                    "pageSize": {
-                      "type": "integer"
-                    },
-                    "totalPages": {
-                      "type": "integer"
-                    },
-                    "totalCount": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "items",
-                    "page",
-                    "pageSize",
-                    "totalPages",
-                    "totalCount"
                   ]
                 }
               }
@@ -21207,6 +21076,29 @@
             },
             "allowEmptyValue": true,
             "allowReserved": true
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "1-based page number"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "description": "Rows per page"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
           }
         ],
         "responses": {
@@ -21215,116 +21107,256 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "format": "uuid"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "code": {},
-                      "family": {
-                        "enum": [
-                          "multispeq",
-                          "ambyte",
-                          "minipar",
-                          "generic",
-                          "ambit"
-                        ],
-                        "type": "string"
-                      },
-                      "sortOrder": {
-                        "anyOf": [
-                          {
-                            "type": "number"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "createdBy": {
-                        "type": "string",
-                        "format": "uuid"
-                      },
-                      "createdByName": {
-                        "type": "string"
-                      },
-                      "forkedFrom": {
-                        "anyOf": [
-                          {
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
                             "type": "string",
                             "format": "uuid"
                           },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "organizationId": {
-                        "anyOf": [
-                          {
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "code": {},
+                          "family": {
+                            "enum": [
+                              "multispeq",
+                              "ambyte",
+                              "minipar",
+                              "generic",
+                              "ambit"
+                            ],
+                            "type": "string"
+                          },
+                          "sortOrder": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "createdBy": {
                             "type": "string",
                             "format": "uuid"
                           },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "organizationName": {
-                        "anyOf": [
-                          {
+                          "createdByName": {
                             "type": "string"
                           },
-                          {
-                            "type": "null"
+                          "forkedFrom": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "organizationId": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "organizationName": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "visibility": {
+                            "enum": [
+                              "private",
+                              "public"
+                            ],
+                            "type": "string"
                           }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "description",
+                          "family",
+                          "sortOrder",
+                          "createdBy",
+                          "createdAt",
+                          "updatedAt",
+                          "organizationId",
+                          "visibility"
                         ]
-                      },
-                      "visibility": {
-                        "enum": [
-                          "private",
-                          "public"
-                        ],
-                        "type": "string"
                       }
                     },
-                    "required": [
-                      "id",
-                      "name",
-                      "description",
-                      "family",
-                      "sortOrder",
-                      "createdBy",
-                      "createdAt",
-                      "updatedAt",
-                      "organizationId",
-                      "visibility"
-                    ]
-                  }
+                    {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "code": {},
+                              "family": {
+                                "enum": [
+                                  "multispeq",
+                                  "ambyte",
+                                  "minipar",
+                                  "generic",
+                                  "ambit"
+                                ],
+                                "type": "string"
+                              },
+                              "sortOrder": {
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "createdBy": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "createdByName": {
+                                "type": "string"
+                              },
+                              "forkedFrom": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "uuid"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "updatedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "organizationId": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "uuid"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "organizationName": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "visibility": {
+                                "enum": [
+                                  "private",
+                                  "public"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name",
+                              "description",
+                              "family",
+                              "sortOrder",
+                              "createdBy",
+                              "createdAt",
+                              "updatedAt",
+                              "organizationId",
+                              "visibility"
+                            ]
+                          }
+                        },
+                        "page": {
+                          "type": "integer"
+                        },
+                        "pageSize": {
+                          "type": "integer"
+                        },
+                        "totalPages": {
+                          "type": "integer"
+                        },
+                        "totalCount": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "items",
+                        "page",
+                        "pageSize",
+                        "totalPages",
+                        "totalCount"
+                      ]
+                    }
+                  ]
                 }
               }
             }
@@ -21875,219 +21907,6 @@
                     "updatedAt",
                     "organizationId",
                     "visibility"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/protocols/paginated": {
-      "get": {
-        "operationId": "protocols.listProtocolsPaginated",
-        "parameters": [
-          {
-            "name": "search",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          },
-          {
-            "name": "filter",
-            "in": "query",
-            "schema": {
-              "enum": [
-                "my"
-              ],
-              "type": "string",
-              "description": "Deprecated alias for scope=related"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          },
-          {
-            "name": "scope",
-            "in": "query",
-            "schema": {
-              "enum": [
-                "related",
-                "all"
-              ],
-              "type": "string",
-              "description": "Which slice of the accessible set to return"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "schema": {
-              "default": 1,
-              "type": "integer",
-              "minimum": 1,
-              "description": "1-based page number"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "schema": {
-              "default": 20,
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100,
-              "description": "Rows per page"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "items": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "description": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "code": {},
-                          "family": {
-                            "enum": [
-                              "multispeq",
-                              "ambyte",
-                              "minipar",
-                              "generic",
-                              "ambit"
-                            ],
-                            "type": "string"
-                          },
-                          "sortOrder": {
-                            "anyOf": [
-                              {
-                                "type": "number"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "createdBy": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "createdByName": {
-                            "type": "string"
-                          },
-                          "forkedFrom": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "createdAt": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "updatedAt": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "organizationId": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "organizationName": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "visibility": {
-                            "enum": [
-                              "private",
-                              "public"
-                            ],
-                            "type": "string"
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "name",
-                          "description",
-                          "family",
-                          "sortOrder",
-                          "createdBy",
-                          "createdAt",
-                          "updatedAt",
-                          "organizationId",
-                          "visibility"
-                        ]
-                      }
-                    },
-                    "page": {
-                      "type": "integer"
-                    },
-                    "pageSize": {
-                      "type": "integer"
-                    },
-                    "totalPages": {
-                      "type": "integer"
-                    },
-                    "totalCount": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "items",
-                    "page",
-                    "pageSize",
-                    "totalPages",
-                    "totalCount"
                   ]
                 }
               }
@@ -26137,6 +25956,29 @@
             },
             "allowEmptyValue": true,
             "allowReserved": true
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "1-based page number"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "description": "Rows per page"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
           }
         ],
         "responses": {
@@ -26145,112 +25987,248 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string",
-                        "format": "uuid"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "metadata": {
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
                         "type": "object",
-                        "additionalProperties": {}
-                      },
-                      "organizationId": {
-                        "anyOf": [
-                          {
+                        "properties": {
+                          "id": {
                             "type": "string",
                             "format": "uuid"
                           },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "organizationName": {
-                        "anyOf": [
-                          {
+                          "name": {
                             "type": "string"
                           },
-                          {
-                            "type": "null"
-                          }
-                        ]
-                      },
-                      "visibility": {
-                        "enum": [
-                          "private",
-                          "public"
-                        ],
-                        "type": "string"
-                      },
-                      "createdBy": {
-                        "type": "string",
-                        "format": "uuid"
-                      },
-                      "createdByName": {
-                        "type": "string"
-                      },
-                      "forkedFrom": {
-                        "anyOf": [
-                          {
+                          "description": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "metadata": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          },
+                          "organizationId": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "organizationName": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "visibility": {
+                            "enum": [
+                              "private",
+                              "public"
+                            ],
+                            "type": "string"
+                          },
+                          "createdBy": {
                             "type": "string",
                             "format": "uuid"
                           },
-                          {
-                            "type": "null"
+                          "createdByName": {
+                            "type": "string"
+                          },
+                          "forkedFrom": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "isUpgradable": {
+                            "type": "boolean"
+                          },
+                          "experimentCount": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "cellTypeCounts": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "integer",
+                              "minimum": 0
+                            }
                           }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "description",
+                          "metadata",
+                          "organizationId",
+                          "visibility",
+                          "createdBy",
+                          "createdAt",
+                          "updatedAt"
                         ]
-                      },
-                      "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "updatedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      "isUpgradable": {
-                        "type": "boolean"
-                      },
-                      "experimentCount": {
-                        "type": "integer",
-                        "minimum": 0
-                      },
-                      "cellTypeCounts": {
-                        "type": "object",
-                        "additionalProperties": {
-                          "type": "integer",
-                          "minimum": 0
-                        }
                       }
                     },
-                    "required": [
-                      "id",
-                      "name",
-                      "description",
-                      "metadata",
-                      "organizationId",
-                      "visibility",
-                      "createdBy",
-                      "createdAt",
-                      "updatedAt"
-                    ]
-                  }
+                    {
+                      "type": "object",
+                      "properties": {
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "metadata": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              },
+                              "organizationId": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "uuid"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "organizationName": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "visibility": {
+                                "enum": [
+                                  "private",
+                                  "public"
+                                ],
+                                "type": "string"
+                              },
+                              "createdBy": {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              "createdByName": {
+                                "type": "string"
+                              },
+                              "forkedFrom": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "uuid"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "createdAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "updatedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                              },
+                              "isUpgradable": {
+                                "type": "boolean"
+                              },
+                              "experimentCount": {
+                                "type": "integer",
+                                "minimum": 0
+                              },
+                              "cellTypeCounts": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "integer",
+                                  "minimum": 0
+                                }
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name",
+                              "description",
+                              "metadata",
+                              "organizationId",
+                              "visibility",
+                              "createdBy",
+                              "createdAt",
+                              "updatedAt"
+                            ]
+                          }
+                        },
+                        "page": {
+                          "type": "integer"
+                        },
+                        "pageSize": {
+                          "type": "integer"
+                        },
+                        "totalPages": {
+                          "type": "integer"
+                        },
+                        "totalCount": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "items",
+                        "page",
+                        "pageSize",
+                        "totalPages",
+                        "totalCount"
+                      ]
+                    }
+                  ]
                 }
               }
             }
@@ -27329,215 +27307,6 @@
                     "createdBy",
                     "createdAt",
                     "updatedAt"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/workbooks/paginated": {
-      "get": {
-        "operationId": "workbooks.listWorkbooksPaginated",
-        "parameters": [
-          {
-            "name": "search",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          },
-          {
-            "name": "filter",
-            "in": "query",
-            "schema": {
-              "enum": [
-                "my"
-              ],
-              "type": "string",
-              "description": "Deprecated alias for scope=related"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          },
-          {
-            "name": "scope",
-            "in": "query",
-            "schema": {
-              "enum": [
-                "related",
-                "all"
-              ],
-              "type": "string",
-              "description": "Which slice of the accessible set to return"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "schema": {
-              "default": 1,
-              "type": "integer",
-              "minimum": 1,
-              "description": "1-based page number"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "schema": {
-              "default": 20,
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100,
-              "description": "Rows per page"
-            },
-            "allowEmptyValue": true,
-            "allowReserved": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "items": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "name": {
-                            "type": "string"
-                          },
-                          "description": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "metadata": {
-                            "type": "object",
-                            "additionalProperties": {}
-                          },
-                          "organizationId": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "organizationName": {
-                            "anyOf": [
-                              {
-                                "type": "string"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "visibility": {
-                            "enum": [
-                              "private",
-                              "public"
-                            ],
-                            "type": "string"
-                          },
-                          "createdBy": {
-                            "type": "string",
-                            "format": "uuid"
-                          },
-                          "createdByName": {
-                            "type": "string"
-                          },
-                          "forkedFrom": {
-                            "anyOf": [
-                              {
-                                "type": "string",
-                                "format": "uuid"
-                              },
-                              {
-                                "type": "null"
-                              }
-                            ]
-                          },
-                          "createdAt": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "updatedAt": {
-                            "type": "string",
-                            "format": "date-time"
-                          },
-                          "isUpgradable": {
-                            "type": "boolean"
-                          },
-                          "experimentCount": {
-                            "type": "integer",
-                            "minimum": 0
-                          },
-                          "cellTypeCounts": {
-                            "type": "object",
-                            "additionalProperties": {
-                              "type": "integer",
-                              "minimum": 0
-                            }
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "name",
-                          "description",
-                          "metadata",
-                          "organizationId",
-                          "visibility",
-                          "createdBy",
-                          "createdAt",
-                          "updatedAt"
-                        ]
-                      }
-                    },
-                    "page": {
-                      "type": "integer"
-                    },
-                    "pageSize": {
-                      "type": "integer"
-                    },
-                    "totalPages": {
-                      "type": "integer"
-                    },
-                    "totalCount": {
-                      "type": "integer"
-                    }
-                  },
-                  "required": [
-                    "items",
-                    "page",
-                    "pageSize",
-                    "totalPages",
-                    "totalCount"
                   ]
                 }
               }

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -426,7 +426,21 @@
                 "member"
               ],
               "type": "string",
-              "description": "Filter experiments by relationship to the user"
+              "description": "Deprecated alias for scope=related"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "related",
+                "all"
+              ],
+              "type": "string",
+              "description": "Which slice of the accessible set to return"
             },
             "allowEmptyValue": true,
             "allowReserved": true
@@ -711,6 +725,373 @@
                       "updatedAt"
                     ]
                   }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/experiments/paginated": {
+      "get": {
+        "operationId": "experiments.listExperimentsPaginated",
+        "parameters": [
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "member"
+              ],
+              "type": "string",
+              "description": "Deprecated alias for scope=related"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "related",
+                "all"
+              ],
+              "type": "string",
+              "description": "Which slice of the accessible set to return"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "active",
+                "stale",
+                "archived",
+                "published"
+              ],
+              "type": "string",
+              "description": "Filter experiments by their status"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "description": "Search term for experiment name"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1,
+              "description": "1-based page number"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "description": "Rows per page"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "status": {
+                            "enum": [
+                              "active",
+                              "stale",
+                              "archived",
+                              "published"
+                            ],
+                            "type": "string"
+                          },
+                          "visibility": {
+                            "enum": [
+                              "private",
+                              "public"
+                            ],
+                            "type": "string"
+                          },
+                          "embargoUntil": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "anonymizeContributors": {
+                            "type": "boolean"
+                          },
+                          "workbookId": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "workbookVersionId": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "organizationId": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "organizationName": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "createdBy": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "ownerFirstName": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "ownerLastName": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "data": {
+                            "type": "object",
+                            "properties": {
+                              "columns": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "type_name": {
+                                      "type": "string"
+                                    },
+                                    "type_text": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "name",
+                                    "type_name",
+                                    "type_text"
+                                  ]
+                                }
+                              },
+                              "rows": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {},
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              "totalRows": {
+                                "type": "integer"
+                              },
+                              "truncated": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "columns",
+                              "rows",
+                              "totalRows",
+                              "truncated"
+                            ]
+                          },
+                          "locations": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string",
+                                  "format": "uuid"
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "minLength": 1,
+                                  "maxLength": 255
+                                },
+                                "latitude": {
+                                  "type": "number",
+                                  "minimum": -90,
+                                  "maximum": 90
+                                },
+                                "longitude": {
+                                  "type": "number",
+                                  "minimum": -180,
+                                  "maximum": 180
+                                },
+                                "country": {
+                                  "type": "string"
+                                },
+                                "region": {
+                                  "type": "string"
+                                },
+                                "municipality": {
+                                  "type": "string"
+                                },
+                                "postalCode": {
+                                  "type": "string"
+                                },
+                                "addressLabel": {
+                                  "type": "string"
+                                },
+                                "createdAt": {
+                                  "type": "string",
+                                  "format": "date-time"
+                                },
+                                "updatedAt": {
+                                  "type": "string",
+                                  "format": "date-time"
+                                }
+                              },
+                              "required": [
+                                "id",
+                                "name",
+                                "latitude",
+                                "longitude",
+                                "createdAt",
+                                "updatedAt"
+                              ]
+                            }
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "description",
+                          "status",
+                          "visibility",
+                          "embargoUntil",
+                          "anonymizeContributors",
+                          "workbookId",
+                          "workbookVersionId",
+                          "organizationId",
+                          "createdBy",
+                          "createdAt",
+                          "updatedAt"
+                        ]
+                      }
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "pageSize": {
+                      "type": "integer"
+                    },
+                    "totalPages": {
+                      "type": "integer"
+                    },
+                    "totalCount": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "page",
+                    "pageSize",
+                    "totalPages",
+                    "totalCount"
+                  ]
                 }
               }
             }
@@ -17504,7 +17885,22 @@
               "enum": [
                 "my"
               ],
-              "type": "string"
+              "type": "string",
+              "description": "Deprecated alias for scope=related"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "related",
+                "all"
+              ],
+              "type": "string",
+              "description": "Which slice of the accessible set to return"
             },
             "allowEmptyValue": true,
             "allowReserved": true
@@ -17806,6 +18202,237 @@
                     "updatedAt",
                     "organizationId",
                     "visibility"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/macros/paginated": {
+      "get": {
+        "operationId": "macros.listMacrosPaginated",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "language",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "python",
+                "r",
+                "javascript"
+              ],
+              "type": "string"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "my"
+              ],
+              "type": "string",
+              "description": "Deprecated alias for scope=related"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "related",
+                "all"
+              ],
+              "type": "string",
+              "description": "Which slice of the accessible set to return"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1,
+              "description": "1-based page number"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "description": "Rows per page"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "filename": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "language": {
+                            "enum": [
+                              "python",
+                              "r",
+                              "javascript"
+                            ],
+                            "type": "string"
+                          },
+                          "code": {
+                            "type": "string"
+                          },
+                          "sortOrder": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "createdBy": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "createdByName": {
+                            "type": "string"
+                          },
+                          "forkedFrom": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "organizationId": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "organizationName": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "visibility": {
+                            "enum": [
+                              "private",
+                              "public"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "filename",
+                          "description",
+                          "language",
+                          "code",
+                          "createdBy",
+                          "createdAt",
+                          "updatedAt",
+                          "organizationId",
+                          "visibility"
+                        ]
+                      }
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "pageSize": {
+                      "type": "integer"
+                    },
+                    "totalPages": {
+                      "type": "integer"
+                    },
+                    "totalCount": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "page",
+                    "pageSize",
+                    "totalPages",
+                    "totalCount"
                   ]
                 }
               }
@@ -20540,7 +21167,22 @@
               "enum": [
                 "my"
               ],
-              "type": "string"
+              "type": "string",
+              "description": "Deprecated alias for scope=related"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "related",
+                "all"
+              ],
+              "type": "string",
+              "description": "Which slice of the accessible set to return"
             },
             "allowEmptyValue": true,
             "allowReserved": true
@@ -21212,6 +21854,219 @@
                     "updatedAt",
                     "organizationId",
                     "visibility"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/protocols/paginated": {
+      "get": {
+        "operationId": "protocols.listProtocolsPaginated",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "my"
+              ],
+              "type": "string",
+              "description": "Deprecated alias for scope=related"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "related",
+                "all"
+              ],
+              "type": "string",
+              "description": "Which slice of the accessible set to return"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1,
+              "description": "1-based page number"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "description": "Rows per page"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "code": {},
+                          "family": {
+                            "enum": [
+                              "multispeq",
+                              "ambyte",
+                              "minipar",
+                              "generic",
+                              "ambit"
+                            ],
+                            "type": "string"
+                          },
+                          "sortOrder": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "createdBy": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "createdByName": {
+                            "type": "string"
+                          },
+                          "forkedFrom": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "organizationId": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "organizationName": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "visibility": {
+                            "enum": [
+                              "private",
+                              "public"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "description",
+                          "family",
+                          "sortOrder",
+                          "createdBy",
+                          "createdAt",
+                          "updatedAt",
+                          "organizationId",
+                          "visibility"
+                        ]
+                      }
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "pageSize": {
+                      "type": "integer"
+                    },
+                    "totalPages": {
+                      "type": "integer"
+                    },
+                    "totalCount": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "page",
+                    "pageSize",
+                    "totalPages",
+                    "totalCount"
                   ]
                 }
               }
@@ -25242,7 +26097,22 @@
               "enum": [
                 "my"
               ],
-              "type": "string"
+              "type": "string",
+              "description": "Deprecated alias for scope=related"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "related",
+                "all"
+              ],
+              "type": "string",
+              "description": "Which slice of the accessible set to return"
             },
             "allowEmptyValue": true,
             "allowReserved": true
@@ -26438,6 +27308,215 @@
                     "createdBy",
                     "createdAt",
                     "updatedAt"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/workbooks/paginated": {
+      "get": {
+        "operationId": "workbooks.listWorkbooksPaginated",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "my"
+              ],
+              "type": "string",
+              "description": "Deprecated alias for scope=related"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "related",
+                "all"
+              ],
+              "type": "string",
+              "description": "Which slice of the accessible set to return"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "default": 1,
+              "type": "integer",
+              "minimum": 1,
+              "description": "1-based page number"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "default": 20,
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "description": "Rows per page"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "metadata": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          },
+                          "organizationId": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "organizationName": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "visibility": {
+                            "enum": [
+                              "private",
+                              "public"
+                            ],
+                            "type": "string"
+                          },
+                          "createdBy": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "createdByName": {
+                            "type": "string"
+                          },
+                          "forkedFrom": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "format": "uuid"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "updatedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "isUpgradable": {
+                            "type": "boolean"
+                          },
+                          "experimentCount": {
+                            "type": "integer",
+                            "minimum": 0
+                          },
+                          "cellTypeCounts": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "integer",
+                              "minimum": 0
+                            }
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "description",
+                          "metadata",
+                          "organizationId",
+                          "visibility",
+                          "createdBy",
+                          "createdAt",
+                          "updatedAt"
+                        ]
+                      }
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "pageSize": {
+                      "type": "integer"
+                    },
+                    "totalPages": {
+                      "type": "integer"
+                    },
+                    "totalCount": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "page",
+                    "pageSize",
+                    "totalPages",
+                    "totalCount"
                   ]
                 }
               }

--- a/apps/mobile/src/features/experiments/hooks/use-experiment-workbook-ref.ts
+++ b/apps/mobile/src/features/experiments/hooks/use-experiment-workbook-ref.ts
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { orpc } from "~/shared/api/orpc";
 
+import { listItems } from "@repo/api/shared/listing";
+
 /**
  * The workbook a given experiment is backed by. Reads the same cached (and
  * persisted) `listExperiments` entry the pickers use, so it resolves offline
@@ -22,7 +24,7 @@ export function useExperimentWorkbookRef(experimentId: string | undefined): {
     }),
   );
 
-  const experiment = experimentId ? data?.find((e) => e.id === experimentId) : undefined;
+  const experiment = experimentId ? listItems(data).find((e) => e.id === experimentId) : undefined;
   return {
     workbookId: experiment?.workbookId ?? undefined,
     isLoading,

--- a/apps/mobile/src/features/experiments/hooks/use-experiments.ts
+++ b/apps/mobile/src/features/experiments/hooks/use-experiments.ts
@@ -3,6 +3,8 @@ import { orpc } from "~/shared/api/orpc";
 import { ellipsize } from "~/shared/utils/ellipsize";
 import { extractTextFromHTML } from "~/shared/utils/extract-text-from-html";
 
+import { listItems } from "@repo/api/shared/listing";
+
 export function useExperiments() {
   const { data, isLoading, error, refetch, isRefetching } = useQuery(
     orpc.experiments.listExperiments.queryOptions({
@@ -20,15 +22,14 @@ export function useExperiments() {
     }),
   );
 
-  const options =
-    data?.map((item) => ({
-      value: item.id,
-      label: item.name,
-      description: item.description
-        ? ellipsize(extractTextFromHTML(item.description), 100)
-        : undefined,
-      fullDescription: item.description,
-    })) ?? [];
+  const options = listItems(data).map((item) => ({
+    value: item.id,
+    label: item.name,
+    description: item.description
+      ? ellipsize(extractTextFromHTML(item.description), 100)
+      : undefined,
+    fullDescription: item.description,
+  }));
 
   return { experiments: options, isLoading, error, refetch, isRefetching };
 }

--- a/apps/mobile/src/features/experiments/hooks/use-precached-experiment-data.ts
+++ b/apps/mobile/src/features/experiments/hooks/use-precached-experiment-data.ts
@@ -1,6 +1,8 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { orpc } from "~/shared/api/orpc";
 
+import { listItems } from "@repo/api/shared/listing";
+
 interface ExperimentRef {
   id: string;
   workbookId: string | null;
@@ -15,7 +17,7 @@ function findExperimentRef(
   const cached = queryClient.getQueryData(
     orpc.experiments.listExperiments.queryKey({ input: { filter: "member" } }),
   );
-  return cached?.find((e) => e.id === experimentId);
+  return listItems(cached).find((e) => e.id === experimentId);
 }
 
 // Finite so an incomplete (offline/failed) precache can retry on reconnect.

--- a/apps/mobile/src/features/measurement-flow/hooks/use-load-experiment-flow.ts
+++ b/apps/mobile/src/features/measurement-flow/hooks/use-load-experiment-flow.ts
@@ -5,6 +5,7 @@ import { useMeasurementFlowStore } from "~/features/measurement-flow/stores/use-
 import { hydrateFlowNodes } from "~/features/measurement-flow/utils/hydrate-flow-nodes";
 import { orpc } from "~/shared/api/orpc";
 
+import { listItems } from "@repo/api/shared/listing";
 import { cellsToFlowGraph } from "@repo/api/transforms/cells-to-flow";
 
 // Loads an experiment's workbook flow into the store: fetch the workbook version
@@ -31,7 +32,7 @@ export function useLoadExperimentFlow(experimentId: string | undefined): {
     }),
   );
 
-  const selected = experimentsData?.find((e) => e.id === experimentId);
+  const selected = listItems(experimentsData).find((e) => e.id === experimentId);
   const workbookId = selected?.workbookId ?? undefined;
   const workbookVersionId = selected?.workbookVersionId ?? undefined;
   const hasWorkbook = !!workbookId && !!workbookVersionId;

--- a/apps/mobile/src/features/measurement-flow/hooks/use-protocols.ts
+++ b/apps/mobile/src/features/measurement-flow/hooks/use-protocols.ts
@@ -3,6 +3,8 @@ import { orpc } from "~/shared/api/orpc";
 import { ellipsize } from "~/shared/utils/ellipsize";
 import { extractTextFromHTML } from "~/shared/utils/extract-text-from-html";
 
+import { listItems } from "@repo/api/shared/listing";
+
 export function useProtocols() {
   const { data, isLoading, error } = useQuery(
     orpc.protocols.listProtocols.queryOptions({
@@ -11,15 +13,14 @@ export function useProtocols() {
     }),
   );
 
-  const options =
-    data?.map((item) => ({
-      value: item.id,
-      label: item.name,
-      description: item.description
-        ? ellipsize(extractTextFromHTML(item.description), 100)
-        : undefined,
-      code: item.code,
-    })) ?? [];
+  const options = listItems(data).map((item) => ({
+    value: item.id,
+    label: item.name,
+    description: item.description
+      ? ellipsize(extractTextFromHTML(item.description), 100)
+      : undefined,
+    code: item.code,
+  }));
 
   return { protocols: options, isLoading, error };
 }

--- a/apps/web/app/[locale]/platform/devices/[deviceId]/monitoring/device-monitoring-content.tsx
+++ b/apps/web/app/[locale]/platform/devices/[deviceId]/monitoring/device-monitoring-content.tsx
@@ -27,6 +27,7 @@ import { useParams } from "next/navigation";
 import { useState } from "react";
 
 import type { DeviceMonitoring } from "@repo/api/domains/iot/iot.schema";
+import { listItems } from "@repo/api/shared/listing";
 import { useTranslation } from "@repo/i18n";
 import { Button } from "@repo/ui/components/button";
 import { Card, CardContent } from "@repo/ui/components/card";
@@ -160,8 +161,8 @@ export default function DeviceMonitoringPage() {
             <ThroughputPanel
               monitoring={monitoring}
               boundExperiments={boundExperiments ?? []}
-              visibleExperiments={visibleExperiments ?? []}
-              visibleProtocols={visibleProtocols ?? []}
+              visibleExperiments={listItems(visibleExperiments)}
+              visibleProtocols={listItems(visibleProtocols)}
               locale={locale}
               from={selection.range.from}
               to={selection.range.to}
@@ -175,7 +176,7 @@ export default function DeviceMonitoringPage() {
             <DataByExperiment
               monitoring={monitoring}
               boundExperiments={boundExperiments ?? []}
-              visibleExperiments={visibleExperiments ?? []}
+              visibleExperiments={listItems(visibleExperiments)}
               locale={locale}
             />
           </PanelCard>
@@ -183,9 +184,9 @@ export default function DeviceMonitoringPage() {
           <PanelCard title={t("iot.devices.monitoring.payloadTitle")}>
             <PayloadProfile
               payload={monitoring.payload}
-              visibleProtocols={visibleProtocols ?? []}
-              visibleWorkbooks={visibleWorkbooks ?? []}
-              visibleMacros={visibleMacros ?? []}
+              visibleProtocols={listItems(visibleProtocols)}
+              visibleWorkbooks={listItems(visibleWorkbooks)}
+              visibleMacros={listItems(visibleMacros)}
               locale={locale}
             />
           </PanelCard>

--- a/apps/web/components/iot-devices/device-onboarding-panel.tsx
+++ b/apps/web/components/iot-devices/device-onboarding-panel.tsx
@@ -20,6 +20,7 @@ import type {
   DeviceOnboardingConfig,
   IotDevice,
 } from "@repo/api/domains/iot/iot.schema";
+import { listItems } from "@repo/api/shared/listing";
 import { applyPlanAnswers } from "@repo/api/transforms/workbook-device-plan";
 import { useTranslation } from "@repo/i18n";
 import { Alert, AlertDescription } from "@repo/ui/components/alert";
@@ -96,7 +97,7 @@ export function DeviceOnboardingPanel({ device }: { device: IotDevice }) {
     refetch: refetchExperiments,
   } = useQuery(orpc.experiments.listExperiments.queryOptions({ input: { filter: "member" } }));
   const selectable = useMemo(
-    () => (experimentsData ?? []).filter((experiment) => !boundIds.has(experiment.id)),
+    () => listItems(experimentsData).filter((experiment) => !boundIds.has(experiment.id)),
     [experimentsData, boundIds],
   );
 

--- a/apps/web/components/iot-devices/device-overview-cards.tsx
+++ b/apps/web/components/iot-devices/device-overview-cards.tsx
@@ -20,6 +20,7 @@ import Link from "next/link";
 import { useMemo } from "react";
 
 import type { IotDeviceDetail, ObservedExperiment } from "@repo/api/domains/iot/iot.schema";
+import { listItems } from "@repo/api/shared/listing";
 import { useTranslation } from "@repo/i18n";
 import { Badge } from "@repo/ui/components/badge";
 import { Button } from "@repo/ui/components/button";
@@ -91,7 +92,7 @@ export function DeviceOverviewCards({ device }: DeviceOverviewCardsProps) {
   );
   const observedEntities = resolveEntities(
     observed.flatMap((entry) => (entry.experimentId === null ? [] : [entry.experimentId])),
-    (visibleExperiments ?? []).map((experiment) => ({
+    listItems(visibleExperiments).map((experiment) => ({
       id: experiment.id,
       name: experiment.name,
     })),

--- a/apps/web/components/iot-devices/groups/group-monitoring-content.tsx
+++ b/apps/web/components/iot-devices/groups/group-monitoring-content.tsx
@@ -18,6 +18,7 @@ import { useParams } from "next/navigation";
 import { useState } from "react";
 
 import type { IotDeviceGroupMemberHealth } from "@repo/api/domains/iot/device-group/iot-device-group.schema";
+import { listItems } from "@repo/api/shared/listing";
 import { useTranslation } from "@repo/i18n";
 import { Button } from "@repo/ui/components/button";
 import { Card, CardContent } from "@repo/ui/components/card";
@@ -228,7 +229,7 @@ export function GroupMonitoringContent() {
           >
             <GroupDataByExperimentPanel
               dataByExperiment={monitoring.dataByExperiment}
-              visibleExperiments={visibleExperiments ?? []}
+              visibleExperiments={listItems(visibleExperiments)}
               locale={locale}
             />
           </PanelCard>

--- a/apps/web/components/iot-devices/groups/group-onboarding-content.tsx
+++ b/apps/web/components/iot-devices/groups/group-onboarding-content.tsx
@@ -22,6 +22,7 @@ import type {
   IotDeviceGroupOnboardRow,
 } from "@repo/api/domains/iot/device-group/iot-device-group.schema";
 import type { DeviceAnswer } from "@repo/api/domains/iot/iot.schema";
+import { listItems } from "@repo/api/shared/listing";
 import { useTranslation } from "@repo/i18n";
 import { Badge } from "@repo/ui/components/badge";
 import { Button } from "@repo/ui/components/button";
@@ -62,7 +63,7 @@ export function GroupOnboardingContent() {
   const { data: experimentsData } = useQuery(
     orpc.experiments.listExperiments.queryOptions({ input: { filter: "member" } }),
   );
-  const experiments = experimentsData ?? [];
+  const experiments = listItems(experimentsData);
 
   const [experimentIds, setExperimentIds] = useState<string[]>([]);
   const [deselectedIds, setDeselectedIds] = useState<Set<string>>(new Set());

--- a/apps/web/components/iot-devices/lineage/device-lineage-content.tsx
+++ b/apps/web/components/iot-devices/lineage/device-lineage-content.tsx
@@ -21,6 +21,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useParams } from "next/navigation";
 import { useMemo, useState } from "react";
 
+import { listItems } from "@repo/api/shared/listing";
 import { useTranslation } from "@repo/i18n";
 import { Button } from "@repo/ui/components/button";
 import { Card, CardContent } from "@repo/ui/components/card";
@@ -112,10 +113,10 @@ export default function DeviceLineagePage() {
       monitoring,
       lastDataAt: activity?.lastDataAt ?? null,
       boundExperiments: boundExperiments ?? [],
-      visibleExperiments: visibleExperiments ?? [],
-      visibleProtocols: visibleProtocols ?? [],
-      visibleWorkbooks: visibleWorkbooks ?? [],
-      visibleMacros: visibleMacros ?? [],
+      visibleExperiments: listItems(visibleExperiments),
+      visibleProtocols: listItems(visibleProtocols),
+      visibleWorkbooks: listItems(visibleWorkbooks),
+      visibleMacros: listItems(visibleMacros),
       locale,
       labels: {
         privateExperiment: (index) => t("iot.devices.monitoring.privateExperiment", { index }),

--- a/apps/web/components/new-protocol/new-protocol-details-card.tsx
+++ b/apps/web/components/new-protocol/new-protocol-details-card.tsx
@@ -9,6 +9,7 @@ import { useMemo, useState } from "react";
 import type { UseFormReturn } from "react-hook-form";
 
 import type { Macro } from "@repo/api/domains/macro/macro.schema";
+import { listItems } from "@repo/api/shared/listing";
 import { useTranslation } from "@repo/i18n";
 import { Button } from "@repo/ui/components/button";
 import {
@@ -51,11 +52,15 @@ export function NewProtocolDetailsCard({
   // Macro search
   const [macroSearch, setMacroSearch] = useState("");
   const [debouncedMacroSearch, isDebounced] = useDebounce(macroSearch, 300);
-  const { data: macroData } = useQuery(
+  const { data: macroResponse } = useQuery(
     orpc.macros.listMacros.queryOptions({
       input: { search: debouncedMacroSearch || undefined },
     }),
   );
+
+  // Narrowed to the array shape: no `page` is sent here, so the response is always
+  // the bare list. Deletable once this caller migrates to the envelope.
+  const macroData = macroResponse ? listItems(macroResponse) : undefined;
   const macroList = macroData;
 
   const selectedMacroIds = useMemo(

--- a/apps/web/components/protocol-settings/protocol-compatible-macros-card.tsx
+++ b/apps/web/components/protocol-settings/protocol-compatible-macros-card.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { useMemo, useState } from "react";
 
 import type { Macro } from "@repo/api/domains/macro/macro.schema";
+import { listItems } from "@repo/api/shared/listing";
 import { useTranslation } from "@repo/i18n";
 import { Badge } from "@repo/ui/components/badge";
 import { Button } from "@repo/ui/components/button";
@@ -47,11 +48,15 @@ export function ProtocolCompatibleMacrosCard({
   // Macro search for the add dropdown
   const [macroSearch, setMacroSearch] = useState("");
   const [debouncedMacroSearch, isDebounced] = useDebounce(macroSearch, 300);
-  const { data: macroData } = useQuery(
+  const { data: macroResponse } = useQuery(
     orpc.macros.listMacros.queryOptions({
       input: { search: debouncedMacroSearch || undefined },
     }),
   );
+
+  // Narrowed to the array shape: no `page` is sent here, so the response is always
+  // the bare list. Deletable once this caller migrates to the envelope.
+  const macroData = macroResponse ? listItems(macroResponse) : undefined;
   const macroList = macroData;
 
   const compatibleMacroIds = useMemo(

--- a/apps/web/components/side-panel-flow/analysis-panel.tsx
+++ b/apps/web/components/side-panel-flow/analysis-panel.tsx
@@ -9,6 +9,7 @@ import { AlertTriangle } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import type { Macro } from "@repo/api/domains/macro/macro.schema";
+import { listItems } from "@repo/api/shared/listing";
 import { useTranslation } from "@repo/i18n";
 import { Card, CardHeader, CardTitle, CardContent } from "@repo/ui/components/card";
 
@@ -32,11 +33,15 @@ export function AnalysisPanel({
   // Macro search state
   const [macroSearch, setMacroSearch] = useState("");
   const [debouncedMacroSearch, isDebounced] = useDebounce(macroSearch, 300);
-  const { data: macroData } = useQuery(
+  const { data: macroResponse } = useQuery(
     orpc.macros.listMacros.queryOptions({
       input: { search: debouncedMacroSearch || undefined },
     }),
   );
+
+  // Narrowed to the array shape: no `page` is sent here, so the response is always
+  // the bare list. Deletable once this caller migrates to the envelope.
+  const macroData = macroResponse ? listItems(macroResponse) : undefined;
   const macroList = macroData;
 
   // Fetch the upstream protocol name for recommendation context

--- a/apps/web/hooks/experiment/useExperiments/useExperiments.ts
+++ b/apps/web/hooks/experiment/useExperiments/useExperiments.ts
@@ -4,6 +4,7 @@ import { useSearchParams, usePathname, useRouter } from "next/navigation";
 import { useState, useEffect, useCallback } from "react";
 
 import type { ExperimentStatus } from "@repo/api/domains/experiment/experiment.schema";
+import { listItems } from "@repo/api/shared/listing";
 
 import { useDebounce } from "../../useDebounce";
 
@@ -79,9 +80,13 @@ export const useExperiments = ({
     }),
   );
 
+  // Narrowed to the array shape: this hook sends no `page`, so the response is
+  // always the bare list. Deletable once the caller migrates to the envelope.
+  const items = data ? listItems(data) : undefined;
+
   // Return query result with filter, status, and search controls
   return {
-    data,
+    data: items,
     filter,
     setFilter,
     status,

--- a/apps/web/hooks/macro/useMacros/useMacros.ts
+++ b/apps/web/hooks/macro/useMacros/useMacros.ts
@@ -4,6 +4,7 @@ import { useSearchParams, usePathname, useRouter } from "next/navigation";
 import { useState, useCallback, useEffect, useRef } from "react";
 
 import type { MacroLanguage } from "@repo/api/domains/macro/macro.schema";
+import { listItems } from "@repo/api/shared/listing";
 
 import { useDebounce } from "../../useDebounce";
 
@@ -64,23 +65,27 @@ export function useMacros({
     }),
   );
 
+  // Narrowed to the array shape: this hook sends no `page`, so the response is
+  // always the bare list. Deletable once the caller migrates to the envelope.
+  const items = query.data ? listItems(query.data) : undefined;
+
   // Auto-switch to "all" if user has no macros of their own on initial load
   const hasAutoSwitched = useRef(false);
   useEffect(() => {
     if (
       !hasAutoSwitched.current &&
       filter === "my" &&
-      query.data?.length === 0 &&
+      items?.length === 0 &&
       !debouncedSearch &&
       !language
     ) {
       hasAutoSwitched.current = true;
       setFilter("all");
     }
-  }, [filter, query.data, setFilter, debouncedSearch, language]);
+  }, [filter, items, setFilter, debouncedSearch, language]);
 
   return {
-    data: query.data,
+    data: items,
     isLoading: query.isLoading,
     error: query.error,
     filter,

--- a/apps/web/hooks/protocol/useProtocolSearch/useProtocolSearch.ts
+++ b/apps/web/hooks/protocol/useProtocolSearch/useProtocolSearch.ts
@@ -2,6 +2,7 @@ import { orpc } from "@/lib/orpc";
 import { useQuery } from "@tanstack/react-query";
 
 import type { ProtocolList } from "@repo/api/domains/protocol/protocol.schema";
+import { listItems } from "@repo/api/shared/listing";
 
 /**
  * Hook to fetch a list of protocols with optional search functionality
@@ -22,8 +23,12 @@ export const useProtocolSearch = (search = ""): useProtocolSearchResult => {
     }),
   );
 
+  // Narrowed to the array shape: no `page` is sent here, so the response is always
+  // the bare list. Deletable once this caller migrates to the envelope.
+  const protocols = data ? listItems(data) : undefined;
+
   return {
-    protocols: data,
+    protocols,
     isLoading: isLoading,
     error,
   };

--- a/apps/web/hooks/protocol/useProtocols/useProtocols.ts
+++ b/apps/web/hooks/protocol/useProtocols/useProtocols.ts
@@ -3,6 +3,8 @@ import { useQuery } from "@tanstack/react-query";
 import { useSearchParams, usePathname, useRouter } from "next/navigation";
 import { useState, useCallback, useEffect, useRef } from "react";
 
+import { listItems } from "@repo/api/shared/listing";
+
 import { useDebounce } from "../../useDebounce";
 
 export type ProtocolFilter = "my" | "all";
@@ -58,17 +60,21 @@ export const useProtocols = ({
     }),
   );
 
+  // Narrowed to the array shape: this hook sends no `page`, so the response is
+  // always the bare list. Deletable once the caller migrates to the envelope.
+  const items = data ? listItems(data) : undefined;
+
   // Auto-switch to "all" if user has no protocols of their own on initial load
   const hasAutoSwitched = useRef(false);
   useEffect(() => {
-    if (!hasAutoSwitched.current && filter === "my" && data?.length === 0 && !debouncedSearch) {
+    if (!hasAutoSwitched.current && filter === "my" && items?.length === 0 && !debouncedSearch) {
       hasAutoSwitched.current = true;
       setFilter("all");
     }
-  }, [filter, data, setFilter, debouncedSearch]);
+  }, [filter, items, setFilter, debouncedSearch]);
 
   return {
-    protocols: data,
+    protocols: items,
     filter,
     setFilter,
     search,

--- a/apps/web/hooks/workbook/useWorkbookList/useWorkbookList.ts
+++ b/apps/web/hooks/workbook/useWorkbookList/useWorkbookList.ts
@@ -1,6 +1,8 @@
 import { orpc } from "@/lib/orpc";
 import { useQuery } from "@tanstack/react-query";
 
+import { listItems } from "@repo/api/shared/listing";
+
 import { useDebounce } from "../../useDebounce";
 
 const SEARCH_DEBOUNCE_MS = 300;
@@ -23,8 +25,12 @@ export function useWorkbookList({ search = "" }: { search?: string } = {}) {
     }),
   );
 
+  // Narrowed to the array shape: no `page` is sent here, so the response is always
+  // the bare list. Deletable once this caller migrates to the envelope.
+  const items = query.data ? listItems(query.data) : undefined;
+
   return {
-    data: query.data,
+    data: items,
     isLoading: query.isLoading,
     error: query.error,
     // Compared against the settled term rather than `useDebounce`'s own flag, which

--- a/apps/web/hooks/workbook/useWorkbooks/useWorkbooks.ts
+++ b/apps/web/hooks/workbook/useWorkbooks/useWorkbooks.ts
@@ -3,6 +3,8 @@ import { useQuery } from "@tanstack/react-query";
 import { useSearchParams, usePathname, useRouter } from "next/navigation";
 import { useState, useCallback, useEffect, useRef } from "react";
 
+import { listItems } from "@repo/api/shared/listing";
+
 import { useDebounce } from "../../useDebounce";
 
 export type WorkbookFilter = "my" | "all";
@@ -58,22 +60,21 @@ export function useWorkbooks({
     }),
   );
 
+  // Narrowed to the array shape: this hook sends no `page`, so the response is
+  // always the bare list. Deletable once the caller migrates to the envelope.
+  const items = query.data ? listItems(query.data) : undefined;
+
   // Auto-switch to "all" if user has no workbooks of their own on initial load
   const hasAutoSwitched = useRef(false);
   useEffect(() => {
-    if (
-      !hasAutoSwitched.current &&
-      filter === "my" &&
-      query.data?.length === 0 &&
-      !debouncedSearch
-    ) {
+    if (!hasAutoSwitched.current && filter === "my" && items?.length === 0 && !debouncedSearch) {
       hasAutoSwitched.current = true;
       setFilter("all");
     }
-  }, [filter, query.data, setFilter, debouncedSearch]);
+  }, [filter, items, setFilter, debouncedSearch]);
 
   return {
-    data: query.data,
+    data: items,
     isLoading: query.isLoading,
     error: query.error,
     filter,

--- a/packages/api/src/domains/experiment/experiment.contract.ts
+++ b/packages/api/src/domains/experiment/experiment.contract.ts
@@ -9,6 +9,8 @@ import {
   zExperimentFilterQuery,
   zExperimentIdPathParam,
   zExperimentList,
+  zExperimentPaginatedList,
+  zExperimentPaginatedQuery,
   zUpdateExperimentBody,
 } from "./experiment.schema";
 
@@ -21,6 +23,10 @@ export const experimentContract = {
     .route({ method: "GET", path: "/api/v1/experiments", successStatus: 200 })
     .input(zExperimentFilterQuery)
     .output(zExperimentList),
+  listExperimentsPaginated: oc
+    .route({ method: "GET", path: "/api/v1/experiments/paginated", successStatus: 200 })
+    .input(zExperimentPaginatedQuery)
+    .output(zExperimentPaginatedList),
   getExperiment: oc
     .route({ method: "GET", path: "/api/v1/experiments/{id}", successStatus: 200 })
     .input(zExperimentIdPathParam)

--- a/packages/api/src/domains/experiment/experiment.contract.ts
+++ b/packages/api/src/domains/experiment/experiment.contract.ts
@@ -8,9 +8,7 @@ import {
   zExperimentAccess,
   zExperimentFilterQuery,
   zExperimentIdPathParam,
-  zExperimentList,
-  zExperimentPaginatedList,
-  zExperimentPaginatedQuery,
+  zExperimentListResponse,
   zUpdateExperimentBody,
 } from "./experiment.schema";
 
@@ -22,11 +20,7 @@ export const experimentContract = {
   listExperiments: oc
     .route({ method: "GET", path: "/api/v1/experiments", successStatus: 200 })
     .input(zExperimentFilterQuery)
-    .output(zExperimentList),
-  listExperimentsPaginated: oc
-    .route({ method: "GET", path: "/api/v1/experiments/paginated", successStatus: 200 })
-    .input(zExperimentPaginatedQuery)
-    .output(zExperimentPaginatedList),
+    .output(zExperimentListResponse),
   getExperiment: oc
     .route({ method: "GET", path: "/api/v1/experiments/{id}", successStatus: 200 })
     .input(zExperimentIdPathParam)

--- a/packages/api/src/domains/experiment/experiment.schema.ts
+++ b/packages/api/src/domains/experiment/experiment.schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { zPaginated, zPaginationQuery, zResourceScope } from "../../shared/listing";
 import { sanitizeQuestionLabel } from "../../transforms/label-sanitization";
 import { zResourceCapabilities } from "../authorization/capabilities.schema";
 import { zExperimentData } from "./data/experiment-data.schema";
@@ -424,10 +425,16 @@ export const embargoSchema = zUpdateExperimentBody
   });
 
 export const zExperimentFilterQuery = z.object({
-  filter: z.enum(["member"]).optional().describe("Filter experiments by relationship to the user"),
+  /** @deprecated Alias for `scope: "related"`, removed once web and mobile have migrated. */
+  filter: z.enum(["member"]).optional().describe("Deprecated alias for scope=related"),
+  scope: zResourceScope.optional().describe("Which slice of the accessible set to return"),
   status: zExperimentStatus.optional().describe("Filter experiments by their status"),
   search: z.string().optional().describe("Search term for experiment name"),
 });
+
+export const zExperimentPaginatedQuery = zExperimentFilterQuery.merge(zPaginationQuery);
+
+export const zExperimentPaginatedList = zPaginated(zExperiment);
 
 export const zExperimentIdPathParam = z.object({
   id: z.string().uuid().describe("ID of the experiment"),
@@ -440,6 +447,8 @@ export type CreateExperimentBody = z.infer<typeof zCreateExperimentBody>;
 export type UpdateExperimentBody = z.infer<typeof zUpdateExperimentBody>;
 export type ExperimentFilterQuery = z.infer<typeof zExperimentFilterQuery>;
 export type ExperimentFilter = ExperimentFilterQuery["filter"];
+export type ExperimentPaginatedQuery = z.infer<typeof zExperimentPaginatedQuery>;
+export type ExperimentPaginatedList = z.infer<typeof zExperimentPaginatedList>;
 export type ExperimentAccess = z.infer<typeof zExperimentAccess>;
 export type CreateExperimentResponse = z.infer<typeof zCreateExperimentResponse>;
 export type ExperimentIdPathParam = z.infer<typeof zExperimentIdPathParam>;

--- a/packages/api/src/domains/experiment/experiment.schema.ts
+++ b/packages/api/src/domains/experiment/experiment.schema.ts
@@ -422,17 +422,20 @@ export const embargoSchema = zUpdateExperimentBody
     validateEmbargoDate(val.embargoUntil, ctx, ["embargoUntil"]);
   });
 
-export const zExperimentFilterQuery = z.object({
-  /** @deprecated Alias for `scope: "related"`, removed once web and mobile have migrated. */
-  filter: z.enum(["member"]).optional().describe("Deprecated alias for scope=related"),
-  scope: zResourceScope.optional().describe("Which slice of the accessible set to return"),
-  status: zExperimentStatus.optional().describe("Filter experiments by their status"),
-  search: z.string().optional().describe("Search term for experiment name"),
-});
-
-export const zExperimentPaginatedQuery = zExperimentFilterQuery.merge(zPaginationQuery);
+export const zExperimentFilterQuery = z
+  .object({
+    /** @deprecated Alias for `scope: "related"`, removed once web and mobile have migrated. */
+    filter: z.enum(["member"]).optional().describe("Deprecated alias for scope=related"),
+    scope: zResourceScope.optional().describe("Which slice of the accessible set to return"),
+    status: zExperimentStatus.optional().describe("Filter experiments by their status"),
+    search: z.string().optional().describe("Search term for experiment name"),
+  })
+  .merge(zPaginationQuery);
 
 export const zExperimentPaginatedList = zPaginated(zExperiment);
+
+/** Array when the caller sent no `page`, envelope when they did. */
+export const zExperimentListResponse = z.union([zExperimentList, zExperimentPaginatedList]);
 
 export const zExperimentIdPathParam = z.object({
   id: z.string().uuid().describe("ID of the experiment"),
@@ -445,8 +448,8 @@ export type CreateExperimentBody = z.infer<typeof zCreateExperimentBody>;
 export type UpdateExperimentBody = z.infer<typeof zUpdateExperimentBody>;
 export type ExperimentFilterQuery = z.infer<typeof zExperimentFilterQuery>;
 export type ExperimentFilter = ExperimentFilterQuery["filter"];
-export type ExperimentPaginatedQuery = z.infer<typeof zExperimentPaginatedQuery>;
 export type ExperimentPaginatedList = z.infer<typeof zExperimentPaginatedList>;
+export type ExperimentListResponse = z.infer<typeof zExperimentListResponse>;
 export type ExperimentAccess = z.infer<typeof zExperimentAccess>;
 export type CreateExperimentResponse = z.infer<typeof zCreateExperimentResponse>;
 export type ExperimentIdPathParam = z.infer<typeof zExperimentIdPathParam>;

--- a/packages/api/src/domains/experiment/experiment.schema.ts
+++ b/packages/api/src/domains/experiment/experiment.schema.ts
@@ -25,15 +25,13 @@ export const zExperiment = z.object({
   workbookId: z.string().uuid().nullable(),
   workbookVersionId: z.string().uuid().nullable(),
   organizationId: z.string().uuid().nullable(),
-  /**
-   * Display name of the owning organization, `null` for a personal workspace.
-   * Populated by the detail read only — the lists have no room for it — which is
-   * why it is optional rather than required.
-   */
+  /** Display name of the owning organization, `null` for a personal workspace. */
   organizationName: z.string().nullish(),
   createdBy: z.string().uuid(),
   ownerFirstName: z.string().nullable().optional(),
   ownerLastName: z.string().nullable().optional(),
+  /** Direct collaborator grants; org/team reach is unbounded and deliberately not counted. */
+  membersCount: z.number().int().optional(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
   data: zExperimentData.optional(),

--- a/packages/api/src/domains/macro/macro.contract.ts
+++ b/packages/api/src/domains/macro/macro.contract.ts
@@ -13,11 +13,9 @@ import {
   zMacroExecutionResponse,
   zMacroFilterQuery,
   zMacroIdPathParam,
-  zMacroList,
   zMacroProtocolList,
   zMacroProtocolPathParams,
-  zMacroPaginatedList,
-  zMacroPaginatedQuery,
+  zMacroListResponse,
   zUpdateMacroRequestBody,
 } from "./macro.schema";
 
@@ -25,11 +23,7 @@ export const macroContract = {
   listMacros: oc
     .route({ method: "GET", path: "/api/v1/macros", successStatus: 200 })
     .input(zMacroFilterQuery)
-    .output(zMacroList),
-  listMacrosPaginated: oc
-    .route({ method: "GET", path: "/api/v1/macros/paginated", successStatus: 200 })
-    .input(zMacroPaginatedQuery)
-    .output(zMacroPaginatedList),
+    .output(zMacroListResponse),
   getMacro: oc
     .route({ method: "GET", path: "/api/v1/macros/{id}", successStatus: 200 })
     .input(zMacroIdPathParam)

--- a/packages/api/src/domains/macro/macro.contract.ts
+++ b/packages/api/src/domains/macro/macro.contract.ts
@@ -16,6 +16,8 @@ import {
   zMacroList,
   zMacroProtocolList,
   zMacroProtocolPathParams,
+  zMacroPaginatedList,
+  zMacroPaginatedQuery,
   zUpdateMacroRequestBody,
 } from "./macro.schema";
 
@@ -24,6 +26,10 @@ export const macroContract = {
     .route({ method: "GET", path: "/api/v1/macros", successStatus: 200 })
     .input(zMacroFilterQuery)
     .output(zMacroList),
+  listMacrosPaginated: oc
+    .route({ method: "GET", path: "/api/v1/macros/paginated", successStatus: 200 })
+    .input(zMacroPaginatedQuery)
+    .output(zMacroPaginatedList),
   getMacro: oc
     .route({ method: "GET", path: "/api/v1/macros/{id}", successStatus: 200 })
     .input(zMacroIdPathParam)

--- a/packages/api/src/domains/macro/macro.schema.ts
+++ b/packages/api/src/domains/macro/macro.schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { zPaginated, zPaginationQuery, zResourceScope } from "../../shared/listing";
 import { zResourceCapabilities } from "../authorization/capabilities.schema";
 import { zVisibility } from "../visibility/visibility.schema";
 
@@ -60,8 +61,14 @@ export const zMacroDetail = zMacro.extend({
 export const zMacroFilterQuery = z.object({
   search: z.string().optional(),
   language: zMacroLanguage.optional(),
-  filter: z.enum(["my"]).optional(),
+  /** @deprecated Alias for `scope: "related"`, removed once web and mobile have migrated. */
+  filter: z.enum(["my"]).optional().describe("Deprecated alias for scope=related"),
+  scope: zResourceScope.optional().describe("Which slice of the accessible set to return"),
 });
+
+export const zMacroPaginatedQuery = zMacroFilterQuery.merge(zPaginationQuery);
+
+export const zMacroPaginatedList = zPaginated(zMacro);
 
 // Path parameters
 export const zMacroIdPathParam = z.object({
@@ -195,6 +202,8 @@ export type MacroDetail = z.infer<typeof zMacroDetail>;
 export type MacroList = z.infer<typeof zMacroList>;
 export type MacroFilterQuery = z.infer<typeof zMacroFilterQuery>;
 export type MacroFilter = MacroFilterQuery["search"];
+export type MacroPaginatedQuery = z.infer<typeof zMacroPaginatedQuery>;
+export type MacroPaginatedList = z.infer<typeof zMacroPaginatedList>;
 export type MacroIdPathParam = z.infer<typeof zMacroIdPathParam>;
 export type CreateMacroRequestBody = z.infer<typeof zCreateMacroRequestBody>;
 export type UpdateMacroRequestBody = z.infer<typeof zUpdateMacroRequestBody>;

--- a/packages/api/src/domains/macro/macro.schema.ts
+++ b/packages/api/src/domains/macro/macro.schema.ts
@@ -58,17 +58,20 @@ export const zMacroDetail = zMacro.extend({
 });
 
 // Query parameters
-export const zMacroFilterQuery = z.object({
-  search: z.string().optional(),
-  language: zMacroLanguage.optional(),
-  /** @deprecated Alias for `scope: "related"`, removed once web and mobile have migrated. */
-  filter: z.enum(["my"]).optional().describe("Deprecated alias for scope=related"),
-  scope: zResourceScope.optional().describe("Which slice of the accessible set to return"),
-});
-
-export const zMacroPaginatedQuery = zMacroFilterQuery.merge(zPaginationQuery);
+export const zMacroFilterQuery = z
+  .object({
+    search: z.string().optional(),
+    language: zMacroLanguage.optional(),
+    /** @deprecated Alias for `scope: "related"`, removed once web and mobile have migrated. */
+    filter: z.enum(["my"]).optional().describe("Deprecated alias for scope=related"),
+    scope: zResourceScope.optional().describe("Which slice of the accessible set to return"),
+  })
+  .merge(zPaginationQuery);
 
 export const zMacroPaginatedList = zPaginated(zMacro);
+
+/** Array when the caller sent no `page`, envelope when they did. */
+export const zMacroListResponse = z.union([zMacroList, zMacroPaginatedList]);
 
 // Path parameters
 export const zMacroIdPathParam = z.object({
@@ -202,8 +205,8 @@ export type MacroDetail = z.infer<typeof zMacroDetail>;
 export type MacroList = z.infer<typeof zMacroList>;
 export type MacroFilterQuery = z.infer<typeof zMacroFilterQuery>;
 export type MacroFilter = MacroFilterQuery["search"];
-export type MacroPaginatedQuery = z.infer<typeof zMacroPaginatedQuery>;
 export type MacroPaginatedList = z.infer<typeof zMacroPaginatedList>;
+export type MacroListResponse = z.infer<typeof zMacroListResponse>;
 export type MacroIdPathParam = z.infer<typeof zMacroIdPathParam>;
 export type CreateMacroRequestBody = z.infer<typeof zCreateMacroRequestBody>;
 export type UpdateMacroRequestBody = z.infer<typeof zUpdateMacroRequestBody>;

--- a/packages/api/src/domains/protocol/protocol.contract.ts
+++ b/packages/api/src/domains/protocol/protocol.contract.ts
@@ -11,6 +11,8 @@ import {
   zProtocolIdPathParam,
   zProtocolList,
   zProtocolMacroList,
+  zProtocolPaginatedList,
+  zProtocolPaginatedQuery,
   zProtocolMacroPathParams,
   zUpdateProtocolRequestBody,
 } from "./protocol.schema";
@@ -20,6 +22,10 @@ export const protocolContract = {
     .route({ method: "GET", path: "/api/v1/protocols", successStatus: 200 })
     .input(zProtocolFilterQuery)
     .output(zProtocolList),
+  listProtocolsPaginated: oc
+    .route({ method: "GET", path: "/api/v1/protocols/paginated", successStatus: 200 })
+    .input(zProtocolPaginatedQuery)
+    .output(zProtocolPaginatedList),
   getProtocol: oc
     .route({ method: "GET", path: "/api/v1/protocols/{id}", successStatus: 200 })
     .input(zProtocolIdPathParam)

--- a/packages/api/src/domains/protocol/protocol.contract.ts
+++ b/packages/api/src/domains/protocol/protocol.contract.ts
@@ -9,10 +9,8 @@ import {
   zProtocolDetail,
   zProtocolFilterQuery,
   zProtocolIdPathParam,
-  zProtocolList,
   zProtocolMacroList,
-  zProtocolPaginatedList,
-  zProtocolPaginatedQuery,
+  zProtocolListResponse,
   zProtocolMacroPathParams,
   zUpdateProtocolRequestBody,
 } from "./protocol.schema";
@@ -21,11 +19,7 @@ export const protocolContract = {
   listProtocols: oc
     .route({ method: "GET", path: "/api/v1/protocols", successStatus: 200 })
     .input(zProtocolFilterQuery)
-    .output(zProtocolList),
-  listProtocolsPaginated: oc
-    .route({ method: "GET", path: "/api/v1/protocols/paginated", successStatus: 200 })
-    .input(zProtocolPaginatedQuery)
-    .output(zProtocolPaginatedList),
+    .output(zProtocolListResponse),
   getProtocol: oc
     .route({ method: "GET", path: "/api/v1/protocols/{id}", successStatus: 200 })
     .input(zProtocolIdPathParam)

--- a/packages/api/src/domains/protocol/protocol.schema.ts
+++ b/packages/api/src/domains/protocol/protocol.schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { zPaginated, zPaginationQuery, zResourceScope } from "../../shared/listing";
 import { zResourceCapabilities } from "../authorization/capabilities.schema";
 import { zVisibility } from "../visibility/visibility.schema";
 
@@ -78,8 +79,14 @@ export const zProtocolDetail = zProtocol.extend({
 // Query parameters
 export const zProtocolFilterQuery = z.object({
   search: z.string().optional(),
-  filter: z.enum(["my"]).optional(),
+  /** @deprecated Alias for `scope: "related"`, removed once web and mobile have migrated. */
+  filter: z.enum(["my"]).optional().describe("Deprecated alias for scope=related"),
+  scope: zResourceScope.optional().describe("Which slice of the accessible set to return"),
 });
+
+export const zProtocolPaginatedQuery = zProtocolFilterQuery.merge(zPaginationQuery);
+
+export const zProtocolPaginatedList = zPaginated(zProtocol.extend({ code: z.unknown() }));
 
 // Path parameters
 export const zProtocolIdPathParam = z.object({
@@ -162,6 +169,8 @@ export type ProtocolList = z.infer<typeof zProtocolList>;
 export type ProtocolListItem = ProtocolList[number];
 export type ProtocolFilterQuery = z.infer<typeof zProtocolFilterQuery>;
 export type ProtocolFilter = ProtocolFilterQuery["search"];
+export type ProtocolPaginatedQuery = z.infer<typeof zProtocolPaginatedQuery>;
+export type ProtocolPaginatedList = z.infer<typeof zProtocolPaginatedList>;
 export type ProtocolIdPathParam = z.infer<typeof zProtocolIdPathParam>;
 export type CreateProtocolRequestBody = z.infer<typeof zCreateProtocolRequestBody>;
 export type UpdateProtocolRequestBody = z.infer<typeof zUpdateProtocolRequestBody>;

--- a/packages/api/src/domains/protocol/protocol.schema.ts
+++ b/packages/api/src/domains/protocol/protocol.schema.ts
@@ -77,16 +77,19 @@ export const zProtocolDetail = zProtocol.extend({
 });
 
 // Query parameters
-export const zProtocolFilterQuery = z.object({
-  search: z.string().optional(),
-  /** @deprecated Alias for `scope: "related"`, removed once web and mobile have migrated. */
-  filter: z.enum(["my"]).optional().describe("Deprecated alias for scope=related"),
-  scope: zResourceScope.optional().describe("Which slice of the accessible set to return"),
-});
-
-export const zProtocolPaginatedQuery = zProtocolFilterQuery.merge(zPaginationQuery);
+export const zProtocolFilterQuery = z
+  .object({
+    search: z.string().optional(),
+    /** @deprecated Alias for `scope: "related"`, removed once web and mobile have migrated. */
+    filter: z.enum(["my"]).optional().describe("Deprecated alias for scope=related"),
+    scope: zResourceScope.optional().describe("Which slice of the accessible set to return"),
+  })
+  .merge(zPaginationQuery);
 
 export const zProtocolPaginatedList = zPaginated(zProtocol.extend({ code: z.unknown() }));
+
+/** Array when the caller sent no `page`, envelope when they did. */
+export const zProtocolListResponse = z.union([zProtocolList, zProtocolPaginatedList]);
 
 // Path parameters
 export const zProtocolIdPathParam = z.object({
@@ -169,8 +172,8 @@ export type ProtocolList = z.infer<typeof zProtocolList>;
 export type ProtocolListItem = ProtocolList[number];
 export type ProtocolFilterQuery = z.infer<typeof zProtocolFilterQuery>;
 export type ProtocolFilter = ProtocolFilterQuery["search"];
-export type ProtocolPaginatedQuery = z.infer<typeof zProtocolPaginatedQuery>;
 export type ProtocolPaginatedList = z.infer<typeof zProtocolPaginatedList>;
+export type ProtocolListResponse = z.infer<typeof zProtocolListResponse>;
 export type ProtocolIdPathParam = z.infer<typeof zProtocolIdPathParam>;
 export type CreateProtocolRequestBody = z.infer<typeof zCreateProtocolRequestBody>;
 export type UpdateProtocolRequestBody = z.infer<typeof zUpdateProtocolRequestBody>;

--- a/packages/api/src/domains/search/search.schema.ts
+++ b/packages/api/src/domains/search/search.schema.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 /** Query params for global cross-entity search. */
 export const zGlobalSearchQuery = z.object({
   query: z.string().trim().min(1).max(200).describe("Search term"),
-  // The backend caps each entity type at 8 results across 4 types, so 32 is the most that can ever
-  // be returned — advertise that ceiling instead of over-promising up to 50.
+  // The backend overfetches `limit` per entity type and merges by score, so this also bounds the
+  // heaviest query the palette can issue (4 types x limit candidate rows).
   limit: z.coerce.number().int().min(1).max(32).optional().default(20),
 });
 

--- a/packages/api/src/domains/workbook/workbook.contract.ts
+++ b/packages/api/src/domains/workbook/workbook.contract.ts
@@ -15,6 +15,8 @@ import {
   zWorkbookFilterQuery,
   zWorkbookIdPathParam,
   zWorkbookList,
+  zWorkbookPaginatedList,
+  zWorkbookPaginatedQuery,
 } from "./workbook.schema";
 
 export const workbookContract = {
@@ -22,6 +24,10 @@ export const workbookContract = {
     .route({ method: "GET", path: "/api/v1/workbooks", successStatus: 200 })
     .input(zWorkbookFilterQuery)
     .output(zWorkbookList),
+  listWorkbooksPaginated: oc
+    .route({ method: "GET", path: "/api/v1/workbooks/paginated", successStatus: 200 })
+    .input(zWorkbookPaginatedQuery)
+    .output(zWorkbookPaginatedList),
   getWorkbook: oc
     .route({ method: "GET", path: "/api/v1/workbooks/{id}", successStatus: 200 })
     .input(zWorkbookIdPathParam)

--- a/packages/api/src/domains/workbook/workbook.contract.ts
+++ b/packages/api/src/domains/workbook/workbook.contract.ts
@@ -14,20 +14,14 @@ import {
   zWorkbookDetail,
   zWorkbookFilterQuery,
   zWorkbookIdPathParam,
-  zWorkbookList,
-  zWorkbookPaginatedList,
-  zWorkbookPaginatedQuery,
+  zWorkbookListResponse,
 } from "./workbook.schema";
 
 export const workbookContract = {
   listWorkbooks: oc
     .route({ method: "GET", path: "/api/v1/workbooks", successStatus: 200 })
     .input(zWorkbookFilterQuery)
-    .output(zWorkbookList),
-  listWorkbooksPaginated: oc
-    .route({ method: "GET", path: "/api/v1/workbooks/paginated", successStatus: 200 })
-    .input(zWorkbookPaginatedQuery)
-    .output(zWorkbookPaginatedList),
+    .output(zWorkbookListResponse),
   getWorkbook: oc
     .route({ method: "GET", path: "/api/v1/workbooks/{id}", successStatus: 200 })
     .input(zWorkbookIdPathParam)

--- a/packages/api/src/domains/workbook/workbook.schema.ts
+++ b/packages/api/src/domains/workbook/workbook.schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { zPaginated, zPaginationQuery, zResourceScope } from "../../shared/listing";
 import { zResourceCapabilities } from "../authorization/capabilities.schema";
 import { zVisibility } from "../visibility/visibility.schema";
 import { zWorkbookCellArray, zWorkbookCellArrayInput } from "./workbook-cells.schema";
@@ -47,8 +48,14 @@ export const zWorkbookDetail = zWorkbook.extend({
 
 export const zWorkbookFilterQuery = z.object({
   search: z.string().optional(),
-  filter: z.enum(["my"]).optional(),
+  /** @deprecated Alias for `scope: "related"`, removed once web and mobile have migrated. */
+  filter: z.enum(["my"]).optional().describe("Deprecated alias for scope=related"),
+  scope: zResourceScope.optional().describe("Which slice of the accessible set to return"),
 });
+
+export const zWorkbookPaginatedQuery = zWorkbookFilterQuery.merge(zPaginationQuery);
+
+export const zWorkbookPaginatedList = zPaginated(zWorkbookListItem);
 
 export const zWorkbookIdPathParam = z.object({
   id: z.string().uuid(),
@@ -96,6 +103,8 @@ export type WorkbookDetail = z.infer<typeof zWorkbookDetail>;
 export type WorkbookListItem = z.infer<typeof zWorkbookListItem>;
 export type WorkbookList = z.infer<typeof zWorkbookList>;
 export type WorkbookFilterQuery = z.infer<typeof zWorkbookFilterQuery>;
+export type WorkbookPaginatedQuery = z.infer<typeof zWorkbookPaginatedQuery>;
+export type WorkbookPaginatedList = z.infer<typeof zWorkbookPaginatedList>;
 export type WorkbookIdPathParam = z.infer<typeof zWorkbookIdPathParam>;
 export type CreateWorkbookRequestBody = z.infer<typeof zCreateWorkbookRequestBody>;
 export type UpdateWorkbookRequestBody = z.infer<typeof zUpdateWorkbookRequestBody>;

--- a/packages/api/src/domains/workbook/workbook.schema.ts
+++ b/packages/api/src/domains/workbook/workbook.schema.ts
@@ -46,16 +46,19 @@ export const zWorkbookDetail = zWorkbook.extend({
   capabilities: zResourceCapabilities,
 });
 
-export const zWorkbookFilterQuery = z.object({
-  search: z.string().optional(),
-  /** @deprecated Alias for `scope: "related"`, removed once web and mobile have migrated. */
-  filter: z.enum(["my"]).optional().describe("Deprecated alias for scope=related"),
-  scope: zResourceScope.optional().describe("Which slice of the accessible set to return"),
-});
-
-export const zWorkbookPaginatedQuery = zWorkbookFilterQuery.merge(zPaginationQuery);
+export const zWorkbookFilterQuery = z
+  .object({
+    search: z.string().optional(),
+    /** @deprecated Alias for `scope: "related"`, removed once web and mobile have migrated. */
+    filter: z.enum(["my"]).optional().describe("Deprecated alias for scope=related"),
+    scope: zResourceScope.optional().describe("Which slice of the accessible set to return"),
+  })
+  .merge(zPaginationQuery);
 
 export const zWorkbookPaginatedList = zPaginated(zWorkbookListItem);
+
+/** Array when the caller sent no `page`, envelope when they did. */
+export const zWorkbookListResponse = z.union([zWorkbookList, zWorkbookPaginatedList]);
 
 export const zWorkbookIdPathParam = z.object({
   id: z.string().uuid(),
@@ -103,8 +106,8 @@ export type WorkbookDetail = z.infer<typeof zWorkbookDetail>;
 export type WorkbookListItem = z.infer<typeof zWorkbookListItem>;
 export type WorkbookList = z.infer<typeof zWorkbookList>;
 export type WorkbookFilterQuery = z.infer<typeof zWorkbookFilterQuery>;
-export type WorkbookPaginatedQuery = z.infer<typeof zWorkbookPaginatedQuery>;
 export type WorkbookPaginatedList = z.infer<typeof zWorkbookPaginatedList>;
+export type WorkbookListResponse = z.infer<typeof zWorkbookListResponse>;
 export type WorkbookIdPathParam = z.infer<typeof zWorkbookIdPathParam>;
 export type CreateWorkbookRequestBody = z.infer<typeof zCreateWorkbookRequestBody>;
 export type UpdateWorkbookRequestBody = z.infer<typeof zUpdateWorkbookRequestBody>;

--- a/packages/api/src/shared/listing.spec.ts
+++ b/packages/api/src/shared/listing.spec.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { resolveListScope, zPaginated, zPaginationQuery } from "./listing";
+import {
+  isPaginatedList,
+  listItems,
+  resolveListScope,
+  zPaginated,
+  zPaginationQuery,
+} from "./listing";
 
 describe("resolveListScope", () => {
   it("defaults to the whole accessible set when neither param is sent", () => {
@@ -25,8 +31,14 @@ describe("resolveListScope", () => {
 });
 
 describe("zPaginationQuery", () => {
-  it("defaults to the first page of 20", () => {
-    expect(zPaginationQuery.parse({})).toEqual({ page: 1, pageSize: 20 });
+  it("carries no default, so an unpaginated request stays unpaginated", () => {
+    // A default here would silently switch every caller to the envelope, because
+    // `page` presence is what selects the response shape.
+    expect(zPaginationQuery.parse({})).toEqual({});
+  });
+
+  it("leaves pageSize alone when only page is sent, for the server to default", () => {
+    expect(zPaginationQuery.parse({ page: 2 })).toEqual({ page: 2 });
   });
 
   it("coerces the query-string values a GET route actually receives", () => {
@@ -55,5 +67,34 @@ describe("zPaginated", () => {
         totalCount: 41,
       }),
     ).toEqual({ items: [{ id: "a" }], page: 2, pageSize: 20, totalPages: 3, totalCount: 41 });
+  });
+});
+
+describe("listing response guards", () => {
+  const envelope = {
+    items: [{ id: "a" }, { id: "b" }],
+    page: 1,
+    pageSize: 20,
+    totalPages: 1,
+    totalCount: 2,
+  };
+
+  it("tells the two response shapes apart", () => {
+    expect(isPaginatedList([{ id: "a" }])).toBe(false);
+    expect(isPaginatedList(envelope)).toBe(true);
+  });
+
+  it("yields the rows from either shape", () => {
+    expect(listItems([{ id: "a" }])).toEqual([{ id: "a" }]);
+    expect(listItems(envelope)).toEqual(envelope.items);
+  });
+
+  it("treats an absent response as no rows, so consumers can call it unguarded", () => {
+    expect(listItems(undefined)).toEqual([]);
+  });
+
+  it("does not mistake an empty array for an envelope", () => {
+    expect(isPaginatedList([])).toBe(false);
+    expect(listItems([])).toEqual([]);
   });
 });

--- a/packages/api/src/shared/listing.spec.ts
+++ b/packages/api/src/shared/listing.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { resolveListScope, zPaginated, zPaginationQuery } from "./listing";
+
+describe("resolveListScope", () => {
+  it("defaults to the whole accessible set when neither param is sent", () => {
+    expect(resolveListScope({})).toBe("all");
+  });
+
+  it("maps the deprecated per-entity filter aliases to related", () => {
+    expect(resolveListScope({ filter: "member" })).toBe("related");
+    expect(resolveListScope({ filter: "my" })).toBe("related");
+  });
+
+  it("passes an explicit scope through", () => {
+    expect(resolveListScope({ scope: "related" })).toBe("related");
+    expect(resolveListScope({ scope: "all" })).toBe("all");
+  });
+
+  it("lets scope win when both are sent, including the widening direction", () => {
+    expect(resolveListScope({ scope: "all", filter: "my" })).toBe("all");
+    expect(resolveListScope({ scope: "related", filter: "member" })).toBe("related");
+  });
+});
+
+describe("zPaginationQuery", () => {
+  it("defaults to the first page of 20", () => {
+    expect(zPaginationQuery.parse({})).toEqual({ page: 1, pageSize: 20 });
+  });
+
+  it("coerces the query-string values a GET route actually receives", () => {
+    expect(zPaginationQuery.parse({ page: "3", pageSize: "50" })).toEqual({
+      page: 3,
+      pageSize: 50,
+    });
+  });
+
+  it("rejects a non-positive page and an oversized page", () => {
+    expect(() => zPaginationQuery.parse({ page: 0 })).toThrow();
+    expect(() => zPaginationQuery.parse({ pageSize: 101 })).toThrow();
+  });
+});
+
+describe("zPaginated", () => {
+  it("wraps items alongside the totals the client pages on", () => {
+    const schema = zPaginated(z.object({ id: z.string() }));
+
+    expect(
+      schema.parse({
+        items: [{ id: "a" }],
+        page: 2,
+        pageSize: 20,
+        totalPages: 3,
+        totalCount: 41,
+      }),
+    ).toEqual({ items: [{ id: "a" }], page: 2, pageSize: 20, totalPages: 3, totalCount: 41 });
+  });
+});

--- a/packages/api/src/shared/listing.ts
+++ b/packages/api/src/shared/listing.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+/** `related` narrows to rows the caller is tied to (authorship, any grant, owning-org membership). */
+export const zResourceScope = z.enum(["related", "all"]);
+
+export const zPaginationQuery = z.object({
+  page: z.coerce.number().int().min(1).default(1).describe("1-based page number"),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20).describe("Rows per page"),
+});
+
+/** `totalCount` comes from a separate count query, so an out-of-range page still reports real totals. */
+export function zPaginated<T extends z.ZodTypeAny>(items: T) {
+  return z.object({
+    items: z.array(items),
+    page: z.number().int(),
+    pageSize: z.number().int(),
+    totalPages: z.number().int(),
+    totalCount: z.number().int(),
+  });
+}
+
+/** `scope` wins over the deprecated `filter` alias; a bare legacy `filter` still means "mine". */
+export function resolveListScope(input: {
+  scope?: ResourceScope;
+  filter?: "member" | "my";
+}): ResourceScope {
+  return input.scope ?? (input.filter ? "related" : "all");
+}
+
+export type ResourceScope = z.infer<typeof zResourceScope>;
+export type PaginationQuery = z.infer<typeof zPaginationQuery>;

--- a/packages/api/src/shared/listing.ts
+++ b/packages/api/src/shared/listing.ts
@@ -3,10 +3,19 @@ import { z } from "zod";
 /** `related` narrows to rows the caller is tied to (authorship, any grant, owning-org membership). */
 export const zResourceScope = z.enum(["related", "all"]);
 
+/**
+ * Page selector for the list procedures. Both are optional and neither carries a schema
+ * default: `page` presence is what switches a listing from an array to an envelope, so a
+ * default here would silently paginate every caller. The server applies
+ * {@link DEFAULT_PAGE_SIZE} once it has decided the request is paginated.
+ */
 export const zPaginationQuery = z.object({
-  page: z.coerce.number().int().min(1).default(1).describe("1-based page number"),
-  pageSize: z.coerce.number().int().min(1).max(100).default(20).describe("Rows per page"),
+  page: z.coerce.number().int().min(1).optional().describe("1-based page number"),
+  pageSize: z.coerce.number().int().min(1).max(100).optional().describe("Rows per page"),
 });
+
+/** Applied server-side when `page` is present and `pageSize` is not. */
+export const DEFAULT_PAGE_SIZE = 20;
 
 /** `totalCount` comes from a separate count query, so an out-of-range page still reports real totals. */
 export function zPaginated<T extends z.ZodTypeAny>(items: T) {
@@ -17,6 +26,32 @@ export function zPaginated<T extends z.ZodTypeAny>(items: T) {
     totalPages: z.number().int(),
     totalCount: z.number().int(),
   });
+}
+
+/**
+ * A listing response: a bare array, or the envelope when the caller asked for a page.
+ * The runtime contract is exactly that, in both directions: the response is an array
+ * if and only if the request carried no `page`.
+ */
+export type ListResponse<T> = T[] | PaginatedList<T>;
+
+export interface PaginatedList<T> {
+  items: T[];
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  totalCount: number;
+}
+
+/** Narrow a listing response to the envelope. */
+export function isPaginatedList<T>(response: ListResponse<T>): response is PaginatedList<T> {
+  return !Array.isArray(response);
+}
+
+/** The rows out of a listing response, whichever shape it came back in. */
+export function listItems<T>(response: ListResponse<T> | undefined): T[] {
+  if (!response) return [];
+  return isPaginatedList(response) ? response.items : response;
 }
 
 /** `scope` wins over the deprecated `filter` alias; a bare legacy `filter` still means "mine". */


### PR DESCRIPTION
Backend half of the overview pages & search revamp (epic OJD-1727). Replaces the inconsistent legacy `filter=my|member` narrowing with a unified `scope=related` mode, adds paginated sibling procedures, relationship-tier ranking, and real cross-type scoring in global search. Search stays lexical — semantic/vector search is deliberately deferred (OJD-1730).

## What changed

**Contracts (`packages/api`)**
- New `shared/listing.ts`: `zResourceScope`, pagination query/envelope schemas, and `resolveListScope` (single home for alias precedence).
- All four list endpoints (experiments/protocols/macros/workbooks) gain `scope: "related" | "all"`; legacy `filter=my|member` kept as deprecated aliases mapping to `scope=related` (`scope` wins if both sent). For protocols/macros/workbooks this deliberately upgrades "my" semantics: shared and org-inherited resources now count — the OJD-1724 fix extended to the other three entities.
- Sibling `list*Paginated` procedures (`/api/v1/<entity>/paginated`) returning `{ items, page, pageSize, totalPages, totalCount }`. Existing array procedures' inputs/outputs untouched — deployed mobile keeps working unchanged.

**Backend (`apps/backend`)**
- `resourceTierExpression()` in `resource-access-scope.ts`: highest-wins CASE — owned 3 → shared 2 (user/team grant) → org 1 (org grant / owning-org membership) → public 0. Access control is unchanged and still gates everything before ranking sees it.
- Browse (no search term): `ORDER BY tier DESC` + existing per-entity secondary + `id` tiebreaker. Search: single weighted score = lexical rank + `TIER_WEIGHT (0.15) × tier`; cross-table bonus caps unified (`LEAST(sum, 0.10)`) so scores are comparable across entity types. Scoring is search-path-only (browse pays no scoring overhead).
- Global search: overfetches up to `limit` per type (was hard-capped at 8) and merges on the real score with `id` tiebreak — the 9th-best experiment can now beat every macro. Response contract unchanged.
- Separate `COUNT(*)` query for totals (correct on out-of-range pages); fixed a pre-existing missing tiebreaker in experiments search ordering; fixed `/paginated` route shadowing by `/{id}` on macros/workbooks (with per-entity route-resolution guard tests).

## Verification
- Backend suite: 266 files / 3168 tests green; `@repo/api`: 1699 tests green; monorepo `check-types` green (no web/mobile changes needed); lint clean.
- 25/25 live HTTP contract checks through the real OTP login (alias precedence, envelope shape, out-of-range totals, scope semantics, global-search shape).
- Adversarial review by a second agent: no critical findings (access gating on rows/COUNT/overfetch, injection surface, route order all confirmed); all fixable findings addressed in the second commit.
- Synthetic 40k-row EXPLAIN ANALYZE pass: tier ranking costs +50–100ms vs old ordering; all tier/access predicates index-driven (57k index scans on `resource_grants`, ~0 seq scans); deep pages cost the same as page 1. Browse-path scoring removal measured at 4.3× on workbooks.
- Validated end-to-end from a physical Android device against this branch: org-inherited private experiment appears via `scope=related` (invisible under the old filter), measurement flow works, offline precache intact.

## Known follow-ups (documented on OJD-1728)
- `TIER_WEIGHT=0.15` needs real-corpus rank-gap calibration (synthetic corpus has near-zero rank variance; an intent-pinning spec guards gross violations).
- Workbook global search ~2.2s at 40k scale — inherent to the score definition (4 access-scoped linked-entity EXISTS), not query shape (CTE rewrite measured at only ~6%); candidate fix is two-phase ranking, gated on real data.
- External API callers sending `filter=my` get the upgraded (wider) semantics — deliberate, this is the access-model fix.
- Legacy array procedures + `filter` aliases removed after web/mobile migrate (OJD-1732).

Part of OJD-1727. Implements OJD-1728.
