### PR TITLE
fix(infra): declare the data-platform SP's catalog grants on prod and dev

### DIFF
--- a/infrastructure/env/dev/main.tf
+++ b/infrastructure/env/dev/main.tf
@@ -606,6 +606,27 @@ module "databricks_catalog" {
         "USE_SCHEMA"
       ]
     }
+
+    # Read-only access for the jii-data-platform deploy SP, which runs the
+    # analyst gold pipelines in the sandbox workspace. grebbedijk-ambit-2026-gold
+    # reads centrum.enriched_experiment_raw_data from here cross-catalog.
+    #
+    # These privileges are already live — this block only stops them being
+    # undeclared drift. They were granted by hand and have survived purely
+    # because nothing authoritative covers the catalog securable. The equivalent
+    # prod grant lived at SCHEMA level instead, where the authoritative
+    # `databricks_grants.centrum_schema` reclaimed it on 2026-08-20 and took two
+    # pipelines down for eight days. Same access, different level, opposite
+    # outcome — so it is written down here before someone rediscovers that.
+    data_platform_deploy_sp = {
+      principal = var.data_platform_sp_application_id
+      privileges = [
+        "BROWSE",
+        "SELECT",
+        "USE_CATALOG",
+        "USE_SCHEMA"
+      ]
+    }
   }
 
   providers = {

--- a/infrastructure/env/dev/variables.tf
+++ b/infrastructure/env/dev/variables.tf
@@ -217,3 +217,9 @@ variable "grafana_auth_service_token" {
   type        = string
   sensitive   = true
 }
+
+variable "data_platform_sp_application_id" {
+  description = "Application ID of the jii-data-platform deploy service principal (github-actions-jii-data-platform-sandbox-deploy). It runs the analyst gold pipelines in the sandbox workspace, which read this environment's centrum tables cross-catalog. Read-only; granted at catalog level in main.tf."
+  type        = string
+  default     = "122ea6e5-a082-45b5-9df6-ef5482868fdc"
+}

--- a/infrastructure/env/prod/main.tf
+++ b/infrastructure/env/prod/main.tf
@@ -579,6 +579,30 @@ module "databricks_catalog" {
         "USE_SCHEMA"
       ]
     }
+
+    # Read-only access for the jii-data-platform deploy SP, which runs the
+    # analyst gold pipelines in the sandbox workspace. Those pipelines read
+    # centrum.enriched_experiment_raw_data cross-catalog.
+    #
+    # Declared at CATALOG level on purpose. `databricks_grants.centrum_schema`
+    # below is authoritative over the schema, so a schema-scoped grant to any
+    # principal it does not list is deleted on the next apply. That is exactly
+    # what happened on 2026-08-20: the SP had been granted USE_SCHEMA on centrum
+    # by hand, an apply reclaimed it, and maize-ambit-2026-gold and
+    # barley-nergena-2026-gold then failed every 15 minutes for eight days.
+    #
+    # The catalog module uses `databricks_grant` (singular, additive), so a grant
+    # here is not subject to that, and USE_SCHEMA cascades down to centrum. This
+    # mirrors how dev has always worked — which is why dev never broke.
+    data_platform_deploy_sp = {
+      principal = var.data_platform_sp_application_id
+      privileges = [
+        "BROWSE",
+        "SELECT",
+        "USE_CATALOG",
+        "USE_SCHEMA"
+      ]
+    }
   }
 
   providers = {

--- a/infrastructure/env/prod/variables.tf
+++ b/infrastructure/env/prod/variables.tf
@@ -228,3 +228,9 @@ variable "grafana_auth_service_token" {
   type        = string
   sensitive   = true
 }
+
+variable "data_platform_sp_application_id" {
+  description = "Application ID of the jii-data-platform deploy service principal (github-actions-jii-data-platform-sandbox-deploy). It runs the analyst gold pipelines in the sandbox workspace, which read this environment's centrum tables cross-catalog. Read-only; granted at catalog level in main.tf."
+  type        = string
+  default     = "122ea6e5-a082-45b5-9df6-ef5482868fdc"
+}


### PR DESCRIPTION
## What

Adds the jii-data-platform deploy SP (`github-actions-jii-data-platform-sandbox-deploy`) to the **catalog-level** grants map for `open_jii_prod` and `open_jii_dev`, read-only: `BROWSE, SELECT, USE_CATALOG, USE_SCHEMA`.

## Why

That SP runs the analyst gold pipelines in the sandbox workspace, which read `centrum.enriched_experiment_raw_data` cross-catalog. Its access to prod and dev has never been declared here — it was granted by hand.

On **prod** the grant sat at SCHEMA level. `databricks_grants.centrum_schema` is authoritative over that securable and has never listed the SP, so an apply on **2026-08-20 11:01:59Z** reclaimed it:

```
updatePermissions  securable=open_jii_prod.centrum
changes=[{"principal":"122ea6e5-…","remove":["USE_SCHEMA"]}]
```

`maize-ambit-2026-gold` and `barley-nergena-2026-gold` failed every 15 minutes from `11:15Z` that day until `2026-08-28 10:01Z` — roughly 760 runs — with:

```
[INSUFFICIENT_PERMISSIONS] User does not have USE SCHEMA
on Schema 'open_jii_prod.centrum'. SQLSTATE: 42501
```

Nobody noticed for eight days because the dashboards kept rendering: the gold tables were stale, not missing, so it looked like "the pipeline isn't running" rather than an error.

On **dev** the same access happens to sit at CATALOG level, where the module uses `databricks_grant` (**singular**, additive). Nothing reclaims it — which is why `grebbedijk-ambit-2026-gold`, which reads `open_jii_dev.centrum`, never broke. Same access, different level, opposite outcome.

## Why catalog level rather than schema level

| | Resource | Authority | Verdict |
| --- | --- | --- | --- |
| `module.databricks_catalog` grants | `databricks_grant` | per-principal, additive | safe |
| `databricks_grants.centrum_schema` | `databricks_grants` | whole securable | reclaims anything unlisted |

`USE_SCHEMA` at catalog level cascades into `centrum`, so this grants the same effective access while living in the resource that cannot silently drop it. It also makes prod match dev, which is the configuration that has been quietly working all along.

Note this is slightly broader than a schema-scoped grant — `SELECT` across all schemas in the catalog rather than just `centrum`. That is the tradeoff dev already accepted, and the `JII` group holds the same catalog-level privileges on prod today.

## Expected plan

- **dev** — the privileges are already live and identical, so this should be a state-only create with no effective change to the workspace.
- **prod** — a real change. `USE_CATALOG` is already present; this adds `BROWSE`, `SELECT`, `USE_SCHEMA` at catalog level.
- **prod, additionally** — the plan will show a schema-level grant on `centrum` being **removed**. That is expected. To get the dashboards back this morning the `USE_SCHEMA` grant was re-applied by hand; the authoritative block will reclaim it again, and the catalog grant added here supersedes it within the same apply.

## Testing

No `terraform` binary was available locally. Verified by parsing all four changed files and confirming the grant keys and variable resolve; live grant state was read with `databricks grants get-effective` against both catalogs. **Please confirm with a real plan before merging** — particularly that the dev side comes back empty.

Related: [jii-infra#13](https://github.com/Jan-IngenHousz-Institute/jii-infra/pull/13) does the same for the sandbox catalog and external location.