### PR TITLE
feat(mobile): report the sensor's full hardware address

### DIFF
--- a/apps/mobile/src/features/measurement-flow/domain/flow-transitions.ts
+++ b/apps/mobile/src/features/measurement-flow/domain/flow-transitions.ts
@@ -9,7 +9,18 @@ export type ScanResult = Record<string, unknown>;
 
 /** One device's scan output; device is absent for legacy single-device results. */
 export interface ScanResultEntry {
-  device?: { id: string; name: string; family?: string; firmwareVersion?: string };
+  device?: {
+    id: string;
+    name: string;
+    family?: string;
+    firmwareVersion?: string;
+    /**
+     * The sensor's hardware address as seen by this phone, set only when the
+     * transport gives a real one (Bluetooth MAC). USB device ids are transient
+     * across replugs, so they are not an identity and are left out.
+     */
+    address?: string;
+  };
   result: ScanResult;
   /** Dispatch rounds: the protocol this device actually ran (per-device upload). */
   protocolId?: string;

--- a/apps/mobile/src/features/measurement-flow/hooks/use-measurement-capture.ts
+++ b/apps/mobile/src/features/measurement-flow/hooks/use-measurement-capture.ts
@@ -159,6 +159,8 @@ export function useMeasurementCapture(content: MeasurementContent, nodeId?: stri
             name: device.name,
             ...(identity?.family ? { family: identity.family } : {}),
             ...(identity?.firmwareVersion ? { firmwareVersion: identity.firmwareVersion } : {}),
+            // Bluetooth ids are the sensor's MAC; USB ids are transient.
+            ...(device.type === "bluetooth-classic" ? { address: device.id } : {}),
           },
           result: result as ScanResult,
           ...assignmentMetaRef.current[device.id],

--- a/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-measurement-upload.ts
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner-native";
+import type { ScanResultEntry } from "~/features/measurement-flow/domain/flow-transitions";
 import { useMeasurements } from "~/features/recent-measurements/hooks/use-measurements";
 import { buildUploadPayload } from "~/features/recent-measurements/services/build-upload-payload";
 import { exportSingleMeasurementToFile } from "~/features/recent-measurements/services/export-measurements";
@@ -90,7 +91,7 @@ export function useMeasurementUpload() {
     }: SharedUploadArgs & {
       results: {
         rawMeasurement: any;
-        device?: { id: string; name: string; family?: string; firmwareVersion?: string };
+        device?: ScanResultEntry["device"];
         // Dispatch rounds: the protocol this device actually ran; overrides
         // the batch-level protocolId/protocolName for this result only.
         protocolId?: string;
@@ -140,6 +141,7 @@ export function useMeasurementUpload() {
           workbookId,
           macroContext,
           fallbackDeviceId: device?.id,
+          fallbackDeviceAddress: device?.address,
           fallbackDeviceFamily: device?.family,
           fallbackDeviceFirmware: device?.firmwareVersion,
           location,

--- a/apps/mobile/src/features/recent-measurements/services/build-upload-payload.test.ts
+++ b/apps/mobile/src/features/recent-measurements/services/build-upload-payload.test.ts
@@ -398,3 +398,42 @@ describe("client metadata", () => {
     expect(Object.keys(payload).some((key) => key.startsWith("client_"))).toBe(false);
   });
 });
+
+describe("device_address", () => {
+  // MultispeQ firmware answers device_info with 4 of the 6 MAC octets, and that
+  // native value wins device_id. The complete address only exists at the
+  // transport, so it rides alongside rather than replacing it.
+  it("carries the full transport address next to a truncated native device_id", () => {
+    const payload = buildUploadPayload({
+      ...baseArgs,
+      rawMeasurement: { device_id: "04:09:03:81" },
+      fallbackDeviceId: "20:24:04:09:03:81",
+      fallbackDeviceAddress: "20:24:04:09:03:81",
+    });
+
+    expect(payload).toMatchObject({
+      device_id: "04:09:03:81",
+      device_address: "20:24:04:09:03:81",
+    });
+  });
+
+  it("omits device_address when the transport has no stable address", () => {
+    const payload = buildUploadPayload({
+      ...baseArgs,
+      rawMeasurement: { device_id: "10:91:A8:4F:53:48" },
+      fallbackDeviceId: "1002",
+    }) as Record<string, unknown>;
+
+    expect("device_address" in payload).toBe(false);
+  });
+
+  it("never overwrites a device-native address", () => {
+    const payload = buildUploadPayload({
+      ...baseArgs,
+      rawMeasurement: { device_address: "AA:BB:CC:DD:EE:FF" },
+      fallbackDeviceAddress: "20:24:04:09:03:81",
+    });
+
+    expect(payload.device_address).toBe("AA:BB:CC:DD:EE:FF");
+  });
+});

--- a/apps/mobile/src/features/recent-measurements/services/build-upload-payload.ts
+++ b/apps/mobile/src/features/recent-measurements/services/build-upload-payload.ts
@@ -33,6 +33,8 @@ export interface BuildUploadPayloadArgs {
   fallbackDeviceId?: string;
   /** Canonical sensor family captured by the connection handshake. */
   fallbackDeviceFamily?: string;
+  /** Sensor hardware address seen by this phone (Bluetooth MAC), when stable. */
+  fallbackDeviceAddress?: string;
   /** Physical sensor firmware captured by the connection handshake. */
   fallbackDeviceFirmware?: string;
   /** GPS fix at measurement time; null/absent uploads without location. */
@@ -58,6 +60,7 @@ export function buildUploadPayload({
   macroContext,
   fallbackDeviceId,
   fallbackDeviceFamily,
+  fallbackDeviceAddress,
   fallbackDeviceFirmware,
   location,
   client,
@@ -96,6 +99,13 @@ export function buildUploadPayload({
     // interpreting a device-reported display name.
     ...(rawMeasurement.device_family == null && fallbackDeviceFamily
       ? { device_family: fallbackDeviceFamily }
+      : {}),
+    // The sensor's full hardware address as this phone reached it. Reported
+    // alongside device_id, never instead of it: MultispeQ firmware answers
+    // device_info with a truncated id (4 of 6 octets), so the complete value
+    // only exists at the transport.
+    ...(rawMeasurement.device_address == null && fallbackDeviceAddress
+      ? { device_address: fallbackDeviceAddress }
       : {}),
     // Preserve an explicit device-native value; otherwise report the version
     // learned by the mobile connection handshake for this physical sensor.


### PR DESCRIPTION
Linear: [OJD-1758](https://linear.app/openjii/issue/OJD-1758/end-to-end-measurement-lineage-sensor-to-edge-device-to-server)

## What

Carries the sensor's **full** hardware address on each measurement as `device_address`, alongside the device-reported `device_id`.

## Why

MultispeQ firmware stores only 4 of the 6 Bluetooth MAC bytes:

```c
// src/eeprom.h:25
volatile unsigned char device_id[4];   // the 4 upper bytes of bluetooth mac address

// src/loop.cpp:4158
Serial_Printf("{\"device_name\":\"%s\",\"device_version\":\"%s\",\"device_id\":\"%2.2x:%2.2x:%2.2x:%2.2x\",", ...)
```

So a MultispeQ reports `04:09:03:81`, the tail of `20:24:04:09:03:81`. The `20:24` prefix is never stored and `device_info` returns no other identifier, so the firmware cannot report more. The complete address exists only at the phone's Bluetooth layer, and until now it was discarded because the device-native `device_id` correctly wins.

That leaves sensor identity inconsistent across families: an Ambit reports its full eFuse MAC, a MultispeQ reports a 4-byte fragment.

## How

`device_address` is reported **alongside** `device_id`, never instead of it. Overwriting a device-native value with app-derived metadata is exactly what made `device_family` wrong on Ambit hardware (#1948), so the same precedence rule applies here.

Set only for Bluetooth, where the transport id is a real MAC. Android USB device ids are transient across replugs — the code already calls them a weak fallback — so they are not an identity and are left out.

Also reuses `ScanResultEntry["device"]` in the upload hook instead of restating a narrower copy of the same shape.

## Testing

mobile 1121 tests / 106 files, typecheck and ESLint clean. Three new cases: full address alongside a truncated native `device_id`, omitted when the transport has no stable address, and never overwriting a device-native `device_address`.

Not verified on hardware: the MultispeQ available for testing had its USB header break off mid-session, so this is verified against the firmware source and unit tests rather than a live Bluetooth capture.

## Notes

The matching pipeline extraction is in #1994, so the field reaches silver rather than being dropped at the bronze `from_json`.

