### PR TITLE
fix(mobile): restrict expo platforms to ios/android so eas update export stops bundling web

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -3,6 +3,7 @@
     "scheme": ["openjii"],
     "name": "openJII",
     "slug": "openjii",
+    "platforms": ["ios", "android"],
     "version": "1.1.0",
     "orientation": "default",
     "icon": "./assets/adaptive-icon.png",
@@ -33,10 +34,6 @@
       ],
       "blockedPermissions": ["android.permission.RECORD_AUDIO"],
       "package": "com.openjii.app"
-    },
-    "web": {
-      "favicon": "./assets/favicon.png",
-      "bundler": "metro"
     },
     "plugins": [
       "react-native-ble-plx",


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Test Update
- [ ] Chore
- [ ] Other (please describe)

## Description

Expo treats web as a build target by default, so `eas update` was exporting a web bundle into every OTA update alongside the iOS and Android ones. The app never ships on web (Android is the only published platform, and iOS is dev-only), so that bundle was dead weight in the update payload and a build surface with no consumer.

Declaring `platforms: ["ios", "android"]` in app.json scopes the export to the two real targets, and the vestigial `web` config block (a favicon and the metro bundler) goes with it. OTA update exports stop bundling web; nothing else changes.