### PR TITLE
fix(workbook): pin macro language in version snapshots so mobile runs Python as Python (OJD-1781)

### DIFF
--- a/apps/backend/src/macros/core/repositories/macro-snapshot.repository.spec.ts
+++ b/apps/backend/src/macros/core/repositories/macro-snapshot.repository.spec.ts
@@ -65,6 +65,40 @@ describe("MacroSnapshotRepository", () => {
     });
   });
 
+  it("prefers the snapshot language over a stale cell payload language", async () => {
+    const macroId = faker.string.uuid();
+    const workbook = await testApp.createWorkbook({
+      name: "Stale cell workbook",
+      createdBy: userId,
+    });
+    const versionResult = await workbookVersionRepository.create({
+      workbookId: workbook.id,
+      version: 1,
+      cells: [
+        {
+          id: "macro-cell",
+          type: "macro",
+          isCollapsed: false,
+          payload: { macroId, language: "javascript", name: "Analysis" },
+        },
+      ],
+      metadata: {},
+      entitySnapshots: {
+        protocols: {},
+        macros: { [macroId]: { code: "cGlubmVkLWNvZGU=", language: "python" } },
+      },
+      createdBy: userId,
+    });
+    assertSuccess(versionResult);
+
+    const result = await repository.findScriptsByVersionIds([versionResult.value.id]);
+
+    assertSuccess(result);
+    expect(result.value.get(macroSnapshotKey(versionResult.value.id, macroId))?.language).toBe(
+      "python",
+    );
+  });
+
   it("does not invent a script when a referenced snapshot is missing", async () => {
     const macroId = faker.string.uuid();
     const workbook = await testApp.createWorkbook({ name: "Old workbook", createdBy: userId });

--- a/apps/backend/src/macros/core/repositories/macro-snapshot.repository.ts
+++ b/apps/backend/src/macros/core/repositories/macro-snapshot.repository.ts
@@ -75,10 +75,12 @@ export class MacroSnapshotRepository {
       const macroId = cell.payload.macroId;
       const snapshot = snapshots.macros?.[macroId];
       if (!snapshot?.code) continue;
+      // Snapshot language wins: the cell payload copy goes stale when the macro
+      // row's language is changed outside this workbook.
       bundle[macroId] = {
         id: macroId,
         name: cell.payload.name ?? macroId,
-        language: cell.payload.language,
+        language: snapshot.language ?? cell.payload.language,
         code: snapshot.code,
       };
     }

--- a/apps/backend/src/workbooks/application/use-cases/publish-version/publish-version.spec.ts
+++ b/apps/backend/src/workbooks/application/use-cases/publish-version/publish-version.spec.ts
@@ -129,6 +129,34 @@ describe("PublishVersionUseCase", () => {
     expect(result.error.statusCode).toBe(403);
   });
 
+  it("pins the macro language from the live row, not the cell payload", async () => {
+    const macro = await testApp.createMacro({
+      name: "Python macro",
+      language: "python",
+      code: btoa("# python"),
+      createdBy: userId,
+    });
+    const workbook = await testApp.createWorkbook({
+      name: "WBLang",
+      cells: [
+        {
+          id: "m1",
+          type: "macro",
+          isCollapsed: false,
+          payload: { macroId: macro.id, language: "javascript" },
+        },
+      ],
+      createdBy: userId,
+    });
+
+    const result = await useCase.execute(workbook.id, userId);
+    assertSuccess(result);
+    expect(result.value.entitySnapshots.macros[macro.id]).toEqual({
+      code: btoa("# python"),
+      language: "python",
+    });
+  });
+
   it("snapshots the current cells of the workbook", async () => {
     const cells = [
       {

--- a/apps/backend/src/workbooks/application/use-cases/publish-version/publish-version.ts
+++ b/apps/backend/src/workbooks/application/use-cases/publish-version/publish-version.ts
@@ -118,7 +118,7 @@ export class PublishVersionUseCase {
       entitySnapshots.protocols[id] = { code: p.code, family: p.family };
     }
     for (const [id, m] of macrosResult.value) {
-      entitySnapshots.macros[id] = { code: m.code };
+      entitySnapshots.macros[id] = { code: m.code, language: m.language };
     }
 
     this.logger.log({

--- a/apps/docs/content/guide/devices-protocols/writing-macros.mdx
+++ b/apps/docs/content/guide/devices-protocols/writing-macros.mdx
@@ -169,6 +169,9 @@ return(list(change_from_baseline = current - baseline))
 Use the web workbook runner to test R macros because the mobile runner currently
 selects only JavaScript or Python.
 
+When you select a language in a workbook macro cell, the selection takes effect
+after saving succeeds. If saving fails, the cell keeps its previous language.
+
 The language is pinned into each published workbook version together with the
 macro code. If you change a macro's language after an experiment was published,
 publish the workbook again so the field app runs it with the new language.

--- a/apps/docs/content/guide/devices-protocols/writing-macros.mdx
+++ b/apps/docs/content/guide/devices-protocols/writing-macros.mdx
@@ -9,7 +9,8 @@ A macro is a **data-processing script**: it turns a measurement or earlier
 workbook values into a JSON object of named results. openJII stores Python,
 JavaScript, and R macros. On the web, the backend runs each language in its own
 isolated Lambda sandbox. The mobile field flow runs JavaScript locally and
-Python in Pyodide; it does not currently dispatch R macros.
+Python in Pyodide; an R macro fails on the phone with a "cannot run on this
+device" message instead of running.
 
 Open **Macros** and select **New macro** to choose a language, write the code,
 and optionally associate compatible protocols. You can also create or select a
@@ -167,6 +168,10 @@ return(list(change_from_baseline = current - baseline))
 
 Use the web workbook runner to test R macros because the mobile runner currently
 selects only JavaScript or Python.
+
+The language is pinned into each published workbook version together with the
+macro code. If you change a macro's language after an experiment was published,
+publish the workbook again so the field app runs it with the new language.
 
 ## Runtimes and available libraries
 

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -30287,6 +30287,14 @@
                             "properties": {
                               "code": {
                                 "type": "string"
+                              },
+                              "language": {
+                                "enum": [
+                                  "python",
+                                  "r",
+                                  "javascript"
+                                ],
+                                "type": "string"
                               }
                             },
                             "required": [

--- a/apps/mobile/src/features/measurement-flow/utils/hydrate-flow-nodes.test.ts
+++ b/apps/mobile/src/features/measurement-flow/utils/hydrate-flow-nodes.test.ts
@@ -81,6 +81,28 @@ describe("hydrateFlowNodes", () => {
     });
   });
 
+  it("prefers the snapshot language over a stale cell payload language", () => {
+    const staleCells: WorkbookCell[] = [
+      {
+        id: "c2",
+        type: "macro",
+        isCollapsed: false,
+        payload: { macroId: "m1", language: "javascript", name: "My Macro" },
+      },
+    ];
+    const withLanguage: EntitySnapshots = {
+      protocols: {},
+      macros: { m1: { code: "print(1)", language: "python" } },
+    };
+    const macroNode = hydrateFlowNodes([nodes[1]], staleCells, withLanguage)[0];
+    expect(macroNode.content.macro?.language).toBe("python");
+  });
+
+  it("falls back to the cell payload language for versions published without one", () => {
+    const macroNode = hydrateFlowNodes([nodes[1]], cells, snapshots)[0];
+    expect(macroNode.content.macro?.language).toBe("python");
+  });
+
   it("hydrates repeated protocol references from their exact workbook cells", () => {
     const repeatedCells: WorkbookCell[] = [
       {

--- a/apps/mobile/src/features/measurement-flow/utils/hydrate-flow-nodes.ts
+++ b/apps/mobile/src/features/measurement-flow/utils/hydrate-flow-nodes.ts
@@ -40,6 +40,7 @@ export function hydrateFlowNodes(
     if (node.type === "analysis" && node.content?.macroId) {
       const id = node.content.macroId as string;
       const cell = cells.find((c): c is MacroCell => c.type === "macro" && c.id === node.id);
+      const snapshot = snapshots?.macros[id];
       return {
         ...node,
         content: {
@@ -48,8 +49,10 @@ export function hydrateFlowNodes(
             id,
             name: cell?.payload.name ?? deriveMacroFilename(id),
             filename: deriveMacroFilename(id),
-            language: cell?.payload.language ?? "",
-            code: snapshots?.macros[id]?.code ?? "",
+            // Snapshot language wins over the cell payload copy, which goes
+            // stale when the macro row's language is changed elsewhere.
+            language: snapshot?.language ?? cell?.payload.language ?? "",
+            code: snapshot?.code ?? "",
           },
         },
       };

--- a/apps/mobile/src/features/measurement-flow/utils/process-scan/process-scan.test.ts
+++ b/apps/mobile/src/features/measurement-flow/utils/process-scan/process-scan.test.ts
@@ -263,6 +263,12 @@ describe("applyMacro: canonical once-per-measurement execution", () => {
     }
   });
 
+  it("rejects a language the device cannot run instead of evaluating it as JavaScript", async () => {
+    await expect(
+      applyMacro({ sample: [{ a: 1 }] }, { code: encode("# R comment"), language: "r" }),
+    ).rejects.toMatchObject({ name: "UnsupportedMacroLanguageError", language: "r" });
+  });
+
   it("fails an empty sample envelope once without invoking JavaScript", async () => {
     await expect(
       applyMacro({ sample: [] }, { code: jsRunnerCode, language: "javascript" }),

--- a/apps/mobile/src/features/measurement-flow/utils/process-scan/process-scan.test.ts
+++ b/apps/mobile/src/features/measurement-flow/utils/process-scan/process-scan.test.ts
@@ -269,6 +269,22 @@ describe("applyMacro: canonical once-per-measurement execution", () => {
     ).rejects.toMatchObject({ name: "UnsupportedMacroLanguageError", language: "r" });
   });
 
+  it.each([
+    ["missing", undefined],
+    ["empty", ""],
+  ])("rejects a %s structured language instead of guessing JavaScript", async (_case, language) => {
+    await expect(
+      applyMacro({ sample: [{ a: 1 }] }, { code: jsRunnerCode, language }),
+    ).rejects.toMatchObject({ name: "UnsupportedMacroLanguageError", language: "" });
+    expect((globalThis as Record<string, unknown>).__mobileMacroRunnerCalls).toBe(0);
+  });
+
+  it("keeps bare legacy macro code on the JavaScript runtime", async () => {
+    const outputs = await applyMacro({ sample: [{ a: 1 }] }, jsRunnerCode);
+
+    expect(outputs).toEqual([{ received: { a: 1 } }]);
+  });
+
   it("fails an empty sample envelope once without invoking JavaScript", async () => {
     await expect(
       applyMacro({ sample: [] }, { code: jsRunnerCode, language: "javascript" }),

--- a/apps/mobile/src/features/measurement-flow/utils/process-scan/process-scan.ts
+++ b/apps/mobile/src/features/measurement-flow/utils/process-scan/process-scan.ts
@@ -57,6 +57,13 @@ export interface MacroInput {
   language?: string;
 }
 
+export class UnsupportedMacroLanguageError extends Error {
+  constructor(public readonly language: string) {
+    super(`Macro language "${language}" cannot run on this device (supported: javascript, python)`);
+    this.name = "UnsupportedMacroLanguageError";
+  }
+}
+
 export class MacroInputNormalizationError extends Error {
   constructor(
     public readonly code: "empty-envelope",
@@ -100,6 +107,13 @@ export async function applyMacro(
   const language = (macroInput.language || "javascript").toLowerCase();
 
   log.debug("apply", { language, source: normalized.source, code_bytes: code.length });
+
+  // Never fall through to the JS engine for a language it cannot run: Python
+  // or R source parsed as JS fails on the first `#` with a cryptic Hermes error.
+  if (language !== "javascript" && language !== "python") {
+    log.error("unsupported macro language", { language });
+    throw new UnsupportedMacroLanguageError(language);
+  }
 
   if (language === "python") {
     const runPython = getPythonMacroRunner();

--- a/apps/mobile/src/features/measurement-flow/utils/process-scan/process-scan.ts
+++ b/apps/mobile/src/features/measurement-flow/utils/process-scan/process-scan.ts
@@ -101,10 +101,9 @@ export async function applyMacro(
   const macroInput: MacroInput =
     typeof macro === "string" ? { code: macro, language: "javascript" } : macro;
   const code = atob(macroInput.code);
-  // `||`, not `??`: resolvers hand over "" when the language is unknown, and ""
-  // must fall back to javascript rather than execute as-is.
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const language = (macroInput.language || "javascript").toLowerCase();
+  // Bare code strings are the legacy JavaScript API above. Structured inputs
+  // must identify their runtime; an empty value must not guess JavaScript.
+  const language = macroInput.language?.toLowerCase() ?? "";
 
   log.debug("apply", { language, source: normalized.source, code_bytes: code.length });
 

--- a/apps/mobile/src/features/recent-measurements/hooks/use-measurement-macro-preview.test.tsx
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-measurement-macro-preview.test.tsx
@@ -90,6 +90,33 @@ describe("useMeasurementMacroPreview", () => {
     });
   });
 
+  it("prefers the pinned snapshot language over a stale cell language", () => {
+    results.version = {
+      data: {
+        ...version,
+        cells: [
+          {
+            ...version.cells[0],
+            payload: { ...version.cells[0].payload, language: "javascript" },
+          },
+        ],
+        entitySnapshots: {
+          protocols: {},
+          macros: { "macro-1": { code: "cHJpbnQoMSk=", language: "python" } },
+        },
+      },
+      isLoading: false,
+      error: null,
+    };
+
+    const { result } = renderHook(() => useMeasurementMacroPreview(stored));
+
+    expect(result.current).toMatchObject({
+      status: "ready",
+      preview: { macro: { code: "cHJpbnQoMSk=", language: "python" } },
+    });
+  });
+
   it("is loading while the experiment list or the version read is pending", () => {
     results.list = { data: undefined, isLoading: true };
     const { result, rerender } = renderHook(() => useMeasurementMacroPreview(stored));

--- a/apps/mobile/src/features/recent-measurements/hooks/use-measurement-macro-preview.ts
+++ b/apps/mobile/src/features/recent-measurements/hooks/use-measurement-macro-preview.ts
@@ -110,22 +110,22 @@ export function useMeasurementMacroPreview(measurement: StoredMeasurement): Macr
   };
 }
 
-// The version's snapshot holds the code that ran; the macro cell holds the
-// language it was written in. Mirrors hydrateFlowNodes for the live flow.
+// New snapshots pin the code and language that ran; the macro cell supplies
+// language only for versions published before snapshots carried it. Mirrors
+// hydrateFlowNodes for the live flow.
 // publish-version snapshots exactly the macros its cells reference, so a cell
 // is guaranteed whenever a snapshot exists; a missing cell means the version
-// genuinely doesn't carry this macro. Reporting not-found beats guessing a
-// language: applyMacro reads "" as JavaScript, which would silently run a
-// stored Python macro as JS. (Two cells referencing the same macro with
-// different languages would be ambiguous here — the payload records the macro
-// entity id, not the producing cell id, so there is nothing better available.)
+// genuinely doesn't carry this macro. For a legacy snapshot, reporting
+// not-found beats guessing a language. (Two cells referencing the same macro
+// with different languages are ambiguous in those old versions — the payload
+// records the macro entity id, not the producing cell id.)
 function findMacroSnapshot(
   version: WorkbookVersion | undefined,
   macroId: string,
 ): { code: string; language: string } | undefined {
-  const code = version?.entitySnapshots?.macros?.[macroId]?.code;
-  if (!code) return undefined;
+  const snapshot = version?.entitySnapshots?.macros?.[macroId];
+  if (!snapshot?.code) return undefined;
   const cell = version?.cells?.find((c) => c.type === "macro" && c.payload.macroId === macroId);
   if (cell?.type !== "macro") return undefined;
-  return { code, language: cell.payload.language };
+  return { code: snapshot.code, language: snapshot.language ?? cell.payload.language };
 }

--- a/apps/web/components/workbook/cells/macro-cell.test.tsx
+++ b/apps/web/components/workbook/cells/macro-cell.test.tsx
@@ -6,8 +6,10 @@ import {
 } from "@/test/factories";
 import { API_URL } from "@/test/msw/mount";
 import { server } from "@/test/msw/server";
-import { render, screen, waitFor, userEvent } from "@/test/test-utils";
+import { render, screen, waitFor, userEvent, act } from "@/test/test-utils";
+import { QueryClient } from "@tanstack/react-query";
 import { http, HttpResponse } from "msw";
+import { useState } from "react";
 import { describe, it, expect, vi } from "vitest";
 
 import { contract } from "@repo/api/contract";
@@ -24,10 +26,19 @@ vi.mock("@repo/ui/components/select", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return {
     ...actual,
-    Select: ({ value, onValueChange }: { value: string; onValueChange: (val: string) => void }) => (
+    Select: ({
+      value,
+      onValueChange,
+      disabled,
+    }: {
+      value: string;
+      onValueChange: (val: string) => void;
+      disabled?: boolean;
+    }) => (
       <select
         data-testid="language-select"
         value={value}
+        disabled={disabled}
         onChange={(e) => {
           const result: unknown = onValueChange(e.target.value);
           if (result instanceof Promise) result.catch(() => undefined);
@@ -113,16 +124,15 @@ describe("MacroCellComponent", () => {
     });
   });
 
-  it("writes the live macro language back into a stale cell payload", async () => {
+  it("displays the live macro language without rewriting the cell payload", async () => {
     const onUpdate = vi.fn();
     renderMacroCell(
       { onUpdate, cell: { ...cell, payload: { ...cell.payload, language: "javascript" } } },
       { language: "python" },
     );
 
-    await waitFor(() => expect(onUpdate).toHaveBeenCalled());
-    const updated = onUpdate.mock.lastCall?.[0] as MacroCell;
-    expect(updated.payload.language).toBe("python");
+    await waitFor(() => expect(screen.getByTestId("language-select")).toHaveValue("python"));
+    expect(onUpdate).not.toHaveBeenCalled();
   });
 
   it("renders a pinned snapshot with its pinned language, not the stale cell payload", async () => {
@@ -258,7 +268,9 @@ describe("MacroCellComponent", () => {
   });
 
   it("persists a language change and updates the cell payload with update capability", async () => {
-    const updateSpy = server.mount(contract.macros.updateMacro, { body: baseMacro });
+    const updateSpy = server.mount(contract.macros.updateMacro, {
+      body: { ...baseMacro, language: "r" },
+    });
 
     const onUpdate = vi.fn();
     renderMacroCell({ onUpdate });
@@ -269,8 +281,139 @@ describe("MacroCellComponent", () => {
 
     await waitFor(() => expect(updateSpy.called).toBe(true));
     expect(updateSpy.body).toEqual({ language: "r" });
+    await waitFor(() => expect(onUpdate).toHaveBeenCalled());
     const updated = onUpdate.mock.calls.at(-1)?.[0] as MacroCell | undefined;
     expect(updated?.payload.language).toBe("r");
+  });
+
+  it("updates a rerendering host only after saving the language and refreshing the live query", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    server.mount(contract.macros.getMacro, { body: baseMacro });
+    let releaseSave!: () => void;
+    const saveGate = new Promise<void>((resolve) => (releaseSave = resolve));
+    const updateSpy = server.mount(contract.macros.updateMacro, {
+      body: { ...baseMacro, language: "r" },
+      unblock: saveGate,
+    });
+    const onUpdate = vi.fn();
+    function Host() {
+      const [workbook, setWorkbook] = useState({ cell, otherCell: "Before" });
+      return (
+        <>
+          <output aria-label="Cell language">{workbook.cell.payload.language}</output>
+          <output aria-label="Other cell">{workbook.otherCell}</output>
+          <button onClick={() => setWorkbook({ ...workbook, otherCell: "After" })}>
+            Edit other cell
+          </button>
+          <MacroCellComponent
+            cell={workbook.cell}
+            onUpdate={(updated) => {
+              onUpdate(updated);
+              setWorkbook({ ...workbook, cell: updated });
+            }}
+            onDelete={vi.fn()}
+          />
+        </>
+      );
+    }
+    render(<Host />, { queryClient });
+    const user = userEvent.setup();
+    await user.selectOptions(await screen.findByTestId("language-select"), "r");
+    await waitFor(() => expect(updateSpy.called).toBe(true));
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Cell language")).toHaveTextContent("python");
+    expect(screen.getByTestId("language-select")).toHaveValue("python");
+    expect(screen.getByTestId("language-select")).toBeDisabled();
+    await user.selectOptions(screen.getByTestId("language-select"), "javascript");
+    expect(updateSpy.callCount).toBe(1);
+    await user.click(screen.getByRole("button", { name: "Edit other cell" }));
+
+    let releaseRefresh!: () => void;
+    const refreshGate = new Promise<void>((resolve) => (releaseRefresh = resolve));
+    const refreshSpy = server.mount(contract.macros.getMacro, {
+      body: { ...baseMacro, language: "r" },
+      unblock: refreshGate,
+    });
+    releaseSave();
+    await waitFor(() => expect(refreshSpy.called).toBe(true));
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Cell language")).toHaveTextContent("python");
+    expect(screen.getByTestId("language-select")).toHaveValue("python");
+    releaseRefresh();
+    await waitFor(() => expect(screen.getByLabelText("Cell language")).toHaveTextContent("r"));
+    expect(screen.getByTestId("language-select")).toHaveValue("r");
+    expect(screen.getByTestId("language-select")).toBeEnabled();
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText("Other cell")).toHaveTextContent("After");
+
+    server.mount(contract.macros.getMacro, { body: { ...baseMacro, language: "javascript" } });
+    await act(() => queryClient.invalidateQueries());
+    await waitFor(() => expect(screen.getByTestId("language-select")).toHaveValue("javascript"));
+    expect(screen.getByLabelText("Cell language")).toHaveTextContent("r");
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the saved language after a rejected selection in a rerendering host", async () => {
+    server.mount(contract.macros.getMacro, { body: baseMacro });
+    server.mount(contract.macros.updateMacro, { status: 400 });
+    const { toast } = await import("@repo/ui/hooks/use-toast");
+    function Host() {
+      const [currentCell, setCell] = useState(cell);
+      return (
+        <>
+          <output aria-label="Cell language">{currentCell.payload.language}</output>
+          <MacroCellComponent cell={currentCell} onUpdate={setCell} onDelete={vi.fn()} />
+        </>
+      );
+    }
+    render(<Host />);
+    const user = userEvent.setup();
+    await user.selectOptions(await screen.findByTestId("language-select"), "r");
+    await waitFor(() => expect(toast).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByLabelText("Cell language")).toHaveTextContent("python"));
+    expect(screen.getByTestId("language-select")).toHaveValue("python");
+    expect(screen.getByTestId("language-select")).toBeEnabled();
+  });
+
+  it("does not notify the host after the cell is deleted during a language save", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    server.mount(contract.macros.getMacro, { body: baseMacro });
+    let releaseSave!: () => void;
+    const saveGate = new Promise<void>((resolve) => (releaseSave = resolve));
+    const updateSpy = server.mount(contract.macros.updateMacro, {
+      body: { ...baseMacro, language: "r" },
+      unblock: saveGate,
+    });
+    const onUpdate = vi.fn();
+    function Host() {
+      const [currentCell, setCell] = useState<MacroCell | null>(cell);
+      return currentCell ? (
+        <MacroCellComponent
+          cell={currentCell}
+          onUpdate={(updated) => {
+            onUpdate(updated);
+            setCell(updated);
+          }}
+          onDelete={() => setCell(null)}
+        />
+      ) : (
+        <span>Cell deleted</span>
+      );
+    }
+    render(<Host />, { queryClient });
+    const user = userEvent.setup();
+    await user.selectOptions(await screen.findByTestId("language-select"), "r");
+    await waitFor(() => expect(updateSpy.called).toBe(true));
+    const deleteButton = screen
+      .getAllByRole("button")
+      .find((button) => button.querySelector('svg[class*="lucide-trash"]'));
+    if (!deleteButton) throw new Error("Delete cell button missing");
+    await user.click(deleteButton);
+    expect(screen.getByText("Cell deleted")).toBeInTheDocument();
+    releaseSave();
+    await waitFor(() => expect(queryClient.isMutating()).toBe(0));
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(screen.getByText("Cell deleted")).toBeInTheDocument();
   });
 
   it("debounces and persists a code edit, then notifies the host (no silent loss)", async () => {

--- a/apps/web/components/workbook/cells/macro-cell.test.tsx
+++ b/apps/web/components/workbook/cells/macro-cell.test.tsx
@@ -463,7 +463,9 @@ describe("MacroCellComponent", () => {
   });
 
   it("surfaces a destructive toast when a language change fails to persist", async () => {
-    server.mount(contract.macros.updateMacro, { status: 400 });
+    server.use(
+      http.put(`${API_URL}/api/v1/macros/:id`, () => HttpResponse.json({}, { status: 500 })),
+    );
     const { toast } = await import("@repo/ui/hooks/use-toast");
 
     renderMacroCell();
@@ -475,7 +477,7 @@ describe("MacroCellComponent", () => {
     await waitFor(
       () => {
         expect(toast).toHaveBeenCalledWith({
-          description: expect.any(String) as unknown,
+          description: "cells.languageSaveFailed",
           variant: "destructive",
         });
       },
@@ -543,6 +545,43 @@ describe("MacroCellComponent", () => {
       // The rename must preserve the concurrent language switch, not revert it.
       expect(updated.payload.language).toBe("r");
       expect(updated.payload.name).toBe("Renamed Macro");
+    });
+
+    it("ignores a rename result after the cell switches to a different macro", async () => {
+      server.mount(contract.macros.getMacro, { body: baseMacro });
+      let releaseSave!: () => void;
+      const saveGate = new Promise<void>((resolve) => (releaseSave = resolve));
+      const updateSpy = server.mount(contract.macros.updateMacro, {
+        body: createMacro({ id: "macro-1", name: "Renamed Macro" }),
+        unblock: saveGate,
+      });
+      const onUpdate = vi.fn();
+      const user = userEvent.setup();
+      const { rerender } = render(
+        <MacroCellComponent cell={cell} onUpdate={onUpdate} onDelete={vi.fn()} />,
+      );
+
+      await user.click(await screen.findByLabelText("cells.rename"));
+      const input = screen.getByLabelText("cells.rename");
+      await user.clear(input);
+      await user.type(input, "Renamed Macro");
+      await user.click(screen.getByLabelText("cells.renameSave"));
+      await waitFor(() => expect(updateSpy.called).toBe(true));
+
+      rerender(
+        <MacroCellComponent
+          cell={{
+            ...cell,
+            payload: { ...cell.payload, macroId: "macro-2", name: "Replacement Macro" },
+          }}
+          onUpdate={onUpdate}
+          onDelete={vi.fn()}
+        />,
+      );
+      releaseSave();
+
+      await waitFor(() => expect(screen.getByLabelText("cells.rename")).toBeInTheDocument());
+      expect(onUpdate).not.toHaveBeenCalled();
     });
 
     it("shows the conflict toast and keeps the editor open on a duplicate name", async () => {

--- a/apps/web/components/workbook/cells/macro-cell.test.tsx
+++ b/apps/web/components/workbook/cells/macro-cell.test.tsx
@@ -125,6 +125,17 @@ describe("MacroCellComponent", () => {
     expect(updated.payload.language).toBe("python");
   });
 
+  it("renders a pinned snapshot with its pinned language, not the stale cell payload", async () => {
+    renderMacroCell({
+      cell: { ...cell, payload: { ...cell.payload, language: "javascript" } },
+      snapshot: { code: btoa("print(1)"), language: "python" },
+    });
+
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue("print(1)"));
+    expect(screen.getByText("Python")).toBeInTheDocument();
+    expect(screen.queryByText("JavaScript")).not.toBeInTheDocument();
+  });
+
   it("leaves a stale cell payload alone when rendering a pinned snapshot", async () => {
     const onUpdate = vi.fn();
     renderMacroCell({

--- a/apps/web/components/workbook/cells/macro-cell.test.tsx
+++ b/apps/web/components/workbook/cells/macro-cell.test.tsx
@@ -113,6 +113,30 @@ describe("MacroCellComponent", () => {
     });
   });
 
+  it("writes the live macro language back into a stale cell payload", async () => {
+    const onUpdate = vi.fn();
+    renderMacroCell(
+      { onUpdate, cell: { ...cell, payload: { ...cell.payload, language: "javascript" } } },
+      { language: "python" },
+    );
+
+    await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+    const updated = onUpdate.mock.lastCall?.[0] as MacroCell;
+    expect(updated.payload.language).toBe("python");
+  });
+
+  it("leaves a stale cell payload alone when rendering a pinned snapshot", async () => {
+    const onUpdate = vi.fn();
+    renderMacroCell({
+      onUpdate,
+      cell: { ...cell, payload: { ...cell.payload, language: "javascript" } },
+      snapshot: { code: btoa("print(1)") },
+    });
+
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveValue("print(1)"));
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
   it("shows read-only language label without update capability", async () => {
     renderMacroCell({}, { capabilities: readOnlyCapabilities });
 

--- a/apps/web/components/workbook/cells/macro-cell.tsx
+++ b/apps/web/components/workbook/cells/macro-cell.tsx
@@ -166,6 +166,14 @@ export function MacroCellComponent({
     [macroId, saveMacro, cell, onUpdate],
   );
 
+  // The macro row's language can change outside this workbook (macro page,
+  // another workbook). Offline hosts run off the cell payload, so write the
+  // live value back instead of only displaying it.
+  useEffect(() => {
+    if (readOnly || useSnapshot || !macroLanguage || macroLanguage === language) return;
+    onUpdate({ ...cell, payload: { ...cell.payload, language: macroLanguage } });
+  }, [readOnly, useSnapshot, macroLanguage, language, cell, onUpdate]);
+
   const [langSelectOpen, setLangSelectOpen] = useState(false);
 
   // Track the latest cell so the async rename merges into current state, not a

--- a/apps/web/components/workbook/cells/macro-cell.tsx
+++ b/apps/web/components/workbook/cells/macro-cell.tsx
@@ -47,7 +47,7 @@ interface MacroCellProps {
   readOnly?: boolean;
   // Immutable code pinned at publish time. When present the cell renders
   // exclusively from it and never fetches the live macro row.
-  snapshot?: { code: string };
+  snapshot?: { code: string; language?: MacroLanguage };
 }
 
 const languageLabels: Record<MacroLanguage, string> = {
@@ -77,7 +77,10 @@ export function MacroCellComponent({
   const macroName = macroData?.name;
   const rawCode = useSnapshot ? snapshot.code : (macroData?.code ?? null);
   const macroCode = rawCode ? decodeBase64(rawCode) : null;
-  const macroLanguage = macroData?.language;
+  // Live row in edit mode, pinned language in snapshot mode; the cell payload
+  // copy is only a fallback because it can go stale.
+  const macroLanguage = useSnapshot ? snapshot.language : macroData?.language;
+  const displayLanguage = macroLanguage ?? language;
   // Capability, not ownership: the detail payload already carries the
   // caller's `can(update)`, so an `admin`/"Can edit" grantee edits the macro
   // here exactly as they can on its own page.
@@ -307,7 +310,7 @@ export function MacroCellComponent({
           </Button>
           {canUpdateMacro ? (
             <Select
-              value={macroLanguage ?? language}
+              value={displayLanguage}
               onValueChange={(v) => handleLanguageChange(v as MacroLanguage)}
               open={langSelectOpen}
               onOpenChange={setLangSelectOpen}
@@ -327,7 +330,7 @@ export function MacroCellComponent({
             </Select>
           ) : (
             <span className="text-muted-foreground px-2 text-xs">
-              {languageLabels[macroLanguage ?? language]}
+              {languageLabels[displayLanguage]}
             </span>
           )}
           <Button
@@ -353,7 +356,7 @@ export function MacroCellComponent({
         <WorkbookCodeEditor
           value={localCode ?? macroCode ?? ""}
           onChange={isEditable ? setLocalCode : undefined}
-          language={macroLanguage ?? language}
+          language={displayLanguage}
           minHeight={isEditable ? "120px" : "80px"}
           maxHeight={isEditable ? "500px" : "400px"}
           readOnly={!isEditable}

--- a/apps/web/components/workbook/cells/macro-cell.tsx
+++ b/apps/web/components/workbook/cells/macro-cell.tsx
@@ -92,6 +92,8 @@ export function MacroCellComponent({
   // Lineage: this macro is itself a fork of another one.
   const forkedFrom = useSnapshot ? undefined : macroData?.forkedFrom;
 
+  // Separate mutation state keeps code saves and renames from disabling the
+  // language selector; only its own request should lock it.
   const { mutateAsync: saveMacro } = useMacroUpdate(macroId);
   const { mutate: saveLanguage, isPending: isSavingLanguage } = useMacroUpdate(macroId);
   const { mutateAsync: forkMacro, isPending: isForking } = useMacroCreate();

--- a/apps/web/components/workbook/cells/macro-cell.tsx
+++ b/apps/web/components/workbook/cells/macro-cell.tsx
@@ -171,12 +171,15 @@ export function MacroCellComponent({
             updateLatest({ ...latest, payload: { ...latest.payload, language: saved.language } });
           },
           onError: (err) => {
-            toast({ description: parseApiError(err)?.message, variant: "destructive" });
+            toast({
+              description: parseApiError(err)?.message ?? t("cells.languageSaveFailed"),
+              variant: "destructive",
+            });
           },
         },
       );
     },
-    [macroId, saveLanguage],
+    [macroId, saveLanguage, t],
   );
 
   const [langSelectOpen, setLangSelectOpen] = useState(false);
@@ -198,6 +201,7 @@ export function MacroCellComponent({
       try {
         const res = await saveMacro({ id: macroId, name: next });
         const { cell: latest, onUpdate: updateLatest } = cellRef.current;
+        if (latest.payload.macroId !== macroId) return;
         updateLatest({ ...latest, payload: { ...latest.payload, name: res.name } });
       } catch (err) {
         const parsed = parseApiError(err);

--- a/apps/web/components/workbook/cells/macro-cell.tsx
+++ b/apps/web/components/workbook/cells/macro-cell.tsx
@@ -93,6 +93,7 @@ export function MacroCellComponent({
   const forkedFrom = useSnapshot ? undefined : macroData?.forkedFrom;
 
   const { mutateAsync: saveMacro } = useMacroUpdate(macroId);
+  const { mutate: saveLanguage, isPending: isSavingLanguage } = useMacroUpdate(macroId);
   const { mutateAsync: forkMacro, isPending: isForking } = useMacroCreate();
   const onEntitySaved = useWorkbookEntitySaved();
 
@@ -161,31 +162,32 @@ export function MacroCellComponent({
 
   const handleLanguageChange = useCallback(
     (lang: MacroLanguage) => {
-      void saveMacro({ id: macroId, language: lang }).catch((err: unknown) => {
-        toast({ description: parseApiError(err)?.message, variant: "destructive" });
-      });
-      onUpdate({ ...cell, payload: { ...cell.payload, language: lang } });
+      saveLanguage(
+        { id: macroId, language: lang },
+        {
+          onSuccess: (saved) => {
+            const { cell: latest, onUpdate: updateLatest } = cellRef.current;
+            if (latest.payload.macroId !== macroId) return;
+            updateLatest({ ...latest, payload: { ...latest.payload, language: saved.language } });
+          },
+          onError: (err) => {
+            toast({ description: parseApiError(err)?.message, variant: "destructive" });
+          },
+        },
+      );
     },
-    [macroId, saveMacro, cell, onUpdate],
+    [macroId, saveLanguage],
   );
-
-  // The macro row's language can change outside this workbook (macro page,
-  // another workbook). Offline hosts run off the cell payload, so write the
-  // live value back instead of only displaying it.
-  useEffect(() => {
-    if (readOnly || useSnapshot || !macroLanguage || macroLanguage === language) return;
-    onUpdate({ ...cell, payload: { ...cell.payload, language: macroLanguage } });
-  }, [readOnly, useSnapshot, macroLanguage, language, cell, onUpdate]);
 
   const [langSelectOpen, setLangSelectOpen] = useState(false);
 
-  // Track the latest cell so the async rename merges into current state, not a
+  // Track the latest cell so async saves merge into current state, not a
   // stale snapshot from when the save began. Sync in a layout effect (not during
   // render) so a speculative render never leaks into the ref.
-  const cellRef = useRef(cell);
+  const cellRef = useRef({ cell, onUpdate });
   useLayoutEffect(() => {
-    cellRef.current = cell;
-  }, [cell]);
+    cellRef.current = { cell, onUpdate };
+  }, [cell, onUpdate]);
 
   // Rename the shared macro row and repoint the cell label at the new name.
   // Renaming a fork resolves the auto-generated "Copy of ..." name in place.
@@ -195,8 +197,8 @@ export function MacroCellComponent({
       setIsRenaming(true);
       try {
         const res = await saveMacro({ id: macroId, name: next });
-        const latest = cellRef.current;
-        onUpdate({ ...latest, payload: { ...latest.payload, name: res.name } });
+        const { cell: latest, onUpdate: updateLatest } = cellRef.current;
+        updateLatest({ ...latest, payload: { ...latest.payload, name: res.name } });
       } catch (err) {
         const parsed = parseApiError(err);
         toast({
@@ -211,7 +213,7 @@ export function MacroCellComponent({
         setIsRenaming(false);
       }
     },
-    [macroId, saveMacro, onUpdate, t],
+    [macroId, saveMacro, t],
   );
 
   const displayName = cell.payload.name ?? macroName ?? "Macro";
@@ -311,6 +313,7 @@ export function MacroCellComponent({
           {canUpdateMacro ? (
             <Select
               value={displayLanguage}
+              disabled={isSavingLanguage}
               onValueChange={(v) => handleLanguageChange(v as MacroLanguage)}
               open={langSelectOpen}
               onOpenChange={setLangSelectOpen}

--- a/packages/api/src/domains/workbook/workbook-version.schema.spec.ts
+++ b/packages/api/src/domains/workbook/workbook-version.schema.spec.ts
@@ -36,6 +36,22 @@ describe("Workbook Version Schemas", () => {
       expect(zWorkbookVersion.safeParse(withCells).success).toBe(true);
     });
 
+    it("accepts macro snapshots with and without a pinned language", () => {
+      const snapshots = {
+        ...valid,
+        entitySnapshots: {
+          protocols: {},
+          macros: { a: { code: "x" }, b: { code: "y", language: "python" } },
+        },
+      };
+      expect(zWorkbookVersion.safeParse(snapshots).success).toBe(true);
+      const bad = {
+        ...valid,
+        entitySnapshots: { protocols: {}, macros: { a: { code: "x", language: "java" } } },
+      };
+      expect(zWorkbookVersion.safeParse(bad).success).toBe(false);
+    });
+
     it("rejects version <= 0", () => {
       expect(zWorkbookVersion.safeParse({ ...valid, version: 0 }).success).toBe(false);
       expect(zWorkbookVersion.safeParse({ ...valid, version: -1 }).success).toBe(false);

--- a/packages/api/src/domains/workbook/workbook-version.schema.ts
+++ b/packages/api/src/domains/workbook/workbook-version.schema.ts
@@ -1,17 +1,18 @@
 import { z } from "zod";
 
+import { zMacroLanguage } from "../macro/macro.schema";
 import { zProtocolFamily } from "../protocol/protocol.schema";
 import { zWorkbookCellArray } from "./workbook-cells.schema";
 
-// `family` is captured at publish so the pinned snapshot renders fully without
-// re-fetching the live protocol row. Optional for versions published before it
-// was snapshotted.
+// `family` and macro `language` are captured at publish so the pinned snapshot
+// runs without the live row; the cell payload's language can go stale when the
+// macro row is edited elsewhere. Optional for versions published before that.
 export const zEntitySnapshots = z.object({
   protocols: z.record(
     z.string(),
     z.object({ code: z.unknown(), family: zProtocolFamily.optional() }),
   ),
-  macros: z.record(z.string(), z.object({ code: z.string() })),
+  macros: z.record(z.string(), z.object({ code: z.string(), language: zMacroLanguage.optional() })),
 });
 
 export const zWorkbookVersion = z.object({

--- a/packages/i18n/locales/de-DE/workbook.json
+++ b/packages/i18n/locales/de-DE/workbook.json
@@ -99,6 +99,7 @@
     "renameSave": "Namen speichern",
     "renameCancel": "Abbrechen",
     "renameConflict": "Dieser Name ist bereits vergeben",
-    "renameFailed": "Umbenennen fehlgeschlagen"
+    "renameFailed": "Umbenennen fehlgeschlagen",
+    "languageSaveFailed": "Die Makrosprache konnte nicht gespeichert werden"
   }
 }

--- a/packages/i18n/locales/en-US/workbook.json
+++ b/packages/i18n/locales/en-US/workbook.json
@@ -107,6 +107,7 @@
     "renameSave": "Save name",
     "renameCancel": "Cancel",
     "renameConflict": "That name is already taken",
-    "renameFailed": "Rename failed"
+    "renameFailed": "Rename failed",
+    "languageSaveFailed": "Could not save the macro language"
   }
 }

--- a/packages/i18n/locales/nl-NL/workbook.json
+++ b/packages/i18n/locales/nl-NL/workbook.json
@@ -99,6 +99,7 @@
     "renameSave": "Naam opslaan",
     "renameCancel": "Annuleren",
     "renameConflict": "Die naam is al in gebruik",
-    "renameFailed": "Naam wijzigen mislukt"
+    "renameFailed": "Naam wijzigen mislukt",
+    "languageSaveFailed": "Kan de macrotaal niet opslaan"
   }
 }


### PR DESCRIPTION
A workbook could publish Python macro code with a stale JavaScript cell language, causing mobile, stored-measurement preview, and offline-upload processing to select the wrong runtime.

Published macro snapshots now pin language alongside code. Mobile and backend processing prefer that pinned language, with the cell payload as a fallback for older versions. The same backend snapshot resolver feeds cloud batch execution, so published-version runs choose the pinned Lambda runtime as well. The web editor also uses pinned language when showing a published snapshot. Mobile reports unsupported or missing languages explicitly.

In the live editor, the macro query supplies the displayed language. Selecting a language saves the macro first, then updates the workbook cell from the successful response. There is no effect that copies query data into the cell. Failed saves leave the cell unchanged. The selector is disabled while saving, and mutation callbacks stop when the cell unmounts.

Existing published versions are unchanged. Publish a new workbook version to capture a corrected language.

## Validation

- Stored-preview and runtime-selection regression suites pass locally (53 mobile tests).
- All 30 web macro-cell tests pass locally, including parent rerenders, delayed saves and query refreshes, failed saves, deletion during saving, and repeat selections.
- Mobile and i18n typechecks, targeted ESLint, and formatting pass.
- CI on the previous commit passed build, lint, tests, and security checks.

## Linear issues

Fixes OJD-1781