### PR TITLE
fix(docker): remove vulnerable runtime package managers

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -55,6 +55,16 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm --filter=${PROJECT} deplo
 FROM alpine AS runner
 ARG PROJECT=backend
 
+# The runtime starts Node directly and does not need package managers.
+RUN rm -rf /usr/local/lib/node_modules/npm \
+    /usr/local/lib/node_modules/corepack \
+    /usr/local/bin/npm \
+    /usr/local/bin/npx \
+    /usr/local/bin/corepack \
+    /usr/local/bin/yarn \
+    /usr/local/bin/yarnpkg \
+    /opt/yarn-*
+
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nodejs
 USER nodejs

--- a/packages/database/Dockerfile
+++ b/packages/database/Dockerfile
@@ -56,6 +56,16 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm --filter=@repo/${PROJECT}
 FROM alpine AS runner
 ARG PROJECT=database
 
+# The runtime starts Node directly and does not need package managers.
+RUN rm -rf /usr/local/lib/node_modules/npm \
+    /usr/local/lib/node_modules/corepack \
+    /usr/local/bin/npm \
+    /usr/local/bin/npx \
+    /usr/local/bin/corepack \
+    /usr/local/bin/yarn \
+    /usr/local/bin/yarnpkg \
+    /opt/yarn-*
+
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nodejs
 USER nodejs


### PR DESCRIPTION
## Type of PR

- [x] Bug Fix

## Description

Trivy finds CVE-2026-73566 in tar 7.5.19 under npm inside the node:24-alpine image. It is not an application dependency and does not appear in the workspace manifests or pnpm lockfile.

The backend and database migration containers both invoke node directly. This change removes npm, Corepack, and Yarn from their final runtime stages while leaving the build stages unchanged.

Vulnerability reference: https://avd.aquasec.com/nvd/cve-2026-73566

## Testing

- [x] Built the complete backend image
- [x] Built the complete database migration image
- [x] Confirmed Node 24.20.0 runs in both final images
- [x] Confirmed npm, npx, Corepack, Yarn, and Yarnpkg are absent from both final images
- [x] Ran Trivy high/critical image scans against both images with zero findings

## Changes made

- Remove unused package managers from the backend runtime image
- Remove unused package managers from the database migration runtime image

## Screenshots

Not applicable.