### PR TITLE
feat(mobile): migrate experiment lists to scope-related (OJD-1732)

### DIFF
--- a/apps/mobile/src/features/experiments/hooks/use-experiment-workbook-ref.ts
+++ b/apps/mobile/src/features/experiments/hooks/use-experiment-workbook-ref.ts
@@ -18,7 +18,7 @@ export function useExperimentWorkbookRef(experimentId: string | undefined): {
 } {
   const { data, isLoading, error, isPaused } = useQuery(
     orpc.experiments.listExperiments.queryOptions({
-      input: { filter: "member" },
+      input: { scope: "related" },
       enabled: !!experimentId,
       networkMode: "offlineFirst",
     }),

--- a/apps/mobile/src/features/experiments/hooks/use-experiments.ts
+++ b/apps/mobile/src/features/experiments/hooks/use-experiments.ts
@@ -8,7 +8,7 @@ import { listItems } from "@repo/api/shared/listing";
 export function useExperiments() {
   const { data, isLoading, error, refetch, isRefetching } = useQuery(
     orpc.experiments.listExperiments.queryOptions({
-      input: { filter: "member" },
+      input: { scope: "related" },
       // Explicit: prefer the persisted cache when offline so the picker
       // doesn't render an empty list while the network is unreachable.
       networkMode: "offlineFirst",

--- a/apps/mobile/src/features/experiments/hooks/use-precached-experiment-data.ts
+++ b/apps/mobile/src/features/experiments/hooks/use-precached-experiment-data.ts
@@ -15,7 +15,7 @@ function findExperimentRef(
   experimentId: string,
 ): ExperimentRef | undefined {
   const cached = queryClient.getQueryData(
-    orpc.experiments.listExperiments.queryKey({ input: { filter: "member" } }),
+    orpc.experiments.listExperiments.queryKey({ input: { scope: "related" } }),
   );
   return listItems(cached).find((e) => e.id === experimentId);
 }
@@ -36,7 +36,7 @@ async function precacheExperimentWorkbookFn(
   if (!ref) {
     await queryClient.fetchQuery(
       orpc.experiments.listExperiments.queryOptions({
-        input: { filter: "member" },
+        input: { scope: "related" },
         meta: { suppressToast: true },
       }),
     );

--- a/apps/mobile/src/features/measurement-flow/hooks/use-load-experiment-flow.ts
+++ b/apps/mobile/src/features/measurement-flow/hooks/use-load-experiment-flow.ts
@@ -27,7 +27,7 @@ export function useLoadExperimentFlow(experimentId: string | undefined): {
     error: experimentsError,
   } = useQuery(
     orpc.experiments.listExperiments.queryOptions({
-      input: { filter: "member" },
+      input: { scope: "related" },
       enabled: !!experimentId,
     }),
   );

--- a/apps/mobile/src/shared/composition/prefetch-offline-data.ts
+++ b/apps/mobile/src/shared/composition/prefetch-offline-data.ts
@@ -2,6 +2,8 @@ import type { QueryClient } from "@tanstack/react-query";
 import { orpc } from "~/shared/api/orpc";
 import { createLogger } from "~/shared/observability/logger";
 
+import { listItems } from "@repo/api/shared/listing";
+
 const log = createLogger("prefetch");
 
 let inFlight: Promise<void> | null = null;
@@ -62,21 +64,14 @@ async function _prefetchOfflineData(
 
   const experimentsResponse = await queryClient.fetchQuery(
     orpc.experiments.listExperiments.queryOptions({
-      input: { filter: "member" },
+      input: { scope: "related" },
       staleTime: 0,
       // Reachable from a background reconnect/foreground refetch; stay silent.
       meta: { suppressToast: true },
     }),
   );
 
-  // The response shape can vary (paginated envelope or a bare array); only an
-  // actual array is iterable, so guard before `.map` to avoid
-  // "experiments.map is not a function" crashes seen in production.
-  const experiments = (Array.isArray(experimentsResponse) ? experimentsResponse : []) as {
-    id: string;
-    workbookId: string | null;
-    workbookVersionId: string | null;
-  }[];
+  const experiments = listItems(experimentsResponse);
 
   // Cache each workbook version (cells + pinned snapshots); no per-asset fetches.
   const versionResults = await Promise.allSettled(

--- a/apps/mobile/src/shared/ui/configured-query-client-provider.tsx
+++ b/apps/mobile/src/shared/ui/configured-query-client-provider.tsx
@@ -122,7 +122,9 @@ export function ConfiguredQueryClientProvider({ children }) {
         // hydrating code doesn't see an old shape and crash.
         // v4: the persist filter learned the oRPC key shape ([path, {...}]);
         // previous builds silently persisted none of the oRPC queries.
-        buster: "v4-orpc-key-roots",
+        // v5: listExperiments moved from the deprecated filter=member input
+        // to scope=related, changing its persisted oRPC query key.
+        buster: "v5-experiments-related-scope",
         dehydrateOptions: { shouldDehydrateQuery: shouldPersistQuery },
       }}
     >

--- a/apps/mobile/src/shared/ui/persist-query-filter.test.ts
+++ b/apps/mobile/src/shared/ui/persist-query-filter.test.ts
@@ -17,7 +17,7 @@ describe("shouldPersistQuery", () => {
   it("persists the offline-critical oRPC queries once they hold data", () => {
     expect(shouldPersistQuery(query(orpcKey(["users", "getUserProfile"])))).toBe(true);
     expect(
-      shouldPersistQuery(query(orpcKey(["experiments", "listExperiments"], { filter: "member" }))),
+      shouldPersistQuery(query(orpcKey(["experiments", "listExperiments"], { scope: "related" }))),
     ).toBe(true);
     expect(
       shouldPersistQuery(
@@ -47,7 +47,7 @@ describe("shouldPersistQuery", () => {
 
   it("drops an offline-critical query that has no data", () => {
     const q = {
-      queryKey: orpcKey(["experiments", "listExperiments"], { filter: "member" }),
+      queryKey: orpcKey(["experiments", "listExperiments"], { scope: "related" }),
       state: { status: "pending" },
     } as unknown as Query;
     expect(shouldPersistQuery(q)).toBe(false);

--- a/apps/mobile/vitest.config.ts
+++ b/apps/mobile/vitest.config.ts
@@ -12,7 +12,7 @@ const srcAlias = {
 };
 
 export default defineConfig({
-  // Two projects, both vitest — one `pnpm test` runs everything:
+  // Two projects, both vitest; one `pnpm test` runs everything:
   //   - node  : logic tests + RNTL component tests (via @repo/vitest-config/mobile)
   //   - jsdom : hook tests that rely on @testing-library/react + DOM
   test: {
@@ -48,6 +48,9 @@ export default defineConfig({
         "src/shared/api/**": { lines: 70, statements: 70, branches: 60, functions: 70 },
       },
     },
+    // CI runners OOM-kill vitest workers under full-monorepo parallel load
+    // ("Worker exited unexpectedly", three occurrences across PRs 1967/1968).
+    ...(process.env.CI ? { maxWorkers: 2, minWorkers: 1 } : {}),
     projects: [
       {
         plugins: [react(), reactNative()],


### PR DESCRIPTION
**Stacked on #1967** (backend: scope=related + pagination + tier ranking) — review only the single mobile commit; retarget/merge after #1967 lands.

Mobile half of OJD-1732: all six `filter: "member"` call sites move together to `scope: "related"` (`use-experiments`, `use-load-experiment-flow`, `use-precached-experiment-data` ×2, `prefetch-offline-data`, `use-experiment-workbook-ref`), so experiments reachable through an organization or team finally appear in the app — including the measurement flow and offline precache, which the old bare-`createdBy`-adjacent filter starved. Persistence buster advances `v4-orpc-key-roots` → `v5-experiments-related-scope` (a partial migration would split the persisted query cache; hence all six at once). Still uses the unpaginated array procedures — offline precache needs the full related set.

## Verification
- Mobile lint + typecheck clean; unit suite 105 files / 1110 tests green (92% statement coverage).
- **Validated on a physical Android device** (Nubia NX789J) against this stack's backend over LAN: OTP login; picker shows an org-inherited private experiment (no direct grant — the exact row the old filter hid); measurement flow renders; startup prefetch caches related experiments; **airplane-mode check**: persisted picker still lists all experiments incl. the org-inherited one, cached flow reopens. Device evidence (screenshots + UI Automator dumps) archived in the epic workspace.
- Backend contract compatibility both ways: old app + new backend works via the deprecated `filter` alias; this app + new backend uses `scope` directly.

## Testing scenarios
On OJD-1732 (Linear), including the upgrade-path check for the persistence-version bump.

Part of OJD-1727. Mobile half of OJD-1732.