### PR TITLE
fix(data): align table metadata with serving relations

### DIFF
--- a/apps/data/src/pipelines/centrum/gold/experiment_table_metadata.py
+++ b/apps/data/src/pipelines/centrum/gold/experiment_table_metadata.py
@@ -8,11 +8,11 @@ import dlt
 from pyspark.sql import functions as F
 
 from openjii.centrum import (
+    ENRICHED_UPLOADED_DATA_VIEW,
     EXPERIMENT_DEVICE_DATA_TABLE,
     EXPERIMENT_MACRO_DATA_TABLE,
     EXPERIMENT_RAW_DATA_TABLE,
     EXPERIMENT_TABLE_METADATA,
-    EXPERIMENT_UPLOADED_DATA_TABLE,
     METADATA_SOURCE_TABLE,
 )
 
@@ -117,8 +117,7 @@ def experiment_table_metadata():
     )
 
     upload_metadata = (
-        dlt.read(EXPERIMENT_UPLOADED_DATA_TABLE)
-        .filter("uploaded_data IS NOT NULL")
+        dlt.read(ENRICHED_UPLOADED_DATA_VIEW)
         .groupBy("experiment_id", "upload_table_id")
         .agg(
             F.count("*").alias("row_count"),

--- a/apps/data/src/pipelines/centrum/gold/experiment_table_metadata.py
+++ b/apps/data/src/pipelines/centrum/gold/experiment_table_metadata.py
@@ -8,10 +8,10 @@ import dlt
 from pyspark.sql import functions as F
 
 from openjii.centrum import (
+    ENRICHED_MACRO_DATA_VIEW,
+    ENRICHED_RAW_DATA_VIEW,
     ENRICHED_UPLOADED_DATA_VIEW,
     EXPERIMENT_DEVICE_DATA_TABLE,
-    EXPERIMENT_MACRO_DATA_TABLE,
-    EXPERIMENT_RAW_DATA_TABLE,
     EXPERIMENT_TABLE_METADATA,
     METADATA_SOURCE_TABLE,
 )
@@ -56,8 +56,7 @@ def experiment_table_metadata():
     )
 
     macro_metadata = (
-        dlt.read(EXPERIMENT_MACRO_DATA_TABLE)
-        .filter("macro_output IS NOT NULL")
+        dlt.read(ENRICHED_MACRO_DATA_VIEW)
         .groupBy("experiment_id", "macro_id")
         .agg(
             F.count("*").alias("row_count"),
@@ -79,7 +78,7 @@ def experiment_table_metadata():
     )
 
     raw_data_metadata = (
-        dlt.read(EXPERIMENT_RAW_DATA_TABLE)
+        dlt.read(ENRICHED_RAW_DATA_VIEW)
         .groupBy("experiment_id")
         .agg(
             F.count("*").alias("row_count"),

--- a/apps/data/tests/lib/test_experiment_table_metadata.py
+++ b/apps/data/tests/lib/test_experiment_table_metadata.py
@@ -1,0 +1,21 @@
+import ast
+from pathlib import Path
+
+_PIPELINE_PATH = Path(__file__).parents[2] / "src/pipelines/centrum/gold/experiment_table_metadata.py"
+
+
+def test_upload_metadata_reads_the_api_serving_relation() -> None:
+    module = ast.parse(_PIPELINE_PATH.read_text())
+    upload_metadata = next(
+        node.value
+        for node in ast.walk(module)
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "upload_metadata" for target in node.targets)
+    )
+    group_by_receiver = next(
+        node.func.value
+        for node in ast.walk(upload_metadata)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "groupBy"
+    )
+
+    assert ast.unparse(group_by_receiver) == "dlt.read(ENRICHED_UPLOADED_DATA_VIEW)"

--- a/apps/data/tests/lib/test_experiment_table_metadata.py
+++ b/apps/data/tests/lib/test_experiment_table_metadata.py
@@ -1,21 +1,35 @@
 import ast
 from pathlib import Path
 
+import pytest
+
 _PIPELINE_PATH = Path(__file__).parents[2] / "src/pipelines/centrum/gold/experiment_table_metadata.py"
 
 
-def test_upload_metadata_reads_the_api_serving_relation() -> None:
+@pytest.mark.parametrize(
+    ("metadata_name", "serving_relation"),
+    [
+        ("macro_metadata", "ENRICHED_MACRO_DATA_VIEW"),
+        ("raw_data_metadata", "ENRICHED_RAW_DATA_VIEW"),
+        ("device_metadata", "EXPERIMENT_DEVICE_DATA_TABLE"),
+        ("upload_metadata", "ENRICHED_UPLOADED_DATA_VIEW"),
+    ],
+)
+def test_table_metadata_reads_the_api_serving_relation(
+    metadata_name: str,
+    serving_relation: str,
+) -> None:
     module = ast.parse(_PIPELINE_PATH.read_text())
-    upload_metadata = next(
+    metadata = next(
         node.value
         for node in ast.walk(module)
         if isinstance(node, ast.Assign)
-        and any(isinstance(target, ast.Name) and target.id == "upload_metadata" for target in node.targets)
+        and any(isinstance(target, ast.Name) and target.id == metadata_name for target in node.targets)
     )
     group_by_receiver = next(
         node.func.value
-        for node in ast.walk(upload_metadata)
+        for node in ast.walk(metadata)
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "groupBy"
     )
 
-    assert ast.unparse(group_by_receiver) == "dlt.read(ENRICHED_UPLOADED_DATA_VIEW)"
+    assert ast.unparse(group_by_receiver) == f"dlt.read({serving_relation})"


### PR DESCRIPTION
## Summary

- derive raw, macro, and uploaded-table row counts and schemas from the exact relations served by the API
- remove upstream payload filters so cached metadata represents every API-visible row
- retain the existing device metadata source because it already is the API-serving relation
- add source-lineage regressions that reject upstream tables or an intervening `filter`/`where`

## Why

The API serves raw, macro, and uploaded rows from enriched relations, while `experiment_table_metadata` previously counted and inferred schemas from upstream gold tables. Those relations can represent different pipeline snapshots, allowing metadata counts to update before the corresponding measurements are queryable.

Reading each serving relation makes Lakeflow order metadata after enrichment and keeps cached counts and schemas aligned with platform-visible rows for manual uploads, MQTT/Kinesis measurements, and large-IoT S3 payloads. Device metadata already reads the same relation as the API.

## Verification

- `uv run pytest -q` — 101 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright` — 0 errors; 12 pre-existing warnings
- independent Codex review — no actionable findings
- Databricks-only dev deployment of the original upload change: workflow run 33501210502
- post-deploy Centrum update `00cd8819-e53c-4352-b0c4-8220cb2c5ccb` completed
- metadata and enriched counts/schemas matched for three uploaded Barley tables: 18, 6,366, and 6 rows
- raw/macro extension is statically and locally validated; no new Databricks deployment was launched

## Linear issues

Closes OJD-1767