### PR TITLE
feat(data): surface device family and phone provenance in silver

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -167,11 +167,17 @@ jobs:
         shell: bash
         run: |
           BASE_SHA=${{ github.event.pull_request.base.sha || github.event.before || 'HEAD~1' }}
-          if git diff --name-only "$BASE_SHA" HEAD -- \
+          # Fail closed: an unresolvable base would otherwise land in the "no
+          # changes" branch and silently skip the gate below.
+          if ! CONTRACT_CHANGES=$(git diff --name-only "$BASE_SHA" HEAD -- \
               asyncapi.yaml \
               apps/data/src/lib/openjii/openjii/centrum/schemas.py \
               apps/data/src/pipelines/centrum/bronze/raw_data.py \
-              apps/docs/scripts/check-mqtt-contract.mjs | grep -q .; then
+              apps/docs/scripts/check-mqtt-contract.mjs); then
+            echo "::error::Could not diff against base $BASE_SHA; refusing to skip the MQTT ingest contract check."
+            exit 1
+          fi
+          if [ -n "$CONTRACT_CHANGES" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
             echo "✅ MQTT ingest contract changes detected"
           else

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -173,6 +173,7 @@ jobs:
               asyncapi.yaml \
               apps/data/src/lib/openjii/openjii/centrum/schemas.py \
               apps/data/src/pipelines/centrum/bronze/raw_data.py \
+              apps/docs/package.json \
               apps/docs/scripts/check-mqtt-contract.mjs); then
             echo "::error::Could not diff against base $BASE_SHA; refusing to skip the MQTT ingest contract check."
             exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -159,8 +159,28 @@ jobs:
             echo "No API/spec changes detected"
           fi
 
+      # asyncapi.yaml is hand-written, so the MQTT contract needs its own
+      # trigger: a pipeline-only PR that adds an ingest field must still be
+      # held to documenting it.
+      - name: Detect MQTT ingest contract changes
+        id: contract
+        shell: bash
+        run: |
+          BASE_SHA=${{ github.event.pull_request.base.sha || github.event.before || 'HEAD~1' }}
+          if git diff --name-only "$BASE_SHA" HEAD -- \
+              asyncapi.yaml \
+              apps/data/src/lib/openjii/openjii/centrum/schemas.py \
+              apps/data/src/pipelines/centrum/bronze/raw_data.py \
+              apps/docs/scripts/check-mqtt-contract.mjs | grep -q .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "✅ MQTT ingest contract changes detected"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No MQTT ingest contract changes detected"
+          fi
+
       - name: Setup Node.js and pnpm
-        if: steps.changed.outputs.changed == 'true'
+        if: steps.changed.outputs.changed == 'true' || steps.contract.outputs.changed == 'true'
         uses: ./.github/actions/setup-nodejs-pnpm
         with:
           node-version: "24"
@@ -176,6 +196,15 @@ jobs:
             exit 1
           fi
           echo "ok — API spec copies are up to date"
+
+      - name: Check MQTT ingest contract
+        if: steps.contract.outputs.changed == 'true'
+        shell: bash
+        run: |
+          if ! pnpm --filter docs check-mqtt-contract; then
+            echo "::error::asyncapi.yaml is out of sync with the centrum ingest schemas. See the assertion above for the fields to add or remove."
+            exit 1
+          fi
 
   build_lint_test:
     name: Build, Lint, & Test

--- a/apps/data/src/lib/openjii/openjii/centrum/schemas.py
+++ b/apps/data/src/lib/openjii/openjii/centrum/schemas.py
@@ -108,6 +108,14 @@ large_iot_schema = StructType(
         StructField("macros", ArrayType(macro_schema), True),
         StructField("annotations", ArrayType(annotation_schema), True),
         StructField("experiment_id", StringType(), True),
+        # Canonical sensor family from the mobile identification handshake.
+        StructField("device_family", StringType(), True),
+        # The publishing phone, as opposed to the sensor's device_* fields.
+        StructField("client_model", StringType(), True),
+        StructField("client_manufacturer", StringType(), True),
+        StructField("client_os", StringType(), True),
+        StructField("client_os_version", StringType(), True),
+        StructField("client_app_version", StringType(), True),
         # Workbook execution metadata; absent on single-device uploads.
         # macro_context stays a JSON string because its keys are dynamic.
         StructField("workbook_run_id", StringType(), True),

--- a/apps/data/src/lib/openjii/openjii/centrum/schemas.py
+++ b/apps/data/src/lib/openjii/openjii/centrum/schemas.py
@@ -110,6 +110,8 @@ large_iot_schema = StructType(
         StructField("experiment_id", StringType(), True),
         # Canonical sensor family from the mobile identification handshake.
         StructField("device_family", StringType(), True),
+        # Sensor hardware address seen by the edge device (Bluetooth MAC).
+        StructField("device_address", StringType(), True),
         # The publishing phone, as opposed to the sensor's device_* fields.
         StructField("client_model", StringType(), True),
         StructField("client_manufacturer", StringType(), True),

--- a/apps/data/src/pipelines/centrum/bronze/raw_data.py
+++ b/apps/data/src/pipelines/centrum/bronze/raw_data.py
@@ -77,6 +77,10 @@ def raw_data():
             F.get_json_object(F.col("data").cast("string"), "$.device_family"),
         )
         .withColumn(
+            "device_address",
+            F.get_json_object(F.col("data").cast("string"), "$.device_address"),
+        )
+        .withColumn(
             "client_model",
             F.get_json_object(F.col("data").cast("string"), "$.client_model"),
         )
@@ -102,6 +106,7 @@ def raw_data():
             "workbook_version_id",
             "macro_context",
             "device_family",
+            "device_address",
             "client_model",
             "client_manufacturer",
             "client_os",

--- a/apps/data/src/pipelines/centrum/bronze/raw_data.py
+++ b/apps/data/src/pipelines/centrum/bronze/raw_data.py
@@ -69,11 +69,44 @@ def raw_data():
             "macro_context",
             F.get_json_object(F.col("data").cast("string"), "$.macro_context"),
         )
+        # Device and publisher provenance, extracted top-level for the same
+        # reason: device_family names the sensor's canonical driver family, and
+        # client_* describes the phone that published, not the sensor.
+        .withColumn(
+            "device_family",
+            F.get_json_object(F.col("data").cast("string"), "$.device_family"),
+        )
+        .withColumn(
+            "client_model",
+            F.get_json_object(F.col("data").cast("string"), "$.client_model"),
+        )
+        .withColumn(
+            "client_manufacturer",
+            F.get_json_object(F.col("data").cast("string"), "$.client_manufacturer"),
+        )
+        .withColumn(
+            "client_os",
+            F.get_json_object(F.col("data").cast("string"), "$.client_os"),
+        )
+        .withColumn(
+            "client_os_version",
+            F.get_json_object(F.col("data").cast("string"), "$.client_os_version"),
+        )
+        .withColumn(
+            "client_app_version",
+            F.get_json_object(F.col("data").cast("string"), "$.client_app_version"),
+        )
         .select(
             "experiment_id",
             "client_id",
             "workbook_version_id",
             "macro_context",
+            "device_family",
+            "client_model",
+            "client_manufacturer",
+            "client_os",
+            "client_os_version",
+            "client_app_version",
             "parsed_data",
             "ingestion_timestamp",
             "ingest_date",

--- a/apps/data/src/pipelines/centrum/silver/clean_data.py
+++ b/apps/data/src/pipelines/centrum/silver/clean_data.py
@@ -92,6 +92,7 @@ def clean_data():
         # Sensor family and publishing-phone provenance. Extracted top-level in
         # bronze, so they are read as columns rather than out of parsed_data.
         .withColumn("device_family", F.col("device_family"))
+        .withColumn("device_address", F.col("device_address"))
         .withColumn("client_model", F.col("client_model"))
         .withColumn("client_manufacturer", F.col("client_manufacturer"))
         .withColumn("client_os", F.col("client_os"))
@@ -224,6 +225,7 @@ def clean_data():
         "workbook_version_id",
         "macro_context",
         "device_family",
+        "device_address",
         "client_model",
         "client_manufacturer",
         "client_os",
@@ -283,6 +285,7 @@ def clean_data():
         .withColumn("macro_context", F.lit(None).cast("string"))
         # Imported/transfer rows carry no driver family or phone provenance.
         .withColumn("device_family", F.lit(None).cast("string"))
+        .withColumn("device_address", F.lit(None).cast("string"))
         .withColumn("client_model", F.lit(None).cast("string"))
         .withColumn("client_manufacturer", F.lit(None).cast("string"))
         .withColumn("client_os", F.lit(None).cast("string"))
@@ -311,6 +314,7 @@ def clean_data():
             "workbook_version_id",
             "macro_context",
             "device_family",
+            "device_address",
             "client_model",
             "client_manufacturer",
             "client_os",
@@ -425,6 +429,7 @@ def clean_data_large_iot():
             "workbook_version_id",
             "macro_context",
             "device_family",
+            "device_address",
             "client_model",
             "client_manufacturer",
             "client_os",

--- a/apps/data/src/pipelines/centrum/silver/clean_data.py
+++ b/apps/data/src/pipelines/centrum/silver/clean_data.py
@@ -89,6 +89,14 @@ def clean_data():
         .withColumn("workbook_run_id", F.col("parsed_data.workbook_run_id"))
         .withColumn("workbook_version_id", F.col("workbook_version_id"))
         .withColumn("macro_context", F.col("macro_context"))
+        # Sensor family and publishing-phone provenance. Extracted top-level in
+        # bronze, so they are read as columns rather than out of parsed_data.
+        .withColumn("device_family", F.col("device_family"))
+        .withColumn("client_model", F.col("client_model"))
+        .withColumn("client_manufacturer", F.col("client_manufacturer"))
+        .withColumn("client_os", F.col("client_os"))
+        .withColumn("client_os_version", F.col("client_os_version"))
+        .withColumn("client_app_version", F.col("client_app_version"))
         # GPS fix at measurement time; null on older payloads / no permission.
         .withColumn("latitude", F.col("parsed_data.latitude"))
         .withColumn("longitude", F.col("parsed_data.longitude"))
@@ -215,6 +223,12 @@ def clean_data():
         "workbook_run_id",
         "workbook_version_id",
         "macro_context",
+        "device_family",
+        "client_model",
+        "client_manufacturer",
+        "client_os",
+        "client_os_version",
+        "client_app_version",
         "latitude",
         "longitude",
         "timestamp",
@@ -267,6 +281,13 @@ def clean_data():
         .withColumn("workbook_run_id", F.lit(None).cast("string"))
         .withColumn("workbook_version_id", F.lit(None).cast("string"))
         .withColumn("macro_context", F.lit(None).cast("string"))
+        # Imported/transfer rows carry no driver family or phone provenance.
+        .withColumn("device_family", F.lit(None).cast("string"))
+        .withColumn("client_model", F.lit(None).cast("string"))
+        .withColumn("client_manufacturer", F.lit(None).cast("string"))
+        .withColumn("client_os", F.lit(None).cast("string"))
+        .withColumn("client_os_version", F.lit(None).cast("string"))
+        .withColumn("client_app_version", F.lit(None).cast("string"))
         # Mark imported data to skip macro processing
         .withColumn("skip_macro_processing", F.lit(True))
         .select(
@@ -289,6 +310,12 @@ def clean_data():
             "workbook_run_id",
             "workbook_version_id",
             "macro_context",
+            "device_family",
+            "client_model",
+            "client_manufacturer",
+            "client_os",
+            "client_os_version",
+            "client_app_version",
             "latitude",
             "longitude",
             "timestamp",
@@ -397,6 +424,12 @@ def clean_data_large_iot():
             "workbook_run_id",
             "workbook_version_id",
             "macro_context",
+            "device_family",
+            "client_model",
+            "client_manufacturer",
+            "client_os",
+            "client_os_version",
+            "client_app_version",
             "latitude",
             "longitude",
             "timestamp",

--- a/apps/data/tests/lib/test_device_provenance_fields.py
+++ b/apps/data/tests/lib/test_device_provenance_fields.py
@@ -1,0 +1,38 @@
+"""Device and publisher provenance fields carried from the mobile payload."""
+
+from __future__ import annotations
+
+import openjii.centrum as centrum
+
+# Written by the mobile app: device_family is the sensor's canonical driver
+# family, client_* describes the phone that published.
+PROVENANCE_FIELDS = (
+    "device_family",
+    "client_model",
+    "client_manufacturer",
+    "client_os",
+    "client_os_version",
+    "client_app_version",
+)
+
+
+def test_large_iot_schema_parses_provenance_fields() -> None:
+    names = {field.name for field in centrum.large_iot_schema.fields}
+    missing = [field for field in PROVENANCE_FIELDS if field not in names]
+    assert not missing, f"large_iot_schema would drop {missing} at parse time"
+
+
+def test_large_iot_provenance_fields_are_nullable_strings() -> None:
+    fields = {field.name: field for field in centrum.large_iot_schema.fields}
+    for name in PROVENANCE_FIELDS:
+        assert fields[name].dataType.typeName() == "string"
+        # Older payloads predate these keys and must still parse.
+        assert fields[name].nullable
+
+
+def test_sensor_schema_does_not_gain_provenance_fields() -> None:
+    # The MQTT path reads these with get_json_object instead: adding them here
+    # would evolve the non-resettable bronze parsed_data struct.
+    names = {field.name for field in centrum.sensor_schema.fields}
+    for name in PROVENANCE_FIELDS:
+        assert name not in names

--- a/apps/data/tests/lib/test_device_provenance_fields.py
+++ b/apps/data/tests/lib/test_device_provenance_fields.py
@@ -8,6 +8,7 @@ import openjii.centrum as centrum
 # family, client_* describes the phone that published.
 PROVENANCE_FIELDS = (
     "device_family",
+    "device_address",
     "client_model",
     "client_manufacturer",
     "client_os",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,6 +9,7 @@
     "check-links": "node scripts/check-internal-links.mjs",
     "check-media-references": "node scripts/check-media-references.mjs",
     "check-media-tooling": "node scripts/check-media-tooling.mjs",
+    "check-mqtt-contract": "node scripts/check-mqtt-contract.mjs",
     "check-routing": "node scripts/check-cloudfront-function.mjs",
     "check-types": "tsc --noEmit",
     "clean": "git clean -xdf .cache .next .source .turbo out node_modules",

--- a/apps/docs/public/asyncapi.yaml
+++ b/apps/docs/public/asyncapi.yaml
@@ -268,9 +268,43 @@ components:
             description: >
               Battery reading as the device reports it; the unit is
               device-defined (volts on some families, percent on others).
+          device_family:
+            type: string
+            description: >
+              Canonical driver family of the sensor (e.g. "multispeq",
+              "ambit", "minipar"), resolved by the publisher's identification
+              handshake. Lets consumers tell families apart without
+              interpreting a device-reported display name.
+          device_address:
+            type: string
+            description: >
+              The sensor's hardware address as the publisher reached it
+              (Bluetooth MAC). Reported alongside device_id, never instead of
+              it: MultispeQ firmware answers device_info with a truncated id
+              (4 of 6 octets), so the complete value only exists at the
+              transport.
           output:
             type: string
             description: Device-native output block, passed through as text.
+          client_model:
+            type: string
+            description: >
+              The publishing phone, as opposed to the sensor's device_*
+              fields. Best-effort: omitted rather than invented when the
+              platform will not report a value. (Distinct from client_id,
+              which the broker rule stamps on the stored envelope.)
+          client_manufacturer:
+            type: string
+            description: Manufacturer of the publishing phone.
+          client_os:
+            type: string
+            description: OS name of the publishing phone (e.g. "Android", "iOS").
+          client_os_version:
+            type: string
+            description: OS version of the publishing phone.
+          client_app_version:
+            type: string
+            description: Native app version of the publishing mobile build.
           latitude:
             type: number
             description: GPS latitude at measurement time, if available.
@@ -287,6 +321,10 @@ components:
             sample: '{"moisture": 30.5, "temperature": 22.1}'
             device_version: "1.1.0"
             device_battery: 4.1
+            device_family: "multispeq"
+            device_address: "AA:BB:CC:DD:EE:FF"
+            client_os: "Android"
+            client_app_version: "1.1.0"
 
     DeviceScriptMessage:
       contentType: application/json

--- a/apps/docs/scripts/check-deploy-workflow.mjs
+++ b/apps/docs/scripts/check-deploy-workflow.mjs
@@ -216,10 +216,8 @@ for (const prerequisite of ["deploy-backend", "deploy-frontend", "deploy-databri
 }
 
 const prWorkflow = load(await readFile(prWorkflowPath, "utf8"));
-const driftStep = stepByName(
-  workflowSteps(prWorkflow, "docs_spec_drift"),
-  "Detect docs-relevant spec changes",
-);
+const driftSteps = workflowSteps(prWorkflow, "docs_spec_drift");
+const driftStep = stepByName(driftSteps, "Detect docs-relevant spec changes");
 for (const requiredPath of [
   "package.json",
   "pnpm-lock.yaml",
@@ -229,6 +227,25 @@ for (const requiredPath of [
 ]) {
   assert.ok(driftStep.run.includes(requiredPath), `spec drift guard omits ${requiredPath}`);
 }
+
+// asyncapi.yaml has no generator, so the MQTT contract guard has to trigger on
+// the pipeline sources it is checked against, not just on the spec itself.
+const contractStep = stepByName(driftSteps, "Detect MQTT ingest contract changes");
+for (const requiredPath of [
+  "asyncapi.yaml",
+  "apps/data/src/lib/openjii/openjii/centrum/schemas.py",
+  "apps/data/src/pipelines/centrum/bronze/raw_data.py",
+]) {
+  assert.ok(contractStep.run.includes(requiredPath), `MQTT contract guard omits ${requiredPath}`);
+}
+const contractCheckStep = stepByName(driftSteps, "Check MQTT ingest contract");
+assert.match(contractCheckStep.run, /pnpm --filter docs check-mqtt-contract/);
+assert.equal(contractCheckStep.if, "steps.contract.outputs.changed == 'true'");
+assert.match(
+  stepByName(driftSteps, "Setup Node.js and pnpm").if,
+  /steps\.contract\.outputs\.changed == 'true'/,
+  "MQTT contract check would run without a Node.js setup",
+);
 
 const runbook = await readFile(path.join(appRoot, "ROLLBACK.md"), "utf8");
 for (const requiredCommand of [

--- a/apps/docs/scripts/check-deploy-workflow.mjs
+++ b/apps/docs/scripts/check-deploy-workflow.mjs
@@ -11,6 +11,7 @@ const repoRoot = path.resolve(appRoot, "../..");
 const deployWorkflowPath = path.join(repoRoot, ".github/workflows/deploy-docs.yml");
 const orchestratorWorkflowPath = path.join(repoRoot, ".github/workflows/deploy.yml");
 const prWorkflowPath = path.join(repoRoot, ".github/workflows/pr.yml");
+const docsPackagePath = path.join(appRoot, "package.json");
 
 function workflowSteps(workflow, job) {
   const steps = workflow.jobs?.[job]?.steps;
@@ -235,6 +236,7 @@ for (const requiredPath of [
   "asyncapi.yaml",
   "apps/data/src/lib/openjii/openjii/centrum/schemas.py",
   "apps/data/src/pipelines/centrum/bronze/raw_data.py",
+  "apps/docs/package.json",
 ]) {
   assert.ok(contractStep.run.includes(requiredPath), `MQTT contract guard omits ${requiredPath}`);
 }
@@ -252,6 +254,12 @@ assert.match(
 assert.ok(
   driftSteps.indexOf(setupStep) < driftSteps.indexOf(contractCheckStep),
   "MQTT contract check would run before pnpm is installed",
+);
+const docsPackage = JSON.parse(await readFile(docsPackagePath, "utf8"));
+assert.equal(
+  docsPackage.scripts?.["check-mqtt-contract"],
+  "node scripts/check-mqtt-contract.mjs",
+  "docs package no longer exposes the MQTT contract checker used by CI",
 );
 
 const runbook = await readFile(path.join(appRoot, "ROLLBACK.md"), "utf8");

--- a/apps/docs/scripts/check-deploy-workflow.mjs
+++ b/apps/docs/scripts/check-deploy-workflow.mjs
@@ -238,13 +238,20 @@ for (const requiredPath of [
 ]) {
   assert.ok(contractStep.run.includes(requiredPath), `MQTT contract guard omits ${requiredPath}`);
 }
+// A base it cannot diff against must fail the step, not record "unchanged".
+assert.match(contractStep.run, /::error::/, "MQTT contract detection fails open");
 const contractCheckStep = stepByName(driftSteps, "Check MQTT ingest contract");
 assert.match(contractCheckStep.run, /pnpm --filter docs check-mqtt-contract/);
 assert.equal(contractCheckStep.if, "steps.contract.outputs.changed == 'true'");
+const setupStep = stepByName(driftSteps, "Setup Node.js and pnpm");
 assert.match(
-  stepByName(driftSteps, "Setup Node.js and pnpm").if,
+  setupStep.if,
   /steps\.contract\.outputs\.changed == 'true'/,
   "MQTT contract check would run without a Node.js setup",
+);
+assert.ok(
+  driftSteps.indexOf(setupStep) < driftSteps.indexOf(contractCheckStep),
+  "MQTT contract check would run before pnpm is installed",
 );
 
 const runbook = await readFile(path.join(appRoot, "ROLLBACK.md"), "utf8");

--- a/apps/docs/scripts/check-mqtt-contract.mjs
+++ b/apps/docs/scripts/check-mqtt-contract.mjs
@@ -1,0 +1,97 @@
+import { load } from "js-yaml";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// asyncapi.yaml is the published contract for the MQTT ingest payload, but the
+// pipeline is what actually consumes it. Nothing regenerates one from the
+// other, so this check fails the PR when a field is added to (or dropped from)
+// the pipeline without the same move in the spec.
+
+const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = path.resolve(appRoot, "../..");
+const specPath = path.join(repoRoot, "asyncapi.yaml");
+const schemasPath = path.join(repoRoot, "apps/data/src/lib/openjii/openjii/centrum/schemas.py");
+const bronzePath = path.join(repoRoot, "apps/data/src/pipelines/centrum/bronze/raw_data.py");
+
+// Present in the pipeline but never published by a device, so they have no
+// place in a spec that describes what publishers send.
+const BROKER_INJECTED = {
+  // "SELECT topic() as topic, clientid() as client_id, *" in the IoT topic rule.
+  topic: "stamped by the AWS IoT topic rule",
+  client_id: "stamped by the AWS IoT topic rule",
+  // The large-IoT path reads this from the S3 object key, not the payload.
+  experiment_id: "extracted from the S3 object key",
+};
+
+// Documented but not read by the pipeline: a publisher-side field that must
+// still appear in the contract.
+const PUBLISHER_ONLY = {
+  workbook_id: "mobile-local macro replay aid; the pipeline keys on workbook_version_id",
+};
+
+function structFields(source, schemaName) {
+  const start = source.indexOf(`${schemaName} = StructType(`);
+  assert.notEqual(start, -1, `${schemaName} not found in ${path.basename(schemasPath)}`);
+  const end = source.indexOf("\n)\n", start);
+  assert.notEqual(end, -1, `${schemaName} block is not terminated`);
+  const names = [...source.slice(start, end).matchAll(/StructField\("([^"]+)"/g)].map((m) => m[1]);
+  // A silently-empty match set would make every assertion below pass vacuously.
+  assert.ok(names.length >= 15, `${schemaName} parsed as only ${names.length} fields`);
+  return names;
+}
+
+function jsonPathExtractions(source) {
+  const names = [...source.matchAll(/"\$\.([A-Za-z0-9_]+)"/g)].map((m) => m[1]);
+  assert.ok(names.includes("client_id"), "bronze get_json_object extractions parsed as empty");
+  return names;
+}
+
+const [specSource, schemasSource, bronzeSource] = await Promise.all([
+  readFile(specPath, "utf8"),
+  readFile(schemasPath, "utf8"),
+  readFile(bronzePath, "utf8"),
+]);
+
+const spec = load(specSource);
+const documented = spec?.components?.messages?.ExperimentDataMessage?.payload?.properties;
+assert.ok(documented, "asyncapi.yaml has no ExperimentDataMessage payload properties");
+const documentedNames = new Set(Object.keys(documented));
+assert.ok(documentedNames.has("timestamp"), "ExperimentDataMessage payload parsed as empty");
+
+// Every publisher-sent field the pipeline consumes, from all three ingest
+// surfaces: the Kinesis/MQTT parse schema, the large-payload S3 parse schema,
+// and the fields bronze pulls off the raw JSON with get_json_object.
+const consumed = new Map();
+const record = (name, origin) => {
+  if (!(name in BROKER_INJECTED)) consumed.set(name, consumed.get(name) ?? origin);
+};
+for (const name of structFields(schemasSource, "sensor_schema")) record(name, "sensor_schema");
+for (const name of structFields(schemasSource, "large_iot_schema"))
+  record(name, "large_iot_schema");
+for (const name of jsonPathExtractions(bronzeSource)) record(name, "bronze raw_data extraction");
+
+const undocumented = [...consumed].filter(([name]) => !documentedNames.has(name));
+assert.equal(
+  undocumented.length,
+  0,
+  `asyncapi.yaml does not document ${undocumented.length} field(s) the centrum pipeline reads:\n` +
+    undocumented.map(([name, origin]) => `  - ${name} (${origin})`).join("\n") +
+    "\nAdd them under components.messages.ExperimentDataMessage.payload.properties, " +
+    "then run 'pnpm --filter docs sync-specs'.",
+);
+
+const stale = [...documentedNames].filter(
+  (name) => !consumed.has(name) && !(name in PUBLISHER_ONLY),
+);
+assert.equal(
+  stale.length,
+  0,
+  `asyncapi.yaml documents ${stale.length} field(s) no centrum pipeline schema reads: ${stale.join(", ")}.\n` +
+    "Remove them, or record the exemption in PUBLISHER_ONLY in this script with the reason.",
+);
+
+console.log(
+  `MQTT ingest contract check passed: asyncapi.yaml documents all ${consumed.size} pipeline-consumed payload fields.`,
+);

--- a/apps/docs/scripts/check-mqtt-contract.mjs
+++ b/apps/docs/scripts/check-mqtt-contract.mjs
@@ -31,16 +31,37 @@ const PUBLISHER_ONLY = {
   workbook_id: "mobile-local macro replay aid; the pipeline keys on workbook_version_id",
 };
 
+function structFieldNames(schemaBlock) {
+  const fieldCalls = [...schemaBlock.matchAll(/\bStructField\s*\(/g)].length;
+  const names = [...schemaBlock.matchAll(/\bStructField\s*\(\s*(["'])([^"']+)\1/g)].map(
+    (match) => match[2],
+  );
+  assert.equal(
+    names.length,
+    fieldCalls,
+    `parsed ${names.length} of ${fieldCalls} StructField declarations; field names must be string literals`,
+  );
+  return names;
+}
+
 function structFields(source, schemaName) {
   const start = source.indexOf(`${schemaName} = StructType(`);
   assert.notEqual(start, -1, `${schemaName} not found in ${path.basename(schemasPath)}`);
   const end = source.indexOf("\n)\n", start);
   assert.notEqual(end, -1, `${schemaName} block is not terminated`);
-  const names = [...source.slice(start, end).matchAll(/StructField\("([^"]+)"/g)].map((m) => m[1]);
+  const names = structFieldNames(source.slice(start, end));
   // A silently-empty match set would make every assertion below pass vacuously.
   assert.ok(names.length >= 15, `${schemaName} parsed as only ${names.length} fields`);
   return names;
 }
+
+assert.deepEqual(
+  structFieldNames(`StructField(
+    'line_wrapped', StringType(), True
+  )\nStructField("same_line", StringType(), True)`),
+  ["line_wrapped", "same_line"],
+  "StructField parsing must accept line breaks and either Python quote style",
+);
 
 function jsonPathExtractions(source) {
   const names = [...source.matchAll(/"\$\.([A-Za-z0-9_]+)"/g)].map((m) => m[1]);

--- a/asyncapi.yaml
+++ b/asyncapi.yaml
@@ -268,9 +268,43 @@ components:
             description: >
               Battery reading as the device reports it; the unit is
               device-defined (volts on some families, percent on others).
+          device_family:
+            type: string
+            description: >
+              Canonical driver family of the sensor (e.g. "multispeq",
+              "ambit", "minipar"), resolved by the publisher's identification
+              handshake. Lets consumers tell families apart without
+              interpreting a device-reported display name.
+          device_address:
+            type: string
+            description: >
+              The sensor's hardware address as the publisher reached it
+              (Bluetooth MAC). Reported alongside device_id, never instead of
+              it: MultispeQ firmware answers device_info with a truncated id
+              (4 of 6 octets), so the complete value only exists at the
+              transport.
           output:
             type: string
             description: Device-native output block, passed through as text.
+          client_model:
+            type: string
+            description: >
+              The publishing phone, as opposed to the sensor's device_*
+              fields. Best-effort: omitted rather than invented when the
+              platform will not report a value. (Distinct from client_id,
+              which the broker rule stamps on the stored envelope.)
+          client_manufacturer:
+            type: string
+            description: Manufacturer of the publishing phone.
+          client_os:
+            type: string
+            description: OS name of the publishing phone (e.g. "Android", "iOS").
+          client_os_version:
+            type: string
+            description: OS version of the publishing phone.
+          client_app_version:
+            type: string
+            description: Native app version of the publishing mobile build.
           latitude:
             type: number
             description: GPS latitude at measurement time, if available.
@@ -287,6 +321,10 @@ components:
             sample: '{"moisture": 30.5, "temperature": 22.1}'
             device_version: "1.1.0"
             device_battery: 4.1
+            device_family: "multispeq"
+            device_address: "AA:BB:CC:DD:EE:FF"
+            client_os: "Android"
+            client_app_version: "1.1.0"
 
     DeviceScriptMessage:
       contentType: application/json


### PR DESCRIPTION
## What

Carries device identity and publishing-phone provenance through the Centrum ingest pipeline into silver:

- device_family
- device_address
- client_model
- client_manufacturer
- client_os
- client_os_version
- client_app_version

PR #1948, which emits these fields from mobile, is merged. This PR supplies the downstream pipeline and MQTT-contract support.

## Why

Bronze parses the payload with a fixed StructType. Keys absent from that schema do not reach parsed_data, and silver selects an explicit column list. The new provenance fields were therefore discarded before silver.

Bronze retains the raw data string, so historical values can still be backfilled separately.

## How

- Extracts provenance fields at the top level in the MQTT/Kinesis bronze flow with get_json_object, following the existing client_id and workbook_version_id pattern without evolving the non-resettable parsed_data struct.
- Carries the fields through each silver append flow. Imported/transfer rows receive nullable string columns.
- Adds the fields to large_iot_schema for the Auto Loader S3 path.
- Documents the payload fields in the root and published AsyncAPI specifications.
- Adds a fail-closed CI guard that checks the hand-written MQTT contract against every pipeline-consumed payload field.

device_id needs no change: it already flows through the existing schema. device_address is the sensor hardware address seen by the edge device, while client_* describes the publishing phone.

## Testing

- apps/data: 104 tests passed
- Ruff check and format check passed
- Pyright: 0 errors (12 existing warnings)
- MQTT ingest contract check passed for all 27 consumed payload fields
- Deployment workflow guard passed
- git diff --check passed

## Notes for reviewers

- This adds nullable columns to the silver target and the large-IoT bronze table. The DLT update path has not been run live.
- Historical rows and imported/transfer rows have NULL provenance values until separately backfilled.

## Linear issues

Closes OJD-1757