### PR TITLE
feat(backend,web): full-text, tier-ranked global search for organizations

### DIFF
--- a/.trivyignore.docker-images.yaml
+++ b/.trivyignore.docker-images.yaml
@@ -25,18 +25,21 @@ vulnerabilities:
     statement: "DoS via unbounded arrays, same copy."
     expired_at: 2026-11-05
 
-  # tar@7.5.16 / 7.5.19, fixed in 7.5.21. Pinned by purl: a bumped base that still
-  # ships a vulnerable tar re-fails the scan instead of inheriting these.
+  # Pinned by purl: a bumped base that still ships a vulnerable tar re-fails the
+  # scan instead of inheriting a suppression for a different bundled npm copy.
+  # tar@7.5.16, fixed in 7.5.19.
   - id: CVE-2026-59873
     purls:
       - "pkg:npm/tar@7.5.16"
     statement: "tar DoS via crafted archives. npm extracts nothing at runtime."
     expired_at: 2026-11-05
+  # tar@7.5.16, fixed in 7.5.18.
   - id: CVE-2026-59874
     purls:
       - "pkg:npm/tar@7.5.16"
     statement: "Same tar DoS family, different CVE id."
     expired_at: 2026-11-05
+  # tar@7.5.16 / 7.5.19, fixed in 7.5.21.
   - id: CVE-2026-73566
     purls:
       - "pkg:npm/tar@7.5.16"

--- a/.trivyignore.docker-images.yaml
+++ b/.trivyignore.docker-images.yaml
@@ -25,7 +25,7 @@ vulnerabilities:
     statement: "DoS via unbounded arrays, same copy."
     expired_at: 2026-11-05
 
-  # tar@7.5.16, fixed in 7.5.21. Pinned by purl: a bumped base that still
+  # tar@7.5.16 / 7.5.19, fixed in 7.5.21. Pinned by purl: a bumped base that still
   # ships a vulnerable tar re-fails the scan instead of inheriting these.
   - id: CVE-2026-59873
     purls:
@@ -40,6 +40,7 @@ vulnerabilities:
   - id: CVE-2026-73566
     purls:
       - "pkg:npm/tar@7.5.16"
+      - "pkg:npm/tar@7.5.19"
     statement: "tar DoS via crafted long-path archive, same copy."
     expired_at: 2026-11-05
 

--- a/apps/backend/src/common/utils/fts.ts
+++ b/apps/backend/src/common/utils/fts.ts
@@ -4,7 +4,8 @@ import type { SQL, SQLWrapper } from "@repo/database";
 /**
  * Shared helpers for PostgreSQL full-text search (tsvector/tsquery) + pg_trgm fuzzy matching.
  *
- * Searchable entities (experiments, protocols, macros) have a generated `search_vector` weighting
+ * Searchable entities (experiments, protocols, macros, workbooks, organizations) have a generated
+ * `search_vector` weighting
  * name (A) above description (B). Queries combine FTS prefix matching on the vector (stemming +
  * "photo" -> "photosynthesis") with trigram similarity on the name (typos, "experimnt" ->
  * "experiment"). `ts_rank` + `setweight` make name hits outrank description hits; callers add small

--- a/apps/backend/src/organizations/application/use-cases/list-organizations/list-organizations.ts
+++ b/apps/backend/src/organizations/application/use-cases/list-organizations/list-organizations.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from "@nestjs/common";
 
 import type { OrganizationDirectory } from "@repo/api/domains/organization/organization.schema";
+import type { ResourceScope } from "@repo/api/shared/listing";
 
 import { Result } from "../../../../common/utils/fp-utils";
 import { OrganizationRepository } from "../../../core/repositories/organization.repository";
@@ -16,6 +17,9 @@ import { OrganizationRepository } from "../../../core/repositories/organization.
  * Unpaged, and deliberately so: this is the only listing of organizations there is, so
  * "all organizations" has to mean all of them. The payload is unbounded in the number
  * of organizations — an accepted trade, the same one the resources showcase makes.
+ *
+ * "My organizations" is `scope: "related"` on this same read, not a separate one — so
+ * both slices of the listing match, rank and order identically.
  */
 @Injectable()
 export class ListOrganizationsUseCase {
@@ -25,13 +29,14 @@ export class ListOrganizationsUseCase {
 
   async execute(
     userId: string,
-    params: { search?: string },
+    params: { search?: string; scope?: ResourceScope },
   ): Promise<Result<OrganizationDirectory>> {
     this.logger.log({
       msg: "Listing the organization directory",
       operation: "list-organizations",
       userId,
       hasSearch: Boolean(params.search),
+      scope: params.scope ?? "all",
     });
 
     return this.organizationRepository.listDirectory(userId, params);

--- a/apps/backend/src/organizations/core/models/organization.model.ts
+++ b/apps/backend/src/organizations/core/models/organization.model.ts
@@ -39,6 +39,16 @@ export type GranteeTeamDto = GranteeTeam;
 export type OrganizationDeletionBlockersDto = OrganizationDeletionBlockers;
 export type MembershipStatus = OrganizationMembershipStatus;
 
+/**
+ * What global search merges on, plus the score it merges by. Picked rather than the whole
+ * entry: the listing's counts are correlated subqueries the palette neither shows nor
+ * should pay for on every keystroke.
+ */
+export type OrganizationSearchRow = Pick<
+  OrganizationDirectoryEntryDto,
+  "id" | "name" | "description" | "type"
+> & { score: number };
+
 /** Everything the read use-cases need to decide what a caller may see. */
 export interface OrganizationAccessRow {
   id: string;

--- a/apps/backend/src/organizations/core/repositories/organization.repository.ts
+++ b/apps/backend/src/organizations/core/repositories/organization.repository.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from "@nestjs/common";
 
+import type { ResourceScope } from "@repo/api/shared/listing";
 import {
   and,
   asc,
@@ -12,6 +13,7 @@ import {
   ilike,
   iotDevices,
   isNotPersonalOrgSql,
+  isNull,
   isPersonalOrgSlug,
   macros,
   organizationJoinRequests,
@@ -30,14 +32,23 @@ import {
 import type { AnyColumn, DatabaseInstance, ResourceType, SQL } from "@repo/database";
 
 import { Result, tryCatch } from "../../../common/utils/fp-utils";
-import { escapeLike } from "../../../common/utils/fts";
+import {
+  crossTableBonus,
+  escapeLike,
+  ftsMatch,
+  ftsRank,
+  searchScore,
+} from "../../../common/utils/fts";
 import {
   getAnonymizedAvatarUrl,
   getAnonymizedEmail,
   getAnonymizedFirstName,
   getAnonymizedLastName,
 } from "../../../common/utils/profile-anonymization";
-import { accessibleResourceCondition } from "../../../common/utils/resource-access-scope";
+import {
+  RESOURCE_TIER,
+  accessibleResourceCondition,
+} from "../../../common/utils/resource-access-scope";
 import type {
   GranteeTeamDto,
   MembershipStatus,
@@ -46,6 +57,7 @@ import type {
   OrganizationDirectoryEntryDto,
   OrganizationMemberDto,
   OrganizationResourceTotalsDto,
+  OrganizationSearchRow,
   OrganizationTeamDto,
   OrganizationTeamGrantDto,
 } from "../models/organization.model";
@@ -189,6 +201,12 @@ function resourceCountSql(database: DatabaseInstance, userId: string | undefined
     sql` + `,
   )})`.mapWith(Number);
 }
+
+/**
+ * The type as a user would type it: stored `research_institute`, shown "Research
+ * institute". Normalized on both sides so either spelling matches.
+ */
+const ORGANIZATION_TYPE_TEXT: SQL<string> = sql<string>`replace(${organizations.type}::text, '_', ' ')`;
 
 /** Profile columns every people-shaped read in this domain selects. */
 const personFields = {
@@ -343,23 +361,17 @@ export class OrganizationRepository {
    * Personal workspaces stay out regardless — they are not organizations in product
    * terms. Unpaged: every matching row comes back, so the payload is unbounded in the
    * number of organizations. Accepted, as with the resources showcase.
+   *
+   * `scope: "related"` is "my organizations": one extra condition here, never a second
+   * read. The memberships used to be filtered client-side, so the two slices disagreed
+   * about what matched.
    */
   async listDirectory(
     userId: string,
-    params: { search?: string },
+    params: { search?: string; scope?: ResourceScope },
   ): Promise<Result<{ organizations: OrganizationDirectoryEntryDto[] }>> {
     return tryCatch(async () => {
-      const isMember = exists(
-        this.database
-          .select()
-          .from(organizationMembers)
-          .where(
-            and(
-              eq(organizationMembers.organizationId, organizations.id),
-              eq(organizationMembers.userId, userId),
-            ),
-          ),
-      );
+      const isMember = this.membershipExists(userId);
       const hasPendingRequest = exists(
         this.database
           .select()
@@ -373,15 +385,13 @@ export class OrganizationRepository {
           ),
       );
 
-      const like = params.search ? `%${escapeLike(params.search)}%` : undefined;
+      const { match, score } = this.buildDirectorySearch(userId, params.search);
       const where = and(
-        // Public, or the caller's own. A private organization they do not belong to
-        // stays invisible — this is the visibility boundary, not a convenience.
-        or(eq(organizations.visibility, "public"), isMember),
-        isNotPersonalOrgSql(),
-        like
-          ? sql`(${ilike(organizations.name, like)} OR ${ilike(organizations.description, like)})`
-          : undefined,
+        this.visibleOrganizationsCondition(userId),
+        match,
+        // "Mine": the visible set narrowed to what the caller belongs to. Applied on top
+        // of the visibility boundary, never instead of it.
+        params.scope === "related" ? isMember : undefined,
       );
 
       const rows = await this.database
@@ -406,10 +416,165 @@ export class OrganizationRepository {
         })
         .from(organizations)
         .where(where)
-        .orderBy(asc(organizations.name));
+        // Browsing has nothing to rank against, so it stays alphabetical. A search
+        // orders by relevance, ending on `id` so repeated queries are stable.
+        .orderBy(
+          ...(params.search ? [desc(score), asc(organizations.id)] : [asc(organizations.name)]),
+        );
 
       return { organizations: rows };
     });
+  }
+
+  /**
+   * Global search's view of {@link listDirectory}: same boundary, same match rules, same
+   * score, minus the columns a result row never renders.
+   */
+  async searchDirectory(
+    userId: string,
+    search: string,
+    limit: number,
+  ): Promise<Result<OrganizationSearchRow[]>> {
+    return tryCatch(async () => {
+      const { match, score } = this.buildDirectorySearch(userId, search);
+
+      return this.database
+        .select({
+          id: organizations.id,
+          name: organizations.name,
+          description: organizations.description,
+          type: organizations.type,
+          score,
+        })
+        .from(organizations)
+        .where(and(this.visibleOrganizationsCondition(userId), match))
+        .orderBy(desc(score), asc(organizations.id))
+        .limit(limit);
+    });
+  }
+
+  /** Whether the caller belongs to the `organizations` row the outer query is on. */
+  private membershipExists(userId: string) {
+    return exists(
+      this.database
+        .select()
+        .from(organizationMembers)
+        .where(
+          and(
+            eq(organizationMembers.organizationId, organizations.id),
+            eq(organizationMembers.userId, userId),
+          ),
+        ),
+    );
+  }
+
+  /**
+   * The visibility boundary: public plus the caller's own, personal workspaces never.
+   * Shared by the listing and global search — a drift would either hide an organization
+   * from its own member or reveal a private one to an outsider.
+   */
+  private visibleOrganizationsCondition(userId: string): SQL | undefined {
+    return and(
+      or(eq(organizations.visibility, "public"), this.membershipExists(userId)),
+      isNotPersonalOrgSql(),
+    );
+  }
+
+  /**
+   * One definition of what a search matches and how well, so the listing and global
+   * search can never disagree. Three separate bonus args, not one OR'd together, so the
+   * ceiling is the full 0.1 and matching on two fronts outranks one.
+   */
+  private buildDirectorySearch(
+    userId: string,
+    search: string | undefined,
+  ): { match: SQL | undefined; score: SQL<number> } {
+    if (!search) {
+      // Cast, never a bare integer: Postgres reads an unadorned constant in ORDER BY as
+      // an ordinal position, so a plain `0` would fail the query rather than sort by it.
+      return { match: undefined, score: sql<number>`0::int` };
+    }
+
+    const typeMatch = ilike(ORGANIZATION_TYPE_TEXT, `%${escapeLike(search.replace(/_/g, " "))}%`);
+    const memberMatch = this.memberNameMatch(userId, search);
+    const teamMatch = this.teamNameMatch(userId, search);
+
+    return {
+      match: sql`(${ftsMatch(organizations.searchVector, organizations.name, search)} OR ${typeMatch} OR ${memberMatch} OR ${teamMatch})`,
+      score: searchScore(
+        sql<number>`(${ftsRank(organizations.searchVector, organizations.name, search)} + ${crossTableBonus(typeMatch, memberMatch, teamMatch)})`,
+        this.organizationTierExpression(userId),
+      ),
+    };
+  }
+
+  /**
+   * Whether anyone here is named `term`, gated to the caller's own organizations. The
+   * roster is members-only even on a public org, so an ungated probe would leak the very
+   * list that guard refuses. Deactivated/deleted profiles are anonymized on the way out,
+   * so matching them would surface a name the response never prints.
+   */
+  private memberNameMatch(userId: string, term: string): SQL {
+    return sql`(${this.membershipExists(userId)} AND ${exists(
+      this.database
+        .select()
+        .from(organizationMembers)
+        .innerJoin(profiles, eq(profiles.userId, organizationMembers.userId))
+        .where(
+          and(
+            eq(organizationMembers.organizationId, organizations.id),
+            eq(profiles.activated, true),
+            isNull(profiles.deletedAt),
+            ilike(
+              sql<string>`(${profiles.firstName} || ' ' || ${profiles.lastName})`,
+              `%${escapeLike(term)}%`,
+            ),
+          ),
+        ),
+    )})`;
+  }
+
+  /**
+   * Same gate as {@link memberNameMatch}: a team is a slice of the roster, so it cannot
+   * be less private than one.
+   */
+  private teamNameMatch(userId: string, term: string): SQL {
+    return sql`(${this.membershipExists(userId)} AND ${exists(
+      this.database
+        .select()
+        .from(teams)
+        .where(
+          and(
+            eq(teams.organizationId, organizations.id),
+            ilike(teams.name, `%${escapeLike(term)}%`),
+          ),
+        ),
+    )})`;
+  }
+
+  /**
+   * The caller's tie to each row, on the shared tier scale. No `created_by` exists here,
+   * so the owner role stands in for authorship.
+   */
+  private organizationTierExpression(userId: string): SQL<number> {
+    const isOwner = exists(
+      this.database
+        .select()
+        .from(organizationMembers)
+        .where(
+          and(
+            eq(organizationMembers.organizationId, organizations.id),
+            eq(organizationMembers.userId, userId),
+            eq(organizationMembers.role, "owner"),
+          ),
+        ),
+    );
+
+    return sql<number>`(CASE
+      WHEN ${isOwner} THEN ${sql.raw(String(RESOURCE_TIER.owned))}
+      WHEN ${this.membershipExists(userId)} THEN ${sql.raw(String(RESOURCE_TIER.org))}
+      ELSE ${sql.raw(String(RESOURCE_TIER.public))}
+    END)`;
   }
 
   /**

--- a/apps/backend/src/organizations/core/repositories/organization.repository.ts
+++ b/apps/backend/src/organizations/core/repositories/organization.repository.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from "@nestjs/common";
 
+import { ORGANIZATION_TYPE_SEARCH_ALIASES } from "@repo/api/domains/organization/organization.schema";
 import type { ResourceScope } from "@repo/api/shared/listing";
 import {
   and,
@@ -210,11 +211,12 @@ function resourceCountSql(database: DatabaseInstance, userId: string | undefined
  * while preventing arbitrary mid-word fragments such as `ate` → `private`.
  */
 const ORGANIZATION_TYPE_SEARCH_TEXT: SQL<string> = sql<string>`(CASE ${organizations.type}
-  WHEN 'research_institute' THEN 'research institute Forschungsinstitut Onderzoeksinstituut'
-  WHEN 'non_profit' THEN 'non profit nonprofit Gemeinnützige Organisation'
-  WHEN 'private_company' THEN 'private company Privatunternehmen Particulier bedrijf'
-  WHEN 'government_agency' THEN 'government agency Behörde Overheidsinstantie'
-  WHEN 'university' THEN 'university Universität Universiteit'
+  ${sql.join(
+    Object.entries(ORGANIZATION_TYPE_SEARCH_ALIASES).map(
+      ([type, aliases]) => sql`WHEN ${type} THEN ${aliases}`,
+    ),
+    sql` `,
+  )}
   ELSE ''
 END)`;
 

--- a/apps/backend/src/organizations/core/repositories/organization.repository.ts
+++ b/apps/backend/src/organizations/core/repositories/organization.repository.ts
@@ -38,6 +38,7 @@ import {
   ftsMatch,
   ftsRank,
   searchScore,
+  tsQuery,
 } from "../../../common/utils/fts";
 import {
   getAnonymizedAvatarUrl,
@@ -203,10 +204,19 @@ function resourceCountSql(database: DatabaseInstance, userId: string | undefined
 }
 
 /**
- * The type as a user would type it: stored `research_institute`, shown "Research
- * institute". Normalized on both sides so either spelling matches.
+ * Search aliases for every organization type label shown by the supported locales.
+ * The compact spellings cover punctuated input after {@link tsQuery} sanitizes it
+ * (`non-profit` becomes `nonprofit:*`). A tsvector match keeps partial words useful
+ * while preventing arbitrary mid-word fragments such as `ate` → `private`.
  */
-const ORGANIZATION_TYPE_TEXT: SQL<string> = sql<string>`replace(${organizations.type}::text, '_', ' ')`;
+const ORGANIZATION_TYPE_SEARCH_TEXT: SQL<string> = sql<string>`(CASE ${organizations.type}
+  WHEN 'research_institute' THEN 'research institute Forschungsinstitut Onderzoeksinstituut'
+  WHEN 'non_profit' THEN 'non profit nonprofit Gemeinnützige Organisation'
+  WHEN 'private_company' THEN 'private company Privatunternehmen Particulier bedrijf'
+  WHEN 'government_agency' THEN 'government agency Behörde Overheidsinstantie'
+  WHEN 'university' THEN 'university Universität Universiteit'
+  ELSE ''
+END)`;
 
 /** Profile columns every people-shaped read in this domain selects. */
 const personFields = {
@@ -495,7 +505,9 @@ export class OrganizationRepository {
       return { match: undefined, score: sql<number>`0::int` };
     }
 
-    const typeMatch = ilike(ORGANIZATION_TYPE_TEXT, `%${escapeLike(search.replace(/_/g, " "))}%`);
+    const typeMatch = sql`to_tsvector('english', ${ORGANIZATION_TYPE_SEARCH_TEXT}) @@ ${tsQuery(
+      search.replace(/_/g, " "),
+    )}`;
     const memberMatch = this.memberNameMatch(userId, search);
     const teamMatch = this.teamNameMatch(userId, search);
 
@@ -565,7 +577,7 @@ export class OrganizationRepository {
           and(
             eq(organizationMembers.organizationId, organizations.id),
             eq(organizationMembers.userId, userId),
-            eq(organizationMembers.role, "owner"),
+            orgRoleIncludes(organizationMembers.role, ["owner"]),
           ),
         ),
     );
@@ -791,8 +803,20 @@ export class OrganizationRepository {
  * and admins both can — admins run the membership surface.
  */
 function orgRoleDecides(roleRef: typeof organizationMembers.role): SQL {
+  return orgRoleIncludes(roleRef, ["owner", "admin"]);
+}
+
+/** Better Auth may persist more than one role as a comma-separated string. */
+function orgRoleIncludes(
+  roleRef: typeof organizationMembers.role,
+  acceptedRoles: readonly string[],
+): SQL {
+  const acceptedRoleList = sql.join(
+    acceptedRoles.map((role) => sql`${role}`),
+    sql`, `,
+  );
   return sql`EXISTS (
     SELECT 1 FROM unnest(string_to_array(${roleRef}, ',')) AS role_token
-    WHERE trim(role_token) IN ('owner', 'admin')
+    WHERE trim(role_token) IN (${acceptedRoleList})
   )`;
 }

--- a/apps/backend/src/organizations/organization.module.ts
+++ b/apps/backend/src/organizations/organization.module.ts
@@ -72,5 +72,8 @@ import { OrganizationController } from "./presentation/organization.controller";
     DecideOrganizationJoinRequestUseCase,
     OrganizationAuthHook,
   ],
+  // Global search composes the directory read, on the same visibility boundary the
+  // listing uses.
+  exports: [OrganizationRepository],
 })
 export class OrganizationModule {}

--- a/apps/backend/src/organizations/presentation/organization.controller.spec.ts
+++ b/apps/backend/src/organizations/presentation/organization.controller.spec.ts
@@ -145,6 +145,49 @@ describe("OrganizationController", () => {
       expect(response.body.organizations).toHaveLength(0);
     });
 
+    it("scope=related narrows to the caller's memberships without changing what matches", async () => {
+      // "My organizations" is this same query plus one condition, so a term that finds a
+      // row in the directory finds it under `related` too whenever the caller belongs to
+      // it. The old listing filtered memberships client-side on name/description only,
+      // which is exactly the disagreement this asserts is gone.
+      const mine = await testApp.createOrganization("Delta Phenotyping Centre", {
+        visibility: "public",
+        location: "Wageningen, Netherlands",
+      });
+      await testApp.addOrganizationMember(mine, ownerId, "owner");
+      await testApp.createOrganization("Someone Else Lab", {
+        visibility: "public",
+        location: "Wageningen, Netherlands",
+      });
+
+      const all: SuperTestResponse<OrganizationDirectory> = await testApp
+        .get(`${path()}?search=wageningen`)
+        .withAuth(ownerId)
+        .expect(StatusCodes.OK);
+      expect(all.body.organizations.map((o) => o.name).sort()).toEqual([
+        "Delta Phenotyping Centre",
+        "Someone Else Lab",
+      ]);
+
+      const related: SuperTestResponse<OrganizationDirectory> = await testApp
+        .get(`${path()}?search=wageningen&scope=related`)
+        .withAuth(ownerId)
+        .expect(StatusCodes.OK);
+      expect(related.body.organizations.map((o) => o.name)).toEqual(["Delta Phenotyping Centre"]);
+    });
+
+    it("scope=related never widens past the visibility boundary", async () => {
+      // The narrowing rides on top of the boundary, never instead of it.
+      await seedPrivateOrg();
+
+      const response: SuperTestResponse<OrganizationDirectory> = await testApp
+        .get(`${path()}?scope=related`)
+        .withAuth(outsiderId)
+        .expect(StatusCodes.OK);
+
+      expect(response.body.organizations).toHaveLength(0);
+    });
+
     it("filters by name and description", async () => {
       await seedPublicOrg("Photosynthesis Lab");
       const other = await testApp.createOrganization("Soil Institute", {

--- a/apps/backend/src/organizations/presentation/organization.controller.ts
+++ b/apps/backend/src/organizations/presentation/organization.controller.ts
@@ -38,6 +38,7 @@ export class OrganizationController {
     return implement(organizationContract.listOrganizations).handler(async ({ input }) => {
       const result = await this.listOrganizationsUseCase.execute(session.user.id, {
         search: input.search,
+        scope: input.scope,
       });
 
       if (result.isSuccess()) {

--- a/apps/backend/src/search/application/use-cases/global-search/global-search.spec.ts
+++ b/apps/backend/src/search/application/use-cases/global-search/global-search.spec.ts
@@ -29,7 +29,7 @@ describe("GlobalSearchUseCase", () => {
     await testApp.teardown();
   });
 
-  it("returns ranked matches across experiments, protocols, macros and workbooks", async () => {
+  it("returns ranked matches across experiments, protocols, macros, workbooks and organizations", async () => {
     await testApp.createExperiment({
       name: "Photosynthesis trial",
       userId,
@@ -38,6 +38,7 @@ describe("GlobalSearchUseCase", () => {
     await testApp.createProtocol({ name: "Photosynthesis protocol", createdBy: userId });
     await testApp.createMacro({ name: "Photosynthesis macro", createdBy: userId });
     await testApp.createWorkbook({ name: "Photosynthesis workbook", createdBy: userId });
+    await testApp.createOrganization("Photosynthesis Lab", { visibility: "public" });
 
     const result = await useCase.execute(userId, "photosynthesis", 20);
 
@@ -47,10 +48,15 @@ describe("GlobalSearchUseCase", () => {
     expect(types).toContain("protocol");
     expect(types).toContain("macro");
     expect(types).toContain("workbook");
+    expect(types).toContain("organization");
     // The workbook result carries no type-specific meta label (like experiments).
     const workbook = result.value.results.find((r) => r.type === "workbook");
     expect(workbook?.title).toBe("Photosynthesis workbook");
     expect(workbook?.meta).toBeNull();
+    // An organization that never set a type has no label either.
+    const organization = result.value.results.find((r) => r.type === "organization");
+    expect(organization?.title).toBe("Photosynthesis Lab");
+    expect(organization?.meta).toBeNull();
   });
 
   it("matches description text (FTS) and tolerates typos in the name (trigram)", async () => {
@@ -332,6 +338,163 @@ describe("GlobalSearchUseCase", () => {
       expect(titles).toContain("Shared photosynthesis macro");
       expect(titles).toContain("Shared photosynthesis protocol");
       expect(titles).toContain("Shared photosynthesis workbook");
+    });
+  });
+
+  // Organizations are a grantee, never a grantable resource, so they carry the
+  // directory's boundary rather than the shared resource access scope.
+  describe("organizations", () => {
+    it("hides a private organization from a non-member and shows it to a member", async () => {
+      const orgId = await testApp.createOrganization("Photosynthesis Consortium", {
+        visibility: "private",
+      });
+      await testApp.addOrganizationMember(orgId, otherUserId, "owner");
+
+      const toOutsider = await useCase.execute(userId, "photosynthesis", 20);
+      assertSuccess(toOutsider);
+      expect(toOutsider.value.results.some((r) => r.title === "Photosynthesis Consortium")).toBe(
+        false,
+      );
+
+      await testApp.addOrganizationMember(orgId, userId, "member");
+
+      const toMember = await useCase.execute(userId, "photosynthesis", 20);
+      assertSuccess(toMember);
+      expect(toMember.value.results.some((r) => r.title === "Photosynthesis Consortium")).toBe(
+        true,
+      );
+    });
+
+    it("never surfaces a personal workspace, even when it matches", async () => {
+      // Personal workspaces are named after their owner and are not organizations in
+      // product terms — every user having one would make them noise in every search.
+      const personalOrgId = await testApp.personalOrganizationId(userId);
+      await testApp.database.execute(
+        `UPDATE organizations SET name = 'Photosynthesis workspace', visibility = 'public' WHERE id = '${personalOrgId}'`,
+      );
+
+      const result = await useCase.execute(userId, "photosynthesis", 20);
+
+      assertSuccess(result);
+      expect(result.value.results.some((r) => r.type === "organization")).toBe(false);
+    });
+
+    it("matches the organization type and returns it as the meta label", async () => {
+      // The name deliberately omits the type — only the enum should match, and the
+      // spaced spelling is the one the UI shows.
+      await testApp.createOrganization("Vorbulon Collective", {
+        visibility: "public",
+        type: "research_institute",
+      });
+
+      const byType = await useCase.execute(userId, "research institute", 20);
+      assertSuccess(byType);
+      const organization = byType.value.results.find((r) => r.title === "Vorbulon Collective");
+      expect(organization?.meta).toBe("research_institute");
+    });
+
+    it("finds an organization by its location, ranked below a name hit", async () => {
+      // Location sits at weight C, so a place-name hit is findable but never outranks an
+      // organization whose actual name matches the same term.
+      await testApp.createOrganization("Delta Phenotyping Centre", {
+        visibility: "public",
+        location: "Wageningen, Netherlands",
+      });
+      await testApp.createOrganization("Wageningen Collective", { visibility: "public" });
+
+      const result = await useCase.execute(userId, "wageningen", 20);
+
+      assertSuccess(result);
+      const titles = result.value.results
+        .filter((r) => r.type === "organization")
+        .map((r) => r.title);
+      expect(titles).toContain("Delta Phenotyping Centre");
+      expect(titles.indexOf("Wageningen Collective")).toBeLessThan(
+        titles.indexOf("Delta Phenotyping Centre"),
+      );
+    });
+
+    // Member and team names are matched only for organizations the caller belongs to.
+    // The roster and the team list are both members-only reads — enforced even on a
+    // public organization — so an ungated probe would hand back through search exactly
+    // what those guards refuse to answer.
+    describe("member and team names", () => {
+      it("finds an organization by a member's name, but only one the caller belongs to", async () => {
+        const colleague = await testApp.createTestUser({ name: "Zephyrina Quibbleworth" });
+
+        const mine = await testApp.createOrganization("Delta Phenotyping Centre", {
+          visibility: "public",
+        });
+        await testApp.addOrganizationMember(mine, userId, "member");
+        await testApp.addOrganizationMember(mine, colleague, "member");
+
+        // Same person, an organization the caller has no part in. Public, so the row
+        // itself is visible — it is the *member name* that must not match.
+        const theirs = await testApp.createOrganization("Rhine Sensors", { visibility: "public" });
+        await testApp.addOrganizationMember(theirs, colleague, "member");
+
+        const result = await useCase.execute(userId, "zephyrina", 20);
+
+        assertSuccess(result);
+        const titles = result.value.results
+          .filter((r) => r.type === "organization")
+          .map((r) => r.title);
+        expect(titles).toContain("Delta Phenotyping Centre");
+        expect(titles).not.toContain("Rhine Sensors");
+      });
+
+      it("finds an organization by a team's name, under the same gate", async () => {
+        const mine = await testApp.createOrganization("Delta Phenotyping Centre", {
+          visibility: "public",
+        });
+        await testApp.addOrganizationMember(mine, userId, "member");
+        await testApp.createTeam(mine, "Vorbulon Canopy Squad");
+
+        const theirs = await testApp.createOrganization("Rhine Sensors", { visibility: "public" });
+        await testApp.createTeam(theirs, "Vorbulon Canopy Squad");
+
+        const result = await useCase.execute(userId, "vorbulon", 20);
+
+        assertSuccess(result);
+        const titles = result.value.results
+          .filter((r) => r.type === "organization")
+          .map((r) => r.title);
+        expect(titles).toContain("Delta Phenotyping Centre");
+        expect(titles).not.toContain("Rhine Sensors");
+      });
+
+      it("does not match a deactivated member's name", async () => {
+        // Deactivated and deleted profiles are anonymized on the way out, so matching
+        // them would surface a name the response itself would never print.
+        const departed = await testApp.createTestUser({
+          name: "Grindelwax Thornbury",
+          activated: false,
+        });
+        const orgId = await testApp.createOrganization("Delta Phenotyping Centre", {
+          visibility: "public",
+        });
+        await testApp.addOrganizationMember(orgId, userId, "member");
+        await testApp.addOrganizationMember(orgId, departed, "member");
+
+        const result = await useCase.execute(userId, "grindelwax", 20);
+
+        assertSuccess(result);
+        expect(result.value.results.some((r) => r.type === "organization")).toBe(false);
+      });
+    });
+
+    it("matches an organization description and links to it by id", async () => {
+      const orgId = await testApp.createOrganization("Grindelwax Institute", {
+        visibility: "public",
+        description: "studies chlorophyll fluorescence",
+      });
+
+      const result = await useCase.execute(userId, "chlorophyll", 20);
+
+      assertSuccess(result);
+      const organization = result.value.results.find((r) => r.type === "organization");
+      expect(organization?.id).toBe(orgId);
+      expect(organization?.subtitle).toBe("studies chlorophyll fluorescence");
     });
   });
 });

--- a/apps/backend/src/search/application/use-cases/global-search/global-search.spec.ts
+++ b/apps/backend/src/search/application/use-cases/global-search/global-search.spec.ts
@@ -1,6 +1,7 @@
-import { eq, experiments } from "@repo/database";
+import { eq, experiments, organizationMembers } from "@repo/database";
 
 import { assertSuccess } from "../../../../common/utils/fp-utils";
+import { OrganizationRepository } from "../../../../organizations/core/repositories/organization.repository";
 import { TestHarness } from "../../../../test/test-harness";
 import { GlobalSearchUseCase } from "./global-search";
 
@@ -391,6 +392,60 @@ describe("GlobalSearchUseCase", () => {
       assertSuccess(byType);
       const organization = byType.value.results.find((r) => r.title === "Vorbulon Collective");
       expect(organization?.meta).toBe("research_institute");
+    });
+
+    it.each([
+      ["non_profit", "non-profit"],
+      ["research_institute", "Forschungsinstitut"],
+      ["government_agency", "Overheidsinstantie"],
+    ] as const)("matches the visible %s label %s", async (type, query) => {
+      const name = `Vorbulon ${type}`;
+      await testApp.createOrganization(name, { visibility: "public", type });
+
+      const result = await useCase.execute(userId, query, 20);
+
+      assertSuccess(result);
+      expect(result.value.results.some((row) => row.title === name)).toBe(true);
+    });
+
+    it("does not match arbitrary fragments inside an organization type", async () => {
+      await testApp.createOrganization("Vorbulon Collective", {
+        visibility: "public",
+        type: "private_company",
+      });
+
+      const result = await useCase.execute(userId, "ate", 20);
+
+      assertSuccess(result);
+      expect(result.value.results.some((row) => row.title === "Vorbulon Collective")).toBe(false);
+    });
+
+    it("recognizes owner inside a stored multi-role when ranking organizations", async () => {
+      const owned = await testApp.createOrganization("Owned Vorbulon", {
+        visibility: "public",
+        description: "zephyrine research",
+      });
+      const member = await testApp.createOrganization("Member Vorbulon", {
+        visibility: "public",
+        description: "zephyrine research",
+      });
+      await testApp.addOrganizationMember(owned, userId, "owner");
+      await testApp.addOrganizationMember(member, userId, "member");
+      await testApp.database
+        .update(organizationMembers)
+        .set({ role: "owner,admin" })
+        .where(eq(organizationMembers.organizationId, owned));
+
+      const repository = testApp.module.get(OrganizationRepository);
+      const result = await repository.searchDirectory(userId, "zephyrine", 20);
+
+      assertSuccess(result);
+      const ownedScore = result.value.find((row) => row.id === owned)?.score;
+      const memberScore = result.value.find((row) => row.id === member)?.score;
+      if (ownedScore === undefined || memberScore === undefined) {
+        throw new Error("Expected both organizations in the ranked result set");
+      }
+      expect(ownedScore).toBeGreaterThan(memberScore);
     });
 
     it("finds an organization by its location, ranked below a name hit", async () => {

--- a/apps/backend/src/search/application/use-cases/global-search/global-search.ts
+++ b/apps/backend/src/search/application/use-cases/global-search/global-search.ts
@@ -5,6 +5,7 @@ import type { SearchResult, SearchResultType } from "@repo/api/domains/search/se
 import { Result, isFailure, success } from "../../../../common/utils/fp-utils";
 import { ExperimentRepository } from "../../../../experiments/core/repositories/experiment.repository";
 import { MacroRepository } from "../../../../macros/core/repositories/macro.repository";
+import { OrganizationRepository } from "../../../../organizations/core/repositories/organization.repository";
 import { ProtocolRepository } from "../../../../protocols/core/repositories/protocol.repository";
 import { WorkbookRepository } from "../../../../workbooks/core/repositories/workbook.repository";
 
@@ -25,6 +26,7 @@ export class GlobalSearchUseCase {
     private readonly protocolRepository: ProtocolRepository,
     private readonly macroRepository: MacroRepository,
     private readonly workbookRepository: WorkbookRepository,
+    private readonly organizationRepository: OrganizationRepository,
   ) {}
 
   async execute(
@@ -38,7 +40,7 @@ export class GlobalSearchUseCase {
     // by exactly the same rules: there is one search definition per entity, and global search
     // is purely a consumer of it. Overfetching `limit` per type removes any per-type recall
     // ceiling, so the 9th-best experiment can still outrank every macro.
-    const [experiments, protocols, macros, workbooks] = await Promise.all([
+    const [experiments, protocols, macros, workbooks, organizations] = await Promise.all([
       this.experimentRepository.findAll(userId, undefined, undefined, query, limit),
       // Pass the caller so each findAll applies the same access scoping it uses
       // for listing: global search must not surface private resources the caller
@@ -46,12 +48,17 @@ export class GlobalSearchUseCase {
       this.protocolRepository.findAll(query, undefined, userId, limit),
       this.macroRepository.findAll({ search: query, userId }, limit),
       this.workbookRepository.findAll({ search: query, userId }, limit),
+      // Organizations are a grantee, never a grantable resource, so their boundary is
+      // the directory's own — public or the caller's, personal workspaces never —
+      // rather than the shared resource access scope.
+      this.organizationRepository.searchDirectory(userId, query, limit),
     ]);
 
     if (isFailure(experiments)) return experiments;
     if (isFailure(protocols)) return protocols;
     if (isFailure(macros)) return macros;
     if (isFailure(workbooks)) return workbooks;
+    if (isFailure(organizations)) return organizations;
 
     // The repositories compute one comparable score per row (same lexical base, same capped
     // cross-table bonus, same tier weight), so merging is a plain sort. `id` breaks ties, making
@@ -61,6 +68,7 @@ export class GlobalSearchUseCase {
       ...toResults(protocols.value, "protocol", (p) => p.family),
       ...toResults(macros.value, "macro", (m) => m.language),
       ...toResults(workbooks.value, "workbook", () => null),
+      ...toResults(organizations.value, "organization", (o) => o.type),
     ]
       .sort((a, b) => b.score - a.score || a.id.localeCompare(b.id))
       .slice(0, limit);

--- a/apps/backend/src/search/search.module.ts
+++ b/apps/backend/src/search/search.module.ts
@@ -2,6 +2,7 @@ import { Module } from "@nestjs/common";
 
 import { ExperimentModule } from "../experiments/experiment.module";
 import { MacroModule } from "../macros/macro.module";
+import { OrganizationModule } from "../organizations/organization.module";
 import { ProtocolModule } from "../protocols/protocol.module";
 import { WorkbookModule } from "../workbooks/workbook.module";
 import { GlobalSearchUseCase } from "./application/use-cases/global-search/global-search";
@@ -9,7 +10,7 @@ import { SearchController } from "./presentation/search.controller";
 
 @Module({
   // Imported modules export the repositories the global-search use case composes.
-  imports: [ExperimentModule, ProtocolModule, MacroModule, WorkbookModule],
+  imports: [ExperimentModule, ProtocolModule, MacroModule, WorkbookModule, OrganizationModule],
   controllers: [SearchController],
   providers: [GlobalSearchUseCase],
 })

--- a/apps/backend/src/test/test-harness.ts
+++ b/apps/backend/src/test/test-harness.ts
@@ -462,6 +462,7 @@ export class TestHarness {
       slug?: string;
       visibility?: "private" | "public";
       description?: string | null;
+      location?: string | null;
       type?:
         | "research_institute"
         | "non_profit"
@@ -477,6 +478,7 @@ export class TestHarness {
         slug: options.slug ?? `org-${faker.string.uuid()}`,
         ...(options.visibility ? { visibility: options.visibility } : {}),
         ...(options.description === undefined ? {} : { description: options.description }),
+        ...(options.location === undefined ? {} : { location: options.location }),
         ...(options.type ? { type: options.type } : {}),
       })
       .returning();

--- a/apps/docs/content/guide/get-started/platform-tour.mdx
+++ b/apps/docs/content/guide/get-started/platform-tour.mdx
@@ -3,7 +3,7 @@ title: "A tour of the platform"
 description: "Find your way around the openJII web platform: the sidebar, command palette, keyboard shortcuts, and activity feed."
 ---
 
-{/* verified: code@b92f75cb4 2026-07-23 */}
+{/* verified: code@b324ade7b 2026-08-28 */}
 
 Once you are signed in, everything in openJII lives inside one consistent shell.
 This page is a quick visual tour of that shell so you know where to look before
@@ -12,10 +12,10 @@ diving into experiments and data.
 ## The sidebar
 
 The left sidebar is your main navigation: experiments, protocols, macros,
-workbooks, and devices. You can collapse it to get more room for your data; when
-collapsed, hovering the left edge peeks it back open, and a floating button
-reopens it permanently. The sidebar footer also holds **What's New**, a feed of
-recent platform releases.
+workbooks, organizations, and devices. You can collapse it to get more room for
+your data; when collapsed, hovering the left edge peeks it back open, and a
+floating button reopens it permanently. The sidebar footer also holds
+**What's New**, a feed of recent platform releases.
 See <PlatformLink path="/releases">openJII Releases</PlatformLink> for the full history.
 
 ![Collapsed sidebar peeking open on hover](/img/chrome-refresh/sidebar-peek.jpg)
@@ -23,15 +23,18 @@ See <PlatformLink path="/releases">openJII Releases</PlatformLink> for the full 
 ## The command palette
 
 Press <kbd>Ctrl</kbd>+<kbd>K</kbd> (<kbd>⌘</kbd>+<kbd>K</kbd> on macOS) anywhere
-to open the command palette. It searches pages and actions, so you can jump to an
-experiment or start a common task without reaching for the mouse.
+to open the command palette. It searches pages and actions as well as the
+experiments, protocols, macros, workbooks, and organizations you can access.
+Matches from every resource type share one relevance-ranked list, so the closest
+match appears first. Select a result to open it without reaching for the mouse.
 
 ![Command palette open over the dashboard](/img/chrome-refresh/command-palette.jpg)
 
 ## Keyboard shortcuts
 
-Most navigation has a keyboard shortcut. Press <kbd>?</kbd> to open the shortcut
-cheatsheet and see what is available on the page you are on.
+Most navigation has a keyboard shortcut. Press <kbd>G</kbd> followed by <kbd>O</kbd>
+to open Organizations. Press <kbd>?</kbd> to open the shortcut cheatsheet and see
+what is available on the page you are on.
 
 ![Keyboard shortcut cheatsheet](/img/chrome-refresh/cheatsheet.jpg)
 

--- a/apps/docs/content/guide/get-started/platform-tour.mdx
+++ b/apps/docs/content/guide/get-started/platform-tour.mdx
@@ -3,7 +3,7 @@ title: "A tour of the platform"
 description: "Find your way around the openJII web platform: the sidebar, command palette, keyboard shortcuts, and activity feed."
 ---
 
-{/* verified: code@b324ade7b 2026-08-28 */}
+{/* verified: code@334d63b10 2026-08-28 */}
 
 Once you are signed in, everything in openJII lives inside one consistent shell.
 This page is a quick visual tour of that shell so you know where to look before

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -19343,7 +19343,21 @@
             "schema": {
               "type": "string",
               "maxLength": 200,
-              "description": "Name or description substring"
+              "description": "Name, description, location or type; also member and team names, for organizations you belong to"
+            },
+            "allowEmptyValue": true,
+            "allowReserved": true
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "schema": {
+              "enum": [
+                "related",
+                "all"
+              ],
+              "type": "string",
+              "description": "Which slice of the visible set to return"
             },
             "allowEmptyValue": true,
             "allowReserved": true
@@ -23188,7 +23202,8 @@
                               "experiment",
                               "protocol",
                               "macro",
-                              "workbook"
+                              "workbook",
+                              "organization"
                             ],
                             "type": "string"
                           },

--- a/apps/web/components/command/cheatsheet-dialog.tsx
+++ b/apps/web/components/command/cheatsheet-dialog.tsx
@@ -28,6 +28,7 @@ function buildSections(mod: string): Section[] {
         { keys: ["G", "W"], label: "Workbooks" },
         { keys: ["G", "P"], label: "Protocols" },
         { keys: ["G", "M"], label: "Macros" },
+        { keys: ["G", "O"], label: "Organizations" },
         { keys: ["G", "T"], label: "Transfer requests" },
         { keys: ["G", "S"], label: "Settings" },
         { keys: ["G", "A"], label: "Account" },

--- a/apps/web/components/command/command-palette.test.tsx
+++ b/apps/web/components/command/command-palette.test.tsx
@@ -130,10 +130,17 @@ describe("CommandPalette", () => {
     expect(screen.queryByText("commandPalette.entries.home")).not.toBeInTheDocument();
   });
 
-  it("renders grouped server results and navigates to a selected one", async () => {
+  it("renders server results in backend rank order and navigates to a selected one", async () => {
     mockSearch({
       enabled: true,
       results: [
+        {
+          type: "organization",
+          id: "44444444-4444-4444-4444-444444444444",
+          title: "Photosynthesis Lab",
+          subtitle: null,
+          meta: "research_institute",
+        },
         {
           type: "experiment",
           id: "11111111-1111-1111-1111-111111111111",
@@ -155,13 +162,6 @@ describe("CommandPalette", () => {
           subtitle: null,
           meta: null,
         },
-        {
-          type: "organization",
-          id: "44444444-4444-4444-4444-444444444444",
-          title: "Photosynthesis Lab",
-          subtitle: null,
-          meta: "research_institute",
-        },
       ],
     });
     const user = userEvent.setup();
@@ -170,14 +170,15 @@ describe("CommandPalette", () => {
     const input = await screen.findByPlaceholderText("commandPalette.placeholder");
     await user.type(input, "photo");
 
-    expect(await screen.findByText("Photosynthesis trial")).toBeInTheDocument();
+    const organization = await screen.findByText("Photosynthesis Lab");
+    const experiment = screen.getByText("Photosynthesis trial");
+    expect(
+      organization.compareDocumentPosition(experiment) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
+    expect(experiment).toBeInTheDocument();
     expect(screen.getByText("Photosynthesis protocol")).toBeInTheDocument();
     expect(screen.getByText("Photosynthesis workbook")).toBeInTheDocument();
-    expect(screen.getByText("Photosynthesis Lab")).toBeInTheDocument();
-    expect(screen.getByText("commandPalette.results.experiments")).toBeInTheDocument();
-    expect(screen.getByText("commandPalette.results.protocols")).toBeInTheDocument();
-    expect(screen.getByText("commandPalette.results.workbooks")).toBeInTheDocument();
-    expect(screen.getByText("commandPalette.results.organizations")).toBeInTheDocument();
+    expect(screen.getByText("commandPalette.groups.searchResults")).toBeInTheDocument();
 
     await user.click(screen.getByText("Photosynthesis workbook"));
     expect(router.push).toHaveBeenCalledWith(

--- a/apps/web/components/command/command-palette.test.tsx
+++ b/apps/web/components/command/command-palette.test.tsx
@@ -74,6 +74,7 @@ describe("CommandPalette", () => {
       ["commandPalette.entries.workbooks", "/en-US/platform/workbooks"],
       ["commandPalette.entries.protocols", "/en-US/platform/protocols"],
       ["commandPalette.entries.macros", "/en-US/platform/macros"],
+      ["commandPalette.entries.organizations", "/en-US/platform/organizations"],
       ["commandPalette.entries.transferRequests", "/en-US/platform/transfer-request"],
       ["commandPalette.entries.settings", "/en-US/platform/account"],
       ["commandPalette.entries.createExperiment", "/en-US/platform/experiments/new"],
@@ -154,6 +155,13 @@ describe("CommandPalette", () => {
           subtitle: null,
           meta: null,
         },
+        {
+          type: "organization",
+          id: "44444444-4444-4444-4444-444444444444",
+          title: "Photosynthesis Lab",
+          subtitle: null,
+          meta: "research_institute",
+        },
       ],
     });
     const user = userEvent.setup();
@@ -165,13 +173,43 @@ describe("CommandPalette", () => {
     expect(await screen.findByText("Photosynthesis trial")).toBeInTheDocument();
     expect(screen.getByText("Photosynthesis protocol")).toBeInTheDocument();
     expect(screen.getByText("Photosynthesis workbook")).toBeInTheDocument();
+    expect(screen.getByText("Photosynthesis Lab")).toBeInTheDocument();
     expect(screen.getByText("commandPalette.results.experiments")).toBeInTheDocument();
     expect(screen.getByText("commandPalette.results.protocols")).toBeInTheDocument();
     expect(screen.getByText("commandPalette.results.workbooks")).toBeInTheDocument();
+    expect(screen.getByText("commandPalette.results.organizations")).toBeInTheDocument();
 
     await user.click(screen.getByText("Photosynthesis workbook"));
     expect(router.push).toHaveBeenCalledWith(
       "/en-US/platform/workbooks/33333333-3333-3333-3333-333333333333",
+    );
+  });
+
+  it("navigates to a selected organization result", async () => {
+    mockSearch({
+      enabled: true,
+      results: [
+        {
+          type: "organization",
+          id: "44444444-4444-4444-4444-444444444444",
+          title: "Photosynthesis Lab",
+          subtitle: "A shared greenhouse",
+          meta: "research_institute",
+        },
+      ],
+    });
+    const user = userEvent.setup();
+    const { router } = render(<CommandPalette locale="en-US" />);
+    openPalette();
+    const input = await screen.findByPlaceholderText("commandPalette.placeholder");
+    await user.type(input, "photo");
+
+    // The type renders through the shared organization label map, not raw enum text.
+    expect(await screen.findByText("organizations.types.research_institute")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Photosynthesis Lab"));
+    expect(router.push).toHaveBeenCalledWith(
+      "/en-US/platform/organizations/44444444-4444-4444-4444-444444444444",
     );
   });
 

--- a/apps/web/components/command/command-palette.tsx
+++ b/apps/web/components/command/command-palette.tsx
@@ -41,6 +41,7 @@ const RESULT_GROUPS: { type: SearchResultType; headingKey: string }[] = [
   { type: "protocol", headingKey: "commandPalette.results.protocols" },
   { type: "macro", headingKey: "commandPalette.results.macros" },
   { type: "workbook", headingKey: "commandPalette.results.workbooks" },
+  { type: "organization", headingKey: "commandPalette.results.organizations" },
 ];
 
 export function CommandPalette({ locale }: { locale: string }) {
@@ -115,6 +116,14 @@ export function CommandPalette({ locale }: { locale: string }) {
         run: () => navigate(`/${locale}/platform/macros`),
       },
       {
+        id: "page.organizations",
+        labelKey: "commandPalette.entries.organizations",
+        group: "pages",
+        icon: iconMap.Building2,
+        shortcut: "G O",
+        run: () => navigate(`/${locale}/platform/organizations`),
+      },
+      {
         id: "page.transfer",
         labelKey: "commandPalette.entries.transferRequests",
         group: "pages",
@@ -187,6 +196,7 @@ export function CommandPalette({ locale }: { locale: string }) {
       protocol: [],
       macro: [],
       workbook: [],
+      organization: [],
     };
     for (const result of results) groups[result.type].push(result);
     return groups;
@@ -203,6 +213,8 @@ export function CommandPalette({ locale }: { locale: string }) {
           return navigate(`/${locale}/platform/macros/${result.id}`);
         case "workbook":
           return navigate(`/${locale}/platform/workbooks/${result.id}`);
+        case "organization":
+          return navigate(`/${locale}/platform/organizations/${result.id}`);
       }
     },
     [locale, navigate],

--- a/apps/web/components/command/command-palette.tsx
+++ b/apps/web/components/command/command-palette.tsx
@@ -12,7 +12,7 @@ import { useRouter } from "next/navigation";
 import * as React from "react";
 import { env } from "~/env";
 
-import type { SearchResult, SearchResultType } from "@repo/api/domains/search/search.schema";
+import type { SearchResult } from "@repo/api/domains/search/search.schema";
 import { useTranslation } from "@repo/i18n";
 import {
   CommandDialog,
@@ -35,14 +35,6 @@ interface PaletteEntry {
   shortcut?: string;
   run: () => void;
 }
-
-const RESULT_GROUPS: { type: SearchResultType; headingKey: string }[] = [
-  { type: "experiment", headingKey: "commandPalette.results.experiments" },
-  { type: "protocol", headingKey: "commandPalette.results.protocols" },
-  { type: "macro", headingKey: "commandPalette.results.macros" },
-  { type: "workbook", headingKey: "commandPalette.results.workbooks" },
-  { type: "organization", headingKey: "commandPalette.results.organizations" },
-];
 
 export function CommandPalette({ locale }: { locale: string }) {
   const [open, setOpen] = React.useState(false);
@@ -190,18 +182,6 @@ export function CommandPalette({ locale }: { locale: string }) {
   const pages = entries.filter((e) => e.group === "pages" && matchesQuery(t(e.labelKey)));
   const actions = entries.filter((e) => e.group === "actions" && matchesQuery(t(e.labelKey)));
 
-  const resultsByType = React.useMemo(() => {
-    const groups: Record<SearchResultType, SearchResult[]> = {
-      experiment: [],
-      protocol: [],
-      macro: [],
-      workbook: [],
-      organization: [],
-    };
-    for (const result of results) groups[result.type].push(result);
-    return groups;
-  }, [results]);
-
   const onSelectResult = React.useCallback(
     (result: SearchResult) => {
       switch (result.type) {
@@ -282,19 +262,15 @@ export function CommandPalette({ locale }: { locale: string }) {
             <>
               {hasStaticEntries && <CommandSeparator />}
               {showSearchResults ? (
-                RESULT_GROUPS.map(({ type, headingKey }) =>
-                  resultsByType[type].length > 0 ? (
-                    <CommandGroup key={type} heading={t(headingKey)}>
-                      {resultsByType[type].map((result) => (
-                        <SearchResultItem
-                          key={`${result.type}:${result.id}`}
-                          result={result}
-                          onSelect={onSelectResult}
-                        />
-                      ))}
-                    </CommandGroup>
-                  ) : null,
-                )
+                <CommandGroup heading={t("commandPalette.groups.searchResults")}>
+                  {results.map((result) => (
+                    <SearchResultItem
+                      key={`${result.type}:${result.id}`}
+                      result={result}
+                      onSelect={onSelectResult}
+                    />
+                  ))}
+                </CommandGroup>
               ) : (
                 // No results to list — center the status message in whatever space is left so it
                 // doesn't cling to the static entries above it.

--- a/apps/web/components/command/search-result-item.tsx
+++ b/apps/web/components/command/search-result-item.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import { organizationTypeLabelKey } from "@/components/organizations/organization-labels";
 import { stripHtml } from "@/util/strip-html";
-import { BookOpen, Code, FileSliders, Leaf } from "lucide-react";
+import { BookOpen, Building2, Code, FileSliders, Leaf } from "lucide-react";
 import * as React from "react";
 
+import { zOrganizationType } from "@repo/api/domains/organization/organization.schema";
 import type { SearchResult, SearchResultType } from "@repo/api/domains/search/search.schema";
+import { useTranslation } from "@repo/i18n";
 import { Badge } from "@repo/ui/components/badge";
 import { CommandItem } from "@repo/ui/components/command";
 
@@ -13,6 +16,7 @@ const ICONS: Record<SearchResultType, React.ComponentType<{ className?: string }
   protocol: FileSliders,
   macro: Code,
   workbook: BookOpen,
+  organization: Building2,
 };
 
 const LANGUAGE_LABELS: Record<string, string> = {
@@ -21,9 +25,19 @@ const LANGUAGE_LABELS: Record<string, string> = {
   javascript: "JavaScript",
 };
 
-/** Human-readable form of the type-specific `meta` label (macro language, protocol family). */
-function metaLabel(type: SearchResultType, meta: string): string {
+/**
+ * Human-readable form of the type-specific `meta` label (macro language, protocol family,
+ * organization type). Organization types are the one kind that is translated: they have real
+ * labels ("Research institute") rather than the single-word identifier the others carry, and
+ * the key map already exists for the pickers and the profile header.
+ */
+function metaLabel(type: SearchResultType, meta: string, t: (key: string) => string): string {
   if (type === "macro") return LANGUAGE_LABELS[meta] ?? meta;
+  if (type === "organization") {
+    const parsed = zOrganizationType.safeParse(meta);
+    // An unrecognised spelling renders as stored rather than as a missing-key placeholder.
+    return parsed.success ? t(organizationTypeLabelKey(parsed.data)) : meta;
+  }
   // Protocol family and any other label: capitalize the first letter.
   return meta.charAt(0).toUpperCase() + meta.slice(1);
 }
@@ -35,6 +49,7 @@ export function SearchResultItem({
   result: SearchResult;
   onSelect: (result: SearchResult) => void;
 }) {
+  const { t } = useTranslation();
   const Icon = ICONS[result.type];
   // Descriptions can contain rich-text markup (experiments), so strip tags for a clean one-liner.
   const subtitle = result.subtitle ? stripHtml(result.subtitle) : "";
@@ -53,7 +68,7 @@ export function SearchResultItem({
               variant="outline"
               className="text-muted-foreground shrink-0 px-1.5 py-0 text-[10px] font-medium"
             >
-              {metaLabel(result.type, result.meta)}
+              {metaLabel(result.type, result.meta, t)}
             </Badge>
           )}
         </span>

--- a/apps/web/components/organizations/list-organizations.test.tsx
+++ b/apps/web/components/organizations/list-organizations.test.tsx
@@ -1,14 +1,12 @@
-import { createMyOrganization, createOrganizationDirectoryEntry } from "@/test/factories";
+import { createOrganizationDirectoryEntry } from "@/test/factories";
+import type { SpyCall } from "@/test/msw/mount";
 import { server } from "@/test/msw/server";
 import { render, screen, userEvent, waitFor, within } from "@/test/test-utils";
 import { ReadonlyURLSearchParams, useSearchParams } from "next/navigation";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { contract } from "@repo/api/contract";
-import type {
-  MyOrganization,
-  OrganizationDirectoryEntry,
-} from "@repo/api/domains/organization/organization.schema";
+import type { OrganizationDirectoryEntry } from "@repo/api/domains/organization/organization.schema";
 import { useSession } from "@repo/auth/client";
 
 import { ListOrganizations } from "./list-organizations";
@@ -33,8 +31,18 @@ function mountDirectory(organizations: OrganizationDirectoryEntry[]) {
   return server.mount(contract.organizations.listOrganizations, { body: { organizations } });
 }
 
-function mountMyOrganizations(organizations: MyOrganization[]) {
-  return server.mount(contract.organizations.listMyOrganizations, { body: organizations });
+/**
+ * The "my organizations" slice. It is the *same* endpoint as the directory with
+ * `scope=related`, not a second one — so these mount the directory too, and rows carry
+ * `membershipStatus: "member"` because that is what the caller's own organizations
+ * come back as.
+ */
+function mountMine(organizations: Partial<OrganizationDirectoryEntry>[]) {
+  return mountDirectory(
+    organizations.map((organization) =>
+      createOrganizationDirectoryEntry({ membershipStatus: "member", ...organization }),
+    ),
+  );
 }
 
 /** The card for an organization — the whole card is the link to it. */
@@ -50,28 +58,27 @@ describe("<ListOrganizations />", () => {
   });
 
   describe("my organizations", () => {
-    it("lands on the caller's own organizations, personal workspace excluded", async () => {
+    it("lands on the caller's own organizations, asking the directory for that slice", async () => {
       mockSession({ id: "user-1" });
-      mountMyOrganizations([
-        createMyOrganization({ id: "org-1", name: "Greenhouse Lab", memberCount: 4 }),
-        createMyOrganization({ name: "Grace Hopper", isPersonal: true }),
-      ]);
+      // Personal workspaces are excluded server-side now, so there is nothing to filter
+      // out here — what this has to prove instead is that the slice is requested at all.
+      const spy = mountMine([{ id: "org-1", name: "Greenhouse Lab", memberCount: 4 }]);
 
       render(<ListOrganizations />);
 
       await screen.findByText("Greenhouse Lab");
-      expect(screen.queryByText("Grace Hopper")).not.toBeInTheDocument();
+      expect(spy.calls.at(-1)?.query.scope).toBe("related");
     });
 
     it("shows the card's description, count pills and visibility on a private organization", async () => {
       mockSession({ id: "user-1" });
-      mountMyOrganizations([
-        createMyOrganization({
+      mountMine([
+        {
           id: "org-7",
           name: "Greenhouse Lab",
           description: "Chlorophyll fluorescence at scale",
           visibility: "private",
-        }),
+        },
       ]);
 
       render(<ListOrganizations />);
@@ -96,13 +103,13 @@ describe("<ListOrganizations />", () => {
      */
     it("clamps a plain-text description, which does not arrive with markup", async () => {
       mockSession({ id: "user-1" });
-      mountMyOrganizations([
-        createMyOrganization({
+      mountMine([
+        {
           name: "Greenhouse Lab",
           description:
             "A field group studying canopy photosynthesis across three continents, " +
             "with a long enough profile to run past three lines in a card column.",
-        }),
+        },
       ]);
 
       render(<ListOrganizations />);
@@ -118,7 +125,7 @@ describe("<ListOrganizations />", () => {
 
     it("falls back to the shared placeholder when an organization has no description", async () => {
       mockSession({ id: "user-1" });
-      mountMyOrganizations([createMyOrganization({ name: "Greenhouse Lab", description: null })]);
+      mountMine([{ name: "Greenhouse Lab", description: null }]);
 
       render(<ListOrganizations />);
 
@@ -129,7 +136,7 @@ describe("<ListOrganizations />", () => {
     /** The my-organizations branch is all memberships, so always the plain label. */
     it("labels the resource count plainly, since every row here is one you belong to", async () => {
       mockSession({ id: "user-1" });
-      mountMyOrganizations([createMyOrganization({ name: "Greenhouse Lab", resourceCount: 7 })]);
+      mountMine([{ name: "Greenhouse Lab", resourceCount: 7 }]);
 
       render(<ListOrganizations />);
 
@@ -141,7 +148,7 @@ describe("<ListOrganizations />", () => {
 
     it("carries no membership badge or in-card action", async () => {
       mockSession({ id: "user-1" });
-      mountMyOrganizations([createMyOrganization({ name: "Greenhouse Lab", role: "owner" })]);
+      mountMine([{ name: "Greenhouse Lab" }]);
 
       render(<ListOrganizations />);
 
@@ -153,9 +160,7 @@ describe("<ListOrganizations />", () => {
 
     it("leaves the visibility badge off a listed organization", async () => {
       mockSession({ id: "user-1" });
-      mountMyOrganizations([
-        createMyOrganization({ name: "Greenhouse Lab", visibility: "public" }),
-      ]);
+      mountMine([{ name: "Greenhouse Lab", visibility: "public" }]);
 
       render(<ListOrganizations />);
 
@@ -165,13 +170,26 @@ describe("<ListOrganizations />", () => {
       expect(card.queryByText("resourceVisibility.publicStatus")).not.toBeInTheDocument();
     });
 
-    it("searches the caller's own organizations too", async () => {
+    /**
+     * Searching "mine" is a server round trip carrying `scope=related`, not a substring
+     * test in the browser. That is the whole point of the change: the memberships used to
+     * be filtered client-side on name and description only, so a location or type match —
+     * or a stemmed or misspelled term — found rows under "all" and nothing under "my".
+     * Answering off the query proves the term reaches the server with the slice intact.
+     */
+    it("searches its own slice server-side, carrying the term and the scope", async () => {
       const user = userEvent.setup();
       mockSession({ id: "user-1" });
-      mountMyOrganizations([
-        createMyOrganization({ name: "Greenhouse Lab" }),
-        createMyOrganization({ name: "Coastal Station" }),
-      ]);
+      const spy = server.mount(contract.organizations.listOrganizations, {
+        body: ({ query }: SpyCall) => ({
+          organizations: query.search
+            ? [createOrganizationDirectoryEntry({ name: "Coastal Station" })]
+            : [
+                createOrganizationDirectoryEntry({ name: "Greenhouse Lab" }),
+                createOrganizationDirectoryEntry({ name: "Coastal Station" }),
+              ],
+        }),
+      });
 
       render(<ListOrganizations />);
 
@@ -183,11 +201,12 @@ describe("<ListOrganizations />", () => {
         expect(screen.queryByText("Greenhouse Lab")).not.toBeInTheDocument();
       });
       expect(screen.getByText("Coastal Station")).toBeVisible();
+      expect(spy.calls.at(-1)?.query).toMatchObject({ search: "coastal", scope: "related" });
     });
 
     it("offers the empty state a way to create the first organization", async () => {
       mockSession({ id: "user-1" });
-      mountMyOrganizations([]);
+      mountMine([]);
 
       render(<ListOrganizations />);
 
@@ -201,10 +220,17 @@ describe("<ListOrganizations />", () => {
     it("switches to the directory from the filter, without leaving the route", async () => {
       const user = userEvent.setup();
       mockSession({ id: "user-1" });
-      mountMyOrganizations([createMyOrganization({ name: "Greenhouse Lab" })]);
-      const directorySpy = mountDirectory([
-        createOrganizationDirectoryEntry({ name: "Coastal Station" }),
-      ]);
+      // One endpoint answering both slices off `scope` — the filter changes the query,
+      // not which endpoint is called.
+      const directorySpy = server.mount(contract.organizations.listOrganizations, {
+        body: ({ query }: SpyCall) => ({
+          organizations: [
+            createOrganizationDirectoryEntry({
+              name: query.scope === "related" ? "Greenhouse Lab" : "Coastal Station",
+            }),
+          ],
+        }),
+      });
 
       render(<ListOrganizations />);
 
@@ -217,9 +243,37 @@ describe("<ListOrganizations />", () => {
       await user.click(screen.getByRole("option", { name: "organizations.filter.all" }));
 
       await waitFor(() => {
-        expect(directorySpy.called).toBe(true);
+        expect(directorySpy.calls.at(-1)?.query.scope).toBe("all");
       });
       expect(await screen.findByText("Coastal Station")).toBeVisible();
+    });
+
+    /**
+     * Held-over rows are right for a new search term — it narrows the set already on
+     * screen — and wrong across a scope change, where the two slices are different sets.
+     * Without the guard the directory's rows render under "My organizations", counts and
+     * all, for as long as the related request is in flight.
+     */
+    it("does not show the other scope's rows while the switch is in flight", async () => {
+      const user = userEvent.setup();
+      mockSession({ id: "user-1" });
+      vi.mocked(useSearchParams).mockReturnValue(new ReadonlyURLSearchParams("filter=all"));
+      mountDirectory([createOrganizationDirectoryEntry({ name: "Somebody Elses Lab" })]);
+
+      render(<ListOrganizations />);
+      await screen.findByText("Somebody Elses Lab");
+
+      // Hangs, so the switch stays mid-flight for the whole assertion.
+      server.mount(contract.organizations.listOrganizations, {
+        body: { organizations: [] },
+        delay: "infinite",
+      });
+      await user.click(screen.getByRole("combobox", { name: "organizations.filter.label" }));
+      await user.click(screen.getByRole("option", { name: "organizations.filter.my" }));
+
+      await waitFor(() => {
+        expect(screen.queryByText("Somebody Elses Lab")).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/apps/web/components/organizations/organization-and-sharing-strings.test.ts
+++ b/apps/web/components/organizations/organization-and-sharing-strings.test.ts
@@ -4,6 +4,10 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { zExperimentStatus } from "@repo/api/domains/experiment/experiment.schema";
+import {
+  ORGANIZATION_TYPE_SEARCH_ALIASES,
+  zOrganizationType,
+} from "@repo/api/domains/organization/organization.schema";
 import { zSharingResourceType } from "@repo/api/domains/sharing/sharing.schema";
 import deCommon from "@repo/i18n/locales/de-DE/common.json";
 import deNavigation from "@repo/i18n/locales/de-DE/navigation.json";
@@ -156,14 +160,7 @@ describe("organization and sharing strings", () => {
         `organizations.roles.${role}`,
         `organizations.roleHints.${role}`,
       ]),
-      ...[
-        "unspecified",
-        "research_institute",
-        "non_profit",
-        "private_company",
-        "government_agency",
-        "university",
-      ].map((type) => `organizations.types.${type}`),
+      ...["unspecified", ...zOrganizationType.options].map((type) => `organizations.types.${type}`),
       ...["required", "format", "tooLong", "reserved", "taken"].map(
         (reason) => `organizations.errors.slug.${reason}`,
       ),
@@ -188,6 +185,13 @@ describe("organization and sharing strings", () => {
     const missing = expected.filter((key) => !resolves(bundles[locale].common, key));
 
     expect(missing).toEqual([]);
+  });
+
+  it.each(localeNames)("%s keeps visible organization types searchable", (locale) => {
+    for (const type of zOrganizationType.options) {
+      const visibleLabel = LOCALES[locale].common.organizations.types[type].toLowerCase();
+      expect(ORGANIZATION_TYPE_SEARCH_ALIASES[type].toLowerCase(), type).toContain(visibleLabel);
+    }
   });
 
   // Kept after the scan was widened to `sharing.*`, which now finds these too. Redundant

--- a/apps/web/components/shortcuts/shortcuts-root.test.tsx
+++ b/apps/web/components/shortcuts/shortcuts-root.test.tsx
@@ -51,6 +51,13 @@ describe("ShortcutsRoot", () => {
     expect(router.push).toHaveBeenCalledWith("/en-US/platform/experiments");
   });
 
+  it("navigates via g-then-o to organizations", () => {
+    const { router } = renderShortcuts();
+    key("g");
+    key("o");
+    expect(router.push).toHaveBeenCalledWith("/en-US/platform/organizations");
+  });
+
   it("g-then-n opens the notification bell instead of navigating", () => {
     const handler = vi.fn();
     window.addEventListener(NOTIFICATION_BELL_OPEN_EVENT, handler);

--- a/apps/web/components/shortcuts/shortcuts-root.tsx
+++ b/apps/web/components/shortcuts/shortcuts-root.tsx
@@ -91,6 +91,7 @@ export function ShortcutsRoot({ locale }: { locale: string }) {
       { key: "W", label: "Workbooks", path: `/${locale}/platform/workbooks` },
       { key: "P", label: "Protocols", path: `/${locale}/platform/protocols` },
       { key: "M", label: "Macros", path: `/${locale}/platform/macros` },
+      { key: "O", label: "Organizations", path: `/${locale}/platform/organizations` },
       { key: "T", label: "Transfer requests", path: `/${locale}/platform/transfer-request` },
       { key: "S", label: "Settings", path: `/${locale}/platform/account` },
       {

--- a/apps/web/hooks/auth/useSignOut/useSignOut.test.tsx
+++ b/apps/web/hooks/auth/useSignOut/useSignOut.test.tsx
@@ -41,6 +41,9 @@ describe("useSignOut", () => {
     const deletionBlockersKey = orpc.users.getDeletionBlockers.queryKey({
       input: { id: "user-a" },
     });
+    const globalSearchKey = orpc.search.globalSearch.queryKey({
+      input: { query: "photosynthesis", limit: 20 },
+    });
     const myInvitationsKey = myOrganizationInvitationsQueryKey("user-a");
     queryClient.setQueryData(grantsKey, []);
     queryClient.setQueryData(orgsKey, []);
@@ -64,6 +67,17 @@ describe("useSignOut", () => {
       updatedAt: "2026-01-01T00:00:00.000Z",
     });
     queryClient.setQueryData(deletionBlockersKey, { resources: [], organizations: [] });
+    queryClient.setQueryData(globalSearchKey, {
+      results: [
+        {
+          type: "organization",
+          id: "org-1",
+          title: "Private Lab",
+          subtitle: null,
+          meta: "research_institute",
+        },
+      ],
+    });
     queryClient.setQueryData(myInvitationsKey, [{ id: "invitation-1" }]);
 
     const { result } = renderHook(() => useSignOut(), { queryClient });
@@ -78,6 +92,7 @@ describe("useSignOut", () => {
     expect(queryClient.getQueryData(accessKey)).toBeUndefined();
     expect(queryClient.getQueryData(joinRequestKey)).toBeUndefined();
     expect(queryClient.getQueryData(deletionBlockersKey)).toBeUndefined();
+    expect(queryClient.getQueryData(globalSearchKey)).toBeUndefined();
     // Better Auth reads only get invalidated with the rest of the `auth` namespace,
     // which leaves their data in place; the organizations that invited this account
     // are removed outright.

--- a/apps/web/hooks/auth/useSignOut/useSignOut.ts
+++ b/apps/web/hooks/auth/useSignOut/useSignOut.ts
@@ -32,6 +32,7 @@ export function useSignOut() {
         orpc.users.listInvitations.key(),
         orpc.experiments.getMyJoinRequest.key(),
         orpc.users.getDeletionBlockers.key(),
+        orpc.search.globalSearch.key(),
         // The signed-out user's own pending invitations name the organizations that
         // asked for them; invalidating the `auth` namespace would leave them readable.
         myOrganizationInvitationsFamily(),

--- a/apps/web/hooks/experiment/useSetExperimentVisibility/useSetExperimentVisibility.ts
+++ b/apps/web/hooks/experiment/useSetExperimentVisibility/useSetExperimentVisibility.ts
@@ -2,7 +2,7 @@ import { listQueryKeys } from "@/hooks/list-query-keys";
 import { orpc } from "@/lib/orpc";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-/** Publishes an experiment and invalidates its detail, access, and list caches. */
+/** Publishes an experiment and refreshes its detail, access, list, and search caches. */
 export const useSetExperimentVisibility = () => {
   const queryClient = useQueryClient();
 
@@ -19,6 +19,7 @@ export const useSetExperimentVisibility = () => {
         for (const queryKey of listQueryKeys.experiments()) {
           await queryClient.invalidateQueries({ queryKey });
         }
+        await queryClient.invalidateQueries({ queryKey: orpc.search.globalSearch.key() });
       },
     }),
   );

--- a/apps/web/hooks/organization/organization-cache.test.ts
+++ b/apps/web/hooks/organization/organization-cache.test.ts
@@ -74,6 +74,10 @@ describe("organizationMembershipFamilies", () => {
   it("refreshes the collaborators lists, where membership decides the outside badge", () => {
     expect(invalidates(families, orpc.sharing.listGrants.key())).toBe(true);
   });
+
+  it("refreshes global search, where membership controls visibility and roster matching", () => {
+    expect(invalidates(families, orpc.search.globalSearch.key())).toBe(true);
+  });
 });
 
 describe("organizationAuthFamilies", () => {
@@ -95,6 +99,10 @@ describe("organizationProfileFamilies", () => {
     // collaborators family is added at the call sites that can — rename and delete.
     expect(invalidates(organizationProfileFamilies(), orpc.sharing.listGrants.key())).toBe(false);
   });
+
+  it("refreshes global search after organization create, update or delete", () => {
+    expect(invalidates(organizationProfileFamilies(), orpc.search.globalSearch.key())).toBe(true);
+  });
 });
 
 describe("organizationTeamFamilies", () => {
@@ -105,6 +113,7 @@ describe("organizationTeamFamilies", () => {
       orpc.organizations.listOrganizationTeams.key(),
       orpc.organizations.listGranteeTeams.key(),
       orpc.sharing.listGrants.key(),
+      orpc.search.globalSearch.key(),
     ]) {
       expect(invalidates(families, key), JSON.stringify(key)).toBe(true);
     }

--- a/apps/web/hooks/organization/organization-cache.ts
+++ b/apps/web/hooks/organization/organization-cache.ts
@@ -69,6 +69,7 @@ export function organizationProfileFamilies(): QueryKey[] {
     orpc.organizations.listMyOrganizations.key(),
     orpc.organizations.listOrganizations.key(),
     orpc.organizations.getOrganization.key(),
+    orpc.search.globalSearch.key(),
   ];
 }
 
@@ -100,7 +101,11 @@ export function organizationTeamGranteeFamilies(): QueryKey[] {
 }
 
 export function organizationTeamFamilies(): QueryKey[] {
-  return [orpc.organizations.listOrganizationTeams.key(), ...organizationTeamGranteeFamilies()];
+  return [
+    orpc.organizations.listOrganizationTeams.key(),
+    orpc.search.globalSearch.key(),
+    ...organizationTeamGranteeFamilies(),
+  ];
 }
 
 /**

--- a/apps/web/hooks/organization/useOrganizations/useOrganizations.ts
+++ b/apps/web/hooks/organization/useOrganizations/useOrganizations.ts
@@ -1,8 +1,23 @@
 import { withPrincipal } from "@/hooks/principal-query-key";
 import { orpc } from "@/lib/orpc";
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 
+import type { ResourceScope } from "@repo/api/shared/listing";
 import { useSession } from "@repo/auth/client";
+
+/**
+ * The `scope` a query key carries. Searched for rather than indexed: where oRPC nests
+ * the input is its business, and `withPrincipal` appends a segment of its own.
+ */
+function scopeOfKey(key: readonly unknown[] | undefined): ResourceScope | undefined {
+  for (const segment of key ?? []) {
+    if (segment !== null && typeof segment === "object" && "input" in segment) {
+      const { input } = segment as { input?: { scope?: ResourceScope } };
+      if (input) return input.scope;
+    }
+  }
+  return undefined;
+}
 
 /**
  * The organization directory: public organizations plus the caller's own private
@@ -10,10 +25,13 @@ import { useSession } from "@repo/auth/client";
  * the cache is principal-scoped — a module-level QueryClient survives sign-out, and
  * the next user must not inherit the previous one's directory or join state.
  *
+ * `scope: "related"` is the "my organizations" slice. It is the same endpoint with one
+ * more condition, so both slices search the same fields and rank the same way.
+ *
  * Unpaged: the endpoint returns every match.
  */
 export const useOrganizations = (
-  params: { search?: string } = {},
+  params: { search?: string; scope?: ResourceScope } = {},
   options?: { enabled?: boolean },
 ) => {
   const { data: session, isPending: isSessionPending } = useSession();
@@ -22,6 +40,7 @@ export const useOrganizations = (
   const input = {
     // An empty box is "no filter", not a search for the empty string.
     search: search === "" ? undefined : search,
+    scope: params.scope,
   };
 
   return useQuery(
@@ -32,7 +51,13 @@ export const useOrganizations = (
       // back to its pending state — unmounting every row, including a join dialog the
       // reader had open. The rows stay put while the next result set loads; the search
       // input's own spinner is what says it is still moving.
-      placeholderData: keepPreviousData,
+      //
+      // Held only within one scope. A term narrows the set it is already showing, but
+      // "mine" and "all" are different sets: carrying rows across would render public
+      // organizations the reader does not belong to under "My organizations", counts
+      // and all, until the refetch lands.
+      placeholderData: (previous, previousQuery) =>
+        scopeOfKey(previousQuery?.queryKey) === input.scope ? previous : undefined,
       enabled: (options?.enabled ?? true) && !isSessionPending,
     }),
   );

--- a/apps/web/hooks/organization/useOrganizations/useOrganizations.ts
+++ b/apps/web/hooks/organization/useOrganizations/useOrganizations.ts
@@ -1,23 +1,9 @@
-import { withPrincipal } from "@/hooks/principal-query-key";
+import { ANONYMOUS_PRINCIPAL, withPrincipal } from "@/hooks/principal-query-key";
 import { orpc } from "@/lib/orpc";
 import { useQuery } from "@tanstack/react-query";
 
 import type { ResourceScope } from "@repo/api/shared/listing";
 import { useSession } from "@repo/auth/client";
-
-/**
- * The `scope` a query key carries. Searched for rather than indexed: where oRPC nests
- * the input is its business, and `withPrincipal` appends a segment of its own.
- */
-function scopeOfKey(key: readonly unknown[] | undefined): ResourceScope | undefined {
-  for (const segment of key ?? []) {
-    if (segment !== null && typeof segment === "object" && "input" in segment) {
-      const { input } = segment as { input?: { scope?: ResourceScope } };
-      if (input) return input.scope;
-    }
-  }
-  return undefined;
-}
 
 /**
  * The organization directory: public organizations plus the caller's own private
@@ -36,6 +22,7 @@ export const useOrganizations = (
 ) => {
   const { data: session, isPending: isSessionPending } = useSession();
   const userId = session?.user.id;
+  const principal = userId ?? ANONYMOUS_PRINCIPAL;
   const search = params.search?.trim();
   const input = {
     // An empty box is "no filter", not a search for the empty string.
@@ -47,6 +34,7 @@ export const useOrganizations = (
     orpc.organizations.listOrganizations.queryOptions({
       input,
       queryKey: withPrincipal(orpc.organizations.listOrganizations.queryKey({ input }), userId),
+      meta: { scope: input.scope, principal },
       // A new search term is a new cache key, and without this the list would fall
       // back to its pending state — unmounting every row, including a join dialog the
       // reader had open. The rows stay put while the next result set loads; the search
@@ -57,7 +45,9 @@ export const useOrganizations = (
       // organizations the reader does not belong to under "My organizations", counts
       // and all, until the refetch lands.
       placeholderData: (previous, previousQuery) =>
-        scopeOfKey(previousQuery?.queryKey) === input.scope ? previous : undefined,
+        previousQuery?.meta?.scope === input.scope && previousQuery?.meta?.principal === principal
+          ? previous
+          : undefined,
       enabled: (options?.enabled ?? true) && !isSessionPending,
     }),
   );

--- a/apps/web/hooks/organization/useOrganizationsList/useOrganizationsList.ts
+++ b/apps/web/hooks/organization/useOrganizationsList/useOrganizationsList.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMyOrganizations } from "@/hooks/organization/useMyOrganizations/useMyOrganizations";
 import { useOrganizations } from "@/hooks/organization/useOrganizations/useOrganizations";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useUrlState } from "@/hooks/useUrlState";
@@ -9,7 +8,7 @@ import type { OrganizationVisibility } from "@repo/api/domains/organization/orga
 
 export type OrganizationFilter = "my" | "all";
 
-/** One card's worth of organization, whichever of the two reads produced it. */
+/** One card's worth of organization, whichever slice of the listing produced it. */
 export interface OrganizationListItem {
   id: string;
   name: string;
@@ -21,26 +20,13 @@ export interface OrganizationListItem {
   isMember: boolean;
 }
 
-function matches(organization: OrganizationListItem, term: string): boolean {
-  const needle = term.trim().toLowerCase();
-  if (needle === "") return true;
-
-  return (
-    organization.name.toLowerCase().includes(needle) ||
-    (organization.description ?? "").toLowerCase().includes(needle)
-  );
-}
-
 /**
- * The organizations listing: the caller's memberships or the public directory,
- * chosen by a filter the URL carries — the same `?filter=all` the experiments and
- * macros listings use.
+ * The organizations listing: the caller's memberships or the whole directory, chosen by
+ * a filter the URL carries — the same `?filter=all` the experiments and macros use.
  *
- * The two states are two endpoints rather than one filtered read, so only the
- * selected one is fetched. Both come back whole — neither is paged — so "all" means
- * all. The directory searches server-side; the memberships are already fetched
- * complete for the picker on every create form, so searching them here costs no round
- * trip and no second cache entry per keystroke.
+ * One endpoint serves both, the filter riding along as `scope`. It used to be two reads,
+ * the memberships filtered here by substring, so "my" missed location, type, stemming
+ * and typos that "all" found. Personal workspaces are excluded server-side.
  */
 export function useOrganizationsList() {
   const [filter, setFilter] = useUrlState<OrganizationFilter>({
@@ -57,36 +43,20 @@ export function useOrganizationsList() {
 
   const isMine = filter === "my";
 
-  const mine = useMyOrganizations({ enabled: isMine });
-  const directory = useOrganizations({ search: debouncedSearch }, { enabled: !isMine });
+  const directory = useOrganizations({
+    search: debouncedSearch,
+    scope: isMine ? "related" : "all",
+  });
 
-  // Personal workspaces are absent: the endpoint returns them — the resource create
-  // pickers need one as their default target — but they are not organizations in
-  // product terms, so nothing about them is manageable and listing one here would
-  // offer management it lacks.
-  const myOrganizations: OrganizationListItem[] = (mine.data ?? [])
-    .filter((organization) => !organization.isPersonal)
-    .map((organization) => ({
-      id: organization.id,
-      name: organization.name,
-      description: organization.description,
-      memberCount: organization.memberCount,
-      resourceCount: organization.resourceCount,
-      visibility: organization.visibility,
-      // This read is the caller's own memberships.
-      isMember: true,
-    }))
-    .filter((organization) => matches(organization, debouncedSearch));
-
-  const directoryOrganizations: OrganizationListItem[] = (directory.data?.organizations ?? []).map(
+  const organizations: OrganizationListItem[] = (directory.data?.organizations ?? []).map(
     (organization) => ({
       id: organization.id,
       name: organization.name,
       description: organization.description,
       memberCount: organization.memberCount,
       resourceCount: organization.resourceCount,
-      // Read from the row, not assumed: the directory now carries the caller's own
-      // private organizations, so hardcoding "public" here would strip their badge.
+      // Read from the row, not assumed: the directory carries the caller's own private
+      // organizations, so hardcoding "public" here would strip their badge.
       visibility: organization.visibility,
       // `pending_request` is not membership.
       isMember: organization.membershipStatus === "member",
@@ -99,11 +69,11 @@ export function useOrganizationsList() {
     search,
     setSearch,
     /** The search box's own spinner: a pending term, or the request it triggered. */
-    isSearching: !isDebounced || (!isMine && directory.isFetching),
+    isSearching: !isDebounced || directory.isFetching,
     debouncedSearch,
-    organizations: isMine ? myOrganizations : directoryOrganizations,
-    isPending: isMine ? mine.isPending : directory.isPending,
-    isError: isMine ? mine.isError : directory.isError,
+    organizations,
+    isPending: directory.isPending,
+    isError: directory.isError,
     isFetching: directory.isFetching,
   };
 }

--- a/apps/web/hooks/organization/useUpdateOrganization/useUpdateOrganization.ts
+++ b/apps/web/hooks/organization/useUpdateOrganization/useUpdateOrganization.ts
@@ -59,6 +59,10 @@ export const useUpdateOrganization = (organizationId: string) => {
         // An organization is a grantee too, and its name is what a collaborator row
         // shows for one — so a rename has to reach the collaborators lists.
         orpc.sharing.listGrants.key(),
+        // Name, description, type and visibility are all searchable, and publishing a
+        // private organization is what makes it findable at all — a cached result set
+        // would keep answering from before the flip.
+        orpc.search.globalSearch.key(),
       ]);
     },
   });

--- a/apps/web/hooks/organization/useUpdateOrganization/useUpdateOrganization.ts
+++ b/apps/web/hooks/organization/useUpdateOrganization/useUpdateOrganization.ts
@@ -59,10 +59,6 @@ export const useUpdateOrganization = (organizationId: string) => {
         // An organization is a grantee too, and its name is what a collaborator row
         // shows for one — so a rename has to reach the collaborators lists.
         orpc.sharing.listGrants.key(),
-        // Name, description, type and visibility are all searchable, and publishing a
-        // private organization is what makes it findable at all — a cached result set
-        // would keep answering from before the flip.
-        orpc.search.globalSearch.key(),
       ]);
     },
   });

--- a/apps/web/hooks/profile/useCreateUserProfile/useCreateUserProfile.test.tsx
+++ b/apps/web/hooks/profile/useCreateUserProfile/useCreateUserProfile.test.tsx
@@ -1,0 +1,30 @@
+import { orpc } from "@/lib/orpc";
+import { server } from "@/test/msw/server";
+import { createTestQueryClient, renderHook, waitFor } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+
+import { contract } from "@repo/api/contract";
+
+import { useCreateUserProfile } from "./useCreateUserProfile";
+
+describe("useCreateUserProfile", () => {
+  it("invalidates global search because member names are searchable", async () => {
+    server.mount(contract.users.createUserProfile, { body: {} });
+    const queryClient = createTestQueryClient();
+    const globalSearchKey = orpc.search.globalSearch.queryKey({
+      input: { query: "ada", limit: 20 },
+    });
+    queryClient.setQueryData(globalSearchKey, { results: [] });
+
+    const { result } = renderHook(() => useCreateUserProfile({}), { queryClient });
+    await result.current.mutateAsync({
+      firstName: "Ada",
+      lastName: "Lovelace",
+      avatarUrl: null,
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryState(globalSearchKey)?.isInvalidated).toBe(true);
+    });
+  });
+});

--- a/apps/web/hooks/profile/useCreateUserProfile/useCreateUserProfile.ts
+++ b/apps/web/hooks/profile/useCreateUserProfile/useCreateUserProfile.ts
@@ -14,7 +14,7 @@ export const useCreateUserProfile = (props: CreateUserProfileProps) => {
         if (props.onSuccess) await props.onSuccess();
       },
       onSettled: async () => {
-        // A profile name is also part of organization global search for fellow members.
+        // The caller's profile name is searchable inside organizations they belong to.
         await queryClient.invalidateQueries({ queryKey: orpc.users.getUserProfile.key() });
         await queryClient.invalidateQueries({ queryKey: orpc.search.globalSearch.key() });
       },

--- a/apps/web/hooks/profile/useCreateUserProfile/useCreateUserProfile.ts
+++ b/apps/web/hooks/profile/useCreateUserProfile/useCreateUserProfile.ts
@@ -14,8 +14,9 @@ export const useCreateUserProfile = (props: CreateUserProfileProps) => {
         if (props.onSuccess) await props.onSuccess();
       },
       onSettled: async () => {
-        // Ensure any component reading the user profile refetches and gets the latest data
+        // A profile name is also part of organization global search for fellow members.
         await queryClient.invalidateQueries({ queryKey: orpc.users.getUserProfile.key() });
+        await queryClient.invalidateQueries({ queryKey: orpc.search.globalSearch.key() });
       },
     }),
   );

--- a/apps/web/hooks/useGlobalSearch.test.tsx
+++ b/apps/web/hooks/useGlobalSearch.test.tsx
@@ -8,10 +8,10 @@ import { useSession } from "@repo/auth/client";
 
 import { useGlobalSearch } from "./useGlobalSearch";
 
-function mockSession(userId: string | undefined) {
+function mockSession(userId: string | undefined, isPending = false) {
   vi.mocked(useSession).mockReturnValue({
     data: userId ? { user: { id: userId } } : null,
-    isPending: false,
+    isPending,
   } as ReturnType<typeof useSession>);
 }
 
@@ -31,6 +31,15 @@ describe("useGlobalSearch", () => {
     });
     expect(query.queryKey.at(-1)).toEqual({ principal: "user-a" });
     expect(query.meta).toEqual({ principal: "user-a" });
+  });
+
+  it("stays in the searching state while the session is resolving", async () => {
+    mockSession(undefined, true);
+    const { result } = renderHook(() => useGlobalSearch("photosynthesis"));
+
+    await waitFor(() => expect(result.current.enabled).toBe(true));
+    expect(result.current.isSearching).toBe(true);
+    expect(result.current.results).toEqual([]);
   });
 
   it("does not retain one principal's results while another principal loads", async () => {

--- a/apps/web/hooks/useGlobalSearch.test.tsx
+++ b/apps/web/hooks/useGlobalSearch.test.tsx
@@ -1,0 +1,69 @@
+import { orpc } from "@/lib/orpc";
+import { server } from "@/test/msw/server";
+import { createTestQueryClient, renderHook, waitFor } from "@/test/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { contract } from "@repo/api/contract";
+import { useSession } from "@repo/auth/client";
+
+import { useGlobalSearch } from "./useGlobalSearch";
+
+function mockSession(userId: string | undefined) {
+  vi.mocked(useSession).mockReturnValue({
+    data: userId ? { user: { id: userId } } : null,
+    isPending: false,
+  } as ReturnType<typeof useSession>);
+}
+
+describe("useGlobalSearch", () => {
+  afterEach(() => mockSession(undefined));
+
+  it("scopes cached results to the signed-in principal", async () => {
+    mockSession("user-a");
+    server.mount(contract.search.globalSearch, { body: { results: [] } });
+    const queryClient = createTestQueryClient();
+
+    const { result } = renderHook(() => useGlobalSearch("photosynthesis"), { queryClient });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const [query] = queryClient.getQueryCache().findAll({
+      queryKey: orpc.search.globalSearch.key(),
+    });
+    expect(query.queryKey.at(-1)).toEqual({ principal: "user-a" });
+    expect(query.meta).toEqual({ principal: "user-a" });
+  });
+
+  it("does not retain one principal's results while another principal loads", async () => {
+    mockSession("user-a");
+    server.mount(contract.search.globalSearch, {
+      body: {
+        results: [
+          {
+            type: "organization",
+            id: "org-private",
+            title: "Private Lab",
+            subtitle: null,
+            meta: "research_institute",
+          },
+        ],
+      },
+    });
+    const queryClient = createTestQueryClient();
+    const { result, rerender } = renderHook(() => useGlobalSearch("photosynthesis"), {
+      queryClient,
+    });
+    await waitFor(() => expect(result.current.results).toHaveLength(1));
+
+    let release!: () => void;
+    const unblock = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    server.mount(contract.search.globalSearch, { body: { results: [] }, unblock });
+    mockSession("user-b");
+    rerender();
+
+    expect(result.current.results).toEqual([]);
+    release();
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+  });
+});

--- a/apps/web/hooks/useGlobalSearch.ts
+++ b/apps/web/hooks/useGlobalSearch.ts
@@ -24,13 +24,14 @@ export function useGlobalSearch(query: string, limit = DEFAULT_LIMIT) {
   const trimmed = query.trim();
   const [debouncedQuery, isDebounced] = useDebounce(trimmed, SEARCH_DEBOUNCE_MS);
   const enabled = debouncedQuery.length >= MIN_QUERY_LENGTH;
+  const queryEnabled = enabled && !isSessionPending;
   const input = { query: debouncedQuery, limit };
 
   const result = useQuery(
     orpc.search.globalSearch.queryOptions({
       input,
       queryKey: withPrincipal(orpc.search.globalSearch.queryKey({ input }), userId),
-      enabled: enabled && !isSessionPending,
+      enabled: queryEnabled,
       meta: { principal },
       // Keep a settled result while the same person types the next term, but never
       // carry private results through a sign-out/sign-in transition.
@@ -41,7 +42,7 @@ export function useGlobalSearch(query: string, limit = DEFAULT_LIMIT) {
 
   const isSearching =
     trimmed.length >= MIN_QUERY_LENGTH &&
-    (!isDebounced || (enabled && !isSessionPending && result.isFetching));
+    (isSessionPending || !isDebounced || (queryEnabled && result.isFetching));
 
   return {
     ...result,

--- a/apps/web/hooks/useGlobalSearch.ts
+++ b/apps/web/hooks/useGlobalSearch.ts
@@ -1,5 +1,8 @@
+import { ANONYMOUS_PRINCIPAL, withPrincipal } from "@/hooks/principal-query-key";
 import { orpc } from "@/lib/orpc";
 import { useQuery } from "@tanstack/react-query";
+
+import { useSession } from "@repo/auth/client";
 
 import { useDebounce } from "./useDebounce";
 
@@ -15,20 +18,30 @@ const DEFAULT_LIMIT = 20;
  * loading state. Previous results are kept while the next query loads to avoid flicker.
  */
 export function useGlobalSearch(query: string, limit = DEFAULT_LIMIT) {
+  const { data: session, isPending: isSessionPending } = useSession();
+  const userId = session?.user.id;
+  const principal = userId ?? ANONYMOUS_PRINCIPAL;
   const trimmed = query.trim();
   const [debouncedQuery, isDebounced] = useDebounce(trimmed, SEARCH_DEBOUNCE_MS);
   const enabled = debouncedQuery.length >= MIN_QUERY_LENGTH;
+  const input = { query: debouncedQuery, limit };
 
   const result = useQuery(
     orpc.search.globalSearch.queryOptions({
-      input: { query: debouncedQuery, limit },
-      enabled,
-      placeholderData: (prev) => prev,
+      input,
+      queryKey: withPrincipal(orpc.search.globalSearch.queryKey({ input }), userId),
+      enabled: enabled && !isSessionPending,
+      meta: { principal },
+      // Keep a settled result while the same person types the next term, but never
+      // carry private results through a sign-out/sign-in transition.
+      placeholderData: (previous, previousQuery) =>
+        previousQuery?.meta?.principal === principal ? previous : undefined,
     }),
   );
 
   const isSearching =
-    trimmed.length >= MIN_QUERY_LENGTH && (!isDebounced || (enabled && result.isFetching));
+    trimmed.length >= MIN_QUERY_LENGTH &&
+    (!isDebounced || (enabled && !isSessionPending && result.isFetching));
 
   return {
     ...result,

--- a/apps/web/hooks/useGlobalSearch.ts
+++ b/apps/web/hooks/useGlobalSearch.ts
@@ -8,7 +8,8 @@ const SEARCH_DEBOUNCE_MS = 250;
 const DEFAULT_LIMIT = 20;
 
 /**
- * Debounced global search across experiments, protocols and macros. The query is disabled until
+ * Debounced global search across experiments, protocols, macros, workbooks and organizations. The
+ * query is disabled until
  * the (trimmed) input reaches {@link MIN_QUERY_LENGTH} characters. `isSearching` is true while the
  * user has typed enough but results are still debouncing or fetching, so callers can show a single
  * loading state. Previous results are kept while the next query loads to avoid flicker.

--- a/packages/api/src/domains/organization/organization.schema.ts
+++ b/packages/api/src/domains/organization/organization.schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { zResourceScope } from "../../shared/listing";
 import { zExperimentStatus } from "../experiment/experiment.schema";
 import { zDeviceType } from "../iot/iot.schema";
 import { zMacroLanguage } from "../macro/macro.schema";
@@ -33,7 +34,20 @@ export const zOrganizationIdPathParam = z.object({
 });
 
 export const zOrganizationDirectoryQuery = z.object({
-  search: z.string().trim().max(200).optional().describe("Name or description substring"),
+  search: z
+    .string()
+    .trim()
+    .max(200)
+    .optional()
+    .describe(
+      "Name, description, location or type; also member and team names, for organizations you belong to",
+    ),
+  /**
+   * The same `scope` the experiment, macro and protocol listings take. `related` narrows
+   * to the caller's own memberships — a filter over this one query, not a second
+   * endpoint, so both slices match and rank identically.
+   */
+  scope: zResourceScope.optional().describe("Which slice of the visible set to return"),
 });
 
 /**

--- a/packages/api/src/domains/organization/organization.schema.ts
+++ b/packages/api/src/domains/organization/organization.schema.ts
@@ -15,6 +15,20 @@ export const zOrganizationType = z.enum([
   "government_agency",
   "university",
 ]);
+export type OrganizationType = z.infer<typeof zOrganizationType>;
+
+/**
+ * Every visible organization-type label the search service accepts. Kept beside
+ * {@link zOrganizationType} so a new enum member cannot silently become unsearchable;
+ * the web locale contract tests keep these aliases aligned with the translated labels.
+ */
+export const ORGANIZATION_TYPE_SEARCH_ALIASES = {
+  research_institute: "Research institute Forschungsinstitut Onderzoeksinstituut",
+  non_profit: "Non-profit non profit nonprofit Gemeinnützige Organisation",
+  private_company: "Private company Privatunternehmen Particulier bedrijf",
+  government_agency: "Government agency Behörde Overheidsinstantie",
+  university: "University Universität Universiteit",
+} as const satisfies Record<OrganizationType, string>;
 
 /** Directory listing state. Private organizations are invisible to non-members. */
 export const zOrganizationVisibility = z.enum(["private", "public"]);
@@ -299,7 +313,6 @@ export const zGranteeTeamsPathParams = z.object({
   id: z.string().uuid().describe("ID of the resource being shared"),
 });
 
-export type OrganizationType = z.infer<typeof zOrganizationType>;
 export type OrganizationVisibility = z.infer<typeof zOrganizationVisibility>;
 export type OrganizationRole = z.infer<typeof zOrganizationRole>;
 export type OrganizationMembershipStatus = z.infer<typeof zOrganizationMembershipStatus>;

--- a/packages/api/src/domains/search/search.schema.ts
+++ b/packages/api/src/domains/search/search.schema.ts
@@ -4,12 +4,18 @@ import { z } from "zod";
 export const zGlobalSearchQuery = z.object({
   query: z.string().trim().min(1).max(200).describe("Search term"),
   // The backend overfetches `limit` per entity type and merges by score, so this also bounds the
-  // heaviest query the palette can issue (4 types x limit candidate rows).
+  // heaviest query the palette can issue (5 types x limit candidate rows).
   limit: z.coerce.number().int().min(1).max(32).optional().default(20),
 });
 
 /** Entity types surfaced by global search (users are intentionally excluded — no profile page). */
-export const zSearchResultType = z.enum(["experiment", "protocol", "macro", "workbook"]);
+export const zSearchResultType = z.enum([
+  "experiment",
+  "protocol",
+  "macro",
+  "workbook",
+  "organization",
+]);
 
 /** A single normalized, ranked search result. */
 export const zSearchResult = z.object({
@@ -18,8 +24,9 @@ export const zSearchResult = z.object({
   title: z.string(),
   subtitle: z.string().nullable(),
   /**
-   * Short type-specific label shown beside the title (e.g. a macro's language or a protocol's
-   * sensor family). `null` when the type has no such label (experiments).
+   * Short type-specific label shown beside the title (e.g. a macro's language, a protocol's
+   * sensor family or an organization's type). `null` when the type has no such label
+   * (experiments, workbooks) or when the row leaves it unset (organizations).
    */
   meta: z.string().nullable(),
 });

--- a/packages/database/drizzle/0048_organizations_search_vector.sql
+++ b/packages/database/drizzle/0048_organizations_search_vector.sql
@@ -1,0 +1,8 @@
+-- Organizations join full-text search: name (A), description (B), location (C).
+-- Hand-edited after `drizzle-kit generate`, as 0036 was — the GENERATED expression needs bare
+-- column names (Postgres rejects table-qualified ones) and drizzle-kit cannot serialise
+-- gin_trgm_ops, so the indexes live here and the snapshot does not track them.
+-- The `type` enum is matched at query time: enum->text casts are not immutable.
+ALTER TABLE "organizations" ADD COLUMN "search_vector" tsvector GENERATED ALWAYS AS (setweight(to_tsvector('english', coalesce("name", '')), 'A') || setweight(to_tsvector('english', coalesce("description", '')), 'B') || setweight(to_tsvector('english', coalesce("location", '')), 'C')) STORED;--> statement-breakpoint
+CREATE INDEX "organizations_search_vector_idx" ON "organizations" USING gin ("search_vector");--> statement-breakpoint
+CREATE INDEX "organizations_name_trgm_idx" ON "organizations" USING gin ("name" gin_trgm_ops);

--- a/packages/database/drizzle/meta/0048_snapshot.json
+++ b/packages/database/drizzle/meta/0048_snapshot.json
@@ -1,0 +1,4127 @@
+{
+  "id": "4f32881d-b68f-45b2-bd3c-2052e231c365",
+  "prevId": "2b1d754e-fba3-41e7-8ae6-f2aa6ad4c7a0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "api_keys_key_idx": {
+          "name": "api_keys_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_reference_id_idx": {
+          "name": "api_keys_reference_id_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_config_id_idx": {
+          "name": "api_keys_config_id_idx",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_reference_id_users_id_fk": {
+          "name": "api_keys_reference_id_users_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reference_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_group_members": {
+      "name": "device_group_members",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "device_group_members_device_idx": {
+          "name": "device_group_members_device_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_group_members_group_id_device_groups_id_fk": {
+          "name": "device_group_members_group_id_device_groups_id_fk",
+          "tableFrom": "device_group_members",
+          "tableTo": "device_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_group_members_device_id_iot_devices_id_fk": {
+          "name": "device_group_members_device_id_iot_devices_id_fk",
+          "tableFrom": "device_group_members",
+          "tableTo": "iot_devices",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_group_members_added_by_users_id_fk": {
+          "name": "device_group_members_added_by_users_id_fk",
+          "tableFrom": "device_group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "device_group_members_group_id_device_id_pk": {
+          "name": "device_group_members_group_id_device_id_pk",
+          "columns": [
+            "group_id",
+            "device_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_groups": {
+      "name": "device_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "device_groups_created_by_idx": {
+          "name": "device_groups_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_groups_organization_id_idx": {
+          "name": "device_groups_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_groups_organization_id_organizations_id_fk": {
+          "name": "device_groups_organization_id_organizations_id_fk",
+          "tableFrom": "device_groups",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "device_groups_created_by_users_id_fk": {
+          "name": "device_groups_created_by_users_id_fk",
+          "tableFrom": "device_groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_dashboards": {
+      "name": "experiment_dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"columns\":12,\"rowHeight\":80,\"gap\":16}'::jsonb"
+        },
+        "widgets": {
+          "name": "widgets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "experiment_dashboards_experiment_id_idx": {
+          "name": "experiment_dashboards_experiment_id_idx",
+          "columns": [
+            {
+              "expression": "experiment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiment_dashboards_experiment_id_experiments_id_fk": {
+          "name": "experiment_dashboards_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_dashboards",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_dashboards_created_by_users_id_fk": {
+          "name": "experiment_dashboards_created_by_users_id_fk",
+          "tableFrom": "experiment_dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_devices": {
+      "name": "experiment_devices",
+      "schema": "",
+      "columns": {
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "experiment_devices_device_idx": {
+          "name": "experiment_devices_device_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiment_devices_experiment_id_experiments_id_fk": {
+          "name": "experiment_devices_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_devices",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_devices_device_id_iot_devices_id_fk": {
+          "name": "experiment_devices_device_id_iot_devices_id_fk",
+          "tableFrom": "experiment_devices",
+          "tableTo": "iot_devices",
+          "columnsFrom": [
+            "device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_devices_added_by_users_id_fk": {
+          "name": "experiment_devices_added_by_users_id_fk",
+          "tableFrom": "experiment_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "added_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "experiment_devices_experiment_id_device_id_pk": {
+          "name": "experiment_devices_experiment_id_device_id_pk",
+          "columns": [
+            "experiment_id",
+            "device_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_join_requests": {
+      "name": "experiment_join_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "join_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "experiment_join_requests_pending_uniq": {
+          "name": "experiment_join_requests_pending_uniq",
+          "columns": [
+            {
+              "expression": "experiment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"experiment_join_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "experiment_join_requests_experiment_idx": {
+          "name": "experiment_join_requests_experiment_idx",
+          "columns": [
+            {
+              "expression": "experiment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiment_join_requests_experiment_id_experiments_id_fk": {
+          "name": "experiment_join_requests_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_join_requests",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_join_requests_user_id_users_id_fk": {
+          "name": "experiment_join_requests_user_id_users_id_fk",
+          "tableFrom": "experiment_join_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_join_requests_decided_by_users_id_fk": {
+          "name": "experiment_join_requests_decided_by_users_id_fk",
+          "tableFrom": "experiment_join_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_locations": {
+      "name": "experiment_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "numeric(10, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "numeric(11, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "municipality": {
+          "name": "municipality",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_label": {
+          "name": "address_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_locations_experiment_id_experiments_id_fk": {
+          "name": "experiment_locations_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_locations",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_members": {
+      "name": "experiment_members",
+      "schema": "",
+      "columns": {
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "experiment_members_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_members_experiment_id_experiments_id_fk": {
+          "name": "experiment_members_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_members",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "experiment_members_user_id_users_id_fk": {
+          "name": "experiment_members_user_id_users_id_fk",
+          "tableFrom": "experiment_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "experiment_members_experiment_id_user_id_pk": {
+          "name": "experiment_members_experiment_id_user_id_pk",
+          "columns": [
+            "experiment_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_visualizations": {
+      "name": "experiment_visualizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chart_family": {
+          "name": "chart_family",
+          "type": "chart_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chart_type": {
+          "name": "chart_type",
+          "type": "chart_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_config": {
+          "name": "data_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "experiment_visualizations_experiment_id_experiments_id_fk": {
+          "name": "experiment_visualizations_experiment_id_experiments_id_fk",
+          "tableFrom": "experiment_visualizations",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "experiment_visualizations_created_by_users_id_fk": {
+          "name": "experiment_visualizations_created_by_users_id_fk",
+          "tableFrom": "experiment_visualizations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiments": {
+      "name": "experiments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "experiment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "experiment_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "embargo_until": {
+          "name": "embargo_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "((now() AT TIME ZONE 'UTC') + interval '90 days')"
+        },
+        "anonymize_contributors": {
+          "name": "anonymize_contributors",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "workbook_id": {
+          "name": "workbook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workbook_version_id": {
+          "name": "workbook_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(\"experiments\".\"name\", '')), 'A') || setweight(to_tsvector('english', coalesce(\"experiments\".\"description\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "experiments_organization_id_idx": {
+          "name": "experiments_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "experiments_workbook_id_workbooks_id_fk": {
+          "name": "experiments_workbook_id_workbooks_id_fk",
+          "tableFrom": "experiments",
+          "tableTo": "workbooks",
+          "columnsFrom": [
+            "workbook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "experiments_workbook_version_id_workbook_versions_id_fk": {
+          "name": "experiments_workbook_version_id_workbook_versions_id_fk",
+          "tableFrom": "experiments",
+          "tableTo": "workbook_versions",
+          "columnsFrom": [
+            "workbook_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "experiments_created_by_users_id_fk": {
+          "name": "experiments_created_by_users_id_fk",
+          "tableFrom": "experiments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "experiments_organization_id_organizations_id_fk": {
+          "name": "experiments_organization_id_organizations_id_fk",
+          "tableFrom": "experiments",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "experiments_name_unique": {
+          "name": "experiments_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flows": {
+      "name": "flows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "graph": {
+          "name": "graph",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "flows_experiment_id_experiments_id_fk": {
+          "name": "flows_experiment_id_experiments_id_fk",
+          "tableFrom": "flows",
+          "tableTo": "experiments",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flows_experiment_id_unique": {
+          "name": "flows_experiment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "experiment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "invitation_resource_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "invitations_email_status_idx": {
+          "name": "invitations_email_status_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_invited_by_users_id_fk": {
+          "name": "invitations_invited_by_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "resource_id_check": {
+          "name": "resource_id_check",
+          "value": "(\"invitations\".\"resource_type\" = 'platform' AND \"invitations\".\"resource_id\" IS NULL) OR (\"invitations\".\"resource_type\" != 'platform' AND \"invitations\".\"resource_id\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.iot_devices": {
+      "name": "iot_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "thing_name": {
+          "name": "thing_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thing_arn": {
+          "name": "thing_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "sensor_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "device_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "certificate_id": {
+          "name": "certificate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "certificate_arn": {
+          "name": "certificate_arn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "iot_devices_created_by_idx": {
+          "name": "iot_devices_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "iot_devices_organization_id_idx": {
+          "name": "iot_devices_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "iot_devices_organization_id_organizations_id_fk": {
+          "name": "iot_devices_organization_id_organizations_id_fk",
+          "tableFrom": "iot_devices",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "iot_devices_created_by_users_id_fk": {
+          "name": "iot_devices_created_by_users_id_fk",
+          "tableFrom": "iot_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "iot_devices_thing_name_unique": {
+          "name": "iot_devices_thing_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "thing_name"
+          ]
+        },
+        "iot_devices_serial_number_unique": {
+          "name": "iot_devices_serial_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "serial_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.macros": {
+      "name": "macros",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "macro_language",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forked_from": {
+          "name": "forked_from",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(\"macros\".\"name\", '')), 'A') || setweight(to_tsvector('english', coalesce(\"macros\".\"description\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "macros_organization_id_idx": {
+          "name": "macros_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "macros_created_by_users_id_fk": {
+          "name": "macros_created_by_users_id_fk",
+          "tableFrom": "macros",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "macros_forked_from_macros_id_fk": {
+          "name": "macros_forked_from_macros_id_fk",
+          "tableFrom": "macros",
+          "tableTo": "macros",
+          "columnsFrom": [
+            "forked_from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "macros_organization_id_organizations_id_fk": {
+          "name": "macros_organization_id_organizations_id_fk",
+          "tableFrom": "macros",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "macros_name_unique": {
+          "name": "macros_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "macros_filename_unique": {
+          "name": "macros_filename_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "filename"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_invitations": {
+      "name": "organization_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "organization_invitations_email_status_idx": {
+          "name": "organization_invitations_email_status_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_invitations_organization_id_organizations_id_fk": {
+          "name": "organization_invitations_organization_id_organizations_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_inviter_id_users_id_fk": {
+          "name": "organization_invitations_inviter_id_users_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_team_id_teams_id_fk": {
+          "name": "organization_invitations_team_id_teams_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_join_requests": {
+      "name": "organization_join_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "varchar(250)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "join_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "organization_join_requests_pending_uniq": {
+          "name": "organization_join_requests_pending_uniq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"organization_join_requests\".\"status\" = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_join_requests_organization_idx": {
+          "name": "organization_join_requests_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_join_requests_organization_id_organizations_id_fk": {
+          "name": "organization_join_requests_organization_id_organizations_id_fk",
+          "tableFrom": "organization_join_requests",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_join_requests_user_id_users_id_fk": {
+          "name": "organization_join_requests_user_id_users_id_fk",
+          "tableFrom": "organization_join_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_join_requests_decided_by_users_id_fk": {
+          "name": "organization_join_requests_decided_by_users_id_fk",
+          "tableFrom": "organization_join_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "decided_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_members": {
+      "name": "organization_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "organization_members_org_user_uniq": {
+          "name": "organization_members_org_user_uniq",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_users_id_fk": {
+          "name": "organization_members_user_id_users_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "organization_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_permission": {
+          "name": "base_permission",
+          "type": "org_base_permission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(\"organizations\".\"name\", '')), 'A') || setweight(to_tsvector('english', coalesce(\"organizations\".\"description\", '')), 'B') || setweight(to_tsvector('english', coalesce(\"organizations\".\"location\", '')), 'C')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkeys": {
+      "name": "passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "passkeys_credential_id_uniq": {
+          "name": "passkeys_credential_id_uniq",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkeys_user_idx": {
+          "name": "passkeys_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkeys_user_id_users_id_fk": {
+          "name": "passkeys_user_id_users_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activated": {
+          "name": "activated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "whats_new_last_seen_at": {
+          "name": "whats_new_last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_user_id_users_id_fk": {
+          "name": "profiles_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_user_id_unique": {
+          "name": "profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.protocol_macros": {
+      "name": "protocol_macros",
+      "schema": "",
+      "columns": {
+        "protocol_id": {
+          "name": "protocol_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "macro_id": {
+          "name": "macro_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "protocol_macros_protocol_id_protocols_id_fk": {
+          "name": "protocol_macros_protocol_id_protocols_id_fk",
+          "tableFrom": "protocol_macros",
+          "tableTo": "protocols",
+          "columnsFrom": [
+            "protocol_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "protocol_macros_macro_id_macros_id_fk": {
+          "name": "protocol_macros_macro_id_macros_id_fk",
+          "tableFrom": "protocol_macros",
+          "tableTo": "macros",
+          "columnsFrom": [
+            "macro_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "protocol_macros_protocol_id_macro_id_pk": {
+          "name": "protocol_macros_protocol_id_macro_id_pk",
+          "columns": [
+            "protocol_id",
+            "macro_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.protocols": {
+      "name": "protocols",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "sensor_family",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forked_from": {
+          "name": "forked_from",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(\"protocols\".\"name\", '')), 'A') || setweight(to_tsvector('english', coalesce(\"protocols\".\"description\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "protocols_organization_id_idx": {
+          "name": "protocols_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "protocols_created_by_users_id_fk": {
+          "name": "protocols_created_by_users_id_fk",
+          "tableFrom": "protocols",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "protocols_forked_from_protocols_id_fk": {
+          "name": "protocols_forked_from_protocols_id_fk",
+          "tableFrom": "protocols",
+          "tableTo": "protocols",
+          "columnsFrom": [
+            "forked_from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "protocols_organization_id_organizations_id_fk": {
+          "name": "protocols_organization_id_organizations_id_fk",
+          "tableFrom": "protocols",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "protocols_name_unique": {
+          "name": "protocols_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limits": {
+      "name": "rate_limits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "rate_limits_key_unique": {
+          "name": "rate_limits_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_grants": {
+      "name": "resource_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "resource_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_type": {
+          "name": "grantee_type",
+          "type": "grantee_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantee_id": {
+          "name": "grantee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "resource_grants_unique": {
+          "name": "resource_grants_unique",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grantee_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grantee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resource_grants_resource_idx": {
+          "name": "resource_grants_resource_idx",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "resource_grants_grantee_idx": {
+          "name": "resource_grants_grantee_idx",
+          "columns": [
+            {
+              "expression": "grantee_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "grantee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resource_grants_created_by_users_id_fk": {
+          "name": "resource_grants_created_by_users_id_fk",
+          "tableFrom": "resource_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_team_id": {
+          "name": "active_team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_organizations_id_fk": {
+          "name": "sessions_active_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "active_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_active_team_id_teams_id_fk": {
+          "name": "sessions_active_team_id_teams_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "active_team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "team_members_team_user_uniq": {
+          "name": "team_members_team_user_uniq",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "team_members_user_idx": {
+          "name": "team_members_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_users_id_fk": {
+          "name": "team_members_user_id_users_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {
+        "teams_organization_idx": {
+          "name": "teams_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_organization_id_organizations_id_fk": {
+          "name": "teams_organization_id_organizations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registered": {
+          "name": "registered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workbook_versions": {
+      "name": "workbook_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workbook_id": {
+          "name": "workbook_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cells": {
+          "name": "cells",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "entity_snapshots": {
+          "name": "entity_snapshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"protocols\":{},\"macros\":{}}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workbook_versions_workbook_id_idx": {
+          "name": "workbook_versions_workbook_id_idx",
+          "columns": [
+            {
+              "expression": "workbook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workbook_versions_workbook_id_workbooks_id_fk": {
+          "name": "workbook_versions_workbook_id_workbooks_id_fk",
+          "tableFrom": "workbook_versions",
+          "tableTo": "workbooks",
+          "columnsFrom": [
+            "workbook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workbook_versions_created_by_users_id_fk": {
+          "name": "workbook_versions_created_by_users_id_fk",
+          "tableFrom": "workbook_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workbook_versions_workbook_version_uniq": {
+          "name": "workbook_versions_workbook_version_uniq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workbook_id",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workbooks": {
+      "name": "workbooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cells": {
+          "name": "cells",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "forked_from": {
+          "name": "forked_from",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(now() AT TIME ZONE 'UTC')"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(\"workbooks\".\"name\", '')), 'A') || setweight(to_tsvector('english', coalesce(\"workbooks\".\"description\", '')), 'B')",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "workbooks_created_by_idx": {
+          "name": "workbooks_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workbooks_organization_id_idx": {
+          "name": "workbooks_organization_id_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workbooks_created_by_users_id_fk": {
+          "name": "workbooks_created_by_users_id_fk",
+          "tableFrom": "workbooks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "workbooks_forked_from_workbooks_id_fk": {
+          "name": "workbooks_forked_from_workbooks_id_fk",
+          "tableFrom": "workbooks",
+          "tableTo": "workbooks",
+          "columnsFrom": [
+            "forked_from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workbooks_organization_id_organizations_id_fk": {
+          "name": "workbooks_organization_id_organizations_id_fk",
+          "tableFrom": "workbooks",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.chart_family": {
+      "name": "chart_family",
+      "schema": "public",
+      "values": [
+        "basic",
+        "scientific",
+        "3d",
+        "statistical"
+      ]
+    },
+    "public.chart_type": {
+      "name": "chart_type",
+      "schema": "public",
+      "values": [
+        "line",
+        "scatter",
+        "bar",
+        "pie",
+        "area",
+        "dot-plot",
+        "bubble",
+        "lollipop",
+        "box-plot",
+        "histogram",
+        "violin-plot",
+        "density-plot",
+        "ridge-plot",
+        "histogram-2d",
+        "density-plot-2d",
+        "spc-control-chart",
+        "heatmap",
+        "contour",
+        "carpet",
+        "ternary",
+        "parallel-coordinates",
+        "wind-rose",
+        "radar",
+        "polar",
+        "correlation-matrix",
+        "alluvial"
+      ]
+    },
+    "public.device_status": {
+      "name": "device_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "rotating",
+        "revoked"
+      ]
+    },
+    "public.experiment_members_role": {
+      "name": "experiment_members_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member"
+      ]
+    },
+    "public.experiment_status": {
+      "name": "experiment_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "stale",
+        "archived",
+        "published"
+      ]
+    },
+    "public.experiment_visibility": {
+      "name": "experiment_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "public"
+      ]
+    },
+    "public.grantee_type": {
+      "name": "grantee_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "organization",
+        "team"
+      ]
+    },
+    "public.invitation_resource_type": {
+      "name": "invitation_resource_type",
+      "schema": "public",
+      "values": [
+        "platform",
+        "experiment"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "revoked"
+      ]
+    },
+    "public.join_request_status": {
+      "name": "join_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "cancelled"
+      ]
+    },
+    "public.macro_language": {
+      "name": "macro_language",
+      "schema": "public",
+      "values": [
+        "python",
+        "r",
+        "javascript"
+      ]
+    },
+    "public.org_base_permission": {
+      "name": "org_base_permission",
+      "schema": "public",
+      "values": [
+        "none",
+        "read",
+        "admin"
+      ]
+    },
+    "public.organization_type": {
+      "name": "organization_type",
+      "schema": "public",
+      "values": [
+        "research_institute",
+        "non_profit",
+        "private_company",
+        "government_agency",
+        "university"
+      ]
+    },
+    "public.resource_type": {
+      "name": "resource_type",
+      "schema": "public",
+      "values": [
+        "experiment",
+        "macro",
+        "protocol",
+        "workbook",
+        "device",
+        "device_group"
+      ]
+    },
+    "public.sensor_family": {
+      "name": "sensor_family",
+      "schema": "public",
+      "values": [
+        "multispeq",
+        "ambyte",
+        "minipar",
+        "generic",
+        "ambit",
+        "mobile"
+      ]
+    },
+    "public.visibility": {
+      "name": "visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "public"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1787132151020,
       "tag": "0047_iam_admission_and_owned_resource_locks",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1787834187577,
+      "tag": "0048_organizations_search_vector",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -244,6 +244,14 @@ export const organizations = pgTable("organizations", {
   // once somebody deliberately publishes it; personal organizations stay private.
   visibility: visibilityEnum("visibility").default("private").notNull(),
   ...timestamps,
+  // Weighted full-text search vector: name (A) + description (B) + location (C), so "Amsterdam"
+  // finds the organizations based there while still ranking below a name or description hit. The
+  // `type` enum is matched at query time (enum->text casts are not immutable, so they can't live
+  // in a generated column).
+  searchVector: tsvector("search_vector").generatedAlwaysAs(
+    (): SQL =>
+      sql`setweight(to_tsvector('english', coalesce(${organizations.name}, '')), 'A') || setweight(to_tsvector('english', coalesce(${organizations.description}, '')), 'B') || setweight(to_tsvector('english', coalesce(${organizations.location}, '')), 'C')`,
+  ),
 });
 
 // Organization Members (Better Auth organization plugin, model "member").

--- a/packages/i18n/locales/de-DE/navigation.json
+++ b/packages/i18n/locales/de-DE/navigation.json
@@ -66,6 +66,7 @@
       "workbooks": "Arbeitsmappen",
       "protocols": "Protokolle",
       "macros": "Makros",
+      "organizations": "Organisationen",
       "transferRequests": "Transferanfragen",
       "settings": "Einstellungen",
       "createExperiment": "Experiment erstellen",
@@ -77,7 +78,8 @@
       "experiments": "Experimente",
       "protocols": "Protokolle",
       "macros": "Makros",
-      "workbooks": "Arbeitsmappen"
+      "workbooks": "Arbeitsmappen",
+      "organizations": "Organisationen"
     },
     "status": {
       "searching": "Suche...",

--- a/packages/i18n/locales/de-DE/navigation.json
+++ b/packages/i18n/locales/de-DE/navigation.json
@@ -58,7 +58,8 @@
     "placeholder": "Seiten und Aktionen suchen...",
     "groups": {
       "pages": "Seiten",
-      "actions": "Aktionen"
+      "actions": "Aktionen",
+      "searchResults": "Suchergebnisse"
     },
     "entries": {
       "home": "Startseite",

--- a/packages/i18n/locales/de-DE/navigation.json
+++ b/packages/i18n/locales/de-DE/navigation.json
@@ -55,7 +55,7 @@
   },
   "commandPalette": {
     "title": "Befehlspalette",
-    "placeholder": "Seiten und Aktionen suchen...",
+    "placeholder": "Seiten, Aktionen und Ressourcen suchen...",
     "groups": {
       "pages": "Seiten",
       "actions": "Aktionen",
@@ -74,13 +74,6 @@
       "openWhatsNew": "Neuigkeiten öffnen",
       "showKeyboardShortcuts": "Tastenkürzel anzeigen",
       "openDocumentation": "Dokumentation öffnen"
-    },
-    "results": {
-      "experiments": "Experimente",
-      "protocols": "Protokolle",
-      "macros": "Makros",
-      "workbooks": "Arbeitsmappen",
-      "organizations": "Organisationen"
     },
     "status": {
       "searching": "Suche...",

--- a/packages/i18n/locales/en-US/navigation.json
+++ b/packages/i18n/locales/en-US/navigation.json
@@ -58,7 +58,8 @@
     "placeholder": "Search pages and actions...",
     "groups": {
       "pages": "Pages",
-      "actions": "Actions"
+      "actions": "Actions",
+      "searchResults": "Search results"
     },
     "entries": {
       "home": "Home",

--- a/packages/i18n/locales/en-US/navigation.json
+++ b/packages/i18n/locales/en-US/navigation.json
@@ -66,6 +66,7 @@
       "workbooks": "Workbooks",
       "protocols": "Protocols",
       "macros": "Macros",
+      "organizations": "Organizations",
       "transferRequests": "Transfer requests",
       "settings": "Settings",
       "createExperiment": "Create experiment",
@@ -77,7 +78,8 @@
       "experiments": "Experiments",
       "protocols": "Protocols",
       "macros": "Macros",
-      "workbooks": "Workbooks"
+      "workbooks": "Workbooks",
+      "organizations": "Organizations"
     },
     "status": {
       "searching": "Searching...",

--- a/packages/i18n/locales/en-US/navigation.json
+++ b/packages/i18n/locales/en-US/navigation.json
@@ -55,7 +55,7 @@
   },
   "commandPalette": {
     "title": "Command palette",
-    "placeholder": "Search pages and actions...",
+    "placeholder": "Search pages, actions, and resources...",
     "groups": {
       "pages": "Pages",
       "actions": "Actions",
@@ -74,13 +74,6 @@
       "openWhatsNew": "Open What's new",
       "showKeyboardShortcuts": "Show keyboard shortcuts",
       "openDocumentation": "Open documentation"
-    },
-    "results": {
-      "experiments": "Experiments",
-      "protocols": "Protocols",
-      "macros": "Macros",
-      "workbooks": "Workbooks",
-      "organizations": "Organizations"
     },
     "status": {
       "searching": "Searching...",

--- a/packages/i18n/locales/nl-NL/navigation.json
+++ b/packages/i18n/locales/nl-NL/navigation.json
@@ -51,7 +51,7 @@
   },
   "commandPalette": {
     "title": "Commandopalet",
-    "placeholder": "Pagina's en acties zoeken...",
+    "placeholder": "Pagina's, acties en bronnen zoeken...",
     "groups": {
       "pages": "Pagina's",
       "actions": "Acties",
@@ -70,13 +70,6 @@
       "openWhatsNew": "Wat is er nieuw openen",
       "showKeyboardShortcuts": "Sneltoetsen tonen",
       "openDocumentation": "Documentatie openen"
-    },
-    "results": {
-      "experiments": "Experimenten",
-      "protocols": "Protocollen",
-      "macros": "Macro's",
-      "workbooks": "Werkboeken",
-      "organizations": "Organisaties"
     },
     "status": {
       "searching": "Zoeken...",

--- a/packages/i18n/locales/nl-NL/navigation.json
+++ b/packages/i18n/locales/nl-NL/navigation.json
@@ -54,7 +54,8 @@
     "placeholder": "Pagina's en acties zoeken...",
     "groups": {
       "pages": "Pagina's",
-      "actions": "Acties"
+      "actions": "Acties",
+      "searchResults": "Zoekresultaten"
     },
     "entries": {
       "home": "Home",

--- a/packages/i18n/locales/nl-NL/navigation.json
+++ b/packages/i18n/locales/nl-NL/navigation.json
@@ -62,6 +62,7 @@
       "workbooks": "Werkboeken",
       "protocols": "Protocollen",
       "macros": "Macro's",
+      "organizations": "Organisaties",
       "transferRequests": "Transferverzoeken",
       "settings": "Instellingen",
       "createExperiment": "Experiment aanmaken",
@@ -73,7 +74,8 @@
       "experiments": "Experimenten",
       "protocols": "Protocollen",
       "macros": "Macro's",
-      "workbooks": "Werkboeken"
+      "workbooks": "Werkboeken",
+      "organizations": "Organisaties"
     },
     "status": {
       "searching": "Zoeken...",


### PR DESCRIPTION
## Type of PR (check all applicable)

- [x] Feature
- [x] Bug Fix
- [x] Refactor
- [x] Documentation Update
- [ ] Performance Improvement
- [x] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Organizations become the fifth resource type in global search, alongside experiments, protocols, macros, and workbooks. The command palette now preserves the backend's flat score ordering, so organizations can genuinely outrank weaker matches of another type.

**Search signals and privacy boundary**

| Signal | Behavior |
|---|---|
| `name` | generated tsvector, weight **A**, plus typo-tolerant fallback |
| `description` | generated tsvector, weight **B** |
| `location` | generated tsvector, weight **C** |
| localized organization type | shared, exhaustive English/German/Dutch aliases matched as search lexemes |
| member and team names | matched only when the caller belongs to that organization |

Member and team names are deliberately membership-gated. The corresponding roster use cases are members-only even for public organizations, so an ungated search probe would reveal information those reads deny.

Organizations use the directory boundary rather than `accessibleResourceCondition`: public organizations or the caller's own organizations are visible, while personal workspaces are excluded. Listing and global search share this condition to prevent access drift. `scope: "related"` adds the caller-membership filter on top of that boundary.

**Ranking and cache safety**

The score is comparable with the other four resource repositories. Organization ownership supplies the top relationship tier, membership the next tier, and public browse results the base tier. The palette renders one flat ranked collection while retaining visual type labels.

Global-search cache keys are principal-scoped, sign-out removes authorization-sensitive results, session resolution gates fetching without flashing an empty state, and organization/profile/membership/team mutations invalidate the affected search cache.

## Test

Automated verification completed locally:

- [x] Web test suite: 6,213 passed, 2 skipped
- [x] Backend test suite: 3,204 passed
- [x] Focused backend global-search integration suite: 26 passed
- [x] Web TypeScript and backend production builds
- [x] Changed-file ESLint, Prettier, and `git diff --check`
- [x] Docs build, link crawl, and local docs validation
- [x] Backend and database-migration container builds with the CI-equivalent scanner input

Manual authenticated screenshot recapture was not performed because it requires resetting/seeding local development data. The platform-tour copy is updated; existing screenshots are unchanged.

## Changes Made

- **`packages/database`** — migration `0048` adds the generated organization `search_vector`, GIN index, and trigram name index.
- **`packages/api`** — adds organization search results, directory scope, and an exhaustive organization-type search-alias contract.
- **`apps/backend`** — adds organization directory/global search with shared visibility conditions, comparable ranking, localized type aliases, and member/team privacy gates.
- **`apps/web`** — adds ranked organization palette results, Organizations navigation and `G O`, principal-safe query caching, retained-row guards, and mutation invalidation coverage.
- **`packages/i18n`** — adds/updates search and navigation copy in `en-US`, `de-DE`, and `nl-NL`, with a contract test keeping visible type labels searchable.
- **`apps/docs`** — documents organization navigation and ranked resource search in the platform tour.
- **CI fix** — narrows the `tar@7.5.19` Trivy VEX entry to the npm-bundled package and the one applicable CVE; npm is not invoked in the runtime runner images.
